### PR TITLE
fix(gradle): Correctly parse blank `dockerBaseBuildArgs`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -224,7 +224,10 @@ rootDir.walk().maxDepth(4).filter { it.isFile && it.extension == "Dockerfile" }.
     val name = dockerfile.name.substringBeforeLast('.')
     val context = dockerfile.parent
 
-    val buildArgs = dockerBaseBuildArgs.split(',').flatMap { listOf("--build-arg", it.trim()) }
+    val buildArgs = dockerBaseBuildArgs.takeUnless { it.isBlank() }
+        ?.split(',')
+        ?.flatMap { listOf("--build-arg", it.trim()) }
+        .orEmpty()
 
     tasks.register<Exec>("build${name}WorkerImage") {
         group = "Docker"


### PR DESCRIPTION
Splitting an empty string does not return an empty list, but a list with an empty string as the single entry, which results in `--build-arg` having an empty argument.

This only surfaced when running the task under WSL with Docker Desktop for Windows, apparently because empty arguments are handled differently there.