### PR TITLE
Add support for generating a .git-credentials file

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
@@ -21,10 +21,13 @@
 
 package org.eclipse.apoapsis.ortserver.api.v1.mapping
 
+import java.util.EnumSet
+
 import org.eclipse.apoapsis.ortserver.api.v1.model.AdvisorJob as ApiAdvisorJob
 import org.eclipse.apoapsis.ortserver.api.v1.model.AdvisorJobConfiguration as ApiAdvisorJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.AnalyzerJob as ApiAnalyzerJob
 import org.eclipse.apoapsis.ortserver.api.v1.model.AnalyzerJobConfiguration as ApiAnalyzerJobConfiguration
+import org.eclipse.apoapsis.ortserver.api.v1.model.CredentialsType as ApiCredentialsType
 import org.eclipse.apoapsis.ortserver.api.v1.model.EnvironmentConfig as ApiEnvironmentConfig
 import org.eclipse.apoapsis.ortserver.api.v1.model.EnvironmentVariableDeclaration as ApiEnvironmentVariableDeclaration
 import org.eclipse.apoapsis.ortserver.api.v1.model.EvaluatorJob as ApiEvaluatorJob
@@ -66,6 +69,7 @@ import org.eclipse.apoapsis.ortserver.model.AdvisorJob
 import org.eclipse.apoapsis.ortserver.model.AdvisorJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.AnalyzerJob
 import org.eclipse.apoapsis.ortserver.model.AnalyzerJobConfiguration
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.EnvironmentConfig
 import org.eclipse.apoapsis.ortserver.model.EnvironmentVariableDeclaration
 import org.eclipse.apoapsis.ortserver.model.EvaluatorJob
@@ -425,13 +429,27 @@ fun ApiScannerJobConfiguration.mapToModel() = ScannerJobConfiguration(
 fun Secret.mapToApi() = ApiSecret(name, description)
 
 fun InfrastructureService.mapToApi() =
-    ApiInfrastructureService(name, url, description, usernameSecret.name, passwordSecret.name, excludeFromNetrc)
+    ApiInfrastructureService(
+        name,
+        url,
+        description,
+        usernameSecret.name,
+        passwordSecret.name,
+        credentialsTypes.mapToApi()
+    )
 
 fun ApiInfrastructureService.mapToModel() =
-    InfrastructureServiceDeclaration(name, url, description, usernameSecretRef, passwordSecretRef, excludeFromNetrc)
+    InfrastructureServiceDeclaration(
+        name,
+        url,
+        description,
+        usernameSecretRef,
+        passwordSecretRef,
+        credentialsTypes.mapToModel()
+    )
 
 fun InfrastructureServiceDeclaration.mapToApi() =
-    ApiInfrastructureService(name, url, description, usernameSecret, passwordSecret, excludeFromNetrc)
+    ApiInfrastructureService(name, url, description, usernameSecret, passwordSecret, credentialsTypes.mapToApi())
 
 fun ApiEnvironmentVariableDeclaration.mapToModel() = EnvironmentVariableDeclaration(name, secretName)
 
@@ -452,6 +470,16 @@ fun ApiEnvironmentConfig.mapToModel() =
         environmentVariables = environmentVariables.map { it.mapToModel() },
         strict = strict
     )
+
+fun CredentialsType.mapToApi() = ApiCredentialsType.valueOf(name)
+
+fun Set<CredentialsType>.mapToApi(): Set<ApiCredentialsType> =
+    mapTo(EnumSet.noneOf(ApiCredentialsType::class.java)) { it.mapToApi() }
+
+fun ApiCredentialsType.mapToModel() = CredentialsType.valueOf(name)
+
+fun Set<ApiCredentialsType>.mapToModel(): Set<CredentialsType> =
+    mapTo(EnumSet.noneOf(CredentialsType::class.java)) { it.mapToModel() }
 
 fun PackageManagerConfiguration.mapToApi() =
     ApiPackageManagerConfiguration(mustRunAfter = mustRunAfter, options = options)

--- a/api/v1/model/src/commonMain/kotlin/CredentialsType.kt
+++ b/api/v1/model/src/commonMain/kotlin/CredentialsType.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.api.v1.model
+
+/**
+ * An enumeration class defining the supported credential types that are available for infrastructure services.
+ * Depending on the type(s) set, the credentials of the service are added to different configuration files. Note that
+ * infrastructure services can be assigned multiple credential types. It is also possible that they have no type;
+ * then they are ignored when generating configuration files for credentials.
+ */
+enum class CredentialsType {
+    /**
+     * Credentials type indicating that the credentials of the service should be added to the _.netrc_ file. This is
+     * in most cases the desired option, since it allows access to the service from most external tools.
+     */
+    NETRC_FILE,
+
+    /**
+     * Credentials type indicating that the credentials of the service should be added to the _.git-credentials_ file.
+     * For normal cases, it should not be necessary to use this type, since Git should be able to obtain the
+     * credentials from the _.netrc_ file. There are, however, rare cases when Git is not able to authenticate against
+     * a repository based on the information in the _.netrc_ file. This was observed for instance with repositories
+     * hosted on Microsoft Azure DevOps servers.
+     */
+    GIT_CREDENTIALS_FILE
+}

--- a/api/v1/model/src/commonMain/kotlin/InfrastructureService.kt
+++ b/api/v1/model/src/commonMain/kotlin/InfrastructureService.kt
@@ -22,6 +22,8 @@ package org.eclipse.apoapsis.ortserver.api.v1.model
 import io.konform.validation.Validation
 import io.konform.validation.jsonschema.pattern
 
+import java.util.EnumSet
+
 import kotlinx.serialization.Serializable
 
 import org.eclipse.apoapsis.ortserver.api.v1.model.validation.ValidatorFunc
