### PR TITLE
ci(renovate): Configure schedule for `aws.sdk.kotlin:s3`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -12,6 +12,10 @@
     {
       "matchManagers": ["gradle"],
       "commitMessageTopic": "{{depName}}"
+    },
+    {
+      "matchPackageNames": ["aws.sdk.kotlin:s3"],
+      "schedule": ["after 9pm on sunday"]
     }
   ],
   "prHourlyLimit": 5,


### PR DESCRIPTION
Configure Renovate to only do weekly updates [1] of `aws.sdk.kotlin:s3` as the package is updated very often.

[1]: https://docs.renovatebot.com/configuration-options/#packagerules