### PR TITLE
build(Gradle): Remove the `versionCatalogUpdate` plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,6 @@ plugins {
     alias(libs.plugins.kotlinJvm) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
     alias(libs.plugins.mavenPublish)
-    alias(libs.plugins.versionCatalogUpdate)
     alias(libs.plugins.versions)
 }
 
@@ -44,11 +43,6 @@ semver {
 version = semver.semVersion
 
 logger.lifecycle("Building ORT Server version $version.")
-
-versionCatalogUpdate {
-    // Keep the custom sorting / grouping.
-    sortByKey.set(false)
-}
 
 allprojects {
     buildscript {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -31,7 +31,6 @@ kotlinxDatetime = "0.5.0"
 kotlinxSerialization = "1.6.3"
 mavenPublishPlugin = "0.28.0"
 rabbitMq = "5.21.0"
-versionCatalogUpdatePlugin = "0.8.4"
 versionsPlugin = "0.51.0"
 
 # Gradle dependencies
@@ -75,7 +74,6 @@ kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlinPlugin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlinPlugin" }
 kotlinxSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinPlugin" }
 mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublishPlugin" }
-versionCatalogUpdate = { id = "nl.littlerobots.version-catalog-update", version.ref = "versionCatalogUpdatePlugin" }
 versions = { id = "com.github.ben-manes.versions", version.ref = "versionsPlugin" }
 
 [libraries]


### PR DESCRIPTION
Dependency updates are now managed by Renovate bot.