### PR TITLE
ui: Add Products, Repositories and ORT Runs

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-dropdown-menu": "^2.0.6",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.0.2",
+    "@radix-ui/react-select": "^2.0.0",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-toast": "^1.1.5",
     "@radix-ui/react-tooltip": "^1.0.7",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -43,10 +43,10 @@ importers:
         version: 5.32.0(@tanstack/react-query@5.32.0(react@18.3.0))(react@18.3.0)
       '@tanstack/react-router':
         specifier: ^1.22.2
-        version: 1.29.2(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
+        version: 1.31.1(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
       '@tanstack/router-devtools':
         specifier: ^1.22.2
-        version: 1.29.2(csstype@3.1.3)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
+        version: 1.31.1(csstype@3.1.3)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -83,7 +83,7 @@ importers:
     devDependencies:
       '@7nohe/openapi-react-query-codegen':
         specifier: ^0.5.3
-        version: 0.5.3(commander@10.0.1)(glob@10.3.12)(openapi-typescript-codegen@0.24.0)(typescript@5.4.5)
+        version: 0.5.3(commander@4.1.1)(glob@10.3.12)(openapi-typescript-codegen@0.24.0)(typescript@5.4.5)
       '@tanstack/router-vite-plugin':
         specifier: ^1.20.5
         version: 1.30.0(vite@5.2.10(@types/node@20.12.7))
@@ -988,8 +988,8 @@ packages:
     peerDependencies:
       react: ^18.0.0
 
-  '@tanstack/react-router@1.29.2':
-    resolution: {integrity: sha512-rSSLyI+AaVg79qeeH5fH6KA8ZQkckinH9mFdLrGUhA4wX2B7Az7eloepha2TqvsFJon0HgeV7heMqPkq9nyAeg==}
+  '@tanstack/react-router@1.31.1':
+    resolution: {integrity: sha512-FZ7wYCL4UXkkT+yB703RcrnD6WO9dqphnEDWoPQIkN3f4Zk28nZPHRew3dcpK8n9o33sZJbCW24PVAdbjmpdEQ==}
     engines: {node: '>=12'}
     peerDependencies:
       react: '>=16.8'
@@ -1001,8 +1001,8 @@ packages:
       react: '>=16'
       react-dom: '>=16'
 
-  '@tanstack/router-devtools@1.29.2':
-    resolution: {integrity: sha512-8w8wH4++U9WU/CFWN+GbKnoxPeZjTCGX8T9K3qsPYi5dp43H0599RkfQj7nch0fecT3S9HLWIGWdIX74NEU0Jw==}
+  '@tanstack/router-devtools@1.31.1':
+    resolution: {integrity: sha512-vtxzLzPOHx0/5SXEXOHB4CSSUaMHnEOE1IyBTPxNBDizhGGImCxw8C74FoVzDSFQ2ED+4t6sPSLUA0m9FnnTWA==}
     engines: {node: '>=12'}
     peerDependencies:
       react: '>=16.8'
@@ -1311,8 +1311,8 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  electron-to-chromium@1.4.748:
-    resolution: {integrity: sha512-VWqjOlPZn70UZ8FTKUOkUvBLeTQ0xpty66qV0yJcAGY2/CthI4xyW9aEozRVtuwv3Kpf5xTesmJUcPwuJmgP4A==}
+  electron-to-chromium@1.4.749:
+    resolution: {integrity: sha512-LRMMrM9ITOvue0PoBrvNIraVmuDbJV5QC9ierz/z5VilMdPOVMjOtpICNld3PuXuTZ3CHH/UPxX9gHhAPwi+0Q==}
 
   emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
@@ -1620,8 +1620,8 @@ packages:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
-  lru-cache@10.2.0:
-    resolution: {integrity: sha512-2bIM8x+VAf6JT4bKAljS1qUWgMsqZRPGJS6FSahIMPVvctcNhyVp7AJu7quxOW9jwkryBReKZY5tY5JYv2n/7Q==}
+  lru-cache@10.2.1:
+    resolution: {integrity: sha512-tS24spDe/zXhWbNPErCHs/AGOzbKGHT+ybSBqmdLm8WZ1xXLWvH8Qn71QPAlqVhd0qUTWjy+Kl9JmISgDdEjsA==}
     engines: {node: 14 || >=16.14}
 
   lru-cache@5.1.1:
@@ -1827,8 +1827,8 @@ packages:
       oidc-client-ts: ^3.0.0
       react: '>=16.8.0'
 
-  react-refresh@0.14.0:
-    resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
+  react-refresh@0.14.1:
+    resolution: {integrity: sha512-iZiRCtNGY3QYP3pYOSSBOvQmBpQTcJccr/VcK2blpJrpPTUDjeN51mxm5nsrkCzBwsbGUj+TN9q2oPz5E13FLg==}
     engines: {node: '>=0.10.0'}
 
   react-remove-scroll-bar@2.3.6:
@@ -2067,8 +2067,8 @@ packages:
       '@types/react':
         optional: true
 
-  use-sync-external-store@1.2.0:
-    resolution: {integrity: sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==}
+  use-sync-external-store@1.2.1:
+    resolution: {integrity: sha512-6MCBDr76UJmRpbF8pzP27uIoTocf3tITaMJ52mccgAhMJycuh5A/RL6mDZCTwTisj0Qfeq69FtjMCUX27U78oA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
 
@@ -2139,9 +2139,9 @@ packages:
 
 snapshots:
 
-  '@7nohe/openapi-react-query-codegen@0.5.3(commander@10.0.1)(glob@10.3.12)(openapi-typescript-codegen@0.24.0)(typescript@5.4.5)':
+  '@7nohe/openapi-react-query-codegen@0.5.3(commander@4.1.1)(glob@10.3.12)(openapi-typescript-codegen@0.24.0)(typescript@5.4.5)':
     dependencies:
-      commander: 10.0.1
+      commander: 4.1.1
       glob: 10.3.12
       openapi-typescript-codegen: 0.24.0
       typescript: 5.4.5
@@ -2964,7 +2964,7 @@ snapshots:
       '@tanstack/query-core': 5.32.0
       react: 18.3.0
 
-  '@tanstack/react-router@1.29.2(react-dom@18.3.0(react@18.3.0))(react@18.3.0)':
+  '@tanstack/react-router@1.31.1(react-dom@18.3.0(react@18.3.0))(react@18.3.0)':
     dependencies:
       '@tanstack/history': 1.28.9
       '@tanstack/react-store': 0.2.1(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
@@ -2978,11 +2978,11 @@ snapshots:
       '@tanstack/store': 0.1.3
       react: 18.3.0
       react-dom: 18.3.0(react@18.3.0)
-      use-sync-external-store: 1.2.0(react@18.3.0)
+      use-sync-external-store: 1.2.1(react@18.3.0)
 
-  '@tanstack/router-devtools@1.29.2(csstype@3.1.3)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)':
+  '@tanstack/router-devtools@1.31.1(csstype@3.1.3)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)':
     dependencies:
-      '@tanstack/react-router': 1.29.2(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
+      '@tanstack/react-router': 1.31.1(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
       clsx: 2.1.1
       date-fns: 2.30.0
       goober: 2.1.14(csstype@3.1.3)
@@ -3154,7 +3154,7 @@ snapshots:
       '@babel/plugin-transform-react-jsx-self': 7.24.1(@babel/core@7.24.4)
       '@babel/plugin-transform-react-jsx-source': 7.24.1(@babel/core@7.24.4)
       '@types/babel__core': 7.20.5
-      react-refresh: 0.14.0
+      react-refresh: 0.14.1
       vite: 5.2.10(@types/node@20.12.7)
     transitivePeerDependencies:
       - supports-color
@@ -3233,7 +3233,7 @@ snapshots:
   browserslist@4.23.0:
     dependencies:
       caniuse-lite: 1.0.30001612
-      electron-to-chromium: 1.4.748
+      electron-to-chromium: 1.4.749
       node-releases: 2.0.14
       update-browserslist-db: 1.0.13(browserslist@4.23.0)
 
@@ -3330,7 +3330,7 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  electron-to-chromium@1.4.748: {}
+  electron-to-chromium@1.4.749: {}
 
   emoji-regex@8.0.0: {}
 
@@ -3652,7 +3652,7 @@ snapshots:
     dependencies:
       js-tokens: 4.0.0
 
-  lru-cache@10.2.0: {}
+  lru-cache@10.2.1: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -3750,7 +3750,7 @@ snapshots:
 
   path-scurry@1.10.2:
     dependencies:
-      lru-cache: 10.2.0
+      lru-cache: 10.2.1
       minipass: 7.0.4
 
   path-type@4.0.0: {}
@@ -3823,7 +3823,7 @@ snapshots:
       oidc-client-ts: 3.0.1
       react: 18.3.0
 
-  react-refresh@0.14.0: {}
+  react-refresh@0.14.1: {}
 
   react-remove-scroll-bar@2.3.6(@types/react@18.3.0)(react@18.3.0):
     dependencies:
@@ -4070,7 +4070,7 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.0
 
-  use-sync-external-store@1.2.0(react@18.3.0):
+  use-sync-external-store@1.2.1(react@18.3.0):
     dependencies:
       react: 18.3.0
 

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@radix-ui/react-label':
         specifier: ^2.0.2
         version: 2.0.2(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
+      '@radix-ui/react-select':
+        specifier: ^2.0.0
+        version: 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
       '@radix-ui/react-slot':
         specifier: ^1.0.2
         version: 1.0.2(@types/react@18.3.0)(react@18.3.0)
@@ -547,6 +550,9 @@ packages:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
 
+  '@radix-ui/number@1.0.1':
+    resolution: {integrity: sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==}
+
   '@radix-ui/primitive@1.0.1':
     resolution: {integrity: sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==}
 
@@ -782,6 +788,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-select@2.0.0':
+    resolution: {integrity: sha512-RH5b7af4oHtkcHS7pG6Sgv5rk5Wxa7XI8W5gvB1N/yiuDGZxko1ynvOiVhFM7Cis2A8zxF9bTOUVbRDzPepe6w==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+      react-dom: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-slot@1.0.2':
     resolution: {integrity: sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==}
     peerDependencies:
@@ -846,6 +865,15 @@ packages:
 
   '@radix-ui/react-use-layout-effect@1.0.1':
     resolution: {integrity: sha512-v/5RegiJWYdoCvMnITBkNNx6bCj20fiaJnWtRkU18yITptraXjffz5Qbn05uOiQnOvi+dbkznkoaMltz1GnszQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.0.1':
+    resolution: {integrity: sha512-cV5La9DPwiQ7S0gf/0qiD6YgNqM5Fk97Kdrlc5yBcrF3jyEZQwm7vYFqMo4IfeHgJXsRaMvLABFtd0OVEmZhDw==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0
@@ -2537,6 +2565,10 @@ snapshots:
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
+  '@radix-ui/number@1.0.1':
+    dependencies:
+      '@babel/runtime': 7.24.4
+
   '@radix-ui/primitive@1.0.1':
     dependencies:
       '@babel/runtime': 7.24.4
@@ -2789,6 +2821,36 @@ snapshots:
       '@types/react': 18.3.0
       '@types/react-dom': 18.3.0
 
+  '@radix-ui/react-select@2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)':
+    dependencies:
+      '@babel/runtime': 7.24.4
+      '@radix-ui/number': 1.0.1
+      '@radix-ui/primitive': 1.0.1
+      '@radix-ui/react-collection': 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
+      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-context': 1.0.1(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-direction': 1.0.1(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-dismissable-layer': 1.0.5(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
+      '@radix-ui/react-focus-guards': 1.0.1(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-focus-scope': 1.0.4(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
+      '@radix-ui/react-id': 1.0.1(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-popper': 1.1.3(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
+      '@radix-ui/react-portal': 1.0.4(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
+      '@radix-ui/react-primitive': 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
+      '@radix-ui/react-slot': 1.0.2(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-use-callback-ref': 1.0.1(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-use-controllable-state': 1.0.1(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-use-layout-effect': 1.0.1(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-use-previous': 1.0.1(@types/react@18.3.0)(react@18.3.0)
+      '@radix-ui/react-visually-hidden': 1.0.3(@types/react-dom@18.3.0)(@types/react@18.3.0)(react-dom@18.3.0(react@18.3.0))(react@18.3.0)
+      aria-hidden: 1.2.4
+      react: 18.3.0
+      react-dom: 18.3.0(react@18.3.0)
+      react-remove-scroll: 2.5.5(@types/react@18.3.0)(react@18.3.0)
+    optionalDependencies:
+      '@types/react': 18.3.0
+      '@types/react-dom': 18.3.0
+
   '@radix-ui/react-slot@1.0.2(@types/react@18.3.0)(react@18.3.0)':
     dependencies:
       '@babel/runtime': 7.24.4
@@ -2863,6 +2925,13 @@ snapshots:
       '@types/react': 18.3.0
 
   '@radix-ui/react-use-layout-effect@1.0.1(@types/react@18.3.0)(react@18.3.0)':
+    dependencies:
+      '@babel/runtime': 7.24.4
+      react: 18.3.0
+    optionalDependencies:
+      '@types/react': 18.3.0
+
+  '@radix-ui/react-use-previous@1.0.1(@types/react@18.3.0)(react@18.3.0)':
     dependencies:
       '@babel/runtime': 7.24.4
       react: 18.3.0

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -30,6 +30,7 @@ export interface RouterContext {
     organization: string | undefined;
     product: string | undefined;
     repo: string | undefined;
+    run: string | undefined;
   };
   auth: ReturnType<typeof useAuth>;
 }
@@ -43,6 +44,7 @@ const router = createRouter({
       organization: undefined, 
       product: undefined,
       repo: undefined,
+      run: undefined,
     },
     auth: undefined!,
   },

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -28,6 +28,7 @@ export interface RouterContext {
   queryClient: typeof queryClient;
   breadcrumbs: {
     organization: string | undefined;
+    product: string | undefined;
   };
   auth: ReturnType<typeof useAuth>;
 }
@@ -37,7 +38,7 @@ const router = createRouter({
   routeTree,
   context: {
     queryClient,
-    breadcrumbs: { organization: undefined },
+    breadcrumbs: { organization: undefined, product: undefined },
     auth: undefined!,
   },
 });

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -29,6 +29,7 @@ export interface RouterContext {
   breadcrumbs: {
     organization: string | undefined;
     product: string | undefined;
+    repo: string | undefined;
   };
   auth: ReturnType<typeof useAuth>;
 }
@@ -38,7 +39,11 @@ const router = createRouter({
   routeTree,
   context: {
     queryClient,
-    breadcrumbs: { organization: undefined, product: undefined },
+    breadcrumbs: { 
+      organization: undefined, 
+      product: undefined,
+      repo: undefined,
+    },
     auth: undefined!,
   },
 });

--- a/ui/src/components/header.tsx
+++ b/ui/src/components/header.tsx
@@ -64,6 +64,12 @@ export const Header = () => {
       match.routeId ===
       '/_layout/organizations/$orgId/products/$productId/repositories/$repoId'
   );
+
+  const runMatch = matches.find(
+    (match) =>
+      match.routeId ===
+      '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runId'
+  );
   
   return (
     <header className="sticky top-0 flex justify-between h-16 gap-4 px-4 border-b bg-background md:px-6">
@@ -126,6 +132,18 @@ export const Header = () => {
                   <BreadcrumbLink asChild>
                     <Link to={repoMatch.pathname}>
                       {repoMatch.context.breadcrumbs.repo}
+                    </Link>
+                  </BreadcrumbLink>
+                </BreadcrumbItem>
+              </>
+            )}
+            {runMatch && (
+              <>
+                <BreadcrumbSeparator />
+                <BreadcrumbItem>
+                  <BreadcrumbLink asChild>
+                    <Link to={runMatch.pathname}>
+                      {runMatch.context.breadcrumbs.run}
                     </Link>
                   </BreadcrumbLink>
                 </BreadcrumbItem>

--- a/ui/src/components/header.tsx
+++ b/ui/src/components/header.tsx
@@ -33,6 +33,7 @@ import {
   BreadcrumbItem,
   BreadcrumbLink,
   BreadcrumbList,
+  BreadcrumbSeparator,
 } from './ui/breadcrumb';
 
 export const Header = () => {
@@ -52,6 +53,12 @@ export const Header = () => {
     (match) => match.routeId === '/_layout/organizations/$orgId'
   );
 
+  // The same breadcrumb logic applies to the other breadcrumb levels.
+  const productMatch = matches.find(
+    (match) =>
+      match.routeId === '/_layout/organizations/$orgId/products/$productId'
+  );
+  
   return (
     <header className="sticky top-0 flex justify-between h-16 gap-4 px-4 border-b bg-background md:px-6">
       <div className="flex flex-row items-center gap-4">
@@ -85,14 +92,26 @@ export const Header = () => {
         </Sheet>
         <Breadcrumb>
           <BreadcrumbList>
-          {organizationMatch && (
+            {organizationMatch && (
+                  <BreadcrumbItem>
+                    <BreadcrumbLink asChild>
+                      <Link to={organizationMatch.pathname}>
+                        {organizationMatch.context.breadcrumbs.organization}
+                      </Link>
+                    </BreadcrumbLink>
+                  </BreadcrumbItem>
+            )}
+            {productMatch && (
+              <>
+                <BreadcrumbSeparator />
                 <BreadcrumbItem>
                   <BreadcrumbLink asChild>
-                    <Link to={organizationMatch.pathname}>
-                      {organizationMatch.context.breadcrumbs.organization}
+                    <Link to={productMatch.pathname}>
+                      {productMatch.context.breadcrumbs.product}
                     </Link>
                   </BreadcrumbLink>
                 </BreadcrumbItem>
+              </>
             )}
           </BreadcrumbList>
         </Breadcrumb>

--- a/ui/src/components/header.tsx
+++ b/ui/src/components/header.tsx
@@ -59,6 +59,12 @@ export const Header = () => {
       match.routeId === '/_layout/organizations/$orgId/products/$productId'
   );
   
+  const repoMatch = matches.find(
+    (match) =>
+      match.routeId ===
+      '/_layout/organizations/$orgId/products/$productId/repositories/$repoId'
+  );
+  
   return (
     <header className="sticky top-0 flex justify-between h-16 gap-4 px-4 border-b bg-background md:px-6">
       <div className="flex flex-row items-center gap-4">
@@ -108,6 +114,18 @@ export const Header = () => {
                   <BreadcrumbLink asChild>
                     <Link to={productMatch.pathname}>
                       {productMatch.context.breadcrumbs.product}
+                    </Link>
+                  </BreadcrumbLink>
+                </BreadcrumbItem>
+              </>
+            )}
+            {repoMatch && (
+              <>
+                <BreadcrumbSeparator />
+                <BreadcrumbItem>
+                  <BreadcrumbLink asChild>
+                    <Link to={repoMatch.pathname}>
+                      {repoMatch.context.breadcrumbs.repo}
                     </Link>
                   </BreadcrumbLink>
                 </BreadcrumbItem>

--- a/ui/src/components/ui/select.tsx
+++ b/ui/src/components/ui/select.tsx
@@ -1,0 +1,171 @@
+/*
+ * The component is originally a part of the shadcn/ui library at https://github.com/shadcn-ui/ui.
+ * The library is licensed as set out below:
+ *
+ * Copyright (c) 2023 shadcn
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import * as React from "react"
+import {
+  CaretSortIcon,
+  CheckIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+} from "@radix-ui/react-icons"
+import * as SelectPrimitive from "@radix-ui/react-select"
+
+import { cn } from "@/lib/utils"
+
+const Select = SelectPrimitive.Root
+
+const SelectGroup = SelectPrimitive.Group
+
+const SelectValue = SelectPrimitive.Value
+
+const SelectTrigger = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      className
+    )}
+    {...props}
+  >
+    {children}
+    <SelectPrimitive.Icon asChild>
+      <CaretSortIcon className="h-4 w-4 opacity-50" />
+    </SelectPrimitive.Icon>
+  </SelectPrimitive.Trigger>
+))
+SelectTrigger.displayName = SelectPrimitive.Trigger.displayName
+
+const SelectScrollUpButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollUpButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronUpIcon />
+  </SelectPrimitive.ScrollUpButton>
+))
+SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName
+
+const SelectScrollDownButton = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.ScrollDownButton
+    ref={ref}
+    className={cn(
+      "flex cursor-default items-center justify-center py-1",
+      className
+    )}
+    {...props}
+  >
+    <ChevronDownIcon />
+  </SelectPrimitive.ScrollDownButton>
+))
+SelectScrollDownButton.displayName =
+  SelectPrimitive.ScrollDownButton.displayName
+
+const SelectContent = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
+>(({ className, children, position = "popper", ...props }, ref) => (
+  <SelectPrimitive.Portal>
+    <SelectPrimitive.Content
+      ref={ref}
+      className={cn(
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        position === "popper" &&
+          "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
+        className
+      )}
+      position={position}
+      {...props}
+    >
+      <SelectScrollUpButton />
+      <SelectPrimitive.Viewport
+        className={cn(
+          "p-1",
+          position === "popper" &&
+            "h-[var(--radix-select-trigger-height)] w-full min-w-[var(--radix-select-trigger-width)]"
+        )}
+      >
+        {children}
+      </SelectPrimitive.Viewport>
+      <SelectScrollDownButton />
+    </SelectPrimitive.Content>
+  </SelectPrimitive.Portal>
+))
+SelectContent.displayName = SelectPrimitive.Content.displayName
+
+const SelectLabel = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Label>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-sm font-semibold", className)}
+    {...props}
+  />
+))
+SelectLabel.displayName = SelectPrimitive.Label.displayName
+
+const SelectItem = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
+>(({ className, children, ...props }, ref) => (
+  <SelectPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className
+    )}
+    {...props}
+  >
+    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+      <SelectPrimitive.ItemIndicator>
+        <CheckIcon className="h-4 w-4" />
+      </SelectPrimitive.ItemIndicator>
+    </span>
+    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+  </SelectPrimitive.Item>
+))
+SelectItem.displayName = SelectPrimitive.Item.displayName
+
+const SelectSeparator = React.forwardRef<
+  React.ElementRef<typeof SelectPrimitive.Separator>,
+  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>
+>(({ className, ...props }, ref) => (
+  <SelectPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+))
+SelectSeparator.displayName = SelectPrimitive.Separator.displayName
+
+export {
+  Select,
+  SelectGroup,
+  SelectValue,
+  SelectTrigger,
+  SelectContent,
+  SelectLabel,
+  SelectItem,
+  SelectSeparator,
+  SelectScrollUpButton,
+  SelectScrollDownButton,
+}

--- a/ui/src/routeTree.gen.ts
+++ b/ui/src/routeTree.gen.ts
@@ -21,6 +21,10 @@ import { Route as LayoutOrganizationsOrgIdCreateProductImport } from './routes/_
 import { Route as LayoutOrganizationsOrgIdProductsProductIdRouteImport } from './routes/_layout/organizations/$orgId.products.$productId.route'
 import { Route as LayoutOrganizationsOrgIdProductsProductIdIndexImport } from './routes/_layout/organizations/$orgId.products.$productId.index'
 import { Route as LayoutOrganizationsOrgIdProductsProductIdEditImport } from './routes/_layout/organizations/$orgId.products.$productId.edit'
+import { Route as LayoutOrganizationsOrgIdProductsProductIdCreateRepositoryImport } from './routes/_layout/organizations/$orgId.products.$productId.create-repository'
+import { Route as LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRouteImport } from './routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.route'
+import { Route as LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdIndexImport } from './routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.index'
+import { Route as LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdEditImport } from './routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.edit'
 
 // Create/Update Routes
 
@@ -81,6 +85,36 @@ const LayoutOrganizationsOrgIdProductsProductIdEditRoute =
     getParentRoute: () => LayoutOrganizationsOrgIdProductsProductIdRouteRoute,
   } as any)
 
+const LayoutOrganizationsOrgIdProductsProductIdCreateRepositoryRoute =
+  LayoutOrganizationsOrgIdProductsProductIdCreateRepositoryImport.update({
+    path: '/create-repository',
+    getParentRoute: () => LayoutOrganizationsOrgIdProductsProductIdRouteRoute,
+  } as any)
+
+const LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRouteRoute =
+  LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRouteImport.update(
+    {
+      path: '/repositories/$repoId',
+      getParentRoute: () => LayoutOrganizationsOrgIdProductsProductIdRouteRoute,
+    } as any,
+  )
+
+const LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdIndexRoute =
+  LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdIndexImport.update(
+    {
+      path: '/',
+      getParentRoute: () =>
+        LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRouteRoute,
+    } as any,
+  )
+
+const LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdEditRoute =
+  LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdEditImport.update({
+    path: '/edit',
+    getParentRoute: () =>
+      LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRouteRoute,
+  } as any)
+
 // Populate the FileRoutesByPath interface
 
 declare module '@tanstack/react-router' {
@@ -117,6 +151,10 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRouteImport
       parentRoute: typeof LayoutOrganizationsOrgIdRouteImport
     }
+    '/_layout/organizations/$orgId/products/$productId/create-repository': {
+      preLoaderRoute: typeof LayoutOrganizationsOrgIdProductsProductIdCreateRepositoryImport
+      parentRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRouteImport
+    }
     '/_layout/organizations/$orgId/products/$productId/edit': {
       preLoaderRoute: typeof LayoutOrganizationsOrgIdProductsProductIdEditImport
       parentRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRouteImport
@@ -124,6 +162,18 @@ declare module '@tanstack/react-router' {
     '/_layout/organizations/$orgId/products/$productId/': {
       preLoaderRoute: typeof LayoutOrganizationsOrgIdProductsProductIdIndexImport
       parentRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRouteImport
+    }
+    '/_layout/organizations/$orgId/products/$productId/repositories/$repoId': {
+      preLoaderRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRouteImport
+      parentRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRouteImport
+    }
+    '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/edit': {
+      preLoaderRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdEditImport
+      parentRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRouteImport
+    }
+    '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/': {
+      preLoaderRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdIndexImport
+      parentRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRouteImport
     }
   }
 }
@@ -139,8 +189,15 @@ export const routeTree = rootRoute.addChildren([
       LayoutOrganizationsOrgIdEditRoute,
       LayoutOrganizationsOrgIdIndexRoute,
       LayoutOrganizationsOrgIdProductsProductIdRouteRoute.addChildren([
+        LayoutOrganizationsOrgIdProductsProductIdCreateRepositoryRoute,
         LayoutOrganizationsOrgIdProductsProductIdEditRoute,
         LayoutOrganizationsOrgIdProductsProductIdIndexRoute,
+        LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRouteRoute.addChildren(
+          [
+            LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdEditRoute,
+            LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdIndexRoute,
+          ],
+        ),
       ]),
     ]),
   ]),

--- a/ui/src/routeTree.gen.ts
+++ b/ui/src/routeTree.gen.ts
@@ -17,6 +17,10 @@ import { Route as LayoutCreateOrganizationImport } from './routes/_layout/create
 import { Route as LayoutOrganizationsOrgIdRouteImport } from './routes/_layout/organizations/$orgId.route'
 import { Route as LayoutOrganizationsOrgIdIndexImport } from './routes/_layout/organizations/$orgId.index'
 import { Route as LayoutOrganizationsOrgIdEditImport } from './routes/_layout/organizations/$orgId.edit'
+import { Route as LayoutOrganizationsOrgIdCreateProductImport } from './routes/_layout/organizations/$orgId.create-product'
+import { Route as LayoutOrganizationsOrgIdProductsProductIdRouteImport } from './routes/_layout/organizations/$orgId.products.$productId.route'
+import { Route as LayoutOrganizationsOrgIdProductsProductIdIndexImport } from './routes/_layout/organizations/$orgId.products.$productId.index'
+import { Route as LayoutOrganizationsOrgIdProductsProductIdEditImport } from './routes/_layout/organizations/$orgId.products.$productId.edit'
 
 // Create/Update Routes
 
@@ -53,6 +57,30 @@ const LayoutOrganizationsOrgIdEditRoute =
     getParentRoute: () => LayoutOrganizationsOrgIdRouteRoute,
   } as any)
 
+const LayoutOrganizationsOrgIdCreateProductRoute =
+  LayoutOrganizationsOrgIdCreateProductImport.update({
+    path: '/create-product',
+    getParentRoute: () => LayoutOrganizationsOrgIdRouteRoute,
+  } as any)
+
+const LayoutOrganizationsOrgIdProductsProductIdRouteRoute =
+  LayoutOrganizationsOrgIdProductsProductIdRouteImport.update({
+    path: '/products/$productId',
+    getParentRoute: () => LayoutOrganizationsOrgIdRouteRoute,
+  } as any)
+
+const LayoutOrganizationsOrgIdProductsProductIdIndexRoute =
+  LayoutOrganizationsOrgIdProductsProductIdIndexImport.update({
+    path: '/',
+    getParentRoute: () => LayoutOrganizationsOrgIdProductsProductIdRouteRoute,
+  } as any)
+
+const LayoutOrganizationsOrgIdProductsProductIdEditRoute =
+  LayoutOrganizationsOrgIdProductsProductIdEditImport.update({
+    path: '/edit',
+    getParentRoute: () => LayoutOrganizationsOrgIdProductsProductIdRouteRoute,
+  } as any)
+
 // Populate the FileRoutesByPath interface
 
 declare module '@tanstack/react-router' {
@@ -73,6 +101,10 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutOrganizationsOrgIdRouteImport
       parentRoute: typeof LayoutRouteImport
     }
+    '/_layout/organizations/$orgId/create-product': {
+      preLoaderRoute: typeof LayoutOrganizationsOrgIdCreateProductImport
+      parentRoute: typeof LayoutOrganizationsOrgIdRouteImport
+    }
     '/_layout/organizations/$orgId/edit': {
       preLoaderRoute: typeof LayoutOrganizationsOrgIdEditImport
       parentRoute: typeof LayoutOrganizationsOrgIdRouteImport
@@ -80,6 +112,18 @@ declare module '@tanstack/react-router' {
     '/_layout/organizations/$orgId/': {
       preLoaderRoute: typeof LayoutOrganizationsOrgIdIndexImport
       parentRoute: typeof LayoutOrganizationsOrgIdRouteImport
+    }
+    '/_layout/organizations/$orgId/products/$productId': {
+      preLoaderRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRouteImport
+      parentRoute: typeof LayoutOrganizationsOrgIdRouteImport
+    }
+    '/_layout/organizations/$orgId/products/$productId/edit': {
+      preLoaderRoute: typeof LayoutOrganizationsOrgIdProductsProductIdEditImport
+      parentRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRouteImport
+    }
+    '/_layout/organizations/$orgId/products/$productId/': {
+      preLoaderRoute: typeof LayoutOrganizationsOrgIdProductsProductIdIndexImport
+      parentRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRouteImport
     }
   }
 }
@@ -91,8 +135,13 @@ export const routeTree = rootRoute.addChildren([
     LayoutCreateOrganizationRoute,
     LayoutIndexRoute,
     LayoutOrganizationsOrgIdRouteRoute.addChildren([
+      LayoutOrganizationsOrgIdCreateProductRoute,
       LayoutOrganizationsOrgIdEditRoute,
       LayoutOrganizationsOrgIdIndexRoute,
+      LayoutOrganizationsOrgIdProductsProductIdRouteRoute.addChildren([
+        LayoutOrganizationsOrgIdProductsProductIdEditRoute,
+        LayoutOrganizationsOrgIdProductsProductIdIndexRoute,
+      ]),
     ]),
   ]),
 ])

--- a/ui/src/routeTree.gen.ts
+++ b/ui/src/routeTree.gen.ts
@@ -25,6 +25,9 @@ import { Route as LayoutOrganizationsOrgIdProductsProductIdCreateRepositoryImpor
 import { Route as LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRouteImport } from './routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.route'
 import { Route as LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdIndexImport } from './routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.index'
 import { Route as LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdEditImport } from './routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.edit'
+import { Route as LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdCreateRunImport } from './routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.create-run'
+import { Route as LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRunsRunIdRouteImport } from './routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.runs.$runId.route'
+import { Route as LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRunsRunIdIndexImport } from './routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.runs.$runId.index'
 
 // Create/Update Routes
 
@@ -115,6 +118,33 @@ const LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdEditRoute =
       LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRouteRoute,
   } as any)
 
+const LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdCreateRunRoute =
+  LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdCreateRunImport.update(
+    {
+      path: '/create-run',
+      getParentRoute: () =>
+        LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRouteRoute,
+    } as any,
+  )
+
+const LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRunsRunIdRouteRoute =
+  LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRunsRunIdRouteImport.update(
+    {
+      path: '/runs/$runId',
+      getParentRoute: () =>
+        LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRouteRoute,
+    } as any,
+  )
+
+const LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRunsRunIdIndexRoute =
+  LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRunsRunIdIndexImport.update(
+    {
+      path: '/',
+      getParentRoute: () =>
+        LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRunsRunIdRouteRoute,
+    } as any,
+  )
+
 // Populate the FileRoutesByPath interface
 
 declare module '@tanstack/react-router' {
@@ -167,6 +197,10 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRouteImport
       parentRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRouteImport
     }
+    '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/create-run': {
+      preLoaderRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdCreateRunImport
+      parentRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRouteImport
+    }
     '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/edit': {
       preLoaderRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdEditImport
       parentRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRouteImport
@@ -174,6 +208,14 @@ declare module '@tanstack/react-router' {
     '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/': {
       preLoaderRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdIndexImport
       parentRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRouteImport
+    }
+    '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runId': {
+      preLoaderRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRunsRunIdRouteImport
+      parentRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRouteImport
+    }
+    '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runId/': {
+      preLoaderRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRunsRunIdIndexImport
+      parentRoute: typeof LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRunsRunIdRouteImport
     }
   }
 }
@@ -194,8 +236,14 @@ export const routeTree = rootRoute.addChildren([
         LayoutOrganizationsOrgIdProductsProductIdIndexRoute,
         LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRouteRoute.addChildren(
           [
+            LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdCreateRunRoute,
             LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdEditRoute,
             LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdIndexRoute,
+            LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRunsRunIdRouteRoute.addChildren(
+              [
+                LayoutOrganizationsOrgIdProductsProductIdRepositoriesRepoIdRunsRunIdIndexRoute,
+              ],
+            ),
           ],
         ),
       ]),

--- a/ui/src/routes/_layout/organizations/$orgId.create-product.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.create-product.tsx
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { useProductsServicePostProduct } from '@/api/queries';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { useToast } from "@/components/ui/use-toast";
+import { ApiError } from '@/api/requests';
+import { ToastError } from '@/components/toast-error';
+
+const formSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+});
+
+const CreateProductPage = () => {
+  const navigate = useNavigate();
+  const params = Route.useParams();
+  const { toast } = useToast();
+
+  const { mutateAsync } = useProductsServicePostProduct({
+    onSuccess() {
+      toast({
+        title: 'Create Product',
+        description: 'New product created successfully.',
+      });
+      navigate({
+        to: '/organizations/$orgId',
+        params: { orgId: params.orgId },
+      });
+    },
+    onError(error: ApiError) {
+      toast({
+        title: error.message,
+        description: <ToastError message={error.body.message} cause={error.body.cause} />,
+        variant: 'destructive',
+      });
+    }
+  });
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+  });
+
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    await mutateAsync({
+      organizationId: Number.parseInt(params.orgId),
+      requestBody: {
+        name: values.name,
+        // There's a bug somewhere in the OpenAPI generation. Swagger UI hints that the bug may be
+        // in the API, as description in CreateOrganization is an empty object.
+        description: values.description as Record<string, unknown> | undefined,
+      },
+    });
+  }
+
+  return (
+    <Card className="w-full max-w-4xl mx-auto">
+      <CardHeader>
+        <CardTitle>Create Product</CardTitle>
+      </CardHeader>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+          <CardContent>
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    Enter the name of the product
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    Optional description of the product
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </CardContent>
+          <CardFooter>
+            <Button type="submit">Create</Button>
+          </CardFooter>
+        </form>
+      </Form>
+    </Card>
+  );
+};
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/create-product'
+)({
+  component: CreateProductPage,
+});

--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.create-repository.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.create-repository.tsx
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { useRepositoriesServiceCreateRepository } from '@/api/queries';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { ApiError, CreateRepository } from '@/api/requests';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useToast } from "@/components/ui/use-toast";
+import { ToastError } from '@/components/toast-error';
+
+const formSchema = z.object({
+  url: z.string(),
+  type: z.nativeEnum(CreateRepository.type),
+});
+
+const CreateRepositoryPage = () => {
+  const navigate = useNavigate();
+  const params = Route.useParams();
+  const { toast } = useToast();
+
+  const { mutateAsync } = useRepositoriesServiceCreateRepository({
+    onSuccess() {
+      toast({
+        title: 'Create Repository',
+        description: 'New repository created successfully.',
+      });
+      navigate({
+        to: '/organizations/$orgId/products/$productId',
+        params: { orgId: params.orgId, productId: params.productId },
+      });
+    },
+    onError(error: ApiError) {
+      toast({
+        title: 'Create Repository - FAILURE',
+        description: <ToastError message={`${error.message}: ${error.body.message}`} cause={error.body.cause} />,
+        variant: 'destructive',
+      });
+    }
+  });
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+  });
+
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    await mutateAsync({
+      productId: Number.parseInt(params.productId),
+      requestBody: {
+        url: values.url,
+        type: values.type,
+      },
+    });
+  }
+
+  return (
+    <Card className="w-full max-w-4xl mx-auto">
+      <CardHeader>
+        <CardTitle>Add repository</CardTitle>
+      </CardHeader>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+          <CardContent>
+            <FormField
+              control={form.control}
+              name="url"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>URL</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormDescription>URL of the repository</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Type</FormLabel>
+                  <Select
+                    onValueChange={field.onChange}
+                    defaultValue={field.value}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select a type" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {Object.keys(CreateRepository.type).map((type) => (
+                        <SelectItem key={type} value={type}>
+                          {type}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormDescription>Type of the repository</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </CardContent>
+          <CardFooter>
+            <Button type="submit">Create</Button>
+          </CardFooter>
+        </form>
+      </Form>
+    </Card>
+  );
+};
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/products/$productId/create-repository'
+)({
+  component: CreateRepositoryPage,
+});

--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.edit.tsx
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { useProductsServiceGetProductByIdKey, useProductsServicePatchProductById } from '@/api/queries';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { ApiError, ProductsService } from '@/api/requests';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+} from '@/components/ui/card';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { useToast } from "@/components/ui/use-toast";
+import { ToastError } from "@/components/toast-error";
+
+const formSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+});
+
+const EditProductPage = () => {
+  const params = Route.useParams();
+  const navigate = useNavigate();
+  const { toast } = useToast();
+
+  const { data: product } = useSuspenseQuery({
+    queryKey: [useProductsServiceGetProductByIdKey, params.orgId, params.productId],
+    queryFn: async () =>
+      await ProductsService.getProductById(
+        Number.parseInt(params.productId)
+      ),
+    },  
+  );
+
+  const { mutateAsync } = useProductsServicePatchProductById({
+    onSuccess() {
+      toast({
+        title: 'Edit Product',
+        description: 'Product updated successfully.',
+      });
+      navigate({
+        to: '/organizations/$orgId/products/$productId',
+        params: { orgId: params.orgId, productId: params.productId },
+      });
+    },
+    onError(error: ApiError) {
+      toast({
+        title: 'Edit Product - FAILURE',
+        description: <ToastError message={`${error.message}: ${error.body.message}`} cause={error.body.cause} />,
+        variant: 'destructive',
+      });
+    }
+  });
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: product.name,
+      description: product.description as unknown as string,
+    },
+  });
+
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    await mutateAsync({
+      productId: product.id,
+      requestBody: {
+        name: values.name,
+        // There's a bug somewhere in the OpenAPI generation, similar to organizations.
+        description: values.description as Record<string, unknown> | undefined,
+      },
+    });
+  }
+
+  return (
+    <Card className="w-full max-w-4xl mx-auto">
+      <CardHeader>Edit Product</CardHeader>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+          <CardContent>
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    Enter the name of your product
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    Optional description of the product
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </CardContent>
+          <CardFooter>
+            <Button className="m-1" variant="outline" onClick={() => navigate({ to: '/organizations/' + params.orgId + '/products/' + params.productId })}>
+              Cancel
+            </Button>
+            <Button type="submit">Submit</Button>
+          </CardFooter>
+        </form>
+      </Form>
+    </Card>
+  );
+}
+
+export const Route = createFileRoute('/_layout/organizations/$orgId/products/$productId/edit')({
+  loader: async ({ context, params }) => {
+    await context.queryClient.ensureQueryData({
+        queryKey: [useProductsServiceGetProductByIdKey, params.productId],
+        queryFn: () =>
+          ProductsService.getProductById(Number.parseInt(params.productId)),
+    });
+  },
+  component: EditProductPage,
+})

--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.create-run.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.create-run.tsx
@@ -1,0 +1,133 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { useRepositoriesServicePostOrtRun } from '@/api/queries';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { useToast } from "@/components/ui/use-toast";
+import { ApiError } from '@/api/requests';
+import { ToastError } from '@/components/toast-error';
+
+const formSchema = z.object({
+  revision: z.string(),
+});
+
+const CreateRunPage = () => {
+  const navigate = useNavigate();
+  const params = Route.useParams();
+  const { toast } = useToast();
+
+  const { mutateAsync } = useRepositoriesServicePostOrtRun({
+    onSuccess() {
+      toast({
+        title: 'Create ORT Run',
+        description: 'New ORT run created successfully for this repository.',
+      });
+      navigate({
+        to: '/organizations/$orgId/products/$productId/repositories/$repoId',
+        params: {
+          orgId: params.orgId,
+          productId: params.productId,
+          repoId: params.repoId,
+        },
+      });
+    },
+    onError(error: ApiError) {
+      toast({
+        title: 'Create ORT Run - FAILURE',
+        description: <ToastError message={`${error.message}: ${error.body.message}`} cause={error.body.cause} />,
+        variant: 'destructive',
+      });
+    }
+  });
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      revision: 'main',
+    },
+  });
+
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    await mutateAsync({
+      repositoryId: Number.parseInt(params.repoId),
+      requestBody: {
+        revision: values.revision,
+        jobConfigs: {},
+      },
+    });
+  }
+
+  return (
+    <Card className="w-full max-w-4xl mx-auto">
+      <CardHeader>
+        <CardTitle>Add repository</CardTitle>
+      </CardHeader>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+          <CardContent>
+            <FormField
+              control={form.control}
+              name="revision"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Revision</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormDescription>Revision to run ORT on</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </CardContent>
+          <CardFooter>
+            <Button type="submit">Create</Button>
+          </CardFooter>
+        </form>
+      </Form>
+    </Card>
+  );
+};
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/create-run'
+)({
+  component: CreateRunPage,
+});

--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.edit.tsx
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { 
+  useRepositoriesServiceGetRepositoryById, 
+  useRepositoriesServiceGetRepositoryByIdKey, 
+  useRepositoriesServicePatchRepositoryById } from '@/api/queries';
+import { createFileRoute, useNavigate } from '@tanstack/react-router'
+import { ApiError, RepositoriesService } from '@/api/requests';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { CreateRepository } from '@/api/requests';
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { useToast } from "@/components/ui/use-toast";
+import { ToastError } from "@/components/toast-error";
+
+const formSchema = z.object({
+  url: z.string(),
+  type: z.nativeEnum(CreateRepository.type),
+});
+
+const EditRepositoryPage = () => {
+  const params = Route.useParams();
+  const navigate = useNavigate();
+  const { toast } = useToast();
+
+  const { data: repository } = useSuspenseQuery({
+    queryKey: [useRepositoriesServiceGetRepositoryById, params.orgId, params.productId, params.repoId],
+    queryFn: async () =>
+      await RepositoriesService.getRepositoryById(
+        Number.parseInt(params.repoId)
+      ),
+    },  
+  );
+
+  const { mutateAsync } = useRepositoriesServicePatchRepositoryById({
+    onSuccess() {
+      toast({
+        title: 'Edit repository',
+        description: 'Repository updated successfully.',
+      });
+      navigate({
+        to: '/organizations/$orgId/products/$productId/repositories/$repoId',
+        params: { orgId: params.orgId, productId: params.productId, repoId: params.repoId},
+      });
+    },
+    onError(error: ApiError) {
+      toast({
+        title: 'Edit repository - FAILURE',
+        description: <ToastError message={`${error.message}: ${error.body.message}`} cause={error.body.cause} />,
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      url: repository.url,
+      type: repository.type,
+    },
+  });
+
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    await mutateAsync({
+      repositoryId: repository.id,
+      requestBody: {
+        url: values.url,
+        type: values.type,
+      },
+    });
+  }
+
+  return (
+    <Card className="w-full max-w-4xl mx-auto">
+      <CardHeader>
+        <CardTitle>Edit repository</CardTitle>
+      </CardHeader>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+          <CardContent>
+            <FormField
+              control={form.control}
+              name="url"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>URL</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormDescription>URL of the repository</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="type"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Type</FormLabel>
+                  <Select
+                    onValueChange={field.onChange}
+                    defaultValue={field.value}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select a type" />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {Object.keys(CreateRepository.type).map((type) => (
+                        <SelectItem key={type} value={type}>
+                          {type}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormDescription>Type of the repository</FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </CardContent>
+          <CardFooter>
+            <Button className="m-1" variant="outline" onClick={() => navigate({ to: '/organizations/' + params.orgId + '/products/' + params.productId })}>
+              Cancel
+            </Button>
+            <Button type="submit">Submit</Button>
+          </CardFooter>
+        </form>
+      </Form>
+    </Card>
+  );
+}
+
+export const Route = createFileRoute('/_layout/organizations/$orgId/products/$productId/repositories/$repoId/edit')({
+  loader: async ({ context, params }) => {
+    await context.queryClient.ensureQueryData({
+        queryKey: [useRepositoriesServiceGetRepositoryByIdKey, params.repoId],
+        queryFn: () =>
+          RepositoriesService.getRepositoryById(Number.parseInt(params.repoId)),
+    });
+  },
+  component: EditRepositoryPage,
+})

--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.index.tsx
@@ -167,8 +167,12 @@ const RepoComponent = () => {
                     <TooltipTrigger asChild>
                       <Button asChild size="sm" className="gap-1 ml-auto">
                         <Link
-                          to='/'
-                          disabled
+                          to="/organizations/$orgId/products/$productId/repositories/$repoId/create-run"
+                          params={{
+                            orgId: params.orgId,
+                            productId: params.productId,
+                            repoId: params.repoId,
+                          }}
                         >
                           New run
                           <PlusIcon className="w-4 h-4" />
@@ -187,8 +191,15 @@ const RepoComponent = () => {
                     <TableCell>
                       <div>
                         <Link
-                          to={'/'}
-                          disabled
+                          to={
+                            '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runId'
+                          }
+                          params={{
+                            orgId: params.orgId,
+                            productId: params.productId,
+                            repoId: repo.id.toString(),
+                            runId: run.id.toString(),
+                          }}
                           className="font-semibold text-blue-400 hover:underline"
                         >
                           {run.index}

--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.route.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.route.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { useRepositoriesServiceGetRepositoryByIdKey } from '@/api/queries';
+import { RepositoriesService } from '@/api/requests';
+import { Outlet, createFileRoute } from '@tanstack/react-router';
+import { Suspense } from 'react';
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/products/$productId/repositories/$repoId'
+)({
+  loader: async ({ context, params }) => {
+    const repo = await context.queryClient.ensureQueryData({
+      queryKey: [useRepositoriesServiceGetRepositoryByIdKey, params.repoId],
+      queryFn: () =>
+        RepositoriesService.getRepositoryById(Number.parseInt(params.repoId)),
+    });
+    context.breadcrumbs.repo = repo.url;
+  },
+  component: () => (
+    <Suspense fallback={<div>Loading...</div>}>
+      <Outlet />
+    </Suspense>
+  ),
+});

--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.runs.$runId.index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.runs.$runId.index.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import {
+  useRepositoriesServiceGetOrtRunByIndexKey,
+} from '@/api/queries';
+import {
+  Card,
+  CardHeader,
+  CardTitle,
+  CardDescription,
+  CardContent,
+} from '@/components/ui/card';
+import {
+  TableHeader,
+  TableRow,
+  TableHead,
+  TableBody,
+  TableCell,
+  Table,
+} from '@/components/ui/table';
+import { RepositoriesService } from '@/api/requests';
+import { createFileRoute } from '@tanstack/react-router';
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+const RunComponent = () => {
+  const params = Route.useParams();
+  
+  const { data: ortRun } = useSuspenseQuery({
+    queryKey: [useRepositoriesServiceGetOrtRunByIndexKey, params.orgId, params.productId, params.repoId, params.runId],
+    queryFn: async () =>
+      await RepositoriesService.getOrtRunByIndex(
+        Number.parseInt(params.repoId),
+        Number.parseInt(params.runId)
+      ),
+  },  
+);
+
+  return (
+    <Card className="w-full max-w-4xl mx-auto">
+      <CardHeader className="flex flex-row items-start">
+        <div className="grid gap-2">
+          <CardTitle>{ortRun.id}</CardTitle>
+          <CardDescription>{ortRun.status}</CardDescription>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Run parameter</TableHead>
+              <TableHead>Value</TableHead>
+              <TableHead className="sr-only">Actions</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            <TableRow>
+              <TableCell>
+                Created At
+              </TableCell>
+              <TableCell>
+                <div className="font-medium">{ortRun.createdAt}</div>
+              </TableCell>
+            </TableRow>
+            <TableRow>
+              <TableCell>
+                Revision
+              </TableCell>
+              <TableCell>
+                <div className="font-medium">{ortRun.revision}</div>
+              </TableCell>
+            </TableRow>
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  )
+}
+
+export const Route = createFileRoute('/_layout/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runId/')({
+  loader: async ({ context, params }) => {
+    await context.queryClient.ensureQueryData({
+        queryKey: [useRepositoriesServiceGetOrtRunByIndexKey, params.orgId, params.productId, params.repoId, params.runId],
+        queryFn: () =>
+          RepositoriesService.getOrtRunByIndex(
+            Number.parseInt(params.repoId),
+            Number.parseInt(params.runId)
+          ),
+    });
+  },
+  component: RunComponent,
+})

--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.runs.$runId.route.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.runs.$runId.route.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { useRepositoriesServiceGetOrtRunByIndexKey } from '@/api/queries';
+import { RepositoriesService } from '@/api/requests';
+import { Outlet, createFileRoute } from '@tanstack/react-router';
+import { Suspense } from 'react';
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runId'
+)({
+  loader: async ({ context, params }) => {
+    const run = await context.queryClient.ensureQueryData({
+      queryKey: [useRepositoriesServiceGetOrtRunByIndexKey, params.orgId, params.productId, params.repoId, params.runId],
+      queryFn: () =>
+        RepositoriesService.getOrtRunByIndex(Number.parseInt(params.repoId), Number.parseInt(params.runId)),
+    });
+    context.breadcrumbs.run = run.id.toString();
+  },
+  component: () => (
+    <Suspense fallback={<div>Loading...</div>}>
+      <Outlet />
+    </Suspense>
+  ),
+});

--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.route.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.route.tsx
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { useProductsServiceGetProductByIdKey } from '@/api/queries';
+import { ProductsService } from '@/api/requests';
+import { Outlet, createFileRoute } from '@tanstack/react-router';
+import { Suspense } from 'react';
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/products/$productId'
+)({
+  loader: async ({ context, params }) => {
+    const product = await context.queryClient.ensureQueryData({
+      queryKey: [useProductsServiceGetProductByIdKey, params.productId],
+      queryFn: () =>
+        ProductsService.getProductById(Number.parseInt(params.productId)),
+    });
+    context.breadcrumbs.product = product.name;
+  },
+  component: () => (
+    <Suspense fallback={<div>Loading...</div>}>
+      <Outlet />
+    </Suspense>
+  ),
+});


### PR DESCRIPTION
This PR adds CRUD (Create, Read, Update, Delete) functionality for Products and Repositories to the ORT Server UI. It also adds minimal proof-of-concept functionality for creating, listing and inspecting ORT Runs for Repositories.  

Note that this has currently some limitations, as Runs cannot be deleted, so if you create an ORT Run for a Repository, the repo cannot be deleted, either.  This will be addressed at a later stage.

Please see individual commits for details.