### PR TITLE
fix(workers): Fix NuGet config file generation path

### DIFF
--- a/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
@@ -170,7 +170,7 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
 
         "The build environment should contain a NuGet.Config file" {
             runEnvironmentTest { homeFolder ->
-                val nuGetFile = homeFolder.resolve("NuGet.Config")
+                val nuGetFile = homeFolder.resolve(".nuget/NuGet/NuGet.Config")
                 val content = nuGetFile.readText()
 
                 content shouldContain "packageSources"

--- a/workers/common/src/main/kotlin/common/env/NuGetGenerator.kt
+++ b/workers/common/src/main/kotlin/common/env/NuGetGenerator.kt
@@ -30,7 +30,7 @@ import org.eclipse.apoapsis.ortserver.workers.common.env.definition.NuGetDefinit
 class NuGetGenerator : EnvironmentConfigGenerator<NuGetDefinition> {
     companion object {
         /** The name of the configuration file created by this generator. */
-        private const val TARGET = "NuGet.Config"
+        private const val TARGET = ".nuget/NuGet/NuGet.Config"
     }
 
     override val environmentDefinitionType: Class<NuGetDefinition>

--- a/workers/common/src/test/kotlin/common/env/NuGetGeneratorTest.kt
+++ b/workers/common/src/test/kotlin/common/env/NuGetGeneratorTest.kt
@@ -51,7 +51,7 @@ class NuGetGeneratorTest : WordSpec({
 
             NuGetGenerator().generate(mockBuilder.builder, listOf(definition))
 
-            mockBuilder.homeFileName shouldBe "NuGet.Config"
+            mockBuilder.homeFileName shouldBe ".nuget/NuGet/NuGet.Config"
         }
 
         "generate a block for a repository with API key authentication" {


### PR DESCRIPTION
Change path of NuGet config generation to one that complies to the NuGet specification [1].

[1]: https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file

Authored-by: Kamil Bielecki <kamil.bielecki@pl.bosch.com>