### PR TITLE
ci: Add UI building to build and test workflow

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -34,6 +34,38 @@ jobs:
     - name: Build all classes
       run: ./gradlew --stacktrace classes
 
+  build-ui:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Install Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 20
+
+    - uses: pnpm/action-setup@v3
+      name: Install pnpm
+      with:
+        version: 8
+
+    - name: Get pnpm store directory
+      shell: bash
+      run: |
+        echo "STORE_PATH=$(pnpm store path --silent)" >> $GITHUB_ENV
+
+    - uses: actions/cache@v4
+      name: Setup pnpm cache
+      with:
+        path: ${{ env.STORE_PATH }}
+        key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+        restore-keys: |
+          ${{ runner.os }}-pnpm-store-
+
+    - name: Build UI
+      run: pnpm -C ui install build
+
   test:
     needs: build
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add UI building to the corresponding workflow, to automatically assess the buildability of the UI codebase after Renovate Bot 's suggested UI dependency updates. Use caching to reduce installation time.

This resolves #126.