### PR TITLE
chore: Prefer `URI.create()` over `URI()`

### DIFF
--- a/core/src/main/kotlin/plugins/Authentication.kt
+++ b/core/src/main/kotlin/plugins/Authentication.kt
@@ -51,7 +51,7 @@ fun Application.configureAuthentication() {
     val keycloakClient by inject<KeycloakClient>()
 
     val issuer = config.property("jwt.issuer").getString()
-    val jwksUri = URI(config.property("jwt.jwksUri").getString()).toURL()
+    val jwksUri = URI.create(config.property("jwt.jwksUri").getString()).toURL()
     val configuredRealm = config.property("jwt.realm").getString()
     val jwkProvider = JwkProviderBuilder(jwksUri)
         .cached(10, 24, TimeUnit.HOURS)

--- a/dao/src/main/kotlin/repositories/DaoInfrastructureServiceRepository.kt
+++ b/dao/src/main/kotlin/repositories/DaoInfrastructureServiceRepository.kt
@@ -177,7 +177,7 @@ class DaoInfrastructureServiceRepository(private val db: Database) : Infrastruct
         organizationId: Long,
         productId: Long
     ): List<InfrastructureService> = db.blockingQuery {
-        val repositoryHost = URI(repositoryUrl).host
+        val repositoryHost = URI.create(repositoryUrl).host
         val hostPattern = "%$repositoryHost%"
         list(ListQueryParameters.DEFAULT) {
             InfrastructureServicesTable.url like hostPattern and (

--- a/dao/src/test/kotlin/repositories/DaoInfrastructureServiceRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/DaoInfrastructureServiceRepositoryTest.kt
@@ -33,8 +33,6 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldInclude
 
-import java.net.URISyntaxException
-
 import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
 import org.eclipse.apoapsis.ortserver.dao.test.Fixtures
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
@@ -526,7 +524,7 @@ class DaoInfrastructureServiceRepositoryTest : WordSpec() {
             }
 
             "throw when passed an invalid repository URL" {
-                shouldThrow<URISyntaxException> {
+                shouldThrow<IllegalArgumentException> {
                     infrastructureServicesRepository.listForRepositoryUrl(
                         "?!invalid URL!?",
                         fixtures.organization.id,

--- a/workers/common/src/main/kotlin/common/OrtServerMappings.kt
+++ b/workers/common/src/main/kotlin/common/OrtServerMappings.kt
@@ -377,7 +377,7 @@ fun AdvisorResult.mapToOrt() =
 fun Defect.mapToOrt() =
     OrtDefect(
         id = externalId,
-        url = URI(url),
+        url = URI.create(url),
         title = title,
         state = state,
         severity = severity,
@@ -398,7 +398,7 @@ fun Vulnerability.mapToOrt() =
         references = references.map(VulnerabilityReference::mapToOrt)
     )
 
-fun VulnerabilityReference.mapToOrt() = OrtVulnerabilityReference(URI(url), scoringSystem, severity)
+fun VulnerabilityReference.mapToOrt() = OrtVulnerabilityReference(URI.create(url), scoringSystem, severity)
 
 fun AnalyzerRun.mapToOrt() =
     OrtAnalyzerRun(

--- a/workers/common/src/main/kotlin/common/env/NetRcGenerator.kt
+++ b/workers/common/src/main/kotlin/common/env/NetRcGenerator.kt
@@ -53,7 +53,7 @@ class NetRcGenerator : EnvironmentConfigGenerator<EnvironmentServiceDefinition> 
          */
         private fun InfrastructureService.host(): String? =
             runCatching {
-                URI(url).host
+                URI.create(url).host
             }.onFailure {
                 logger.error("Could not extract host for service '{}'. Ignoring it.", this, it)
             }.getOrNull()
@@ -73,7 +73,7 @@ class NetRcGenerator : EnvironmentConfigGenerator<EnvironmentServiceDefinition> 
 
         builder.buildInUserHome(TARGET_NAME) {
             deDuplicatedServices.forEach { service ->
-                val host = URI(service.url).host
+                val host = URI.create(service.url).host
                 val username = builder.secretRef(service.usernameSecret)
                 val password = builder.secretRef(service.passwordSecret)
 

--- a/workers/common/src/testFixtures/kotlin/OrtTestData.kt
+++ b/workers/common/src/testFixtures/kotlin/OrtTestData.kt
@@ -202,7 +202,7 @@ object OrtTestData {
         description = "Example description.",
         references = listOf(
             VulnerabilityReference(
-                url = URI("http://cve.example.org"),
+                url = URI.create("http://cve.example.org"),
                 scoringSystem = "CVSS3",
                 severity = "5.5"
             )


### PR DESCRIPTION
The `URI()` constructor has been deprecated in Java 20 [1], so use `URI.create()` instead to be prepared for that.

[1]: https://inside.java/2023/02/15/quality-heads-up/