### PR TITLE
Support configuration for the EnvironmentVariableFilter

### DIFF
--- a/workers/advisor/src/main/resources/application.conf
+++ b/workers/advisor/src/main/resources/application.conf
@@ -8,6 +8,11 @@ configManager {
   gitHubRepositoryName = ${?ADVISOR_CONFIG_GITHUB_REPOSITORY_NAME}
 }
 
+ort {
+  environmentAllowedNames = ${?ORT_ENVIRONMENT_ALLOWED_NAMES}
+  environmentDenySubstrings = ${?ORT_ENVIRONMENT_DENY_SUBSTRINGS}
+}
+
 database {
   host = "localhost"
   host = ${?DB_HOST}

--- a/workers/analyzer/src/main/resources/application.conf
+++ b/workers/analyzer/src/main/resources/application.conf
@@ -8,6 +8,11 @@ configManager {
   gitHubRepositoryName = ${?ANALYZER_CONFIG_GITHUB_REPOSITORY_NAME}
 }
 
+ort {
+  environmentAllowedNames = ${?ORT_ENVIRONMENT_ALLOWED_NAMES}
+  environmentDenySubstrings = ${?ORT_ENVIRONMENT_DENY_SUBSTRINGS}
+}
+
 database {
   host = "localhost"
   host = ${?DB_HOST}

--- a/workers/common/build.gradle.kts
+++ b/workers/common/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
     implementation(projects.dao)
     implementation(projects.model)
     implementation(projects.secrets.secretsSpi)
+    implementation(projects.utils.config)
 
     implementation(libs.kaml)
     implementation(libs.kotlinxCoroutines)

--- a/workers/evaluator/src/main/resources/application.conf
+++ b/workers/evaluator/src/main/resources/application.conf
@@ -8,6 +8,11 @@ configManager {
   gitHubRepositoryName = ${?EVALUATOR_CONFIG_GITHUB_REPOSITORY_NAME}
 }
 
+ort {
+  environmentAllowedNames = ${?ORT_ENVIRONMENT_ALLOWED_NAMES}
+  environmentDenySubstrings = ${?ORT_ENVIRONMENT_DENY_SUBSTRINGS}
+}
+
 database {
   host = "localhost"
   host = ${?DB_HOST}

--- a/workers/reporter/src/main/resources/application.conf
+++ b/workers/reporter/src/main/resources/application.conf
@@ -8,6 +8,11 @@ configManager {
   gitHubRepositoryName = ${?REPORTER_CONFIG_GITHUB_REPOSITORY_NAME}
 }
 
+ort {
+  environmentAllowedNames = ${?ORT_ENVIRONMENT_ALLOWED_NAMES}
+  environmentDenySubstrings = ${?ORT_ENVIRONMENT_DENY_SUBSTRINGS}
+}
+
 database {
   host = "localhost"
   host = ${?DB_HOST}

--- a/workers/scanner/src/main/resources/application.conf
+++ b/workers/scanner/src/main/resources/application.conf
@@ -8,6 +8,11 @@ configManager {
   gitHubRepositoryName = ${?SCANNER_CONFIG_GITHUB_REPOSITORY_NAME}
 }
 
+ort {
+  environmentAllowedNames = ${?ORT_ENVIRONMENT_ALLOWED_NAMES}
+  environmentDenySubstrings = ${?ORT_ENVIRONMENT_DENY_SUBSTRINGS}
+}
+
 database {
   host = "localhost"
   host = ${?DB_HOST}


### PR DESCRIPTION
This PR enables configuration of ORT's `EnvironmentVariableFilter` via environment variables in ORT Server. The configuration is read and applied in `WorkerContextFactory`; so it is available to all workers.

ORT Server did not provide a way to tweak this configuration, which may be required for certain environments.