@@ -50,10 +52,10 @@ data class InfrastructureService(
     val passwordSecretRef: String,
 
     /**
-     * A flag whether this service should be ignored when generating the _.netrc_ file in the runtime environment of
-     * a worker.
+     * The set of [CredentialsType]s for this infrastructure service. This determines in which configuration files the
+     * credentials of the service are listed when generating the runtime environment for a worker.
      */
-    val excludeFromNetrc: Boolean = false
+    val credentialsTypes: Set<CredentialsType> = EnumSet.of(CredentialsType.NETRC_FILE)
 )
 
 /**
@@ -66,7 +68,7 @@ data class CreateInfrastructureService(
     val description: String? = null,
     val usernameSecretRef: String,
     val passwordSecretRef: String,
-    val excludeFromNetrc: Boolean = false
+    val credentialsTypes: Set<CredentialsType> = EnumSet.of(CredentialsType.NETRC_FILE)
 ) {
     companion object {
         val NAME_PATTERN_REGEX = """^(?!\s)[A-Za-z0-9- ]*(?<!\s)$""".toRegex()
@@ -92,5 +94,5 @@ data class UpdateInfrastructureService(
     val description: OptionalValue<String?> = OptionalValue.Absent,
     val usernameSecretRef: OptionalValue<String> = OptionalValue.Absent,
     val passwordSecretRef: OptionalValue<String> = OptionalValue.Absent,
-    val excludeFromNetrc: OptionalValue<Boolean> = OptionalValue.Absent
+    val credentialsTypes: OptionalValue<Set<CredentialsType>> = OptionalValue.Absent
 )

--- a/core/src/main/kotlin/api/OrganizationsRoute.kt
+++ b/core/src/main/kotlin/api/OrganizationsRoute.kt
@@ -276,7 +276,7 @@ fun Route.organizations() = route("organizations") {
                     createService.description,
                     createService.usernameSecretRef,
                     createService.passwordSecretRef,
-                    createService.excludeFromNetrc
+                    createService.credentialsTypes.mapToModel()
                 )
 
                 call.respond(HttpStatusCode.Created, newService.mapToApi())
@@ -297,7 +297,7 @@ fun Route.organizations() = route("organizations") {
                         updateService.description.mapToModel(),
                         updateService.usernameSecretRef.mapToModel(),
                         updateService.passwordSecretRef.mapToModel(),
-                        updateService.excludeFromNetrc.mapToModel()
+                        updateService.credentialsTypes.mapToModel { type -> type.mapToModel() }
                     )
 
                     call.respond(HttpStatusCode.OK, updatedService.mapToApi())

--- a/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
@@ -37,6 +37,8 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.HttpStatusCode
 
+import java.util.EnumSet
+
 import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToApi
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateRepository
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateSecret
@@ -52,6 +54,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateProduct
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateSecret
 import org.eclipse.apoapsis.ortserver.api.v1.model.asPresent
 import org.eclipse.apoapsis.ortserver.core.shouldHaveBody
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.RepositoryType
 import org.eclipse.apoapsis.ortserver.model.authorization.ProductPermission
 import org.eclipse.apoapsis.ortserver.model.authorization.ProductRole
@@ -629,7 +632,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                     description = "good bye, cruel world",
                     usernameSecret = userSecret,
                     passwordSecret = passSecret,
-                    excludeFromNetrc = false,
+                    credentialsTypes = EnumSet.of(CredentialsType.NETRC_FILE),
                     organizationId = null,
                     productId = productId
                 )

--- a/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
@@ -38,11 +38,14 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.HttpStatusCode
 
+import java.util.EnumSet
+
 import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToApi
 import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToApiSummary
 import org.eclipse.apoapsis.ortserver.api.v1.model.AnalyzerJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateSecret
+import org.eclipse.apoapsis.ortserver.api.v1.model.CredentialsType as ApiCredentialsType
 import org.eclipse.apoapsis.ortserver.api.v1.model.EnvironmentConfig
 import org.eclipse.apoapsis.ortserver.api.v1.model.EnvironmentVariableDeclaration as ApiEnvironmentVariableDeclaration
 import org.eclipse.apoapsis.ortserver.api.v1.model.InfrastructureService
@@ -62,6 +65,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateRepository
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateSecret
 import org.eclipse.apoapsis.ortserver.api.v1.model.asPresent
 import org.eclipse.apoapsis.ortserver.core.shouldHaveBody
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.EnvironmentVariableDeclaration
 import org.eclipse.apoapsis.ortserver.model.InfrastructureServiceDeclaration
 import org.eclipse.apoapsis.ortserver.model.JobConfigurations
@@ -468,7 +472,7 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                     description = "a private repository used by this repository",
                     usernameSecretRef = "repositoryUsername",
                     passwordSecretRef = "repositoryPassword",
-                    excludeFromNetrc = true
+                    credentialsTypes = EnumSet.of(ApiCredentialsType.NETRC_FILE)
                 )
                 val environmentDefinitions = mapOf(
                     "maven" to listOf(mapOf("id" to "repositoryServer"))
@@ -504,7 +508,7 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                     description = service.description,
                     usernameSecret = service.usernameSecretRef,
                     passwordSecret = service.passwordSecretRef,
-                    excludeFromNetrc = true
+                    credentialsTypes = EnumSet.of(CredentialsType.NETRC_FILE)
                 )
 
                 val response = superuserClient.post("/api/v1/repositories/${createdRepository.id}/runs") {

--- a/dao/src/main/kotlin/repositories/DaoInfrastructureServiceRepository.kt
+++ b/dao/src/main/kotlin/repositories/DaoInfrastructureServiceRepository.kt
@@ -31,6 +31,7 @@ import org.eclipse.apoapsis.ortserver.dao.tables.OrganizationDao
 import org.eclipse.apoapsis.ortserver.dao.tables.ProductDao
 import org.eclipse.apoapsis.ortserver.dao.tables.SecretDao
 import org.eclipse.apoapsis.ortserver.dao.utils.apply
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 import org.eclipse.apoapsis.ortserver.model.Secret
 import org.eclipse.apoapsis.ortserver.model.repositories.InfrastructureServiceRepository
@@ -75,7 +76,7 @@ class DaoInfrastructureServiceRepository(private val db: Database) : Infrastruct
         description: String?,
         usernameSecret: Secret,
         passwordSecret: Secret,
-        excludeFromNetrc: Boolean,
+        credentialsTypes: Set<CredentialsType>,
         organizationId: Long?,
         productId: Long?
     ): InfrastructureService = db.blockingQuery {
@@ -85,7 +86,7 @@ class DaoInfrastructureServiceRepository(private val db: Database) : Infrastruct
             this.description = description
             this.usernameSecret = SecretDao[usernameSecret.id]
             this.passwordSecret = SecretDao[passwordSecret.id]
-            this.excludeFromNetrc = excludeFromNetrc
+            this.credentialsTypes = credentialsTypes
             this.organization = organizationId?.let { OrganizationDao[it] }
             this.product = productId?.let { ProductDao[it] }
         }.mapToModel()
@@ -120,7 +121,7 @@ class DaoInfrastructureServiceRepository(private val db: Database) : Infrastruct
         description: OptionalValue<String?>,
         usernameSecret: OptionalValue<Secret>,
         passwordSecret: OptionalValue<Secret>,
-        excludeFromNetrc: OptionalValue<Boolean>
+        credentialsTypes: OptionalValue<Set<CredentialsType>>
     ): InfrastructureService =
         update(
             selectByOrganizationAndName(organizationId, name),
@@ -128,7 +129,7 @@ class DaoInfrastructureServiceRepository(private val db: Database) : Infrastruct
             description,
             usernameSecret,
             passwordSecret,
-            excludeFromNetrc
+            credentialsTypes
         )
 
     override fun deleteForOrganizationAndName(organizationId: Long, name: String) {
@@ -148,7 +149,7 @@ class DaoInfrastructureServiceRepository(private val db: Database) : Infrastruct
         description: OptionalValue<String?>,
         usernameSecret: OptionalValue<Secret>,
         passwordSecret: OptionalValue<Secret>,
-        excludeFromNetrc: OptionalValue<Boolean>
+        credentialsTypes: OptionalValue<Set<CredentialsType>>
     ): InfrastructureService =
         update(
             selectByProductAndName(productId, name),
@@ -156,7 +157,7 @@ class DaoInfrastructureServiceRepository(private val db: Database) : Infrastruct
             description,
             usernameSecret,
             passwordSecret,
-            excludeFromNetrc
+            credentialsTypes
         )
 
     override fun deleteForProductAndName(productId: Long, name: String) {
@@ -224,7 +225,7 @@ class DaoInfrastructureServiceRepository(private val db: Database) : Infrastruct
         description: OptionalValue<String?>,
         usernameSecret: OptionalValue<Secret>,
         passwordSecret: OptionalValue<Secret>,
-        excludeFromNetrc: OptionalValue<Boolean>
+        credentialsTypes: OptionalValue<Set<CredentialsType>>
     ): InfrastructureService = db.blockingQuery {
         val service = InfrastructureServicesDao.findSingle(op)
 
@@ -232,7 +233,7 @@ class DaoInfrastructureServiceRepository(private val db: Database) : Infrastruct
         description.ifPresent { service.description = it }
         usernameSecret.ifPresent { service.usernameSecret = SecretDao[it.id] }
         passwordSecret.ifPresent { service.passwordSecret = SecretDao[it.id] }
-        excludeFromNetrc.ifPresent { service.excludeFromNetrc = it }
+        credentialsTypes.ifPresent { service.credentialsTypes = it }
 
         service.mapToModel()
     }

--- a/dao/src/main/resources/db/migration/V66__infrastructureServicesCredentialsType.sql
+++ b/dao/src/main/resources/db/migration/V66__infrastructureServicesCredentialsType.sql
@@ -1,0 +1,14 @@
+ALTER TABLE infrastructure_services
+    ADD COLUMN credentials_type text NULL;
+
+DROP INDEX infrastructure_services_all_value_columns;
+
+UPDATE infrastructure_services
+    SET credentials_type = 'NETRC'
+    WHERE exclude_from_netrc = false;
+
+ALTER TABLE infrastructure_services
+    DROP COLUMN exclude_from_netrc;
+
+CREATE INDEX infrastructure_services_all_value_columns
+    ON infrastructure_services (name, url, description, username_secret_id, password_secret_id, credentials_type);

--- a/dao/src/test/kotlin/repositories/DaoInfrastructureServiceRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/DaoInfrastructureServiceRepositoryTest.kt
@@ -33,8 +33,11 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldInclude
 
+import java.util.EnumSet
+
 import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
 import org.eclipse.apoapsis.ortserver.dao.test.Fixtures
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 import org.eclipse.apoapsis.ortserver.model.Organization
 import org.eclipse.apoapsis.ortserver.model.Product
@@ -83,7 +86,8 @@ class DaoInfrastructureServiceRepositoryTest : WordSpec() {
             }
 
             "create an infrastructure service for a product" {
-                val expectedService = createInfrastructureService(product = fixtures.product, excludeFromNetrc = true)
+                val expectedService =
+                    createInfrastructureService(product = fixtures.product, credentialsTypes = emptySet())
 
                 val service = infrastructureServicesRepository.create(expectedService)
 
@@ -302,7 +306,7 @@ class DaoInfrastructureServiceRepositoryTest : WordSpec() {
                     usernameSecret = newUser,
                     passwordSecret = newPassword,
                     organization = fixtures.organization,
-                    excludeFromNetrc = true
+                    credentialsTypes = EnumSet.of(CredentialsType.NETRC_FILE, CredentialsType.GIT_CREDENTIALS_FILE),
                 )
 
                 infrastructureServicesRepository.create(service)
@@ -314,7 +318,7 @@ class DaoInfrastructureServiceRepositoryTest : WordSpec() {
                     updatedService.description.asPresent(),
                     updatedService.usernameSecret.asPresent(),
                     updatedService.passwordSecret.asPresent(),
-                    excludeFromNetrc = updatedService.excludeFromNetrc.asPresent()
+                    credentialsTypes = updatedService.credentialsTypes.asPresent()
                 )
 
                 result shouldBe updatedService
@@ -329,6 +333,7 @@ class DaoInfrastructureServiceRepositoryTest : WordSpec() {
                     infrastructureServicesRepository.updateForOrganizationAndName(
                         42L,
                         SERVICE_NAME,
+                        OptionalValue.Absent,
                         OptionalValue.Absent,
                         OptionalValue.Absent,
                         OptionalValue.Absent,
@@ -349,7 +354,7 @@ class DaoInfrastructureServiceRepositoryTest : WordSpec() {
                     usernameSecret = newUser,
                     passwordSecret = newPassword,
                     product = fixtures.product,
-                    excludeFromNetrc = true
+                    credentialsTypes = emptySet(),
                 )
 
                 infrastructureServicesRepository.create(service)
@@ -361,7 +366,7 @@ class DaoInfrastructureServiceRepositoryTest : WordSpec() {
                     updatedService.description.asPresent(),
                     updatedService.usernameSecret.asPresent(),
                     updatedService.passwordSecret.asPresent(),
-                    updatedService.excludeFromNetrc.asPresent()
+                    updatedService.credentialsTypes.asPresent()
                 )
 
                 result shouldBe updatedService
@@ -578,7 +583,7 @@ class DaoInfrastructureServiceRepositoryTest : WordSpec() {
         passwordSecret: Secret = this.passwordSecret,
         organization: Organization? = null,
         product: Product? = null,
-        excludeFromNetrc: Boolean = false
+        credentialsTypes: Set<CredentialsType> = setOf(CredentialsType.NETRC_FILE),
     ): InfrastructureService =
         InfrastructureService(
             name,
@@ -588,7 +593,7 @@ class DaoInfrastructureServiceRepositoryTest : WordSpec() {
             passwordSecret,
             organization,
             product,
-            excludeFromNetrc
+            credentialsTypes
         )
 }
 
@@ -606,7 +611,7 @@ private fun DaoInfrastructureServiceRepository.create(service: InfrastructureSer
         service.description,
         service.usernameSecret,
         service.passwordSecret,
-        service.excludeFromNetrc,
+        service.credentialsTypes,
         service.organization?.id,
         service.product?.id
     )

--- a/model/src/commonMain/kotlin/CredentialsType.kt
+++ b/model/src/commonMain/kotlin/CredentialsType.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.model
+
+/**
+ * An enumeration class defining the supported credential types that are available for infrastructure services.
+ * Depending on the type(s) set, the credentials of the service are added to different configuration files. Note that
+ * infrastructure services can be assigned multiple credential types. It is also possible that they have no type;
+ * then they are ignored when generating configuration files for credentials.
+ */
+enum class CredentialsType {
+    /**
+     * Credentials type indicating that the credentials of the service should be added to the _.netrc_ file. This is
+     * in most cases the desired option, since it allows access to the service from most external tools.
+     */
+    NETRC_FILE,
+
+    /**
+     * Credentials type indicating that the credentials of the service should be added to the _.git-credentials_ file.
+     * For normal cases, it should not be necessary to use this type, since Git should be able to obtain the
+     * credentials from the _.netrc_ file. There are, however, rare cases when Git is not able to authenticate against
+     * a repository based on the information in the _.netrc_ file. This was observed for instance with repositories
+     * hosted on Microsoft Azure DevOps servers.
+     */
+    GIT_CREDENTIALS_FILE
+}

