### PR TITLE
feat(core): Filter organizations based on permissions

### DIFF
--- a/core/src/main/kotlin/authorization/Authorization.kt
+++ b/core/src/main/kotlin/authorization/Authorization.kt
@@ -32,6 +32,23 @@ import org.eclipse.apoapsis.ortserver.model.authorization.RepositoryPermission
 import org.eclipse.apoapsis.ortserver.model.authorization.Superuser
 
 /**
+ * Return `true` if the [OrtPrincipal] of the current [call] has the provided [permission] for the organization with the
+ * provided [organizationId].
+ */
+fun PipelineContext<*, ApplicationCall>.hasPermission(
+    organizationId: Long,
+    permission: OrganizationPermission
+): Boolean = hasRole(permission.roleName(organizationId))
+
+/**
+ * Return `true` if the [OrtPrincipal] of the current [call] has the provided [role].
+ */
+fun PipelineContext<*, ApplicationCall>.hasRole(role: String): Boolean {
+    val principal = call.principal<OrtPrincipal>()
+    return principal.isSuperuser() || principal.hasRole(role)
+}
+
+/**
  * Require that the [OrtPrincipal] of the current[call] has the provided [permission]. Throw an [AuthorizationException]
  * otherwise.
  */
@@ -63,8 +80,7 @@ fun PipelineContext<*, ApplicationCall>.requirePermission(permission: Repository
  * otherwise.
  */
 fun PipelineContext<*, ApplicationCall>.requirePermission(requiredRole: String) {
-    val principal = call.principal<OrtPrincipal>()
-    if (!principal.isSuperuser() && !principal.hasRole(requiredRole)) {
+    if (!hasRole(requiredRole)) {
         throw AuthorizationException()
     }
 }

--- a/core/src/main/kotlin/utils/Extensions.kt
+++ b/core/src/main/kotlin/utils/Extensions.kt
@@ -113,3 +113,14 @@ private fun String.toSortProperty(): SortProperty {
     return directionFromPrefix?.let { SortProperty(substring(1), directionFromPrefix) }
         ?: SortProperty(this, SortDirection.ASCENDING)
 }
+
+/**
+ * Paginate this list based on the given [pagingOptions]. If no offset is provided, 0 is used. If no limit is provided,
+ * all elements are returned.
+ */
+fun <T> List<T>.paginate(pagingOptions: PagingOptions): List<T> {
+    val offset = pagingOptions.offset ?: 0L
+    val limit = pagingOptions.limit ?: Integer.MAX_VALUE
+
+    return drop(offset.toInt()).take(limit)
+}

--- a/core/src/test/kotlin/api/AbstractIntegrationTest.kt
+++ b/core/src/test/kotlin/api/AbstractIntegrationTest.kt
@@ -130,4 +130,14 @@ abstract class AbstractIntegrationTest(body: AbstractIntegrationTest.() -> Unit)
             client.request() shouldHaveStatus successStatus
         }
     }
+
+    fun requestShouldRequireAuthentication(
+        successStatus: HttpStatusCode = HttpStatusCode.OK,
+        request: suspend HttpClient.() -> HttpResponse
+    ) {
+        integrationTestApplication {
+            unauthenticatedClient.request() shouldHaveStatus HttpStatusCode.Unauthorized
+            testUserClient.request() shouldHaveStatus successStatus
+        }
+    }
 }


### PR DESCRIPTION
Change the `/organizations` endpoint to only require authentication instead of the superuser role, and to return only those organizations for which the user has `OrganizationPermission.READ`.

As the permissions are managed by Keycloak, the database does not know about them. Therefore the implementation fetches the whole list of organizations from the database and filters them afterward. For a very long list of organizations this might not perform well, so if required, a different solution has to be found later.