### PR TITLE
feat(notifier): Add Jira notifier configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,13 +98,13 @@ without TLS.**
 
 ### Accessing the services
 
-| Service        | URL                              | Credentials       |
-|----------------|----------------------------------|-------------------|
-| ORT Server API | http://localhost:8080/swagger-ui |                   |
-| Keycloak       | http://localhost:8081            | admin:admin       |
-| PostgreSQL     | http://localhost:5433            | postgres:postgres |
-| RabbitMQ       | http://localhost:15672           | admin:admin       |
-| Graphite       | http://localhost:8888            | root:root         |
+| Service        | URL                              | Credentials                                             |
+|----------------|----------------------------------|---------------------------------------------------------|
+| ORT Server API | http://localhost:8080/swagger-ui |                                                         |
+| Keycloak       | http://localhost:8081            | Administrator: admin:admin<br/>User: ort-admin:password |
+| PostgreSQL     | http://localhost:5433            | postgres:postgres                                       |
+| RabbitMQ       | http://localhost:15672           | admin:admin                                             |
+| Graphite       | http://localhost:8888            | root:root                                               |
 
 #### HTTP request collections
 

--- a/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
@@ -30,6 +30,8 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.EnvironmentVariableDeclaratio
 import org.eclipse.apoapsis.ortserver.api.v1.model.EvaluatorJob as ApiEvaluatorJob
 import org.eclipse.apoapsis.ortserver.api.v1.model.EvaluatorJobConfiguration as ApiEvaluatorJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.InfrastructureService as ApiInfrastructureService
+import org.eclipse.apoapsis.ortserver.api.v1.model.JiraNotificationConfiguration as ApiJiraNotificationConfiguration
+import org.eclipse.apoapsis.ortserver.api.v1.model.JiraRestClientConfiguration as ApiJiraRestClientConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.JobConfigurations as ApiJobConfigurations
 import org.eclipse.apoapsis.ortserver.api.v1.model.JobStatus as ApiJobStatus
 import org.eclipse.apoapsis.ortserver.api.v1.model.JobSummaries as ApiJobSummaries
@@ -70,6 +72,8 @@ import org.eclipse.apoapsis.ortserver.model.EvaluatorJob
 import org.eclipse.apoapsis.ortserver.model.EvaluatorJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 import org.eclipse.apoapsis.ortserver.model.InfrastructureServiceDeclaration
+import org.eclipse.apoapsis.ortserver.model.JiraNotificationConfiguration
+import org.eclipse.apoapsis.ortserver.model.JiraRestClientConfiguration
 import org.eclipse.apoapsis.ortserver.model.JobConfigurations
 import org.eclipse.apoapsis.ortserver.model.JobStatus
 import org.eclipse.apoapsis.ortserver.model.Jobs
@@ -351,14 +355,16 @@ fun NotifierJobConfiguration.mapToApi() =
     ApiNotifierJobConfiguration(
         notifierRules = notifierRules,
         resolutionsFile = resolutionsFile,
-        mail = mail?.mapToApi()
+        mail = mail?.mapToApi(),
+        jira = jira?.mapToApi()
     )
 
 fun ApiNotifierJobConfiguration.mapToModel() =
     NotifierJobConfiguration(
         notifierRules = notifierRules,
         resolutionsFile = resolutionsFile,
-        mail = mail?.mapToModel()
+        mail = mail?.mapToModel(),
+        jira = jira?.mapToModel()
     )
 
 fun ApiReporterJobConfiguration.mapToModel() =
@@ -491,6 +497,16 @@ fun ApiMailNotificationConfiguration.mapToModel() =
         mailServerConfiguration = mailServerConfiguration?.mapToModel()
     )
 
+fun JiraNotificationConfiguration.mapToApi() =
+    ApiJiraNotificationConfiguration(
+        jiraRestClientConfiguration = jiraRestClientConfiguration?.mapToApi()
+    )
+
+fun ApiJiraNotificationConfiguration.mapToModel() =
+    JiraNotificationConfiguration(
+        jiraRestClientConfiguration = jiraRestClientConfiguration?.mapToModel()
+    )
+
 fun MailServerConfiguration.mapToApi() =
     ApiMailServerConfiguration(
         hostName = hostName,
@@ -509,6 +525,20 @@ fun ApiMailServerConfiguration.mapToModel() =
         password = password,
         useSsl = useSsl,
         fromAddress = fromAddress
+    )
+
+fun JiraRestClientConfiguration.mapToApi() =
+    ApiJiraRestClientConfiguration(
+        serverUrl = serverUrl,
+        username = username,
+        password = password
+    )
+
+fun ApiJiraRestClientConfiguration.mapToModel() =
+    JiraRestClientConfiguration(
+        serverUrl = serverUrl,
+        username = username,
+        password = password
     )
 
 fun ApiPagingOptions.mapToModel() =

