### PR TITLE
Fix failing services in Docker Compose

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,7 @@
+# Database credentials
+dbUser=postgres
+dbPassword=postgres
+
+# Messaging credentials
+rabbitMqUser=admin
+rabbitMqPassword=admin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -167,14 +167,16 @@ services:
       ORCHESTRATOR_SENDER_TRANSPORT_USERNAME: admin
       ORCHESTRATOR_SENDER_TRANSPORT_PASSWORD: admin
       SECRETS_PROVIDER_NAME: fileBasedSecretsProvider
-      FILE_BASED_PATH: "/etc/fileBasedSecretStorage/secrets.storage"
+      FILE_BASED_PATH: "/etc/fileBasedSecretStorage/.env.development"
       GRAPHITE_HOST: "graphite"
       GRAPHITE_PORT: 2003
       GRAPHITE_PROTOCOL: PLAINTEXT
+      CORE_SECRET_PROVIDER: secret-file
+      CORE_SECRET_FILES: /etc/fileBasedSecretStorage/.env.development
     volumes:
       - type: bind
-        source: ~/.ort/server/secrets
-        target: /etc/fileBasedSecretStorage
+        source: ./.env.development
+        target: /etc/fileBasedSecretStorage/.env.development
 
   orchestrator:
     image: ort-server-orchestrator
@@ -221,6 +223,12 @@ services:
       REPORTER_SENDER_TRANSPORT_QUEUE_NAME: reporter_queue
       REPORTER_SENDER_TRANSPORT_USERNAME: admin
       REPORTER_SENDER_TRANSPORT_PASSWORD: admin
+      ORCHESTRATOR_SECRET_PROVIDER: secret-file
+      ORCHESTRATOR_SECRET_FILES: /etc/fileBasedSecretStorage/.env.development
+    volumes:
+      - type: bind
+        source: ./.env.development
+        target: /etc/fileBasedSecretStorage/.env.development
 
   analyzer-worker:
     image: ort-server-analyzer-worker
@@ -247,6 +255,12 @@ services:
       ANALYZER_RECEIVER_TRANSPORT_QUEUE_NAME: analyzer_queue
       ANALYZER_RECEIVER_TRANSPORT_USERNAME: admin
       ANALYZER_RECEIVER_TRANSPORT_PASSWORD: admin
+      ANALYZER_SECRET_PROVIDER: secret-file
+      ANALYZER_SECRET_FILES: /etc/fileBasedSecretStorage/.env.development
+    volumes:
+      - type: bind
+        source: ./.env.development
+        target: /etc/fileBasedSecretStorage/.env.development
 
   advisor-worker:
     image: ort-server-advisor-worker
@@ -273,6 +287,12 @@ services:
       ADVISOR_RECEIVER_TRANSPORT_QUEUE_NAME: advisor_queue
       ADVISOR_RECEIVER_TRANSPORT_USERNAME: admin
       ADVISOR_RECEIVER_TRANSPORT_PASSWORD: admin
+      ADVISOR_SECRET_PROVIDER: secret-file
+      ADVISOR_SECRET_FILES: /etc/fileBasedSecretStorage/.env.development
+    volumes:
+      - type: bind
+        source: ./.env.development
+        target: /etc/fileBasedSecretStorage/.env.development
 
   scanner-worker:
     image: ort-server-scanner-worker
@@ -299,6 +319,12 @@ services:
       SCANNER_RECEIVER_TRANSPORT_QUEUE_NAME: scanner_queue
       SCANNER_RECEIVER_TRANSPORT_USERNAME: admin
       SCANNER_RECEIVER_TRANSPORT_PASSWORD: admin
+      SCANNER_SECRET_PROVIDER: secret-file
+      SCANNER_SECRET_FILES: /etc/fileBasedSecretStorage/.env.development
+    volumes:
+      - type: bind
+        source: ./.env.development
+        target: /etc/fileBasedSecretStorage/.env.development
 
   evaluator-worker:
     image: ort-server-evaluator-worker
@@ -325,6 +351,12 @@ services:
       EVALUATOR_RECEIVER_TRANSPORT_QUEUE_NAME: evaluator_queue
       EVALUATOR_RECEIVER_TRANSPORT_USERNAME: admin
       EVALUATOR_RECEIVER_TRANSPORT_PASSWORD: admin
+      EVALUATOR_SECRET_PROVIDER: secret-file
+      EVALUATOR_SECRET_FILES: /etc/fileBasedSecretStorage/.env.development
+    volumes:
+      - type: bind
+        source: ./.env.development
+        target: /etc/fileBasedSecretStorage/.env.development
 
   reporter-worker:
     image: ort-server-reporter-worker
@@ -351,6 +383,12 @@ services:
       REPORTER_RECEIVER_TRANSPORT_QUEUE_NAME: reporter_queue
       REPORTER_RECEIVER_TRANSPORT_USERNAME: admin
       REPORTER_RECEIVER_TRANSPORT_PASSWORD: admin
