### PR TITLE
build(github): Update REUSE to the latest version

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -53,6 +53,5 @@ jobs:
 
     - name: Check REUSE Compliance
       run: |
-        pip3 install --user reuse==1.1.2
-        pip3 install --user --force-reinstall python-debian==0.1.40 # See https://github.com/fsfe/reuse-tool/issues/427.
+        pip install --user reuse
         ~/.local/bin/reuse lint


### PR DESCRIPTION
Always use the latest REUSE version, which currently is 3.0.2 [1].

This aligns with the ORT core configuration.

[1]: https://github.com/fsfe/reuse-tool/releases/tag/v3.0.2