### PR TITLE
fix(api): Respond with 400 when receiving an invalid body

### DIFF
--- a/core/src/main/kotlin/plugins/StatusPages.kt
+++ b/core/src/main/kotlin/plugins/StatusPages.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.core.plugins
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
+import io.ktor.server.plugins.BadRequestException
 import io.ktor.server.plugins.requestvalidation.RequestValidationException
 import io.ktor.server.plugins.statuspages.StatusPages
 import io.ktor.server.response.respond
@@ -48,6 +49,14 @@ fun Application.configureStatusPages() {
         }
         exception<AuthorizationException> { call, _ ->
             call.respond(HttpStatusCode.Forbidden)
+        }
+        exception<BadRequestException> { call, e ->
+            val detailedMessage = e.cause?.message ?: e.message
+
+            call.respond(
+                HttpStatusCode.BadRequest,
+                ErrorResponse(message = "Invalid request body.", detailedMessage)
+            )
         }
         exception<EntityNotFoundException> { call, _ ->
             call.respond(HttpStatusCode.NotFound)

--- a/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
@@ -237,6 +237,29 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
             }
         }
 
+        "respond with 'Bad Request' if the request body is invalid" {
+            integrationTestApplication {
+                val invalidJson = """
+                    {
+                      "name": "Example Organization",
+                      "description": This description is missing double quotes.,
+                    }
+                """.trimIndent()
+
+                val response = superuserClient.post("/api/v1/organizations") {
+                    setBody(invalidJson)
+                }
+
+                val body = response.body<ErrorResponse>()
+                body.message shouldBe "Invalid request body."
+                body.cause.shouldContain(
+                    "Illegal input: Unexpected JSON token at offset 53: Expected quotation mark '\"'"
+                )
+
+                organizationService.getOrganization(1)?.mapToApi().shouldBeNull()
+            }
+        }
+
         "create Keycloak roles and groups" {
             integrationTestApplication {
                 val org = CreateOrganization(name = "name", description = "description")


### PR DESCRIPTION
Respond 400 'Bad Request' on invalid JSON bodies instead of 500 'Internal Server Error'.