### PR TITLE
Add a GitHub workflow to build and publish Docker images

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,59 @@
+name: "Free Disk Space"
+description: "Remove unneeded preinstalled Docker images and software to free disk space."
+author: "The ORT Server Authors"
+
+runs:
+  using: "composite"
+
+  steps:
+    - name: Print Disk Space
+      shell: bash
+      run: df -h
+    - name: List Docker Images
+      if: ${{ false }} # Can be enabled if the 'Remove Unneeded Docker Images' step below needs to be updated.
+      shell: bash
+      run: docker images
+    - name: Remove Unneeded Docker Images
+      shell: bash
+      run: |
+        docker image rm \
+          node:16 \
+          node:16-alpine \
+          node:18 \
+          node:18-alpine \
+          node:20 \
+          node:20-alpine \
+          debian:10 \
+          debian:11 \
+          ubuntu:20.04 \
+          ubuntu:22.04
+    - name: Print Disk Space
+      shell: bash
+      run: df -h
+    - name: Get Size of Installed Tools
+      if: ${{ false }} # Can be enabled if the 'Remove Unneeded Tools' step below needs to be updated.
+      shell: bash
+      run: |
+        sudo du -hsc /usr/lib/*
+        sudo du -hsc /usr/local/*
+        sudo du -hsc /usr/local/lib/*
+        sudo du -hsc /usr/local/share/*
+        sudo du -hsc /usr/share/*
+    - name: Remove Unneeded Tools
+      shell: bash
+      run: |
+        sudo rm -rf /usr/local/lib/android
+        sudo rm -rf /usr/local/lib/node_modules
+        sudo rm -rf /usr/local/share/chromium
+        sudo rm -rf /usr/local/share/powershell
+        sudo rm -rf /usr/share/az_11.3.1
+        sudo rm -rf /usr/share/dotnet
+        sudo rm -rf /usr/share/kotlinc
+        sudo rm -rf /usr/share/mecab
+        sudo rm -rf /usr/share/miniconda
+        sudo rm -rf /usr/share/ri
+        sudo rm -rf /usr/share/sbt
+        sudo rm -rf /usr/share/swift
+    - name: Print Disk Space
+      shell: bash
+      run: df -h

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,132 @@
+name: Docker Build
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    name: Build Docker Image
+    runs-on: ubuntu-22.04
+    permissions:
+      packages: write
+    strategy:
+      matrix:
+        docker:
+        - name: Core
+          image: core
+          task: :core:jibDockerBuild
+        - name: Orchestrator
+          image: orchestrator
+          task: :orchestrator:jibDockerBuild
+        - name: Kubernetes Jobmonitor
+          image: kubernetes-jobmonitor
+          task: :transport:kubernetes-jobmonitor:jibDockerBuild
+        - name: Advisor Worker
+          image: advisor-worker
+          task: :workers:advisor:jibDockerBuild
+        - name: Analyzer Worker
+          image: analyzer-worker
+          task: :workers:analyzer:jibDockerBuild
+          context: workers/analyzer/docker
+          dockerfile: Analyzer.Dockerfile
+          freeDiskSpace: true
+        - name: Config Worker
+          image: config-worker
+          task: :workers:config:jibDockerBuild
+          context: workers/config/docker
+          dockerfile: Config.Dockerfile
+        - name: Notifier Worker
+          image: notifier-worker
+          task: :workers:notifier:jibDockerBuild
+          context: workers/notifier/docker
+          dockerfile: Notifier.Dockerfile
+        - name: Reporter Worker
+          image: reporter-worker
+          task: :workers:reporter:jibDockerBuild
+          context: workers/reporter/docker
+          dockerfile: Reporter.Dockerfile
+        - name: Scanner Worker
+          image: scanner-worker
+          task: :workers:scanner:jibDockerBuild
+          context: workers/scanner/docker
+          dockerfile: Scanner.Dockerfile
+
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Free Disk Space
+      if: ${{ matrix.docker.freeDiskSpace }}
+      uses: ./.github/actions/free-disk-space
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Login to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ${{ env.REGISTRY }}
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v3
+      with:
+        gradle-home-cache-cleanup: true
+
+    - name: Get ORT-Server Version
+      run: |
+        ORT_SERVER_VERSION=$(./gradlew -q properties --property version | sed -nr 's/version: (.+)/\1/p' | sed 's/+/-/')
+        echo "ORT_SERVER_VERSION=${ORT_SERVER_VERSION}" >> $GITHUB_ENV
+
+    - name: Extract Docker Metadata for ${{ matrix.docker.name }} Base Image
+      if: ${{ matrix.docker.dockerfile != '' }}
+      id: meta-base
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/ort-server-${{ matrix.docker.image }}-base-image
+        tags: |
+          type=raw,value=${{ env.ORT_SERVER_VERSION }}
+          type=ref,event=branch
+          type=sha
+
+    - name: Build ${{ matrix.docker.name }} Base Image
+      if: ${{ matrix.docker.dockerfile != '' }}
+      uses: docker/build-push-action@v5
+      with:
+        context: ${{ matrix.docker.context }}
+        file: ${{ matrix.docker.context }}/${{ matrix.docker.dockerfile }}
+        push: true
+        tags: ${{ steps.meta-base.outputs.tags }}
+        labels: ${{ steps.meta-base.outputs.labels }}
+        cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/ort-server-${{ matrix.docker.image }}-base-image:cache
+        cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/ort-server-${{ matrix.docker.image }}-base-image:cache,mode=max
+
+    - name: Extract Docker Metadata for ${{ matrix.docker.name }} Image
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        tags: |
+          type=raw,value=${{ env.ORT_SERVER_VERSION }}
+          type=ref,event=branch
+          type=sha
+
+    - name: Build ${{ matrix.docker.name }} Image
+      run: |
+        ./gradlew \
+          -PdockerBaseImagePrefix=${{ env.REGISTRY }}/${{ github.repository_owner }}/ \
+          -PdockerBaseImageTag=${{ env.ORT_SERVER_VERSION }} \
+          -PdockerImagePrefix=${{ env.REGISTRY }}/${{ github.repository_owner }}/ \
+          -PdockerImageTag=${{ env.ORT_SERVER_VERSION }} \
+          ${{ matrix.docker.task }} \
+          -Djib.console=plain \
+          -Djib.container.labels="$(echo "${{ steps.meta.outputs.labels }}" | tr '\n' ',' | sed 's/,$//')" \
+          -Djib.to.tags="$(echo "${{ steps.meta.outputs.tags }}" | tr '\n' ',' | sed 's/,$//')"
+        docker push ${{ env.REGISTRY }}/${{ github.repository_owner }}/ort-server-${{ matrix.docker.image }} --all-tags

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,4 +26,5 @@ kotlin.mpp.stability.nowarn=true
 
 dockerImagePrefix=
 dockerImageTag=latest
+dockerBaseImagePrefix=docker://
 dockerBaseImageTag=latest

--- a/workers/analyzer/build.gradle.kts
+++ b/workers/analyzer/build.gradle.kts
@@ -21,6 +21,7 @@ import com.google.cloud.tools.jib.gradle.JibTask
 
 val dockerImagePrefix: String by project
 val dockerImageTag: String by project
+val dockerBaseImagePrefix: String by project
 val dockerBaseImageTag: String by project
 
 plugins {
@@ -93,7 +94,7 @@ dependencies {
 }
 
 jib {
-    from.image = "docker://ort-server-analyzer-worker-base-image:$dockerBaseImageTag"
+    from.image = "${dockerBaseImagePrefix}ort-server-analyzer-worker-base-image:$dockerBaseImageTag"
     to.image = "${dockerImagePrefix}ort-server-analyzer-worker:$dockerImageTag"
 
     container {

--- a/workers/config/build.gradle.kts
+++ b/workers/config/build.gradle.kts
@@ -19,6 +19,8 @@
 
 import com.google.cloud.tools.jib.gradle.JibTask
 
+val dockerBaseImagePrefix: String by project
+val dockerBaseImageTag: String by project
 val dockerImagePrefix: String by project
 val dockerImageTag: String by project
 
@@ -72,7 +74,7 @@ dependencies {
 }
 
 jib {
-    from.image = "docker://ort-server-config-worker-base-image:latest"
+    from.image = "${dockerBaseImagePrefix}ort-server-config-worker-base-image:$dockerBaseImageTag"
     to.image = "${dockerImagePrefix}ort-server-config-worker:$dockerImageTag"
 
     container {

--- a/workers/evaluator/build.gradle.kts
+++ b/workers/evaluator/build.gradle.kts
@@ -21,6 +21,7 @@ import com.google.cloud.tools.jib.gradle.JibTask
 
 val dockerImagePrefix: String by project
 val dockerImageTag: String by project
+val dockerBaseImagePrefix: String by project
 val dockerBaseImageTag: String by project
 
 plugins {
@@ -72,7 +73,7 @@ dependencies {
 }
 
 jib {
-    from.image = "docker://ort-server-evaluator-worker-base-image:$dockerBaseImageTag"
+    from.image = "${dockerBaseImagePrefix}ort-server-evaluator-worker-base-image:$dockerBaseImageTag"
     to.image = "${dockerImagePrefix}ort-server-evaluator-worker:$dockerImageTag"
 
     container {

--- a/workers/notifier/build.gradle.kts
+++ b/workers/notifier/build.gradle.kts
@@ -21,6 +21,7 @@ import com.google.cloud.tools.jib.gradle.JibTask
 
 val dockerImagePrefix: String by project
 val dockerImageTag: String by project
+val dockerBaseImagePrefix: String by project
 val dockerBaseImageTag: String by project
 
 plugins {
@@ -66,7 +67,7 @@ dependencies {
 }
 
 jib {
-    from.image = "docker://ort-server-notifier-worker-base-image:$dockerBaseImageTag"
+    from.image = "${dockerBaseImagePrefix}ort-server-notifier-worker-base-image:$dockerBaseImageTag"
     to.image = "${dockerImagePrefix}ort-server-notifier-worker:$dockerImageTag"
 
     container {

--- a/workers/reporter/build.gradle.kts
+++ b/workers/reporter/build.gradle.kts
@@ -21,6 +21,7 @@ import com.google.cloud.tools.jib.gradle.JibTask
 
 val dockerImagePrefix: String by project
 val dockerImageTag: String by project
+val dockerBaseImagePrefix: String by project
 val dockerBaseImageTag: String by project
 
 plugins {
@@ -81,7 +82,7 @@ dependencies {
 }
 
 jib {
-    from.image = "docker://ort-server-reporter-worker-base-image:$dockerBaseImageTag"
+    from.image = "${dockerBaseImagePrefix}ort-server-reporter-worker-base-image:$dockerBaseImageTag"
     to.image = "${dockerImagePrefix}ort-server-reporter-worker:$dockerImageTag"
 
     container {

--- a/workers/scanner/build.gradle.kts
+++ b/workers/scanner/build.gradle.kts
@@ -21,6 +21,7 @@ import com.google.cloud.tools.jib.gradle.JibTask
 
 val dockerImagePrefix: String by project
 val dockerImageTag: String by project
+val dockerBaseImagePrefix: String by project
 val dockerBaseImageTag: String by project
 
 plugins {
@@ -90,7 +91,7 @@ repositories {
 }
 
 jib {
-    from.image = "docker://ort-server-scanner-worker-base-image:$dockerBaseImageTag"
+    from.image = "${dockerBaseImagePrefix}ort-server-scanner-worker-base-image:$dockerBaseImageTag"
     to.image = "${dockerImagePrefix}ort-server-scanner-worker:$dockerImageTag"
 
     container {


### PR DESCRIPTION
See the commit messages for details.

The workflow was tested in a fork: https://github.com/mnonnenmacher/ort-server
The resulting Docker images can be seen here (they are mixed with test artifacts, only those starting with "ort-server-" are relevant): https://github.com/mnonnenmacher?tab=packages