### PR TITLE
Better notify for failed runs

### DIFF
--- a/workers/common/src/main/kotlin/common/OrtRunService.kt
+++ b/workers/common/src/main/kotlin/common/OrtRunService.kt
@@ -181,20 +181,28 @@ class OrtRunService(
     }
 
     /**
-     * Return the [Repository] information for the provided [OrtRun].
+     * Return the [Repository] information for the provided [OrtRun]. If this information is not available act
+     * accordingly based on the [failIfMissing] flag: If it is *true*, throw an exception; otherwise, return an
+     * empty [Repository] object.
      */
-    fun getOrtRepositoryInformation(ortRun: OrtRun) = db.blockingQuery {
+    fun getOrtRepositoryInformation(ortRun: OrtRun, failIfMissing: Boolean = true) = db.blockingQuery {
         val vcsId = ortRun.vcsId
+        val vcsProcessedId = ortRun.vcsProcessedId
+        val nestedRepositoryIds = ortRun.nestedRepositoryIds
+
+        @Suppress("ComplexCondition")
+        if ((vcsId == null || vcsProcessedId == null || nestedRepositoryIds == null) && !failIfMissing) {
+            return@blockingQuery Repository.EMPTY
+        }
+
         requireNotNull(vcsId) {
             "VCS information is missing from ORT run '${ortRun.id}'."
         }
 
-        val vcsProcessedId = ortRun.vcsProcessedId
         requireNotNull(vcsProcessedId) {
             "VCS processed information is missing from ORT run '${ortRun.id}'."
         }
 
-        val nestedRepositoryIds = ortRun.nestedRepositoryIds
         requireNotNull(nestedRepositoryIds) {
             "Nested repositories information is missing from ORT run '${ortRun.id}'."
         }

--- a/workers/notifier/src/main/kotlin/notifier/NotifierComponent.kt
+++ b/workers/notifier/src/main/kotlin/notifier/NotifierComponent.kt
@@ -68,6 +68,7 @@ class NotifierComponent : EndpointComponent<NotifierRequest>(NotifierEndpoint) {
         listOf(notifierModule(), databaseModule(), ortRunServiceModule(), workerContextModule())
 
     private fun notifierModule() = module {
+        singleOf(::NotifierOrtResultGenerator)
         singleOf(::NotifierRunner)
         singleOf(::NotifierWorker)
     }

--- a/workers/notifier/src/main/kotlin/notifier/NotifierOrtResultGenerator.kt
+++ b/workers/notifier/src/main/kotlin/notifier/NotifierOrtResultGenerator.kt
@@ -79,7 +79,7 @@ internal class NotifierOrtResultGenerator(
      * Generate an [OrtResult] from the given [ortRun] object based on the given [notifierJob].
      */
     fun generateOrtResult(ortRun: OrtRun, notifierJob: NotifierJob): OrtResult {
-        val repository = ortRunService.getOrtRepositoryInformation(ortRun)
+        val repository = ortRunService.getOrtRepositoryInformation(ortRun, failIfMissing = false)
         val resolvedConfiguration = ortRunService.getResolvedConfiguration(ortRun)
         val analyzerRun = ortRunService.getAnalyzerRunForOrtRun(ortRun.id)
         val advisorRun = ortRunService.getAdvisorRunForOrtRun(ortRun.id)

--- a/workers/notifier/src/main/kotlin/notifier/NotifierOrtResultGenerator.kt
+++ b/workers/notifier/src/main/kotlin/notifier/NotifierOrtResultGenerator.kt
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.notifier
+
+import org.eclipse.apoapsis.ortserver.model.NotifierJob
+import org.eclipse.apoapsis.ortserver.model.OrtRun
+import org.eclipse.apoapsis.ortserver.workers.common.OrtRunService
+import org.eclipse.apoapsis.ortserver.workers.common.mapToOrt
+
+import org.ossreviewtoolkit.model.OrtResult
+
+/**
+ * An internally used helper class to generate an [OrtResult] the Notifier can operate on from the current [OrtRun].
+ *
+ * This class loads the results of the previous worker steps and generates an [OrtResult] from them. In addition, it
+ * adds a number of labels that can be evaluated by the notifier script to obtain further information about the run.
+ * The following labels are added:
+ * - emailRecipients: A list of email addresses separated by ';' that should receive a notification mail.
+ * - report_&lt;name&gt;: For each report generated for this run, a label with the name of the report is added.
+ *   The value is the link under which the report can be downloaded. So, these links could be included in a
+ *   notification mail.
+ */
+internal class NotifierOrtResultGenerator(
+    /** Reference to the service to access the current ORT run. */
+    private val ortRunService: OrtRunService
+) {
+    companion object {
+        /** The prefix for labels that represent the download links for reports. */
+        private const val REPORT_LABEL_PREFIX = "report_"
+
+        /** The label for the email recipients. */
+        private const val EMAIL_RECIPIENTS_LABEL = "emailRecipients"
+
+        /** The separator for multiple email recipients. */
+        private const val RECIPIENTS_SEPARATOR = ";"
+    }
+
+    /**
+     * Generate an [OrtResult] from the given [ortRun] object based on the given [notifierJob].
+     */
+    fun generateOrtResult(ortRun: OrtRun, notifierJob: NotifierJob): OrtResult {
+        val repository = ortRunService.getOrtRepositoryInformation(ortRun)
+        val resolvedConfiguration = ortRunService.getResolvedConfiguration(ortRun)
+        val analyzerRun = ortRunService.getAnalyzerRunForOrtRun(ortRun.id)
+        val advisorRun = ortRunService.getAdvisorRunForOrtRun(ortRun.id)
+        val scannerRun = ortRunService.getScannerRunForOrtRun(ortRun.id)
+        val evaluatorRun = ortRunService.getEvaluatorRunForOrtRun(ortRun.id)
+
+        val baseResult = ortRun.mapToOrt(
+            repository = repository,
+            analyzerRun = analyzerRun?.mapToOrt(),
+            advisorRun = advisorRun?.mapToOrt(),
+            scannerRun = scannerRun?.mapToOrt(),
+            evaluatorRun = evaluatorRun?.mapToOrt(),
+            resolvedConfiguration = resolvedConfiguration.mapToOrt()
+        )
+
+        val labelsToAdd = getLabelsForReportDownloadLinks(ortRun) + getMailRecipientsLabels(notifierJob)
+        return baseResult.takeIf { labelsToAdd.isEmpty() }
+            ?: baseResult.copy(labels = baseResult.labels + labelsToAdd)
+    }
+
+    /**
+     * Return a map with labels that represent the direct download links for the reports generated for the given
+     * [ortRun].
+     */
+    private fun getLabelsForReportDownloadLinks(ortRun: OrtRun): Map<String, String> =
+        ortRunService.getDownloadLinksForOrtRun(ortRun.id).associate {
+            "$REPORT_LABEL_PREFIX${it.filename}" to it.downloadLink
+        }
+
+    /**
+     * Return a map with labels that can be queried from notifier scripts in order to obtain the recipients of
+     * notification mails to be sent.
+     * TODO: ORT's Notifier API should be changed to support the email addresses, and not require to handle this
+     *       information as a label in the ORT result.
+     */
+    private fun getMailRecipientsLabels(notifierJob: NotifierJob): Map<String, String> {
+        return notifierJob.configuration.mail?.recipientAddresses?.let { recipients ->
+            mapOf(EMAIL_RECIPIENTS_LABEL to recipients.joinToString(RECIPIENTS_SEPARATOR))
+        }.orEmpty()
+    }
+}

--- a/workers/notifier/src/main/kotlin/notifier/NotifierRunner.kt
+++ b/workers/notifier/src/main/kotlin/notifier/NotifierRunner.kt
@@ -94,7 +94,7 @@ class NotifierRunner {
             val resolutionProvider = DefaultResolutionProvider(resolutionsFromOrtResult.merge(resolutionsFromFile))
 
             val notifier = Notifier(
-                ortResult = config.mail?.recipientAddresses?.let { ortResult.addMailRecipientLabel(it) } ?: ortResult,
+                ortResult = ortResult,
                 config = notifierConfiguration,
                 resolutionProvider = resolutionProvider
             )
@@ -109,11 +109,6 @@ class NotifierRunner {
         }
     }
 }
-
-// TODO: ORT's Notifier API should be changed to support the email addresses, and not require to handle this information
-//       as a label in the ORT result.
-private fun OrtResult.addMailRecipientLabel(recipients: List<String>) =
-    copy(labels = labels + mapOf("emailRecipients" to recipients.joinToString(";")))
 
 data class NotifierRunnerResult(
     val notifierRun: NotifierRun

--- a/workers/notifier/src/test/kotlin/NotifierRunnerTest.kt
+++ b/workers/notifier/src/test/kotlin/NotifierRunnerTest.kt
@@ -107,31 +107,28 @@ class NotifierRunnerTest : WordSpec({
         "invoke the ORT notifier" {
             mockkConstructor(Notifier::class)
 
-            val originalOrtResult = OrtResult.EMPTY.copy(
+            val ortResult = OrtResult.EMPTY.copy(
                 repository = Repository.EMPTY.copy(vcs = VcsInfo(VcsType.GIT, "https://example.com/repo.git", "main")),
                 labels = mapOf("foo" to "bar")
-            )
-            val expectedOrtResult = originalOrtResult.copy(
-                labels = originalOrtResult.labels + ("emailRecipients" to "test@example.com;more-test@example.com")
             )
 
             every {
                 constructedWith<Notifier>(
-                    EqMatcher(expectedOrtResult),
+                    EqMatcher(ortResult),
                     EqMatcher(ortNotifierConfig),
                     OfTypeMatcher<DefaultResolutionProvider>(DefaultResolutionProvider::class)
                 ).run(any())
             } returns mockk()
 
             runner.run(
-                ortResult = originalOrtResult,
+                ortResult = ortResult,
                 config = notifierConfig,
                 workerContext = createWorkerContext()
             )
 
             verify(exactly = 1) {
                 constructedWith<Notifier>(
-                    EqMatcher(expectedOrtResult),
+                    EqMatcher(ortResult),
                     EqMatcher(ortNotifierConfig),
                     OfTypeMatcher<DefaultResolutionProvider>(DefaultResolutionProvider::class)
                 ).run(script.readText())

--- a/workers/notifier/src/test/kotlin/notifier/NotifierOrtResultGeneratorTest.kt
+++ b/workers/notifier/src/test/kotlin/notifier/NotifierOrtResultGeneratorTest.kt
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.notifier
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.shouldBe
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+import org.eclipse.apoapsis.ortserver.model.JobStatus
+import org.eclipse.apoapsis.ortserver.model.MailNotificationConfiguration
+import org.eclipse.apoapsis.ortserver.model.NotifierJob
+import org.eclipse.apoapsis.ortserver.model.NotifierJobConfiguration
+import org.eclipse.apoapsis.ortserver.model.OrtRun
+import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.ResolvedConfiguration
+import org.eclipse.apoapsis.ortserver.model.runs.AnalyzerRun
+import org.eclipse.apoapsis.ortserver.model.runs.EvaluatorRun
+import org.eclipse.apoapsis.ortserver.model.runs.advisor.AdvisorRun
+import org.eclipse.apoapsis.ortserver.model.runs.reporter.Report
+import org.eclipse.apoapsis.ortserver.model.runs.scanner.ScannerRun
+import org.eclipse.apoapsis.ortserver.workers.common.OrtRunService
+import org.eclipse.apoapsis.ortserver.workers.common.mapToOrt
+
+import org.ossreviewtoolkit.model.OrtResult
+
+class NotifierOrtResultGeneratorTest : StringSpec({
+    beforeSpec {
+        mockkStatic(ORT_SERVER_MAPPINGS_FILE)
+    }
+
+    afterSpec {
+        unmockkAll()
+    }
+
+    "A correct OrtResult with default properties should be generated" {
+        val helper = ResultGeneratorTestHelper()
+
+        val result = helper.runResultGeneratorTest()
+
+        result.labels shouldBe originalLabels
+    }
+
+    "Labels for the generated reports should be added" {
+        val reports = listOf(
+            Report(
+                filename = "scan-report.html",
+                downloadLink = "https://example.com/scan-report.html",
+                downloadTokenExpiryDate = Instant.DISTANT_FUTURE
+            ),
+            Report(
+                filename = "another-report.pdf",
+                downloadLink = "https://example.com/some/cryptic/path/another-report.pdf",
+                downloadTokenExpiryDate = Instant.DISTANT_FUTURE
+            )
+        )
+        val helper = ResultGeneratorTestHelper()
+
+        val result = helper.runResultGeneratorTest(reports = reports)
+
+        reports.forAll {
+            result.labels["report_${it.filename}"] shouldBe it.downloadLink
+        }
+    }
+
+    "A label for email recipients should be added" {
+        val recipient1 = "i-am-interested@example.com"
+        val recipient2 = "mee2@example.com"
+        val emailConfig = NotifierJobConfiguration(
+            mail = MailNotificationConfiguration(recipientAddresses = listOf(recipient1, recipient2))
+        )
+
+        val helper = ResultGeneratorTestHelper()
+
+        val result = helper.runResultGeneratorTest(job = notifierJob.copy(configuration = emailConfig))
+
+        result.labels["emailRecipients"] shouldBe "$recipient1;$recipient2"
+    }
+})
+
+private const val ORT_SERVER_MAPPINGS_FILE = "org.eclipse.apoapsis.ortserver.workers.common.OrtServerMappingsKt"
+
+private const val ORT_RUN_ID = 20240502084016L
+private const val REPOSITORY_ID = 20240502084048L
+private const val NOTIFIER_JOB_ID = 20240502084206L
+private val originalLabels = mapOf("label1" to "value1", "label2" to "value2")
+
+private val notifierJob = NotifierJob(
+    id = NOTIFIER_JOB_ID,
+    ortRunId = ORT_RUN_ID,
+    createdAt = Clock.System.now(),
+    startedAt = Clock.System.now(),
+    finishedAt = null,
+    configuration = NotifierJobConfiguration(),
+    status = JobStatus.CREATED
+)
+
+/**
+ * A test helper class that manages test data and mocks required by test cases.
+ */
+private class ResultGeneratorTestHelper {
+    val repository = mockk<org.ossreviewtoolkit.model.Repository>()
+    val analyzerRun = mockk<AnalyzerRun>()
+    val advisorRun = mockk<AdvisorRun>()
+    val evaluatorRun = mockk<EvaluatorRun>()
+    val scannerRun = mockk<ScannerRun>()
+    val resolvedConfig = mockk<ResolvedConfiguration>()
+
+    val ortAnalyzerRun = mockk<org.ossreviewtoolkit.model.AnalyzerRun>()
+    val ortAdvisorRun = mockk<org.ossreviewtoolkit.model.AdvisorRun>()
+    val ortScannerRun = mockk<org.ossreviewtoolkit.model.ScannerRun>()
+    val ortEvaluatorRun = mockk<org.ossreviewtoolkit.model.EvaluatorRun>()
+    val ortResolvedConfig = mockk<org.ossreviewtoolkit.model.ResolvedConfiguration>()
+
+    val ortRun = mockk<OrtRun> {
+        every { id } returns ORT_RUN_ID
+        every { repositoryId } returns REPOSITORY_ID
+        every { revision } returns "main"
+    }
+
+    val ortRunService = mockk<OrtRunService> {
+        every { getAdvisorRunForOrtRun(ORT_RUN_ID) } returns advisorRun
+        every { getAnalyzerRunForOrtRun(ORT_RUN_ID) } returns analyzerRun
+        every { getEvaluatorRunForOrtRun(ORT_RUN_ID) } returns evaluatorRun
+        every { getOrtRepositoryInformation(ortRun) } returns repository
+        every { getOrtRun(ORT_RUN_ID) } returns ortRun
+        every { getNotifierJob(NOTIFIER_JOB_ID) } returns notifierJob
+        every { getResolvedConfiguration(ortRun) } returns resolvedConfig
+        every { getScannerRunForOrtRun(ORT_RUN_ID) } returns scannerRun
+    }
+
+    init {
+        every { analyzerRun.mapToOrt() } returns ortAnalyzerRun
+        every { advisorRun.mapToOrt() } returns ortAdvisorRun
+        every { evaluatorRun.mapToOrt() } returns ortEvaluatorRun
+        every { scannerRun.mapToOrt() } returns ortScannerRun
+        every { resolvedConfig.mapToOrt() } returns ortResolvedConfig
+        every {
+            ortRun.mapToOrt(
+                repository,
+                ortAnalyzerRun,
+                ortAdvisorRun,
+                ortScannerRun,
+                ortEvaluatorRun,
+                ortResolvedConfig
+            )
+        } returns OrtResult.EMPTY.copy(
+            repository = repository,
+            analyzer = ortAnalyzerRun,
+            advisor = ortAdvisorRun,
+            scanner = ortScannerRun,
+            evaluator = ortEvaluatorRun,
+            labels = originalLabels
+        )
+    }
+
+    /**
+     * Run a test to generate an [OrtResult] based on the mocks managed by this instance and the given [job] and
+     * [reports] list. Return the result.
+     */
+    fun runResultGeneratorTest(job: NotifierJob = notifierJob, reports: List<Report> = emptyList()): OrtResult {
+        every { ortRunService.getDownloadLinksForOrtRun(ORT_RUN_ID) } returns reports
+
+        val generator = NotifierOrtResultGenerator(ortRunService)
+
+        return generator.generateOrtResult(ortRun, job).also { result ->
+            result.repository shouldBe repository
+            result.analyzer shouldBe ortAnalyzerRun
+            result.advisor shouldBe ortAdvisorRun
+            result.scanner shouldBe ortScannerRun
+            result.evaluator shouldBe ortEvaluatorRun
+        }
+    }
+}

--- a/workers/notifier/src/test/kotlin/notifier/NotifierOrtResultGeneratorTest.kt
+++ b/workers/notifier/src/test/kotlin/notifier/NotifierOrtResultGeneratorTest.kt
@@ -31,11 +31,17 @@ import io.mockk.unmockkAll
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
+import org.eclipse.apoapsis.ortserver.model.AdvisorJob
+import org.eclipse.apoapsis.ortserver.model.AnalyzerJob
+import org.eclipse.apoapsis.ortserver.model.EvaluatorJob
 import org.eclipse.apoapsis.ortserver.model.JobStatus
 import org.eclipse.apoapsis.ortserver.model.MailNotificationConfiguration
 import org.eclipse.apoapsis.ortserver.model.NotifierJob
 import org.eclipse.apoapsis.ortserver.model.NotifierJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.OrtRun
+import org.eclipse.apoapsis.ortserver.model.ReporterJob
+import org.eclipse.apoapsis.ortserver.model.ScannerJob
+import org.eclipse.apoapsis.ortserver.model.WorkerJob
 import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.ResolvedConfiguration
 import org.eclipse.apoapsis.ortserver.model.runs.AnalyzerRun
 import org.eclipse.apoapsis.ortserver.model.runs.EvaluatorRun
@@ -99,6 +105,38 @@ class NotifierOrtResultGeneratorTest : StringSpec({
 
         result.labels["emailRecipients"] shouldBe "$recipient1;$recipient2"
     }
+
+    "Labels for the status of jobs should be added" {
+        val helper = ResultGeneratorTestHelper()
+        every {
+            helper.ortRunService.getAnalyzerJobForOrtRun(ORT_RUN_ID)
+        } returns createJob<AnalyzerJob>(JobStatus.FINISHED, 11)
+        every {
+            helper.ortRunService.getAdvisorJobForOrtRun(ORT_RUN_ID)
+        } returns createJob<AdvisorJob>(JobStatus.FAILED, 22)
+        every {
+            helper.ortRunService.getEvaluatorJobForOrtRun(ORT_RUN_ID)
+        } returns createJob<EvaluatorJob>(JobStatus.FINISHED, 33)
+        every {
+            helper.ortRunService.getScannerJobForOrtRun(ORT_RUN_ID)
+        } returns createJob<ScannerJob>(JobStatus.RUNNING, 44)
+        every {
+            helper.ortRunService.getReporterJobForOrtRun(ORT_RUN_ID)
+        } returns createJob<ReporterJob>(JobStatus.FINISHED, 55)
+
+        val result = helper.runResultGeneratorTest()
+
+        val expectedLabels = mapOf(
+            "analyzerJobStatus" to "FINISHED",
+            "advisorJobStatus" to "FAILED",
+            "evaluatorJobStatus" to "FINISHED",
+            "scannerJobStatus" to "RUNNING",
+            "reporterJobStatus" to "FINISHED"
+        )
+        expectedLabels.forAll { (key, value) ->
+            result.labels[key] shouldBe value
+        }
+    }
 })
 
 private const val ORT_SERVER_MAPPINGS_FILE = "org.eclipse.apoapsis.ortserver.workers.common.OrtServerMappingsKt"
@@ -117,6 +155,15 @@ private val notifierJob = NotifierJob(
     configuration = NotifierJobConfiguration(),
     status = JobStatus.CREATED
 )
+
+/**
+ * Return a mock for a [WorkerJob] of the given type that is prepared to report the given [jobId] and [status].
+ */
+private inline fun <reified J : WorkerJob> createJob(status: JobStatus, jobId: Long): J =
+    mockk {
+        every { id } returns jobId
+        every { this@mockk.status } returns status
+    }
 
 /**
  * A test helper class that manages test data and mocks required by test cases.
@@ -150,6 +197,11 @@ private class ResultGeneratorTestHelper {
         every { getNotifierJob(NOTIFIER_JOB_ID) } returns notifierJob
         every { getResolvedConfiguration(ortRun) } returns resolvedConfig
         every { getScannerRunForOrtRun(ORT_RUN_ID) } returns scannerRun
+        every { getAnalyzerJobForOrtRun(ORT_RUN_ID) } returns null
+        every { getAdvisorJobForOrtRun(ORT_RUN_ID) } returns null
+        every { getEvaluatorJobForOrtRun(ORT_RUN_ID) } returns null
+        every { getScannerJobForOrtRun(ORT_RUN_ID) } returns null
+        every { getReporterJobForOrtRun(ORT_RUN_ID) } returns null
     }
 
     init {

--- a/workers/notifier/src/test/kotlin/notifier/NotifierOrtResultGeneratorTest.kt
+++ b/workers/notifier/src/test/kotlin/notifier/NotifierOrtResultGeneratorTest.kt
@@ -192,7 +192,7 @@ private class ResultGeneratorTestHelper {
         every { getAdvisorRunForOrtRun(ORT_RUN_ID) } returns advisorRun
         every { getAnalyzerRunForOrtRun(ORT_RUN_ID) } returns analyzerRun
         every { getEvaluatorRunForOrtRun(ORT_RUN_ID) } returns evaluatorRun
-        every { getOrtRepositoryInformation(ortRun) } returns repository
+        every { getOrtRepositoryInformation(ortRun, failIfMissing = false) } returns repository
         every { getOrtRun(ORT_RUN_ID) } returns ortRun
         every { getNotifierJob(NOTIFIER_JOB_ID) } returns notifierJob
         every { getResolvedConfiguration(ortRun) } returns resolvedConfig


### PR DESCRIPTION
This PR extends Notifier to run successful even if the Analyzer step failed. The notifier script now has access to the failed steps and can produce better notifications.