### PR TITLE
chore: Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # last matching pattern is used, see
 # https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#codeowners-syntax
 
-* @oss-review-toolkit/bosch
+* @bs-ondem @MarcelBochtler @mnonnenmacher @nnobelis @oheger-bosch


### PR DESCRIPTION
Set the active committers as CODEOWNERS for the whole project. Note that currently there is not team that can be used, as the automatically created team for project committers is not visible.

Relates to #74.