### PR TITLE
fix(reporter): Fix a version clash with YAML libraries

### DIFF
--- a/workers/reporter/build.gradle.kts
+++ b/workers/reporter/build.gradle.kts
@@ -42,7 +42,9 @@ dependencies {
     implementation(projects.model)
     implementation(projects.storage.storageSpi)
     implementation(projects.transport.transportSpi)
-    implementation(projects.workers.common)
+    implementation(projects.workers.common) {
+        exclude(group = "com.charleskorn.kaml", module = "kaml")
+    }
 
     implementation(platform(libs.ortPackageConfigurationProviders))
     implementation(platform(libs.ortVersionControlSystems))


### PR DESCRIPTION
The recent update of `kaml` dragged in a version of `snakeyaml` that was incompatible with jRuby and thus caused the generation of AsciiDoc reports to fail. Fix this by excluding the `kaml` library for the Reporter worker.