--- a/api/v1/model/src/commonMain/kotlin/JiraNotificationConfiguration.kt
+++ b/api/v1/model/src/commonMain/kotlin/JiraNotificationConfiguration.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.api.v1.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Configuration for Jira notifications.
+ * Notifications are typically sent after an [OrtRun] using a built-in Jira REST client.
+ */
+@Serializable
+data class JiraNotificationConfiguration(
+    val jiraRestClientConfiguration: JiraRestClientConfiguration? = null
+)
+
+/**
+ *  Configuration for a Jira REST client interacting with a Jira server after an [OrtRun].
+ */
+@Serializable
+data class JiraRestClientConfiguration(
+    /**
+     * The URL of the Jira server, e.g. "https://jira.example.com".
+     */
+    val serverUrl: String,
+
+    /**
+     * The username to authenticate with the Jira server.
+     */
+    val username: String,
+
+    /**
+     * The password to authenticate with the Jira server.
+     */
+    val password: String
+)

--- a/api/v1/model/src/commonMain/kotlin/JobConfigurations.kt
+++ b/api/v1/model/src/commonMain/kotlin/JobConfigurations.kt
@@ -344,7 +344,12 @@ data class NotifierJobConfiguration(
     /**
      * The configuration for Email notifications. If this is null, no email notifications will be sent.
      */
-    val mail: MailNotificationConfiguration? = null
+    val mail: MailNotificationConfiguration? = null,
+
+    /**
+     * The configuration for Jira notifications. If this is null, no Jira notifications will be sent.
+     */
+    val jira: JiraNotificationConfiguration? = null
 )
 
 /**

--- a/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
@@ -38,6 +38,8 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.EnvironmentConfig
 import org.eclipse.apoapsis.ortserver.api.v1.model.EvaluatorJob
 import org.eclipse.apoapsis.ortserver.api.v1.model.EvaluatorJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.InfrastructureService
+import org.eclipse.apoapsis.ortserver.api.v1.model.JiraNotificationConfiguration
+import org.eclipse.apoapsis.ortserver.api.v1.model.JiraRestClientConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.JobConfigurations
 import org.eclipse.apoapsis.ortserver.api.v1.model.JobStatus
 import org.eclipse.apoapsis.ortserver.api.v1.model.JobSummaries
@@ -143,6 +145,13 @@ private val fullJobConfigurations = JobConfigurations(
                 password = "password",
                 useSsl = true,
                 fromAddress = "no-reply@example.com"
+            )
+        ),
+        jira = JiraNotificationConfiguration(
+            jiraRestClientConfiguration = JiraRestClientConfiguration(
+                serverUrl = "https://jira.example.com",
+                username = "user",
+                password = "password"
             )
         )
     )

--- a/dao/src/testFixtures/kotlin/Fixtures.kt
+++ b/dao/src/testFixtures/kotlin/Fixtures.kt
@@ -44,6 +44,7 @@ import org.eclipse.apoapsis.ortserver.dao.tables.runs.shared.IdentifierDao
 import org.eclipse.apoapsis.ortserver.model.AdvisorJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.AnalyzerJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.EvaluatorJobConfiguration
+import org.eclipse.apoapsis.ortserver.model.JiraNotificationConfiguration
 import org.eclipse.apoapsis.ortserver.model.JobConfigurations
 import org.eclipse.apoapsis.ortserver.model.MailNotificationConfiguration
 import org.eclipse.apoapsis.ortserver.model.NotifierJobConfiguration
@@ -112,7 +113,8 @@ class Fixtures(private val db: Database) {
         notifier = NotifierJobConfiguration(
             mail = MailNotificationConfiguration(
                 recipientAddresses = listOf("test@example.com")
-            )
+            ),
+            jira = JiraNotificationConfiguration()
         )
     )
 

--- a/model/src/commonMain/kotlin/JiraNotificationConfiguration.kt
+++ b/model/src/commonMain/kotlin/JiraNotificationConfiguration.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Configuration for Jira notifications.
+ * Notifications are typically sent after an [OrtRun] using a built-in Jira REST client.
+ */
+@Serializable
+data class JiraNotificationConfiguration(
+    val jiraRestClientConfiguration: JiraRestClientConfiguration? = null
+)
+
+/**
+ *  Configuration for a Jira REST client interacting with a Jira server after an [OrtRun].
+ */
+@Serializable
+data class JiraRestClientConfiguration(
+    /**
+     * The URL of the Jira server, e.g. "https://jira.example.com".
+     */
+    val serverUrl: String,
+
+    /**
+     * The username to authenticate with the Jira server.
+     */
+    val username: String,
+
+    /**
+     * The password to authenticate with the Jira server.
+     */
+    val password: String
+)