--- a/model/src/commonMain/kotlin/InfrastructureService.kt
+++ b/model/src/commonMain/kotlin/InfrastructureService.kt
@@ -23,6 +23,8 @@ import io.konform.validation.Invalid
 import io.konform.validation.Validation
 import io.konform.validation.jsonschema.pattern
 
+import java.util.EnumSet
+
 import org.eclipse.apoapsis.ortserver.model.validation.ValidationException
 
 /**
@@ -56,14 +58,16 @@ data class InfrastructureService(
     val product: Product?,
 
     /**
-     * A flag whether this service should be ignored when generating the _.netrc_ file in the runtime environment of
-     * a worker. Per default, all the infrastructure services referenced from a repository are taken into account when
-     * generating the _.netrc_ file. This is typically desired, so that all external tools invoked from a worker can
-     * access the credentials they represent. In some constellations, however, there could be conflicting services;
-     * for instance, if multiple repositories with different credentials are defined on the same repository server.
-     * Then this flag can be used to resolve such conflicts manually.
+     * The set of [CredentialsType]s for this infrastructure service. This determines in which configuration files the
+     * credentials of the service are listed when generating the runtime environment for a worker. Per default, the
+     * credentials for all the infrastructure services referenced from a repository are added to the _.netrc_ file.
+     * This is typically desired, so that all external tools invoked from a worker can access the credentials they
+     * represent. In some constellations, however, there could be conflicting services; for instance, if multiple
+     * repositories with different credentials are defined on the same repository server. Such issues can be resolved
+     * by explicitly removing the [CredentialsType.NETRC_FILE] constant from this set. It is also possible to add other
+     * constants if a special treatment of the credentials is required.
      */
