### PR TITLE
ci(renovate): Increase number of parallel PRs to 15

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -25,5 +25,6 @@
       "allowedVersions": "< 18"
     }
   ],
+  "prConcurrentLimit": 15,
   "prHourlyLimit": 5
 }


### PR DESCRIPTION
There are currently many Renovate PRs for the UI and the Docker Compose setup which cannot be merged without manual testing as the automated tests still have to be implemented. As these PRs are concurrently blocking PRs for tested Kotlin code, increase the number of parallel PRs.