### PR TITLE
chore(analyzer): Add ORT Project Authors as copyright holders

### DIFF
--- a/workers/analyzer/docker/Analyzer.Dockerfile
+++ b/workers/analyzer/docker/Analyzer.Dockerfile
@@ -3,6 +3,7 @@
 
 # syntax=docker/dockerfile:1.4
 
+# Copyright (C) 2020 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
 # Copyright (C) 2022 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/workers/analyzer/docker/scripts/export_proxy_certificates.sh
+++ b/workers/analyzer/docker/scripts/export_proxy_certificates.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+# Copyright (C) 2020 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
 # Copyright (C) 2023 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/workers/analyzer/docker/scripts/import_certificates.sh
+++ b/workers/analyzer/docker/scripts/import_certificates.sh
@@ -1,5 +1,6 @@
 #!/bin/sh
 #
+# Copyright (C) 2020 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
 # Copyright (C) 2023 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/workers/analyzer/docker/scripts/set_apt_proxy.sh
+++ b/workers/analyzer/docker/scripts/set_apt_proxy.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 #
+# Copyright (C) 2022 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)
 # Copyright (C) 2022 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
 #
 # Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
The `Analyzer.Dockerfile` and related scripts are based on the respective files of the OSS Review Toolkit [1]. Add the required copyright statements for correct attribution.

[1]: https://github.com/oss-review-toolkit/ort