### PR TITLE
build: Increase the memory for the Gradle daemon

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,7 @@
 
 org.gradle.caching = true
 org.gradle.configuration-cache = true
+org.gradle.jvmargs = -Xmx2g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 org.gradle.kotlin.dsl.allWarningsAsErrors = true
 org.gradle.parallel = true
 


### PR DESCRIPTION
With the default values of 512 MiB heap space and 384 MiB metaspace the Gradle daemon often expired, because it was running out of metaspace.

While at it, also set the file encoding to UTF-8.