### PR TITLE
fix(snippets): Remove the unique constraint on the snippets table

### DIFF
--- a/dao/src/main/kotlin/tables/SnippetsTable.kt
+++ b/dao/src/main/kotlin/tables/SnippetsTable.kt
@@ -66,8 +66,8 @@ class SnippetDao(id: EntityID<Long>) : LongEntity(id) {
                 it.mapToModel().provenance == snippet.provenance && it.additionalData?.data == snippet.additionalData
             }
 
-        fun getOrPut(snippet: Snippet): SnippetDao =
-            findBySnippet(snippet) ?: new {
+        fun put(snippet: Snippet): SnippetDao =
+            new {
                 this.purl = snippet.purl
                 this.path = snippet.location.path
                 this.startLine = snippet.location.startLine

--- a/dao/src/main/resources/db/migration/V63__removeSnippetIndex.sql
+++ b/dao/src/main/resources/db/migration/V63__removeSnippetIndex.sql
@@ -1,0 +1,2 @@
+ALTER TABLE snippets
+DROP CONSTRAINT snippets_purl_artifact_id_vcs_id_path_start_line_end_line_l_key;

--- a/workers/scanner/src/main/kotlin/scanner/OrtServerScanResultStorage.kt
+++ b/workers/scanner/src/main/kotlin/scanner/OrtServerScanResultStorage.kt
@@ -183,7 +183,7 @@ class OrtServerScanResultStorage(
                         this.endLine = snippetFinding.sourceLocation.endLine
                         this.snippets = SizedCollection(
                             snippetFinding.snippets.map { snippet ->
-                                SnippetDao.getOrPut(snippet.mapToModel())
+                                SnippetDao.put(snippet.mapToModel())
                             }
                         )
                     }


### PR DESCRIPTION
In production, there are some errors when inserting snippets in the table, because the column "additional_data" is too large for the index related to the unique constraint on this table's columns. This index is also growing and is currently taking more place than the snippet data itself.
However, this column `additional_data` is also containing the FossID snippet id, which is unique for every FossID scan. Therefore, this unique constraint does not make sense and can be removed.