### PR TITLE
feat(dev): Add basic environment and requests for IDEA HTTP client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,9 @@ out/
 # Helm subcharts and install packages
 /scripts/helm/ort-server/charts/
 /scripts/helm/*.tgz
+
+# Private environment for IDEA HTTP client
+http-client.private.env.json
+
+# Private HTTP requests
+*.private.http

--- a/README.md
+++ b/README.md
@@ -96,6 +96,11 @@ without TLS.**
 | RabbitMQ       | http://localhost:15672           | admin:admin       |
 | Graphite       | http://localhost:8888            | root:root         |
 
+#### HTTP request collections
+
+When using IntelliJ IDEA Ultimate, you can use the [integrated HTTP client](https://www.jetbrains.com/help/idea/http-client-in-product-code-editor.html) to execute requests against the ORT server.
+The requests can be found in [scripts/requests](./scripts/requests).
+
 ### Debugging
 
 To debug the ORT server in IntelliJ, you can use a composition with only some selected services:

--- a/scripts/requests/env/http-client.env.json
+++ b/scripts/requests/env/http-client.env.json
@@ -1,0 +1,78 @@
+{
+  "local": {
+    "host": "http://localhost:8080",
+    "username": "",
+    "password": "",
+    "access_token_url": "",
+    "client_id": "",
+    "Security": {
+      "Auth": {
+        "keycloak": {
+          "Type": "OAuth2",
+          "Grant Type": "Password",
+          "Token URL": "{{access_token_url}}",
+          "Client ID": "{{client_id}}",
+          "Username": "{{username}}",
+          "Password": "{{password}}"
+        }
+      }
+    }
+  },
+  "development": {
+    "host": "",
+    "username": "",
+    "password": "",
+    "access_token_url": "",
+    "client_id": "",
+    "Security": {
+      "Auth": {
+        "keycloak": {
+          "Type": "OAuth2",
+          "Grant Type": "Password",
+          "Token URL": "{{access_token_url}}",
+          "Client ID": "{{client_id}}",
+          "Username": "{{username}}",
+          "Password": "{{password}}"
+        }
+      }
+    }
+  },
+  "staging": {
+    "host": "",
+    "username": "",
+    "password": "",
+    "access_token_url": "",
+    "client_id": "",
+    "Security": {
+      "Auth": {
+        "keycloak": {
+          "Type": "OAuth2",
+          "Grant Type": "Password",
+          "Token URL": "{{access_token_url}}",
+          "Client ID": "{{client_id}}",
+          "Username": "{{username}}",
+          "Password": "{{password}}"
+        }
+      }
+    }
+  },
+  "production": {
+    "host": "",
+    "username": "",
+    "password": "",
+    "access_token_url": "",
+    "client_id": "",
+    "Security": {
+      "Auth": {
+        "keycloak": {
+          "Type": "OAuth2",
+          "Grant Type": "Password",
+          "Token URL": "{{access_token_url}}",
+          "Client ID": "{{client_id}}",
+          "Username": "{{username}}",
+          "Password": "{{password}}"
+        }
+      }
+    }
+  }
+}

--- a/scripts/requests/liveness.http
+++ b/scripts/requests/liveness.http
@@ -1,0 +1,2 @@
+### Check application health
+GET {{host}}/liveness

--- a/scripts/requests/organizations.http
+++ b/scripts/requests/organizations.http
@@ -1,0 +1,17 @@
+### Get all Organizations
+GET {{host}}/organizations
+Authorization: Bearer {{$auth.token("keycloak")}}
+
+### Get a single Organization
+GET {{host}}/organizations/1
+Authorization: Bearer {{$auth.token("keycloak")}}
+
+### Create an Organization
+POST {{host}}/organizations
+Authorization: Bearer {{$auth.token("keycloak")}}
+Content-Type: application/json
+
+{
+  "name": "Example Organization",
+  "description": "This is an example organization"
+}

--- a/scripts/requests/products.http
+++ b/scripts/requests/products.http
@@ -1,0 +1,17 @@
+### Get all Products for an Organization
+GET {{host}}/organizations/1/products
+Authorization: Bearer {{$auth.token("keycloak")}}
+
+### Get a single Product
+GET {{host}}/products/1
+Authorization: Bearer {{$auth.token("keycloak")}}
+
+### Create a Product
+POST {{host}}/organizations/1/products
+Authorization: Bearer {{$auth.token("keycloak")}}
+Content-Type: application/json
+
+{
+  "name": "Example Product",
+  "description": "This is an example product"
+}

--- a/scripts/requests/repositories.http
+++ b/scripts/requests/repositories.http
@@ -1,0 +1,62 @@
+### Get all Repositories of a Product
+GET {{host}}/products/1/repositories
+Authorization: Bearer {{$auth.token("keycloak")}}
+
+### Get a single Repository
+GET {{host}}/repositories/1
+Authorization: Bearer {{$auth.token("keycloak")}}
+
+### Create a Repository
+POST {{host}}/products/1/repositories
+Authorization: Bearer {{$auth.token("keycloak")}}
+Content-Type: application/json
+
+{
+  "type": "GIT",
+  "url": "https://github.com/eclipse-apoapsis/ort-server.git"
+}
+
+### Get all Runs for a Repository
+GET {{host}}/repositories/1/runs
+Authorization: Bearer {{$auth.token("keycloak")}}
+
+### Get latest Run
+GET {{host}}/repositories/1/runs?limit=1&sort=-index
+Authorization: Bearer {{$auth.token("keycloak")}}
+
+### Start a new Run
+POST {{host}}/repositories/1/runs
+Authorization: Bearer {{$auth.token("keycloak")}}
+Content-Type: application/json
+
+{
+  "revision": "main",
+  "jobConfigs": {
+    "analyzer": {},
+    "advisor": {},
+    "scanner": {},
+    "evaluator": {},
+    "reporter": {},
+    "notifier": {}
+  }
+}
+
+> {%
+    client.global.set("runId", response.body.id);
+%}
+
+### Get latest Run
+GET {{host}}/repositories/1/runs?limit=1&sort=-index
+Authorization: Bearer {{$auth.token("keycloak")}}
+
+> {%
+    client.global.set("runId", response.body.data[0].id);
+%}
+
+### Get details of a Run
+GET {{host}}/repositories/1/runs/{{runId}}
+Authorization: Bearer {{$auth.token("keycloak")}}
+
+### Get WebApp Report for Run
+GET {{host}}/runs/{{runId}}/reporter/scan-report-web-app.html
+Authorization: Bearer {{$auth.token("keycloak")}}


### PR DESCRIPTION
Add requests to read and create the basic ORT server entities with the IDEA HTTP client [1].
This setup expects a `http-client.private.env.json` file that configures the authentication.

[1]: https://www.jetbrains.com/help/idea/http-client-in-product-code-editor.html