### PR TITLE
fix(apiDocs): Fix typo in ProductsDocs

### DIFF
--- a/core/src/main/kotlin/apiDocs/ProductsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/ProductsDocs.kt
@@ -64,7 +64,7 @@ val getProductById: OpenApiRoute.() -> Unit = {
 }
 
 val patchProductById: OpenApiRoute.() -> Unit = {
-    operationId = "PathProductById"
+    operationId = "PatchProductById"
     summary = "Update a product."
     tags = listOf("Products")
 


### PR DESCRIPTION
There is a typo in patchProductById, which leads to wrongly named hook generated for the Server UI, and this PR fixes the typo.