### PR TITLE
ci: Add required permission to publish-artifacts worflow

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -11,6 +11,8 @@ env:
 jobs:
   publish:
     runs-on: ubuntu-22.04
+    permissions:
+      packages: write
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4


### PR DESCRIPTION
Grant the `packages: write` permission to the `GITHUB_TOKEN` in the publish-artifacts workflow to fix the publishing of packages to the GitHub package registry.