+      REPORTER_SECRET_PROVIDER: secret-file
+      REPORTER_SECRET_FILES: /etc/fileBasedSecretStorage/.env.development
+    volumes:
+      - type: bind
+        source: ./.env.development
+        target: /etc/fileBasedSecretStorage/.env.development
 
 volumes:
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -185,11 +185,12 @@ services:
         condition: service_healthy
     environment:
       DB_URL: "jdbc:postgresql://postgres:5432"
+      DB_HOST: "postgres"
       DB_NAME: ort_server
       DB_SCHEMA: ort_server
       DB_USERNAME: postgres
       DB_PASSWORD: postgres
-      DB_SSLMODE: disable
+      DB_SSL_MODE: disable
       ORCHESTRATOR_RECEIVER_TRANSPORT_TYPE: rabbitMQ
       ORCHESTRATOR_RECEIVER_TRANSPORT_SERVER_URI: "amqp://rabbitmq:5672"
       ORCHESTRATOR_RECEIVER_TRANSPORT_QUEUE_NAME: orchestrator_queue
@@ -230,11 +231,12 @@ services:
         condition: service_healthy
     environment:
       DB_URL: "jdbc:postgresql://postgres"
+      DB_HOST: "postgres"
       DB_NAME: ort_server
       DB_SCHEMA: ort_server
       DB_USERNAME: postgres
       DB_PASSWORD: postgres
-      DB_SSLMODE: disable
+      DB_SSL_MODE: disable
       ORCHESTRATOR_SENDER_TRANSPORT_TYPE: rabbitMQ
       ORCHESTRATOR_SENDER_TRANSPORT_SERVER_URI: "amqp://rabbitmq:5672"
       ORCHESTRATOR_SENDER_TRANSPORT_QUEUE_NAME: orchestrator_queue
@@ -255,11 +257,12 @@ services:
         condition: service_healthy
     environment:
       DB_URL: "jdbc:postgresql://postgres"
+      DB_HOST: "postgres"
       DB_NAME: ort_server
       DB_SCHEMA: ort_server
       DB_USERNAME: postgres
       DB_PASSWORD: postgres
-      DB_SSLMODE: disable
+      DB_SSL_MODE: disable
       ORCHESTRATOR_SENDER_TRANSPORT_TYPE: rabbitMQ
       ORCHESTRATOR_SENDER_TRANSPORT_SERVER_URI: "amqp://rabbitmq:5672"
       ORCHESTRATOR_SENDER_TRANSPORT_QUEUE_NAME: orchestrator_queue
@@ -280,11 +283,12 @@ services:
         condition: service_healthy
     environment:
       DB_URL: "jdbc:postgresql://postgres"
+      DB_HOST: "postgres"
       DB_NAME: ort_server
       DB_SCHEMA: ort_server
       DB_USERNAME: postgres
       DB_PASSWORD: postgres
-      DB_SSLMODE: disable
+      DB_SSL_MODE: disable
       ORCHESTRATOR_SENDER_TRANSPORT_TYPE: rabbitMQ
       ORCHESTRATOR_SENDER_TRANSPORT_SERVER_URI: "amqp://rabbitmq:5672"
       ORCHESTRATOR_SENDER_TRANSPORT_QUEUE_NAME: orchestrator_queue
@@ -305,11 +309,12 @@ services:
         condition: service_healthy
     environment:
       DB_URL: "jdbc:postgresql://postgres"
+      DB_HOST: "postgres"
       DB_NAME: ort_server
       DB_SCHEMA: ort_server
       DB_USERNAME: postgres
       DB_PASSWORD: postgres
-      DB_SSLMODE: disable
+      DB_SSL_MODE: disable
       ORCHESTRATOR_SENDER_TRANSPORT_TYPE: rabbitMQ
       ORCHESTRATOR_SENDER_TRANSPORT_SERVER_URI: "amqp://rabbitmq:5672"
       ORCHESTRATOR_SENDER_TRANSPORT_QUEUE_NAME: orchestrator_queue
@@ -330,11 +335,12 @@ services:
         condition: service_healthy
     environment:
       DB_URL: "jdbc:postgresql://postgres"
+      DB_HOST: "postgres"
       DB_NAME: ort_server
       DB_SCHEMA: ort_server
       DB_USERNAME: postgres
       DB_PASSWORD: postgres
-      DB_SSLMODE: disable
+      DB_SSL_MODE: disable
       ORCHESTRATOR_SENDER_TRANSPORT_TYPE: rabbitMQ
       ORCHESTRATOR_SENDER_TRANSPORT_SERVER_URI: "amqp://rabbitmq:5672"
       ORCHESTRATOR_SENDER_TRANSPORT_QUEUE_NAME: orchestrator_queue


### PR DESCRIPTION
Orchestrator and workers do not spin up with the current `docker-compose.yml`. The commits fix the errors to allow for launching a development environment with compose.