### PR TITLE
Add convenience tasks to build images

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ Then build the base images for the workers which contain the external tools and 
 ```shell
 # Build all worker images at once:
 ./gradlew buildAllWorkerImages
+
+# Build all worker images at once with custom build arguments:
+./gradlew -PdockerBaseBuildArgs="TEMURIN_VERSION=11" buildAllWorkerImages
 ```
 
 *or* manually by running

--- a/README.md
+++ b/README.md
@@ -51,20 +51,6 @@ Then the Docker images can be built with [Jib](https://github.com/GoogleContaine
 ./gradlew :core:jibDockerBuild
 ```
 
-The `jibDockerBuild` task occasionally gets stuck while pulling the Eclipse Temurin base image. In this case it usually
-helps to clean the project and stop the Gradle Daemon:
-
-```shell
-./gradlew clean
-./gradlew --stop
-```
-
-When building multiple images at once it can also help to disable parallel builds:
-
-```shell
-./gradlew --no-parallel jibDockerBuild
-```
-
 In case multiple base images have been created for the Analyzer supporting different Java versions, the tag of the base
 image to be used can be specified as a property. Note that the JDK on which the build is executed determines the JVM
 target of the resulting artifacts. So, if a specialized Analyzer image for Java 11 is to be created, the build must be

--- a/README.md
+++ b/README.md
@@ -19,7 +19,14 @@ First, ensure to have [Docker BuildKit](https://docs.docker.com/build/buildkit/)
 }
 ```
 
-Then build the base images for the workers which contain the external tools and required configuration:
+Then build the base images for the workers which contain the external tools and required configuration either via the Gradle task
+
+```shell
+# Build all worker images at once:
+./gradlew buildAllWorkerImages
+```
+
+*or* manually by running
 
 ```shell
 docker build workers/analyzer/docker -f workers/analyzer/docker/Analyzer.Dockerfile -t ort-server-analyzer-worker-base-image
@@ -41,7 +48,14 @@ with the desired target version, for instance for targeting Java 11:
 docker build --build-arg="TEMURIN_VERSION=11" . -f Analyzer.Dockerfile -t ort-server-analyzer-worker-base-image:11-latest
 ```
 
-Then the Docker images can be built with [Jib](https://github.com/GoogleContainerTools/jib):
+Then the Docker images containing the projects can be built via the Gradle task
+
+```shell
+# Build all images at once and any dependent base images:
+./gradlew buildAllImages
+```
+
+*or* manually via [Jib](https://github.com/GoogleContainerTools/jib) tasks by running
 
 ```shell
 # Build all images at once:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ plugins {
     alias(libs.plugins.dependencyAnalysis)
     alias(libs.plugins.detekt)
     alias(libs.plugins.gitSemver)
+    alias(libs.plugins.jib) apply false
     alias(libs.plugins.kotlinJvm) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
     alias(libs.plugins.mavenPublish)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,6 +22,7 @@ import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
+val dockerBaseBuildArgs: String by project
 val dockerBaseImageTag: String by project
 
 plugins {
@@ -223,6 +224,8 @@ rootDir.walk().maxDepth(4).filter { it.isFile && it.extension == "Dockerfile" }.
     val name = dockerfile.name.substringBeforeLast('.')
     val context = dockerfile.parent
 
+    val buildArgs = dockerBaseBuildArgs.split(',').flatMap { listOf("--build-arg", it.trim()) }
+
     tasks.register<Exec>("build${name}WorkerImage") {
         group = "Docker"
         description = "Builds the $name worker Docker image."
@@ -233,6 +236,7 @@ rootDir.walk().maxDepth(4).filter { it.isFile && it.extension == "Dockerfile" }.
         commandLine = listOf(
             "docker", "build",
             "-f", dockerfile.path,
+            *buildArgs.toTypedArray(),
             "-t", "ort-server-${name.lowercase()}-worker-base-image:$dockerBaseImageTag",
             "-q",
             context

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,10 +21,10 @@ org.gradle.jvmargs = -Xmx2g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 org.gradle.kotlin.dsl.allWarningsAsErrors = true
 org.gradle.parallel = true
 
-kotlin.code.style=official
-kotlin.mpp.stability.nowarn=true
+kotlin.code.style = official
+kotlin.mpp.stability.nowarn = true
 
-dockerImagePrefix=
-dockerImageTag=latest
-dockerBaseImagePrefix=docker://
-dockerBaseImageTag=latest
+dockerImagePrefix =
+dockerImageTag = latest
+dockerBaseImagePrefix = docker://
+dockerBaseImageTag = latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -26,5 +26,6 @@ kotlin.mpp.stability.nowarn = true
 
 dockerImagePrefix =
 dockerImageTag = latest
+dockerBaseBuildArgs =
 dockerBaseImagePrefix = docker://
 dockerBaseImageTag = latest


### PR DESCRIPTION
I plan to improve docs further with upcoming PRs that also pass Docker build args to the Gradle tasks, but I thought this could be useful already.