-    val excludeFromNetrc: Boolean = false
+    val credentialsTypes: Set<CredentialsType> = EnumSet.of(CredentialsType.NETRC_FILE)
 ) {
     companion object {
         val NAME_PATTERN_REGEX = """^(?!\s)[A-Za-z0-9- ]*(?<!\s)$""".toRegex()

--- a/model/src/commonMain/kotlin/InfrastructureServiceDeclaration.kt
+++ b/model/src/commonMain/kotlin/InfrastructureServiceDeclaration.kt
@@ -19,6 +19,8 @@
 
 package org.eclipse.apoapsis.ortserver.model
 
+import java.util.EnumSet
+
 import kotlinx.serialization.Serializable
 
 /**
@@ -50,6 +52,6 @@ data class InfrastructureServiceDeclaration(
     /** The name of the [Secret] that contains the password of the credentials for this infrastructure service. */
     val passwordSecret: String,
 
-    /** A flag whether this service should be ignored when generating the _.netrc_ file. */
-    val excludeFromNetrc: Boolean = false
+    /** The set of [CredentialsType]s for this infrastructure service. */
+    val credentialsTypes: Set<CredentialsType> = EnumSet.of(CredentialsType.NETRC_FILE)
 )

--- a/model/src/commonMain/kotlin/repositories/InfrastructureServiceRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/InfrastructureServiceRepository.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.apoapsis.ortserver.model.repositories
 
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 import org.eclipse.apoapsis.ortserver.model.Secret
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
@@ -39,7 +40,7 @@ interface InfrastructureServiceRepository {
         description: String?,
         usernameSecret: Secret,
         passwordSecret: Secret,
-        excludeFromNetrc: Boolean,
+        credentialsTypes: Set<CredentialsType>,
         organizationId: Long?,
         productId: Long?
     ): InfrastructureService
@@ -78,7 +79,7 @@ interface InfrastructureServiceRepository {
         description: OptionalValue<String?>,
         usernameSecret: OptionalValue<Secret>,
         passwordSecret: OptionalValue<Secret>,
-        excludeFromNetrc: OptionalValue<Boolean> = OptionalValue.Absent
+        credentialsTypes: OptionalValue<Set<CredentialsType>> = OptionalValue.Absent,
     ): InfrastructureService
 
     /**
@@ -113,7 +114,7 @@ interface InfrastructureServiceRepository {
         description: OptionalValue<String?>,
         usernameSecret: OptionalValue<Secret>,
         passwordSecret: OptionalValue<Secret>,
-        excludeFromNetrc: OptionalValue<Boolean> = OptionalValue.Absent
+        credentialsTypes: OptionalValue<Set<CredentialsType>> = OptionalValue.Absent,
     ): InfrastructureService
 
     /**

--- a/services/infrastructure/src/main/kotlin/InfrastructureServiceService.kt
+++ b/services/infrastructure/src/main/kotlin/InfrastructureServiceService.kt
@@ -20,6 +20,7 @@
 package org.eclipse.apoapsis.ortserver.services
 
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 import org.eclipse.apoapsis.ortserver.model.Secret
 import org.eclipse.apoapsis.ortserver.model.repositories.InfrastructureServiceRepository
@@ -56,7 +57,7 @@ class InfrastructureServiceService(
         description: String?,
         usernameSecretRef: String,
         passwordSecretRef: String,
-        excludeFromNetrc: Boolean
+        credentialsTypes: Set<CredentialsType>
     ): InfrastructureService {
         val usernameSecret = resolveOrganizationSecret(organizationId, usernameSecretRef)
         val passwordSecret = resolveOrganizationSecret(organizationId, passwordSecretRef)
@@ -68,7 +69,7 @@ class InfrastructureServiceService(
                 description,
                 usernameSecret,
                 passwordSecret,
-                excludeFromNetrc,
+                credentialsTypes,
                 organizationId,
                 null
             )
@@ -86,7 +87,7 @@ class InfrastructureServiceService(
         description: OptionalValue<String?>,
         usernameSecretRef: OptionalValue<String>,
         passwordSecretRef: OptionalValue<String>,
-        excludeFromNetrc: OptionalValue<Boolean>
+        credentialsTypes: OptionalValue<Set<CredentialsType>>
     ): InfrastructureService {
         val usernameSecret = resolveOrganizationSecretOptional(organizationId, usernameSecretRef)
         val passwordSecret = resolveOrganizationSecretOptional(organizationId, passwordSecretRef)
@@ -99,7 +100,7 @@ class InfrastructureServiceService(
                 description,
                 usernameSecret,
                 passwordSecret,
-                excludeFromNetrc
+                credentialsTypes
             )
         }
     }

--- a/services/infrastructure/src/test/kotlin/InfrastructureServiceServiceTest.kt
+++ b/services/infrastructure/src/test/kotlin/InfrastructureServiceServiceTest.kt
@@ -35,7 +35,10 @@ import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
 
+import java.util.EnumSet
+
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 import org.eclipse.apoapsis.ortserver.model.Secret
 import org.eclipse.apoapsis.ortserver.model.repositories.InfrastructureServiceRepository
@@ -72,7 +75,7 @@ class InfrastructureServiceServiceTest : WordSpec({
                         SERVICE_DESC,
                         userSecret,
                         passSecret,
-                        false,
+                        EnumSet.of(CredentialsType.NETRC_FILE),
                         ORGANIZATION_ID,
                         null
                     )
@@ -85,7 +88,7 @@ class InfrastructureServiceServiceTest : WordSpec({
                     SERVICE_DESC,
                     USERNAME_SECRET,
                     PASSWORD_SECRET,
-                    false
+                    EnumSet.of(CredentialsType.NETRC_FILE)
                 )
 
                 createResult shouldBe infrastructureService
@@ -107,7 +110,7 @@ class InfrastructureServiceServiceTest : WordSpec({
                         SERVICE_DESC,
                         USERNAME_SECRET,
                         PASSWORD_SECRET,
-                        false
+                        emptySet()
                     )
                 }
 
@@ -142,7 +145,7 @@ class InfrastructureServiceServiceTest : WordSpec({
                     SERVICE_DESC.asPresent(),
                     USERNAME_SECRET.asPresent(),
                     PASSWORD_SECRET.asPresent(),
-                    true.asPresent()
+                    EnumSet.of(CredentialsType.GIT_CREDENTIALS_FILE).asPresent()
                 )
 
                 updateResult shouldBe infrastructureService
@@ -151,7 +154,7 @@ class InfrastructureServiceServiceTest : WordSpec({
                 val slotDescription = slot<OptionalValue<String?>>()
                 val slotUsernameSecret = slot<OptionalValue<Secret>>()
                 val slotPasswordSecret = slot<OptionalValue<Secret>>()
-                val slotExcludeNetrc = slot<OptionalValue<Boolean>>()
+                val slotCredentialsType = slot<OptionalValue<Set<CredentialsType>>>()
                 verify {
                     repository.updateForOrganizationAndName(
                         ORGANIZATION_ID,
@@ -160,7 +163,7 @@ class InfrastructureServiceServiceTest : WordSpec({
                         capture(slotDescription),
                         capture(slotUsernameSecret),
                         capture(slotPasswordSecret),
-                        capture(slotExcludeNetrc)
+                        capture(slotCredentialsType)
                     )
                 }
 
@@ -168,7 +171,10 @@ class InfrastructureServiceServiceTest : WordSpec({
                 equalsOptionalValues(SERVICE_DESC.asPresent(), slotDescription.captured) shouldBe true
                 equalsOptionalValues(userSecret.asPresent(), slotUsernameSecret.captured) shouldBe true
                 equalsOptionalValues(passSecret.asPresent(), slotPasswordSecret.captured) shouldBe true
-                equalsOptionalValues(true.asPresent(), slotExcludeNetrc.captured) shouldBe true
+                equalsOptionalValues(
+                    EnumSet.of(CredentialsType.GIT_CREDENTIALS_FILE).asPresent(),
+                    slotCredentialsType.captured
+                ) shouldBe true
             }
         }
 

--- a/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
@@ -139,6 +139,15 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
             }
         }
 
+        "The build environment should contain a .git-credentials file" {
+            runEnvironmentTest { homeFolder ->
+                val gitCredentialsFile = homeFolder.resolve(".git-credentials")
+                val content = gitCredentialsFile.readText()
+
+                content shouldContain "https://$USERNAME:$PASSWORD@repo2.example.org/test2/other-repository.git"
+            }
+        }
+
         "The build environment should contain a settings.xml file" {
             runEnvironmentTest { homeFolder ->
                 val settingsFile = homeFolder.resolve("settings.xml")

--- a/workers/analyzer/src/test/resources/mavenProject/.ort.env.yml
+++ b/workers/analyzer/src/test/resources/mavenProject/.ort.env.yml
@@ -18,7 +18,7 @@ environmentDefinitions:
     id: "mainRepo"
   - service: "IgnoredInNetrc"
     id: "otherRepo"
-    excludeFromNetrc: true
+    credentialsTypes: ""
   npm:
   - service: "RepositoryService"
     scope: "external"

--- a/workers/analyzer/src/test/resources/mavenProject/.ort.env.yml
+++ b/workers/analyzer/src/test/resources/mavenProject/.ort.env.yml
@@ -3,7 +3,7 @@ infrastructureServices:
   url: "https://repo.example.org/test/repository.git"
   usernameSecret: "repositoryUsername"
   passwordSecret: "repositoryPassword"
-- name: "IgnoredInNetrc"
+- name: "SpecialGitService"
   url: "https://repo2.example.org/test2/other-repository.git"
   usernameSecret: "repositoryUsername"
   passwordSecret: "repositoryPassword"
@@ -16,9 +16,9 @@ environmentDefinitions:
   maven:
   - service: "RepositoryService"
     id: "mainRepo"
-  - service: "IgnoredInNetrc"
+  - service: "SpecialGitService"
     id: "otherRepo"
-    credentialsTypes: ""
+    credentialsTypes: "GIT_CREDENTIALS_FILE"
   npm:
   - service: "RepositoryService"
     scope: "external"

--- a/workers/common/src/main/kotlin/common/env/ConfigFileBuilder.kt
+++ b/workers/common/src/main/kotlin/common/env/ConfigFileBuilder.kt
@@ -28,6 +28,8 @@ import kotlin.random.Random
 import org.eclipse.apoapsis.ortserver.model.Secret
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
 
+import org.slf4j.LoggerFactory
+
 /**
  * A helper class supporting the generation of configuration files.
  *
@@ -43,6 +45,8 @@ import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
  */
 class ConfigFileBuilder(val context: WorkerContext) {
     companion object {
+        private val logger = LoggerFactory.getLogger(ConfigFileBuilder::class.java)
+
         /**
          * Print the given [multiLineText] making sure that the correct line endings are used. This function is
          * intended to be used with a Kotlin multiline string. In multiline strings line endings are always
@@ -68,6 +72,8 @@ class ConfigFileBuilder(val context: WorkerContext) {
      * given [block].
      */
     suspend fun build(file: File, block: suspend PrintWriter.() -> Unit) {
+        logger.info("Generating configuration file at '{}'.", file)
+
         val writer = StringWriter()
         val printWriter = PrintWriter(writer)
 

--- a/workers/common/src/main/kotlin/common/env/EnvironmentModule.kt
+++ b/workers/common/src/main/kotlin/common/env/EnvironmentModule.kt
@@ -46,6 +46,7 @@ fun buildEnvironmentModule(): Module = module {
             get(),
             listOf(
                 ConanGenerator(),
+                GitCredentialsGenerator(),
                 MavenSettingsGenerator(),
                 NetRcGenerator(),
                 NpmRcGenerator(),

--- a/workers/common/src/main/kotlin/common/env/EnvironmentService.kt
+++ b/workers/common/src/main/kotlin/common/env/EnvironmentService.kt
@@ -112,7 +112,7 @@ class EnvironmentService(
                 unreferencedServices.map(::EnvironmentServiceDefinition)
 
         val adjustedServices = config.environmentDefinitions.mapTo(unreferencedServices.toMutableSet()) { definition ->
-            definition.excludeServiceFromNetrc?.let { definition.service.copy(excludeFromNetrc = it) }
+            definition.credentialsTypes?.let { definition.service.copy(credentialsTypes = it) }
                 ?: definition.service
         }
 

--- a/workers/common/src/main/kotlin/common/env/GitCredentialsGenerator.kt
+++ b/workers/common/src/main/kotlin/common/env/GitCredentialsGenerator.kt
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.common.env
+
+import java.net.URI
+
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
+import org.eclipse.apoapsis.ortserver.model.InfrastructureService
+import org.eclipse.apoapsis.ortserver.workers.common.env.definition.EnvironmentServiceDefinition
+
+import org.slf4j.LoggerFactory
+
+/**
+ * A specialized generator class to generate files with special credentials for Git.
+ *
+ * This generator is required only for corner cases. Normally, the Git CLI should be able to obtain credentials from
+ * the _.netrc_ file. However, in some special cases, this mechanism is not working, and authentication against the
+ * repository is only possible if the credentials are placed in a _.git-credentials_ file. This generator is able to
+ * produce such a file, together with a Git configuration file that references it. It only processes infrastructure
+ * services whose credentials types contain [CredentialsType.GIT_CREDENTIALS_FILE].
+ */
+class GitCredentialsGenerator : EnvironmentConfigGenerator<EnvironmentServiceDefinition> {
+    companion object {
+        /** The name of the file storing the actual credentials. */
+        private const val GIT_CREDENTIALS_FILE_NAME = ".git-credentials"
+
+        /** The name of the file with the Git configuration. */
+        private const val GIT_CONFIG_FILE_NAME = ".gitconfig"
+
+        private val logger = LoggerFactory.getLogger(GitCredentialsGenerator::class.java)
+
+        /**
+         * Return a string with the URL of this [InfrastructureService] with the credentials embedded as needed within
+         * the _.git-credentials_ file. Use [builder] to obtain secret references. Return *null* if the URL is invalid.
+         */
+        private fun InfrastructureService.urlWithCredentials(builder: ConfigFileBuilder): String? = runCatching {
+            buildString {
+                val serviceUrl = URI.create(url).toURL()
+                append(serviceUrl.protocol)
+                append("://")
+                append(builder.secretRef(usernameSecret)).append(':')
+                append(builder.secretRef(passwordSecret)).append('@')
+                append(serviceUrl.authority)
+                append(serviceUrl.path)
+            }
+        }.onFailure {
+            logger.error("Invalid URL for service '{}'. Ignoring it.", this, it)
+        }.getOrNull()
+    }
+
+    override val environmentDefinitionType: Class<EnvironmentServiceDefinition>
+        get() = EnvironmentServiceDefinition::class.java
+
+    override suspend fun generate(builder: ConfigFileBuilder, definitions: Collection<EnvironmentServiceDefinition>) {
+        definitions.filter {
+            CredentialsType.GIT_CREDENTIALS_FILE in it.credentialsTypes()
+        }.takeUnless { it.isEmpty() }?.let {
+            generateGitCredentials(builder, it)
+            generateGitConfig(builder)
+        }
+    }
+
+    /**
+     * Generate the content of the _.git-credentials_ file using the given [builder] for the given [definitions].
+     */
+    private suspend fun generateGitCredentials(
+        builder: ConfigFileBuilder,
+        definitions: Collection<EnvironmentServiceDefinition>
+    ) {
+        builder.buildInUserHome(GIT_CREDENTIALS_FILE_NAME) {
+            definitions.mapNotNull { it.service.urlWithCredentials(builder) }
+                .forEach(this::println)
+        }
+    }
+
+    /**
+     * Generate the (static) content of the _.gitconfig_ file using the given [builder]. In this file, only the
+     * credential store is enabled.
+     */
+    private suspend fun generateGitConfig(builder: ConfigFileBuilder) {
+        builder.buildInUserHome(GIT_CONFIG_FILE_NAME) {
+            println("[credential]")
+            println("\thelper = store")
+        }
+    }
+}

--- a/workers/common/src/main/kotlin/common/env/NetRcGenerator.kt
+++ b/workers/common/src/main/kotlin/common/env/NetRcGenerator.kt
@@ -21,6 +21,7 @@ package org.eclipse.apoapsis.ortserver.workers.common.env
 
 import java.net.URI
 
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 import org.eclipse.apoapsis.ortserver.workers.common.env.definition.EnvironmentServiceDefinition
 
@@ -63,7 +64,7 @@ class NetRcGenerator : EnvironmentConfigGenerator<EnvironmentServiceDefinition> 
         get() = EnvironmentServiceDefinition::class.java
 
     override suspend fun generate(builder: ConfigFileBuilder, definitions: Collection<EnvironmentServiceDefinition>) {
-        val serviceHosts = definitions.filterNot(EnvironmentServiceDefinition::excludeServiceFromNetrc)
+        val serviceHosts = definitions.filter { CredentialsType.NETRC_FILE in it.credentialsTypes() }
             .map { it.service to it.service.host() }
             .filter { it.second != null }
             .toMap()

--- a/workers/common/src/main/kotlin/common/env/config/EnvironmentConfigLoader.kt
+++ b/workers/common/src/main/kotlin/common/env/config/EnvironmentConfigLoader.kt
@@ -67,6 +67,8 @@ import org.slf4j.LoggerFactory
  *   description: "Main repository for releases."
  *   usernameSecret: "frogUsername"
  *   passwordSecret: "frogPassword"
+ *   credentialsTypes:
+ *   - "NETRC"
  * environmentDefinitions:
  *   maven:
  *   - service: "JFrog"
@@ -162,7 +164,7 @@ class EnvironmentConfigLoader(
                         passwordSecret,
                         null,
                         null,
-                        service.excludeFromNetrc
+                        service.credentialsTypes
                     )
                 }
             }
@@ -363,7 +365,7 @@ private fun Collection<InfrastructureService>.associateByName(): Map<String, Inf
  * Convert this [InfrastructureServiceDeclaration] to a [RepositoryInfrastructureService].
  */
 private fun InfrastructureServiceDeclaration.toRepositoryService(): RepositoryInfrastructureService =
-    RepositoryInfrastructureService(name, url, description, usernameSecret, passwordSecret, excludeFromNetrc)
+    RepositoryInfrastructureService(name, url, description, usernameSecret, passwordSecret, credentialsTypes)
 
 /**
  * Convert this [EnvironmentVariableDeclaration] to a [RepositoryEnvironmentVariableDefinition].

--- a/workers/common/src/main/kotlin/common/env/config/RepositoryInfrastructureService.kt
+++ b/workers/common/src/main/kotlin/common/env/config/RepositoryInfrastructureService.kt
@@ -19,7 +19,11 @@
 
 package org.eclipse.apoapsis.ortserver.workers.common.env.config
 
+import java.util.EnumSet
+
 import kotlinx.serialization.Serializable
+
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
 
 /**
  * A data class representing the declaration of an infrastructure service in the environment configuration file of a
@@ -48,5 +52,5 @@ internal data class RepositoryInfrastructureService(
     val passwordSecret: String,
 
     /** A flag whether this service should be ignored when generating the _.netrc_ file. */
-    val excludeFromNetrc: Boolean = false
+    val credentialsTypes: Set<CredentialsType> = EnumSet.of(CredentialsType.NETRC_FILE)
 )

--- a/workers/common/src/main/kotlin/common/env/definition/ConanDefinition.kt
+++ b/workers/common/src/main/kotlin/common/env/definition/ConanDefinition.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.apoapsis.ortserver.workers.common.env.definition
 
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 
 /**
@@ -30,7 +31,7 @@ import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 class ConanDefinition(
     service: InfrastructureService,
 
-    excludeFromNetrc: Boolean?,
+    credentialsTypes: Set<CredentialsType>?,
 
     /**
      * Name of the remote. This name will be used in commands like `conan list`.
@@ -46,4 +47,4 @@ class ConanDefinition(
      * Verify SSL certificate of the specified url.
      */
     val verifySsl: Boolean
-) : EnvironmentServiceDefinition(service, excludeFromNetrc)
+) : EnvironmentServiceDefinition(service, credentialsTypes)

--- a/workers/common/src/main/kotlin/common/env/definition/EnvironmentServiceDefinition.kt
+++ b/workers/common/src/main/kotlin/common/env/definition/EnvironmentServiceDefinition.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.apoapsis.ortserver.workers.common.env.definition
 
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 
 /**
@@ -40,15 +41,15 @@ open class EnvironmentServiceDefinition(
     val service: InfrastructureService,
 
     /**
-     * A flag to indicate whether the associated [InfrastructureService] should be excluded from the _.netrc_ file.
-     * If this flag is defined, it overrides the corresponding flag from the service.
+     * A set determining the locations where the credentials of the associated [InfrastructureService] should be
+     * used. If it is defined, it overrides the corresponding property from the service.
      */
-    val excludeServiceFromNetrc: Boolean? = null
+    val credentialsTypes: Set<CredentialsType>? = null
 ) {
     /**
-     * Return a flag whether the [InfrastructureService] associated with this [EnvironmentServiceDefinition] should be
-     * excluded when generating the _.netrc_ file. Per default, this is a property of the [InfrastructureService]
-     * itself, but it is possible to override this flag in the [EnvironmentServiceDefinition].
+     * Return a set indicating where the credentials of the [InfrastructureService] associated with this
+     * [EnvironmentServiceDefinition] should be used. Per default, this is a property of the [InfrastructureService]
+     * itself, but it is possible to override this property in the [EnvironmentServiceDefinition].
      */
-    fun excludeServiceFromNetrc(): Boolean = excludeServiceFromNetrc ?: service.excludeFromNetrc
+    fun credentialsTypes(): Set<CredentialsType> = credentialsTypes ?: service.credentialsTypes
 }

--- a/workers/common/src/main/kotlin/common/env/definition/MavenDefinition.kt
+++ b/workers/common/src/main/kotlin/common/env/definition/MavenDefinition.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.apoapsis.ortserver.workers.common.env.definition
 
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 
 /**
@@ -30,7 +31,7 @@ import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 class MavenDefinition(
     service: InfrastructureService,
 
-    excludeFromNetrc: Boolean?,
+    credentialsTypes: Set<CredentialsType>?,
 
     /**
      * The ID of the represented service. This ID is used in _pom.xml_ files to refer to the represented repository.
@@ -38,4 +39,4 @@ class MavenDefinition(
      * _servers_ section. See https://maven.apache.org/settings.html#servers.
      */
     val id: String
-) : EnvironmentServiceDefinition(service, excludeFromNetrc)
+) : EnvironmentServiceDefinition(service, credentialsTypes)

