### PR TITLE
fix(db): Drop the not null constraint on the score column

### DIFF
--- a/dao/src/main/resources/db/migration/V62__licenseFindingsNullableScore.sql
+++ b/dao/src/main/resources/db/migration/V62__licenseFindingsNullableScore.sql
@@ -1,0 +1,2 @@
+ALTER TABLE license_findings
+    ALTER COLUMN score DROP NOT NULL;


### PR DESCRIPTION
Depending on the scanner the license finding `score` might not be present. E.g. FossID does not provide any score for its findings. The DAO representation of the `license_findings` already defined the `score` field as nullable.

Resolves #99.