### PR TITLE
Support custom license texts

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
@@ -336,6 +336,7 @@ fun ReporterJobConfiguration.mapToApi() =
         licenseClassificationsFile,
         packageConfigurationProviders.map { it.mapToApi() },
         resolutionsFile,
+        customLicenseTextDir,
         assetFiles.map { it.mapToApi() },
         assetDirectories.map { it.mapToApi() },
         config?.mapValues { it.value.mapToApi() }
@@ -374,6 +375,7 @@ fun ApiReporterJobConfiguration.mapToModel() =
         licenseClassificationsFile,
         packageConfigurationProviders.map { it.mapToModel() },
         resolutionsFile,
+        customLicenseTextDir,
         assetFiles.map { it.mapToModel() },
         assetDirectories.map { it.mapToModel() },
         config?.mapValues { it.value.mapToModel() }

--- a/api/v1/model/src/commonMain/kotlin/JobConfigurations.kt
+++ b/api/v1/model/src/commonMain/kotlin/JobConfigurations.kt
@@ -301,6 +301,12 @@ data class ReporterJobConfiguration(
     val resolutionsFile: String? = null,
 
     /**
+     * An optional path to a configuration directory containing custom license texts. If defined, all files from this
+     * directory are downloaded and made available via a `DefaultLicenseTextProvider` instance.
+     */
+    val customLicenseTextDir: String? = null,
+
+    /**
      * A list with [ReporterAsset]s pointing to files that must be downloaded before the generation of reports is
      * started.
      */

--- a/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
@@ -52,6 +52,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.Jobs
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.PagedResponse
 import org.eclipse.apoapsis.ortserver.api.v1.model.PagingOptions
+import org.eclipse.apoapsis.ortserver.api.v1.model.ReporterJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.Repository
 import org.eclipse.apoapsis.ortserver.api.v1.model.RepositoryType as ApiRepositoryType
 import org.eclipse.apoapsis.ortserver.api.v1.model.Secret
@@ -442,11 +443,15 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                     allowDynamicVersions = true,
                     environmentConfig = envConfig
                 )
+                val reporterJob = ReporterJobConfiguration(
+                    copyrightGarbageFile = "COPYRIGHT_GARBAGE",
+                    customLicenseTextDir = "LICENSE_TEXTS"
+                )
                 val parameters = mapOf("p1" to "v1", "p2" to "v2")
                 val createRun = CreateOrtRun(
                     "main",
                     null,
-                    ApiJobConfigurations(analyzerJob, parameters = parameters),
+                    ApiJobConfigurations(analyzerJob, reporter = reporterJob, parameters = parameters),
                     labelsMap
                 )
 
@@ -482,6 +487,11 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                     jobConfig.environmentVariables shouldContainExactly listOf(
                         EnvironmentVariableDeclaration("MY_ENV_VAR", "mySecret")
                     )
+                }
+
+                with(run.jobConfigs.reporter.shouldNotBeNull()) {
+                    copyrightGarbageFile shouldBe "COPYRIGHT_GARBAGE"
+                    customLicenseTextDir shouldBe "LICENSE_TEXTS"
                 }
 
                 run.jobConfigs.parameters shouldBe parameters

