### PR TITLE
ci(renovate): Label PRs with "dependencies"

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,7 @@
   ],
   "branchPrefix": "renovate-action/",
   "dependencyDashboard": false,
+  "labels": ["dependencies"],
   "gitAuthor": "eclipse-apoapsis-bot <159786767+eclipse-apoapsis-bot@users.noreply.github.com>",
   "packageRules": [
     {


### PR DESCRIPTION
Make auto-generated PRs by Renovate stand out more and label them with "dependencies" like also ORT core does.