--- a/workers/common/src/main/kotlin/common/env/definition/NpmDefinition.kt
+++ b/workers/common/src/main/kotlin/common/env/definition/NpmDefinition.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.apoapsis.ortserver.workers.common.env.definition
 
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 
 /**
@@ -69,7 +70,7 @@ enum class NpmAuthMode {
 class NpmDefinition(
     service: InfrastructureService,
 
-    excludeFromNetrc: Boolean?,
+    credentialsTypes: Set<CredentialsType>?,
 
     /**
      * An optional scope of the registry. If defined, the generated _npmrc_ file will contain an entry that assigns
@@ -92,4 +93,4 @@ class NpmDefinition(
      * instructed to always send authentication information.
      */
     val alwaysAuth: Boolean = true
-) : EnvironmentServiceDefinition(service, excludeFromNetrc)
+) : EnvironmentServiceDefinition(service, credentialsTypes)

--- a/workers/common/src/main/kotlin/common/env/definition/NuGetDefinition.kt
+++ b/workers/common/src/main/kotlin/common/env/definition/NuGetDefinition.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.apoapsis.ortserver.workers.common.env.definition
 
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 
 /**
@@ -30,7 +31,7 @@ import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 class NuGetDefinition(
     service: InfrastructureService,
 
-    excludeFromNetrc: Boolean?,
+    credentialsTypes: Set<CredentialsType>?,
 
     /**
      * The name to assign to the package source.
@@ -56,7 +57,7 @@ class NuGetDefinition(
      * Defines the authentication type for this package source.
      */
     val authMode: NuGetAuthMode = NuGetAuthMode.API_KEY
