### PR TITLE
feat(reporter): Only include specified categories in the sources bundle

### DIFF
--- a/workers/common/src/test/kotlin/OrtServerMappingsTest.kt
+++ b/workers/common/src/test/kotlin/OrtServerMappingsTest.kt
@@ -220,13 +220,15 @@ class OrtServerMappingsTest : WordSpec({
                 authors = setOf("Author One", "Author Two"),
                 declaredLicenses = setOf(
                     "LicenseRef-declared",
+                    "LicenseRef-package-declared",
                     "LicenseRef-toBeMapped1",
                     "LicenseRef-toBeMapped2",
                     "LicenseRef-unmapped1",
                     "LicenseRef-unmapped2"
                 ),
                 processedDeclaredLicense = ProcessedDeclaredLicense(
-                    spdxExpression = "LicenseRef-declared OR LicenseRef-mapped1 OR LicenseRef-mapped2",
+                    spdxExpression = "LicenseRef-declared OR LicenseRef-package-declared OR LicenseRef-mapped1 OR " +
+                            "LicenseRef-mapped2",
                     mappedLicenses = mapOf(
                         "LicenseRef-toBeMapped1" to "LicenseRef-mapped1",
                         "LicenseRef-toBeMapped2" to "LicenseRef-mapped2"

--- a/workers/common/src/testFixtures/kotlin/OrtTestData.kt
+++ b/workers/common/src/testFixtures/kotlin/OrtTestData.kt
@@ -341,13 +341,16 @@ object OrtTestData {
         authors = setOf("Author One", "Author Two"),
         declaredLicenses = setOf(
             "LicenseRef-declared",
+            "LicenseRef-package-declared",
             "LicenseRef-toBeMapped1",
             "LicenseRef-toBeMapped2",
             "LicenseRef-unmapped1",
             "LicenseRef-unmapped2"
         ),
         declaredLicensesProcessed = ProcessedDeclaredLicense(
-            spdxExpression = "LicenseRef-declared OR LicenseRef-mapped1 OR LicenseRef-mapped2".toSpdx(),
+            spdxExpression = (
+                    "LicenseRef-declared OR LicenseRef-package-declared OR LicenseRef-mapped1 OR LicenseRef-mapped2"
+                    ).toSpdx(),
             mapped = mapOf(
                 "LicenseRef-toBeMapped1" to "LicenseRef-mapped1".toSpdx(),
                 "LicenseRef-toBeMapped2" to "LicenseRef-mapped2".toSpdx()

--- a/workers/reporter/src/test/kotlin/reporter/SourceCodeBundleReporterTest.kt
+++ b/workers/reporter/src/test/kotlin/reporter/SourceCodeBundleReporterTest.kt
@@ -58,7 +58,7 @@ import org.ossreviewtoolkit.reporter.ReporterInput
 import org.ossreviewtoolkit.utils.common.unpackZip
 import org.ossreviewtoolkit.utils.spdx.SpdxSingleLicenseExpression
 
-private const val PACKAGE_ID_FILENAME = "Maven-com.vdurmont-semver4j-2.0.1.zip"
+private const val PROJECT_ID_FILENAME = "Maven-com.vdurmont-semver4j-2.0.1.zip"
 private const val PROJECT_NAME = "semver4j"
 private const val PROJECT_VERSION = "2.0.1"
 
@@ -94,9 +94,9 @@ class SourceCodeBundleReporterTest : WordSpec({
 
             codeBundleFile.unpackZip(outputDir)
             outputDir shouldContainNFiles 2
-            outputDir shouldContainFile PACKAGE_ID_FILENAME
+            outputDir shouldContainFile PROJECT_ID_FILENAME
 
-            outputDir.resolve(PACKAGE_ID_FILENAME).unpackZip(outputDir)
+            outputDir.resolve(PROJECT_ID_FILENAME).unpackZip(outputDir)
             outputDir shouldContainFile PROJECT_NAME
             outputDir.resolve(PROJECT_NAME) shouldContainFile PROJECT_VERSION
 


### PR DESCRIPTION
Similar to the ORT CLI [1], the SourceCode Bundle should only include packages from specified license categories.

[1]: https://github.com/oss-review-toolkit/ort/blob/8181666dc5d8bfd739b1260c171c4e707c0c7568/model/src/main/resources/reference.yml#L163-L165