### PR TITLE
Fix the build UI job

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -63,8 +63,11 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-pnpm-store-
 
+    - name: Install dependencies
+      run: pnpm -C ui install
+
     - name: Build UI
-      run: pnpm -C ui install build
+      run: pnpm -C ui build
 
   test:
     needs: build


### PR DESCRIPTION
The current command used in the Build UI step, `pnpm -C ui install build`
doesn't `install` and `build` the UI project, but it installs a package
named `build`. Use separate steps to actually build the project.