-) : EnvironmentServiceDefinition(service, excludeFromNetrc)
+) : EnvironmentServiceDefinition(service, credentialsTypes)
 
 enum class NuGetAuthMode {
     /**

--- a/workers/common/src/main/kotlin/common/env/definition/YarnDefinition.kt
+++ b/workers/common/src/main/kotlin/common/env/definition/YarnDefinition.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.apoapsis.ortserver.workers.common.env.definition
 
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 
 /**
@@ -30,7 +31,7 @@ import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 class YarnDefinition(
     service: InfrastructureService,
 
-    excludeFromNetrc: Boolean?,
+    credentialsTypes: Set<CredentialsType>?,
 
     /**
      * A flag to control the generation of the `mpmAlwaysAuth` property for this registry. Via this flag, Yarn can be
@@ -42,7 +43,7 @@ class YarnDefinition(
      * Defines the way authentication should be handled for this private registry.
      */
     val authMode: YarnAuthMode = YarnAuthMode.AUTH_TOKEN
-) : EnvironmentServiceDefinition(service, excludeFromNetrc)
+) : EnvironmentServiceDefinition(service, credentialsTypes)
 
 enum class YarnAuthMode {
     /**

--- a/workers/common/src/test/kotlin/common/env/ConanGeneratorTest.kt
+++ b/workers/common/src/test/kotlin/common/env/ConanGeneratorTest.kt
@@ -40,7 +40,7 @@ class ConanGeneratorTest : WordSpec({
         "generate the file at the correct location" {
             val definition = ConanDefinition(
                 MockConfigFileBuilder.createInfrastructureService(REMOTE_URL),
-                false,
+                emptySet(),
                 REMOTE_NAME,
                 REMOTE_URL,
                 true
@@ -56,7 +56,7 @@ class ConanGeneratorTest : WordSpec({
         "generate a file with a single remote" {
             val definition = ConanDefinition(
                 MockConfigFileBuilder.createInfrastructureService(REMOTE_URL),
-                false,
+                emptySet(),
                 REMOTE_NAME,
                 REMOTE_URL,
                 true
@@ -85,14 +85,14 @@ class ConanGeneratorTest : WordSpec({
             val definitions = listOf(
                 ConanDefinition(
                     MockConfigFileBuilder.createInfrastructureService(REMOTE_URL),
-                    false,
+                    emptySet(),
                     REMOTE_NAME,
                     REMOTE_URL,
                     true
                 ),
                 ConanDefinition(
                     MockConfigFileBuilder.createInfrastructureService(REMOTE_URL + 1),
-                    false,
+                    emptySet(),
                     REMOTE_NAME + 1,
                     REMOTE_URL + 1,
                     false

--- a/workers/common/src/test/kotlin/common/env/EnvironmentServiceTest.kt
+++ b/workers/common/src/test/kotlin/common/env/EnvironmentServiceTest.kt
@@ -36,7 +36,9 @@ import io.mockk.runs
 import io.mockk.slot
 
 import java.io.File
+import java.util.EnumSet
 
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.EnvironmentConfig
 import org.eclipse.apoapsis.ortserver.model.Hierarchy
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
@@ -189,7 +191,7 @@ class EnvironmentServiceTest : WordSpec({
             assignedServices shouldContainExactlyInAnyOrder services
         }
 
-        "set an overridden excludeFromNetRc flag when assigning infrastructure services to the current ORT run" {
+        "set an overridden credentials type when assigning infrastructure services to the current ORT run" {
             val service = InfrastructureService(
                 name = "aTestService",
                 url = "https://test.example.org/test/service.git",
@@ -198,7 +200,10 @@ class EnvironmentServiceTest : WordSpec({
                 organization = null,
                 product = null
             )
-            val definition = EnvironmentServiceDefinition(service, excludeServiceFromNetrc = true)
+            val definition = EnvironmentServiceDefinition(
+                service,
+                credentialsTypes = EnumSet.of(CredentialsType.GIT_CREDENTIALS_FILE)
+            )
 
             val context = mockContext()
             val config = ResolvedEnvironmentConfig(listOf(service), listOf(definition))
@@ -210,7 +215,9 @@ class EnvironmentServiceTest : WordSpec({
             val environmentService = EnvironmentService(serviceRepository, emptyList(), configLoader)
             environmentService.setUpEnvironment(context, repositoryFolder, null)
 
-            val expectedAssignedService = service.copy(excludeFromNetrc = true)
+            val expectedAssignedService = service.copy(
+                credentialsTypes = EnumSet.of(CredentialsType.GIT_CREDENTIALS_FILE)
+            )
             assignedServices shouldContainExactlyInAnyOrder listOf(expectedAssignedService)
         }
 

--- a/workers/common/src/test/kotlin/common/env/GitCredentialsGeneratorTest.kt
+++ b/workers/common/src/test/kotlin/common/env/GitCredentialsGeneratorTest.kt
@@ -1,0 +1,154 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.common.env
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.should
+
+import java.util.EnumSet
+
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
+import org.eclipse.apoapsis.ortserver.workers.common.env.MockConfigFileBuilder.Companion.createInfrastructureService
+import org.eclipse.apoapsis.ortserver.workers.common.env.MockConfigFileBuilder.Companion.createSecret
+import org.eclipse.apoapsis.ortserver.workers.common.env.MockConfigFileBuilder.Companion.testSecretRef
+import org.eclipse.apoapsis.ortserver.workers.common.env.definition.EnvironmentServiceDefinition
+
+class GitCredentialsGeneratorTest : StringSpec({
+    "Files with correct names should be generated" {
+        val mockBuilder = MockConfigFileBuilder()
+        val definition = EnvironmentServiceDefinition(
+            createInfrastructureService(
+                "https://repo.example.org",
+                createSecret("s1"),
+                createSecret("s2"),
+                EnumSet.of(CredentialsType.GIT_CREDENTIALS_FILE)
+            )
+        )
+
+        GitCredentialsGenerator().generate(mockBuilder.builder, listOf(definition))
+
+        mockBuilder.homeFileNames shouldContainExactlyInAnyOrder listOf(".git-credentials", ".gitconfig")
+    }
+
+    "Files should only be generated if services with Git credentials exist" {
+        val mockBuilder = MockConfigFileBuilder()
+        val definition = EnvironmentServiceDefinition(
+            createInfrastructureService(
+                "https://repo.example.org",
+                createSecret("s1"),
+                createSecret("s2")
+            )
+        )
+
+        GitCredentialsGenerator().generate(mockBuilder.builder, listOf(definition))
+
+        mockBuilder.homeFileNames should beEmpty()
+    }
+
+    "A correct .git-credentials file should be generated" {
+        val mockBuilder = MockConfigFileBuilder()
+        val secUser1 = createSecret("user1Secret")
+        val secPass1 = createSecret("pass1Secret")
+        val secUser2 = createSecret("user2Secret")
+        val secPass2 = createSecret("pass2Secret")
+
+        val definitions = listOf(
+            EnvironmentServiceDefinition(
+                createInfrastructureService(
+                    "https://repo1.example.org",
+                    secUser1,
+                    secPass1
+                ),
+                credentialsTypes = EnumSet.of(CredentialsType.GIT_CREDENTIALS_FILE)
+            ),
+            EnvironmentServiceDefinition(
+                createInfrastructureService(
+                    "http://repo2.example.org:444/orga/repo.git",
+                    secUser2,
+                    secPass2,
+                    credentialsTypes = EnumSet.allOf(CredentialsType::class.java)
+                )
+            )
+        )
+
+        GitCredentialsGenerator().generate(mockBuilder.builder, definitions)
+        val lines = mockBuilder.generatedLinesFor(homeFileName = ".git-credentials")
+
+        lines shouldContainExactlyInAnyOrder listOf(
+            "https://${testSecretRef(secUser1)}:${testSecretRef(secPass1)}@repo1.example.org",
+            "http://${testSecretRef(secUser2)}:${testSecretRef(secPass2)}@repo2.example.org:444/orga/repo.git"
+        )
+    }
+
+    "A correct .gitconfig file should be generated" {
+        val mockBuilder = MockConfigFileBuilder()
+        val definition = EnvironmentServiceDefinition(
+            createInfrastructureService(
+                "https://repo.example.org",
+                createSecret("s1"),
+                createSecret("s2"),
+                EnumSet.of(CredentialsType.GIT_CREDENTIALS_FILE)
+            )
+        )
+
+        GitCredentialsGenerator().generate(mockBuilder.builder, listOf(definition))
+        val lines = mockBuilder.generatedLinesFor(homeFileName = ".gitconfig")
+
+        lines shouldContainExactly listOf(
+            "[credential]",
+            "\thelper = store"
+        )
+    }
+
+    "Infrastructure service with invalid URLs should be ignored" {
+        val mockBuilder = MockConfigFileBuilder()
+        val secUser = createSecret("user1Secret")
+        val secPass = createSecret("pass1Secret")
+
+        val definitions = listOf(
+            EnvironmentServiceDefinition(
+                createInfrastructureService(
+                    "?An invalid URL?!",
+                    secUser,
+                    secPass
+                ),
+                credentialsTypes = EnumSet.of(CredentialsType.GIT_CREDENTIALS_FILE)
+            ),
+            EnvironmentServiceDefinition(
+                createInfrastructureService(
+                    "https://repo.example.org/orga/repo.git",
+                    secUser,
+                    secPass,
+                    credentialsTypes = EnumSet.allOf(CredentialsType::class.java)
+                )
+            )
+        )
+
+        GitCredentialsGenerator().generate(mockBuilder.builder, definitions)
+        val lines = mockBuilder.generatedLinesFor(homeFileName = ".git-credentials")
+
+        lines shouldContainExactly listOf(
+            "https://${testSecretRef(secUser)}:${testSecretRef(secPass)}@repo.example.org/orga/repo.git",
+        )
+    }
+})

--- a/workers/common/src/test/kotlin/common/env/MavenSettingsGeneratorTest.kt
+++ b/workers/common/src/test/kotlin/common/env/MavenSettingsGeneratorTest.kt
@@ -43,7 +43,7 @@ class MavenSettingsGeneratorTest : WordSpec({
                     MockConfigFileBuilder.createSecret("sec1"),
                     MockConfigFileBuilder.createSecret("sec2")
                 ),
-                false,
+                emptySet(),
                 "repo"
             )
 
@@ -62,17 +62,17 @@ class MavenSettingsGeneratorTest : WordSpec({
 
             val definition1 = MavenDefinition(
                 MockConfigFileBuilder.createInfrastructureService("https://repo1.example.org", secUser1, secPass1),
-                false,
+                emptySet(),
                 "repo1"
             )
             val definition2 = MavenDefinition(
                 MockConfigFileBuilder.createInfrastructureService("https://repo2.example.org", secUser2, secPass2),
-                false,
+                emptySet(),
                 "repo2"
             )
             val definition3 = MavenDefinition(
                 MockConfigFileBuilder.createInfrastructureService("https://repo3.example.org", secUser2, secPass2),
-                false,
+                emptySet(),
                 "repo3"
             )
 
@@ -93,7 +93,7 @@ class MavenSettingsGeneratorTest : WordSpec({
                     MockConfigFileBuilder.createSecret("sec1"),
                     MockConfigFileBuilder.createSecret("sec2")
                 ),
-                false,
+                emptySet(),
                 "repo"
             )
 

--- a/workers/common/src/test/kotlin/common/env/MockConfigFileBuilder.kt
+++ b/workers/common/src/test/kotlin/common/env/MockConfigFileBuilder.kt
@@ -29,7 +29,9 @@ import io.mockk.mockk
 import java.io.File
 import java.io.PrintWriter
 import java.io.StringWriter
+import java.util.EnumSet
 
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 import org.eclipse.apoapsis.ortserver.model.Secret
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
@@ -60,7 +62,7 @@ class MockConfigFileBuilder {
             url: String = REPOSITORY_URL,
             userSecret: Secret = mockk(),
             passwordSecret: Secret = mockk(),
-            excludeFromNetrc: Boolean = false
+            credentialsTypes: Set<CredentialsType> = EnumSet.of(CredentialsType.NETRC_FILE)
         ): InfrastructureService =
             InfrastructureService(
                 name = url,
@@ -69,7 +71,7 @@ class MockConfigFileBuilder {
                 passwordSecret = passwordSecret,
                 organization = null,
                 product = null,
-                excludeFromNetrc = excludeFromNetrc
+                credentialsTypes = credentialsTypes
             )
 
         /**

--- a/workers/common/src/test/kotlin/common/env/NetRcGeneratorTest.kt
+++ b/workers/common/src/test/kotlin/common/env/NetRcGeneratorTest.kt
@@ -23,6 +23,9 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 
+import java.util.EnumSet
+
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 import org.eclipse.apoapsis.ortserver.workers.common.env.MockConfigFileBuilder.Companion.createInfrastructureService
 import org.eclipse.apoapsis.ortserver.workers.common.env.MockConfigFileBuilder.Companion.createSecret
@@ -55,7 +58,7 @@ class NetRcGeneratorTest : StringSpec({
             val service2 = createInfrastructureService("https://repo2.example.org", secUser2, secPass2)
             val service3 = createInfrastructureService("https://repo3.example.org", secUser2, secPass2)
             val serviceIgnored =
-                createInfrastructureService("https://repo1.example.org", secUser2, secPass2, excludeFromNetrc = true)
+                createInfrastructureService("https://repo1.example.org", secUser2, secPass2, emptySet())
 
             val mockBuilder = MockConfigFileBuilder()
 
@@ -116,17 +119,21 @@ class NetRcGeneratorTest : StringSpec({
             mockBuilder.generatedLines() shouldContainExactly expectedLines
         }
 
-        "The excludeFromNetrc flag should be overridden in the environment definition" {
+        "The credentials types set should be overridden in the environment definition" {
             val secUser = createSecret("user1Secret")
             val secPass = createSecret("pass1Secret")
 
-            val service1 =
-                createInfrastructureService("https://repo1.example.org", secUser, secPass, excludeFromNetrc = true)
+            val service1 = createInfrastructureService(
+                "https://repo1.example.org",
+                secUser,
+                secPass,
+                credentialsTypes = EnumSet.of(CredentialsType.GIT_CREDENTIALS_FILE)
+            )
             val service2 = createInfrastructureService("https://repo2.example.org", secUser, secPass)
 
             val definitions = listOf(
-                EnvironmentServiceDefinition(service1, excludeServiceFromNetrc = false),
-                EnvironmentServiceDefinition(service2, excludeServiceFromNetrc = true)
+                EnvironmentServiceDefinition(service1, credentialsTypes = EnumSet.of(CredentialsType.NETRC_FILE)),
+                EnvironmentServiceDefinition(service2, credentialsTypes = emptySet())
             )
 
             val mockBuilder = MockConfigFileBuilder()

--- a/workers/common/src/test/kotlin/common/env/NpmRcGeneratorTest.kt
+++ b/workers/common/src/test/kotlin/common/env/NpmRcGeneratorTest.kt
@@ -41,7 +41,7 @@ class NpmRcGeneratorTest : WordSpec({
 
     "generate" should {
         "generate the file at the correct location" {
-            val definition = NpmDefinition(MockConfigFileBuilder.createInfrastructureService(REGISTRY_URI), false)
+            val definition = NpmDefinition(MockConfigFileBuilder.createInfrastructureService(REGISTRY_URI), emptySet())
 
             val mockBuilder = MockConfigFileBuilder()
 
@@ -55,7 +55,7 @@ class NpmRcGeneratorTest : WordSpec({
             val passwordSecret = MockConfigFileBuilder.createSecret("registryPass")
             val definition = NpmDefinition(
                 MockConfigFileBuilder.createInfrastructureService(REGISTRY_URI, usernameSecret, passwordSecret),
-                false
+                emptySet()
             )
 
             val mockBuilder = MockConfigFileBuilder()
@@ -80,7 +80,7 @@ class NpmRcGeneratorTest : WordSpec({
             val definitions = listOf(
                 NpmDefinition(
                     MockConfigFileBuilder.createInfrastructureService(REGISTRY_URI, usernameSecret, passwordSecret1),
-                    false
+                    emptySet()
                 ),
                 NpmDefinition(
                     MockConfigFileBuilder.createInfrastructureService(
@@ -88,7 +88,7 @@ class NpmRcGeneratorTest : WordSpec({
                         usernameSecret,
                         passwordSecret2
                     ),
-                    false
+                    emptySet()
                 )
             )
 
@@ -114,7 +114,7 @@ class NpmRcGeneratorTest : WordSpec({
             val passwordSecret = MockConfigFileBuilder.createSecret("registryPass")
             val definition = NpmDefinition(
                 MockConfigFileBuilder.createInfrastructureService(REGISTRY_URI, usernameSecret, passwordSecret),
-                false,
+                emptySet(),
                 authMode = NpmAuthMode.PASSWORD_BASE64
             )
 
@@ -135,7 +135,7 @@ class NpmRcGeneratorTest : WordSpec({
             val passwordSecret = MockConfigFileBuilder.createSecret("registryPass")
             val definition = NpmDefinition(
                 MockConfigFileBuilder.createInfrastructureService(REGISTRY_URI, passwordSecret = passwordSecret),
-                false,
+                emptySet(),
                 authMode = NpmAuthMode.PASSWORD_AUTH
             )
 
@@ -155,7 +155,7 @@ class NpmRcGeneratorTest : WordSpec({
             val passwordSecret = MockConfigFileBuilder.createSecret("registryPass")
             val definition = NpmDefinition(
                 MockConfigFileBuilder.createInfrastructureService(REGISTRY_URI, passwordSecret = passwordSecret),
-                false,
+                emptySet(),
                 authMode = NpmAuthMode.PASSWORD_AUTH_TOKEN
             )
 
@@ -176,7 +176,7 @@ class NpmRcGeneratorTest : WordSpec({
             val passwordSecret = MockConfigFileBuilder.createSecret("registryPass")
             val definition = NpmDefinition(
                 MockConfigFileBuilder.createInfrastructureService(REGISTRY_URI, usernameSecret, passwordSecret),
-                false,
+                emptySet(),
                 authMode = NpmAuthMode.USERNAME_PASSWORD_AUTH
             )
 
@@ -202,7 +202,7 @@ class NpmRcGeneratorTest : WordSpec({
             val passwordSecret = MockConfigFileBuilder.createSecret("registryPass")
             val definition = NpmDefinition(
                 MockConfigFileBuilder.createInfrastructureService(REGISTRY_URI, passwordSecret = passwordSecret),
-                false,
+                emptySet(),
                 authMode = NpmAuthMode.PASSWORD_AUTH,
                 alwaysAuth = false
             )
@@ -221,7 +221,7 @@ class NpmRcGeneratorTest : WordSpec({
             val passwordSecret = MockConfigFileBuilder.createSecret("registryPass")
             val definition = NpmDefinition(
                 MockConfigFileBuilder.createInfrastructureService(REGISTRY_URI, passwordSecret = passwordSecret),
-                false,
+                emptySet(),
                 authMode = NpmAuthMode.PASSWORD_AUTH,
                 email = email
             )
@@ -244,7 +244,7 @@ class NpmRcGeneratorTest : WordSpec({
             val passwordSecret = MockConfigFileBuilder.createSecret("registryPass")
             val definition = NpmDefinition(
                 MockConfigFileBuilder.createInfrastructureService(REGISTRY_URI, passwordSecret = passwordSecret),
-                false,
+                emptySet(),
                 authMode = NpmAuthMode.PASSWORD_AUTH,
                 scope = scope
             )
@@ -270,7 +270,7 @@ class NpmRcGeneratorTest : WordSpec({
                     REGISTRY_URI.dropLast(1),
                     passwordSecret = passwordSecret
                 ),
-                false,
+                emptySet(),
                 authMode = NpmAuthMode.PASSWORD_AUTH,
                 scope = scope
             )
@@ -293,7 +293,7 @@ class NpmRcGeneratorTest : WordSpec({
             val passwordSecret = MockConfigFileBuilder.createSecret("registryPass")
             val definition = NpmDefinition(
                 MockConfigFileBuilder.createInfrastructureService(REGISTRY_URI, usernameSecret, passwordSecret),
-                false
+                emptySet()
             )
 
             val proxy = "http://proxy.example.org:8080"

--- a/workers/common/src/test/kotlin/common/env/NuGetGeneratorTest.kt
+++ b/workers/common/src/test/kotlin/common/env/NuGetGeneratorTest.kt
@@ -41,7 +41,7 @@ class NuGetGeneratorTest : WordSpec({
         "generate the file at the correct location" {
             val definition = NuGetDefinition(
                 MockConfigFileBuilder.createInfrastructureService(REPOSITORY_URI),
-                false,
+                emptySet(),
                 REPOSITORY_NAME,
                 REPOSITORY_URI,
                 REPOSITORY_PROTOCOL_VERSION
@@ -59,7 +59,7 @@ class NuGetGeneratorTest : WordSpec({
             val passwordSecret = MockConfigFileBuilder.createSecret("repositoryApiKey")
             val definition = NuGetDefinition(
                 MockConfigFileBuilder.createInfrastructureService(REPOSITORY_URI, usernameSecret, passwordSecret),
-                false,
+                emptySet(),
                 REPOSITORY_NAME,
                 REPOSITORY_URI,
                 REPOSITORY_PROTOCOL_VERSION
@@ -98,14 +98,14 @@ class NuGetGeneratorTest : WordSpec({
             val definitions = listOf(
                 NuGetDefinition(
                     MockConfigFileBuilder.createInfrastructureService(REPOSITORY_URI, usernameSecret, passwordSecret1),
-                    false,
+                    emptySet(),
                     REPOSITORY_NAME,
                     REPOSITORY_URI,
                     REPOSITORY_PROTOCOL_VERSION
                 ),
                 NuGetDefinition(
                     MockConfigFileBuilder.createInfrastructureService(REPOSITORY_URI, usernameSecret, passwordSecret2),
-                    false,
+                    emptySet(),
                     REPOSITORY_NAME + "1",
                     REPOSITORY_URI + "1",
                     REPOSITORY_PROTOCOL_VERSION,
@@ -113,7 +113,7 @@ class NuGetGeneratorTest : WordSpec({
                 ),
                 NuGetDefinition(
                     MockConfigFileBuilder.createInfrastructureService(REPOSITORY_URI, usernameSecret, passwordSecret3),
-                    false,
+                    emptySet(),
                     REPOSITORY_NAME + "2",
                     REPOSITORY_URI + "2",
                     REPOSITORY_PROTOCOL_VERSION,
@@ -121,7 +121,7 @@ class NuGetGeneratorTest : WordSpec({
                 ),
                 NuGetDefinition(
                     MockConfigFileBuilder.createInfrastructureService(REPOSITORY_URI, usernameSecret, passwordSecret4),
-                    false,
+                    emptySet(),
                     REPOSITORY_NAME + "3",
                     REPOSITORY_URI + "3",
                     REPOSITORY_PROTOCOL_VERSION,
@@ -176,7 +176,7 @@ class NuGetGeneratorTest : WordSpec({
             val passwordSecret = MockConfigFileBuilder.createSecret("repositoryPassword")
             val definition = NuGetDefinition(
                 MockConfigFileBuilder.createInfrastructureService(REPOSITORY_URI, usernameSecret, passwordSecret),
-                false,
+                emptySet(),
                 REPOSITORY_NAME,
                 REPOSITORY_URI,
                 REPOSITORY_PROTOCOL_VERSION,
@@ -220,7 +220,7 @@ class NuGetGeneratorTest : WordSpec({
                 sourceName = REPOSITORY_NAME,
                 sourcePath = REPOSITORY_URI,
                 authMode = NuGetAuthMode.PASSWORD,
-                excludeFromNetrc = null
+                credentialsTypes = null
             )
 
             val mockBuilder = MockConfigFileBuilder()

--- a/workers/common/src/test/kotlin/common/env/YarnRcGeneratorTest.kt
+++ b/workers/common/src/test/kotlin/common/env/YarnRcGeneratorTest.kt
@@ -56,7 +56,7 @@ class YarnRcGeneratorTest : WordSpec({
             val passwordSecret = MockConfigFileBuilder.createSecret("registryPass")
             val definition = YarnDefinition(
                 MockConfigFileBuilder.createInfrastructureService(REGISTRY_URI, usernameSecret, passwordSecret),
-                excludeFromNetrc = false,
+                credentialsTypes = null,
                 alwaysAuth = true,
                 authMode = YarnAuthMode.AUTH_IDENT
             )

--- a/workers/common/src/test/kotlin/common/env/config/EnvironmentDefinitionFactoryTest.kt
+++ b/workers/common/src/test/kotlin/common/env/config/EnvironmentDefinitionFactoryTest.kt
@@ -30,6 +30,9 @@ import io.kotest.matchers.types.shouldBeInstanceOf
 
 import io.mockk.mockk
 
+import java.util.EnumSet
+
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 import org.eclipse.apoapsis.ortserver.workers.common.common.env.REGISTRY_URI
 import org.eclipse.apoapsis.ortserver.workers.common.common.env.REMOTE_NAME
@@ -96,12 +99,18 @@ class EnvironmentDefinitionFactoryTest : WordSpec() {
                 createSuccessful(EnvironmentDefinitionFactory.MAVEN_TYPE, properties)
             }
 
-            "allow overriding the excludeFromNetrc flag" {
-                val properties = mapOf("id" to "someId", EnvironmentDefinitionFactory.EXCLUDE_NETRC_PROPERTY to "true")
+            "allow overriding the credentials types" {
+                val properties = mapOf(
+                    "id" to "someId",
+                    EnvironmentDefinitionFactory.CREDENTIALS_TYPE_PROPERTY to "GIT_CREDENTIALS_FILE, NETRC_FILE"
+                )
 
                 val definition = createSuccessful(EnvironmentDefinitionFactory.MAVEN_TYPE, properties)
 
-                definition.excludeServiceFromNetrc() shouldBe true
+                definition.credentialsTypes() shouldBe EnumSet.of(
+                    CredentialsType.GIT_CREDENTIALS_FILE,
+                    CredentialsType.NETRC_FILE
+                )
             }
         }
 
@@ -146,16 +155,19 @@ class EnvironmentDefinitionFactoryTest : WordSpec() {
                 exception.message shouldContain "'$unsupportedProperty2'"
             }
 
-            "allow overriding the excludeFromNetrc flag" {
+            "allow overriding the credentials types" {
                 val properties = mapOf(
                     "name" to REMOTE_NAME,
                     "url" to REMOTE_URL,
-                    EnvironmentDefinitionFactory.EXCLUDE_NETRC_PROPERTY to "true"
+                    EnvironmentDefinitionFactory.CREDENTIALS_TYPE_PROPERTY to "NETRC_FILE,GIT_CREDENTIALS_FILE"
                 )
 
                 val definition = createSuccessful(EnvironmentDefinitionFactory.CONAN_TYPE, properties)
 
-                definition.excludeServiceFromNetrc() shouldBe true
+                definition.credentialsTypes() shouldBe EnumSet.of(
+                    CredentialsType.GIT_CREDENTIALS_FILE,
+                    CredentialsType.NETRC_FILE
+                )
             }
         }
 
@@ -232,20 +244,26 @@ class EnvironmentDefinitionFactoryTest : WordSpec() {
                 exception.message shouldContain "FALSE"
             }
 
-            "allow overriding the excludeFromNetrc flag" {
-                val properties = mapOf(EnvironmentDefinitionFactory.EXCLUDE_NETRC_PROPERTY to "true")
+            "allow overriding the credentials types" {
+                val properties = mapOf(
+                    EnvironmentDefinitionFactory.CREDENTIALS_TYPE_PROPERTY to " NETRC_FILE  , GIT_CREDENTIALS_FILE  "
+                )
 
                 val definition = createSuccessful(EnvironmentDefinitionFactory.NPM_TYPE, properties)
 
-                definition.excludeServiceFromNetrc() shouldBe true
+                definition.credentialsTypes() shouldBe EnumSet.of(
+                    CredentialsType.GIT_CREDENTIALS_FILE,
+                    CredentialsType.NETRC_FILE
+                )
             }
 
-            "fail for an unsupported value of the excludeFromNetrc flag" {
-                val properties = mapOf(EnvironmentDefinitionFactory.EXCLUDE_NETRC_PROPERTY to "maybe")
+            "fail for an unsupported value of the credentials types property" {
+                val properties = mapOf(EnvironmentDefinitionFactory.CREDENTIALS_TYPE_PROPERTY to "maybe")
 
                 val exception = createFailed(EnvironmentDefinitionFactory.NPM_TYPE, properties)
 
-                exception.message shouldContain properties.getValue(EnvironmentDefinitionFactory.EXCLUDE_NETRC_PROPERTY)
+                exception.message shouldContain
+                        properties.getValue(EnvironmentDefinitionFactory.CREDENTIALS_TYPE_PROPERTY)
             }
         }
 
@@ -330,16 +348,16 @@ class EnvironmentDefinitionFactoryTest : WordSpec() {
                 exception.message shouldContain NuGetAuthMode.PASSWORD.name
             }
 
-            "allow overriding the excludeFromNetrc flag" {
+            "allow overriding the credentials types" {
                 val properties = mapOf(
                     "sourceName" to "someSource",
                     "sourcePath" to "somePath",
-                    EnvironmentDefinitionFactory.EXCLUDE_NETRC_PROPERTY to "true"
+                    EnvironmentDefinitionFactory.CREDENTIALS_TYPE_PROPERTY to ""
                 )
 
                 val definition = createSuccessful(EnvironmentDefinitionFactory.NUGET_TYPE, properties)
 
-                definition.excludeServiceFromNetrc() shouldBe true
+                definition.credentialsTypes() shouldBe EnumSet.noneOf(CredentialsType::class.java)
             }
         }
 
@@ -411,12 +429,14 @@ class EnvironmentDefinitionFactoryTest : WordSpec() {
                 exception.message shouldContain "FALSE"
             }
 
-            "allow overriding the excludeFromNetrc flag" {
-                val properties = mapOf(EnvironmentDefinitionFactory.EXCLUDE_NETRC_PROPERTY to "true")
+            "allow overriding the credentials types" {
+                val properties = mapOf(
+                    EnvironmentDefinitionFactory.CREDENTIALS_TYPE_PROPERTY to "GIT_CREDENTIALS_FILE"
+                )
 
                 val definition = createSuccessful(EnvironmentDefinitionFactory.YARN_TYPE, properties)
 
-                definition.excludeServiceFromNetrc() shouldBe true
+                definition.credentialsTypes() shouldBe EnumSet.of(CredentialsType.GIT_CREDENTIALS_FILE)
             }
         }
     }

--- a/workers/common/src/test/resources/.ort.env.definitions-errors-non-strict.yml
+++ b/workers/common/src/test/resources/.ort.env.definitions-errors-non-strict.yml
@@ -5,6 +5,8 @@ infrastructureServices:
   description: "Test service 1"
   usernameSecret: "testUser"
   passwordSecret: "testPassword1"
+  credentialsTypes:
+  - "GIT_CREDENTIALS_FILE"
 - name: "Test service2"
   url: "https://repo.example.org/test/service2"
   description: "Test service 2"

--- a/workers/common/src/test/resources/.ort.env.definitions.yml
+++ b/workers/common/src/test/resources/.ort.env.definitions.yml
@@ -4,6 +4,8 @@ infrastructureServices:
   description: "Test service 1"
   usernameSecret: "testUser"
   passwordSecret: "testPassword1"
+  credentialsTypes:
+  - "GIT_CREDENTIALS_FILE"
 - name: "Test service2"
   url: "https://repo.example.org/test/service2"
   description: "Test service 2"

--- a/workers/common/src/test/resources/.ort.env.no-credentials-types.yml
+++ b/workers/common/src/test/resources/.ort.env.no-credentials-types.yml
@@ -11,5 +11,4 @@ infrastructureServices:
   description: "Test service 2"
   usernameSecret: "testUser"
   passwordSecret: "testPassword2"
-  credentialsTypes:
-  - "NETRC_FILE"
+  credentialsTypes: []

--- a/workers/common/src/test/resources/.ort.env.non-strict.yml
+++ b/workers/common/src/test/resources/.ort.env.non-strict.yml
@@ -5,9 +5,12 @@ infrastructureServices:
   description: "Test service 1"
   usernameSecret: "testUser"
   passwordSecret: "testPassword1"
+  credentialsTypes:
+  - "GIT_CREDENTIALS_FILE"
 - name: "Test service2"
   url: "https://repo.example.org/test/service2"
   description: "Test service 2"
   usernameSecret: "testUser"
   passwordSecret: "testPassword2"
-  excludeFromNetrc: true
+  credentialsTypes:
+  - "NETRC_FILE"


### PR DESCRIPTION
This PR makes the handling of the credentials for infrastructure services more generic by introducing a new `credentialsTypes` property. The property controls, in which (dynamically generated) configuration files the credentials of services should be listed. While in the past only a `.netrc` file was supported, it is now also possible to have credentials added to a `.git-credentials` file.

This extension of the concept became necessary because we encountered some Git repositories that could not be cloned by the Git command line, even if correct credentials were present in the `.netrc` file. Only after the credentials were made available in a `.git-credentials` file, cloning was possible. This happened with repositories hosted on a Microsoft Teams Foundation Server.

Note that this PR changes the data model for infrastructure services and will therefore affect the UI.