### PR TITLE
deps: Downgrade Tanstack Router to 1.31.20

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -26,7 +26,7 @@
     "@radix-ui/react-tooltip": "^1.0.7",
     "@tanstack/react-query": "^5.29.2",
     "@tanstack/react-query-devtools": "^5.32.0",
-    "@tanstack/react-router": "^1.22.2",
+    "@tanstack/react-router": "1.31.20",
     "@tanstack/router-devtools": "^1.22.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",


### PR DESCRIPTION
Tanstack Router 1.31.23 has a breaking bug [1] which prevents UI to work. Downgrading to 1.31.20 fixes the issue.

[1] https://github.com/TanStack/router/issues/1570https://github.com/TanStack/router/issues/1570