--- a/model/src/commonMain/kotlin/JobConfigurations.kt
+++ b/model/src/commonMain/kotlin/JobConfigurations.kt
@@ -343,7 +343,12 @@ data class NotifierJobConfiguration(
     /**
      * The configuration for Email notifications. Is this is null, no email notifications will be sent.
      */
-    val mail: MailNotificationConfiguration? = null
+    val mail: MailNotificationConfiguration? = null,
+
+    /**
+     * The configuration for Jira notifications. Is this is null, no Jira notifications will be sent.
+     */
+    val jira: JiraNotificationConfiguration? = null
 )
 
 /**

--- a/workers/common/src/main/kotlin/common/OrtServerMappings.kt
+++ b/workers/common/src/main/kotlin/common/OrtServerMappings.kt
@@ -27,6 +27,7 @@ import java.time.Instant
 
 import kotlinx.datetime.toJavaInstant
 
+import org.eclipse.apoapsis.ortserver.model.JiraRestClientConfiguration
 import org.eclipse.apoapsis.ortserver.model.MailServerConfiguration
 import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.PluginConfiguration
@@ -168,6 +169,7 @@ import org.ossreviewtoolkit.model.config.FileStorageConfiguration as OrtFileStor
 import org.ossreviewtoolkit.model.config.HttpFileStorageConfiguration as OrtHttpFileStorageConfiguration
 import org.ossreviewtoolkit.model.config.IssueResolution as OrtIssueResolution
 import org.ossreviewtoolkit.model.config.IssueResolutionReason as OrtIssueResolutionReason
+import org.ossreviewtoolkit.model.config.JiraConfiguration as OrtJiraConfiguration
 import org.ossreviewtoolkit.model.config.LicenseChoices as OrtLicenseChoices
 import org.ossreviewtoolkit.model.config.LicenseFindingCuration as OrtLicenseFindingCuration
 import org.ossreviewtoolkit.model.config.LicenseFindingCurationReason as OrtLicenseFindingCurationReason
@@ -781,4 +783,11 @@ fun MailServerConfiguration.mapToOrt() =
         password = password,
         useSsl = useSsl,
         fromAddress = fromAddress
+    )
+
+fun JiraRestClientConfiguration.mapToOrt() =
+    OrtJiraConfiguration(
+        host = serverUrl,
+        username = username,
+        password = password
     )

--- a/workers/notifier/src/main/kotlin/notifier/NotifierRunner.kt
+++ b/workers/notifier/src/main/kotlin/notifier/NotifierRunner.kt
@@ -70,16 +70,35 @@ class NotifierRunner {
                 workerContext.configManager.getSecret(Path(it))
             }
 
-            val notifierConfiguration = if (mailServerUser != null && mailServerPassword != null) {
-                NotifierConfiguration(
-                    mail = config.mail?.mailServerConfiguration?.copy(
+            val sendMailConfiguration = if (mailServerUser != null && mailServerPassword != null) {
+                config.mail?.mailServerConfiguration?.copy(
                         username = mailServerUser,
                         password = mailServerPassword
                     )?.mapToOrt()
-                )
             } else {
-                NotifierConfiguration()
+                null
             }
+
+            val jiraRestClientUsername = config.jira?.jiraRestClientConfiguration?.username?.let {
+                workerContext.configManager.getSecret(Path(it))
+            }
+            val jiraRestClientPassword = config.jira?.jiraRestClientConfiguration?.password?.let {
+                workerContext.configManager.getSecret(Path(it))
+            }
+
+            val jiraConfiguration = if (jiraRestClientUsername != null && jiraRestClientPassword != null) {
+                config.jira?.jiraRestClientConfiguration?.copy(
+                        username = jiraRestClientUsername,
+                        password = jiraRestClientPassword
+                    )?.mapToOrt()
+            } else {
+                null
+            }
+
+            val notifierConfiguration = NotifierConfiguration(
+                mail = sendMailConfiguration,
+                jira = jiraConfiguration
+            )
 
             val resolutionsFromOrtResult = ortResult.repository.config.resolutions
 

--- a/workers/notifier/src/test/kotlin/NotifierRunnerTest.kt
+++ b/workers/notifier/src/test/kotlin/NotifierRunnerTest.kt
@@ -32,6 +32,8 @@ import java.io.File
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.config.Context
 import org.eclipse.apoapsis.ortserver.config.Path
+import org.eclipse.apoapsis.ortserver.model.JiraNotificationConfiguration
+import org.eclipse.apoapsis.ortserver.model.JiraRestClientConfiguration
 import org.eclipse.apoapsis.ortserver.model.MailNotificationConfiguration
 import org.eclipse.apoapsis.ortserver.model.MailServerConfiguration
 import org.eclipse.apoapsis.ortserver.model.NotifierJobConfiguration
@@ -61,6 +63,13 @@ class NotifierRunnerTest : WordSpec({
                     password = "secret-password",
                     useSsl = false,
                     fromAddress = "no-reply@oss-review-toolkit.org"
+                )
+            ),
+            jira = JiraNotificationConfiguration(
+                jiraRestClientConfiguration = JiraRestClientConfiguration(
+                    serverUrl = "https://jira.example.com",
+                    username = "secret-username",
+                    password = "secret-password"
                 )
             )
         )


### PR DESCRIPTION
Providing a way to configure a Jira notifier to interact with a Jira server at the end of an ORT run, e.g. to create a comment to an existing Jira issue about the result of the ORT run.