--- a/model/src/commonMain/kotlin/JobConfigurations.kt
+++ b/model/src/commonMain/kotlin/JobConfigurations.kt
@@ -317,6 +317,12 @@ data class ReporterJobConfiguration(
     val resolutionsFile: String? = null,
 
     /**
+     * An optional path to a configuration directory containing custom license texts. If defined, all files from this
+     * directory are downloaded and made available via a `DefaultLicenseTextProvider` instance.
+     */
+    val customLicenseTextDir: String? = null,
+
+    /**
      * A list with [ReporterAsset]s pointing to files that must be downloaded before the generation of reports is
      * started.
      */

--- a/workers/common/src/main/kotlin/common/context/WorkerContext.kt
+++ b/workers/common/src/main/kotlin/common/context/WorkerContext.kt
@@ -85,4 +85,12 @@ interface WorkerContext : AutoCloseable {
      * the given [directory]. Return a [Map] that allows access to the resulting files by their paths.
      */
     suspend fun downloadConfigurationFiles(paths: Collection<Path>, directory: File): Map<Path, File>
+
+    /**
+     * Download all the files contained in the configuration directory at the specified [path] to the given
+     * [targetDirectory]. Return a [Map] that allows access to the resulting files by their paths. Note that this
+     * function does not handle nested folder structures; only the direct children of the specified directory are
+     * downloaded.
+     */
+    suspend fun downloadConfigurationDirectory(path: Path, targetDirectory: File): Map<Path, File>
 }

--- a/workers/common/src/main/kotlin/common/context/WorkerContextImpl.kt
+++ b/workers/common/src/main/kotlin/common/context/WorkerContextImpl.kt
@@ -45,6 +45,10 @@ import org.eclipse.apoapsis.ortserver.secrets.SecretStorage
 import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger(WorkerContextImpl::class.java)
+
 /**
  * The internal default implementation of the [WorkerContext] interface.
  */
@@ -134,6 +138,18 @@ internal class WorkerContextImpl(
         )
 
         return results.map { e -> e.key to e.value.getOrThrow() }.toMap()
+    }
+
+    override suspend fun downloadConfigurationDirectory(
+        path: ConfigPath,
+        targetDirectory: File
+    ): Map<ConfigPath, File> {
+        val containedFiles = configManager.listFiles(currentContext, path)
+
+        logger.info("Downloading config directory '{}' to '{}'.", path.path, targetDirectory)
+        logger.debug("The directory contains these files: {}.", containedFiles)
+
+        return downloadConfigurationFiles(containedFiles, targetDirectory)
     }
 
     override fun close() {

--- a/workers/common/src/test/kotlin/common/context/WorkerContextFactoryTest.kt
+++ b/workers/common/src/test/kotlin/common/context/WorkerContextFactoryTest.kt
@@ -288,6 +288,23 @@ class WorkerContextFactoryTest : WordSpec({
         }
     }
 
+    "downloadConfigurationDirectory" should {
+        "download all files in a configuration directory" {
+            val helper = ContextFactoryTestHelper()
+            helper.expectRunRequest()
+
+            helper.context().use { context ->
+                val directoryPath = Path("dir")
+                val files = context.downloadConfigurationDirectory(directoryPath, tempdir())
+
+                files shouldHaveSize 2
+
+                files[Path("dir/subConfig1.txt")]?.readText() shouldBe "subConfig1"
+                files[Path("dir/subConfig2.txt")]?.readText() shouldBe "subConfig2"
+            }
+        }
+    }
+
     "resolveConfigFiles" should {
         "return an empty Map for null input" {
             val helper = ContextFactoryTestHelper()

--- a/workers/common/src/test/resources/config/dir/subConfig1.txt
+++ b/workers/common/src/test/resources/config/dir/subConfig1.txt
@@ -1,0 +1,1 @@
+subConfig1

--- a/workers/common/src/test/resources/config/dir/subConfig2.txt
+++ b/workers/common/src/test/resources/config/dir/subConfig2.txt
@@ -1,0 +1,1 @@
+subConfig2

--- a/workers/reporter/src/main/kotlin/reporter/ReporterRunner.kt
+++ b/workers/reporter/src/main/kotlin/reporter/ReporterRunner.kt
@@ -313,13 +313,8 @@ private suspend fun WorkerContext.downloadAssetFiles(assets: Collection<Reporter
  */
 private suspend fun WorkerContext.downloadAssetDirectories(assets: Collection<ReporterAsset>, directory: File) {
     assets.forEach { asset ->
-        val content = configManager.listFiles(resolvedConfigurationContext, Path(asset.sourcePath))
         val targetDir = createAssetDirectory(asset, directory)
-
-        logger.info("Downloading asset directory '{}' to '{}'.", asset.sourcePath, targetDir)
-        logger.debug("The directory contains these files: {}}.", content)
-
-        downloadConfigurationFiles(content, targetDir)
+        downloadConfigurationDirectory(Path(asset.sourcePath), targetDir)
     }
 }
 


### PR DESCRIPTION
This PR adds the missing feature to Reporter to use custom license texts that are defined as files in a directory in the configuration.