### PR TITLE
ui: Show ORT run and job statuses more clearly in the UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ http-client.private.env.json
 
 # Private HTTP requests
 *.private.http
+
+# VS Code
+.vscode/

--- a/ui/src/components/ort-run-job-status.tsx
+++ b/ui/src/components/ort-run-job-status.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { getStatusBackgroundColor } from '@/helpers/get-status-colors';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { org_eclipse_apoapsis_ortserver_api_v1_model_PagedResponse_org_eclipse_apoapsis_ortserver_api_v1_model_OrtRunSummary_ } from '@/api/requests';
+
+type OrtRunJobStatusProps = {
+  jobs: org_eclipse_apoapsis_ortserver_api_v1_model_PagedResponse_org_eclipse_apoapsis_ortserver_api_v1_model_OrtRunSummary_['data'][0]['jobs'];
+};
+
+export const OrtRunJobStatus = ({ jobs }: OrtRunJobStatusProps) => {
+  return (
+    <TooltipProvider>
+      <div className="flex space-x-1">
+        <Tooltip>
+          <TooltipTrigger>
+            <div
+              className={`w-3 h-3 rounded-full ${getStatusBackgroundColor(jobs.analyzer?.status)}`}
+            ></div>
+          </TooltipTrigger>
+          <TooltipContent>
+            <span>
+              Analyzer: {jobs.analyzer?.status || 'Not included in ORT Run'}
+            </span>
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger>
+            <div
+              className={`w-3 h-3 rounded-full ${getStatusBackgroundColor(jobs.advisor?.status)}`}
+            ></div>
+          </TooltipTrigger>
+          <TooltipContent>
+            <span>
+              Advisor: {jobs.advisor?.status || 'Not included in ORT Run'}
+            </span>
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger>
+            <div
+              className={`w-3 h-3 rounded-full ${getStatusBackgroundColor(jobs.scanner?.status)}`}
+            ></div>
+          </TooltipTrigger>
+          <TooltipContent>
+            <span>
+              Scanner: {jobs.scanner?.status || 'Not included in ORT Run'}
+            </span>
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger>
+            <div
+              className={`w-3 h-3 rounded-full ${getStatusBackgroundColor(jobs.evaluator?.status)}`}
+            ></div>
+          </TooltipTrigger>
+          <TooltipContent>
+            <span>
+              Evaluator: {jobs.evaluator?.status || 'Not included in ORT Run'}
+            </span>
+          </TooltipContent>
+        </Tooltip>
+        <Tooltip>
+          <TooltipTrigger>
+            <div
+              className={`w-3 h-3 rounded-full ${getStatusBackgroundColor(jobs.reporter?.status)}`}
+            ></div>
+          </TooltipTrigger>
+          <TooltipContent>
+            <span>
+              Reporter: {jobs.reporter?.status || 'Not included in ORT Run'}
+            </span>
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    </TooltipProvider>
+  );
+};

--- a/ui/src/components/ui/badge-variants.ts
+++ b/ui/src/components/ui/badge-variants.ts
@@ -1,0 +1,30 @@
+/*
+ * The component is originally a part of the shadcn/ui library at https://github.com/shadcn-ui/ui.
+ * The library is licensed as set out below:
+ *
+ * Copyright (c) 2023 shadcn
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import { cva } from 'class-variance-authority';
+
+export const badgeVariants = cva(
+  'inline-flex items-center rounded-md border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+  {
+    variants: {
+      variant: {
+        default:
+          'border-transparent bg-primary text-primary-foreground shadow hover:bg-primary/80',
+        secondary:
+          'border-transparent bg-secondary text-secondary-foreground hover:bg-secondary/80',
+        destructive:
+          'border-transparent bg-destructive text-destructive-foreground shadow hover:bg-destructive/80',
+        outline: 'text-foreground',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+);

--- a/ui/src/components/ui/badge.tsx
+++ b/ui/src/components/ui/badge.tsx
@@ -1,0 +1,26 @@
+/*
+ * The component is originally a part of the shadcn/ui library at https://github.com/shadcn-ui/ui.
+ * The library is licensed as set out below:
+ *
+ * Copyright (c) 2023 shadcn
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import * as React from 'react';
+import { type VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/lib/utils';
+import { badgeVariants } from './badge-variants';
+
+export interface BadgeProps
+  extends React.HTMLAttributes<HTMLDivElement>,
+    VariantProps<typeof badgeVariants> {}
+
+function Badge({ className, variant, ...props }: BadgeProps) {
+  return (
+    <div className={cn(badgeVariants({ variant }), className)} {...props} />
+  );
+}
+
+export { Badge };

--- a/ui/src/helpers/get-status-colors.ts
+++ b/ui/src/helpers/get-status-colors.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import {
+  Status,
+  STATUS_FONT_COLOR,
+  STATUS_BACKGROUND_COLOR,
+} from '@/types/status-types-and-constants';
+
+// Get the color class for font coloring
+export function getStatusFontColor(status: Status): string {
+  if (status === undefined) {
+    return 'text-gray-300'; // Define the color for undefined status here
+  }
+  return STATUS_FONT_COLOR[status]; // This will now only be called for defined statuses
+}
+
+// Get the color class for coloring the background of elements
+export function getStatusBackgroundColor(status: Status): string {
+  if (status === undefined) {
+    return 'bg-gray-300'; // Define the color for undefined status here
+  }
+  return STATUS_BACKGROUND_COLOR[status]; // This will now only be called for defined statuses
+}

--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.index.tsx
@@ -64,6 +64,7 @@ import {
 import { useToast } from '@/components/ui/use-toast';
 import { ToastError } from '@/components/toast-error';
 import { getStatusBackgroundColor } from '@/helpers/get-status-colors';
+import { OrtRunJobStatus } from '@/components/ort-run-job-status';
 
 const RepoComponent = () => {
   const params = Route.useParams();
@@ -179,7 +180,8 @@ const RepoComponent = () => {
             <TableHeader>
               <TableRow>
                 <TableHead>Run</TableHead>
-                <TableHead>Status</TableHead>
+                <TableHead>Run Status</TableHead>
+                <TableHead>Job Statuses</TableHead>
                 <TableHead className="pb-1.5 pr-0 text-right">
                   <Tooltip>
                     <TooltipTrigger asChild>
@@ -232,6 +234,9 @@ const RepoComponent = () => {
                       >
                         {run.status}
                       </Badge>
+                    </TableCell>
+                    <TableCell>
+                      <OrtRunJobStatus jobs={run.jobs} />
                     </TableCell>
                   </TableRow>
                 );

--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.index.tsx
@@ -19,7 +19,6 @@
 
 import {
   useRepositoriesServiceGetOrtRunsKey,
-  useRepositoriesServiceGetRepositoryById,
   useRepositoriesServiceGetRepositoryByIdKey,
   useRepositoriesServiceDeleteRepositoryById,
 } from '@/api/queries';
@@ -77,7 +76,7 @@ const RepoComponent = () => {
   const [{ data: repo }, { data: runs }] = useSuspenseQueries({
     queries: [
       {
-        queryKey: [useRepositoriesServiceGetRepositoryById, params.repoId],
+        queryKey: [useRepositoriesServiceGetRepositoryByIdKey, params.repoId],
         queryFn: async () =>
           await RepositoriesService.getRepositoryById({
             repositoryId: Number.parseInt(params.repoId),
@@ -88,6 +87,7 @@ const RepoComponent = () => {
         queryFn: async () =>
           await RepositoriesService.getOrtRuns({
             repositoryId: Number.parseInt(params.repoId),
+            sort: '-index',
           }),
         refetchInterval: pollInterval,
       },
@@ -270,6 +270,7 @@ export const Route = createFileRoute(
         queryFn: () =>
           RepositoriesService.getOrtRuns({
             repositoryId: Number.parseInt(params.repoId),
+            sort: '-index',
           }),
       }),
     ]);

--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.index.tsx
@@ -66,6 +66,9 @@ import { ToastError } from '@/components/toast-error';
 import { getStatusBackgroundColor } from '@/helpers/get-status-colors';
 import { OrtRunJobStatus } from '@/components/ort-run-job-status';
 
+const pollInterval =
+  Number.parseInt(import.meta.env.VITE_RUN_POLL_INTERVAL) || 10000;
+
 const RepoComponent = () => {
   const params = Route.useParams();
   const navigate = useNavigate();
@@ -86,6 +89,7 @@ const RepoComponent = () => {
           await RepositoriesService.getOrtRuns({
             repositoryId: Number.parseInt(params.repoId),
           }),
+        refetchInterval: pollInterval,
       },
     ],
   });

--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.index.tsx
@@ -35,6 +35,7 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -62,6 +63,7 @@ import {
 } from '@/components/ui/tooltip';
 import { useToast } from '@/components/ui/use-toast';
 import { ToastError } from '@/components/toast-error';
+import { getStatusBackgroundColor } from '@/helpers/get-status-colors';
 
 const RepoComponent = () => {
   const params = Route.useParams();
@@ -225,7 +227,11 @@ const RepoComponent = () => {
                       </div>
                     </TableCell>
                     <TableCell>
-                      <div className="font-medium">{run.status}</div>
+                      <Badge
+                        className={`border ${getStatusBackgroundColor(run.status)}`}
+                      >
+                        {run.status}
+                      </Badge>
                     </TableCell>
                   </TableRow>
                 );

--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.runs.$runId.index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.runs.$runId.index.tsx
@@ -18,13 +18,7 @@
  */
 
 import { useRepositoriesServiceGetOrtRunByIndexKey } from '@/api/queries';
-import {
-  Card,
-  CardHeader,
-  CardTitle,
-  CardDescription,
-  CardContent,
-} from '@/components/ui/card';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import {
   TableHeader,
   TableRow,
@@ -37,6 +31,8 @@ import { RepositoriesService, OpenAPI } from '@/api/requests';
 import { Link, createFileRoute } from '@tanstack/react-router';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
+import { getStatusBackgroundColor } from '@/helpers/get-status-colors';
+import { Badge } from '@/components/ui/badge';
 
 const RunComponent = () => {
   const params = Route.useParams();
@@ -101,10 +97,12 @@ const RunComponent = () => {
       <CardHeader className="flex flex-row items-start">
         <div className="grid gap-2">
           <CardTitle>{ortRun.id}</CardTitle>
-          <CardDescription>{ortRun.status}</CardDescription>
         </div>
       </CardHeader>
       <CardContent>
+        <Badge className={`border ${getStatusBackgroundColor(ortRun.status)}`}>
+          {ortRun.status}
+        </Badge>
         <Table>
           <TableHeader>
             <TableRow>

--- a/ui/src/types/status-types-and-constants.ts
+++ b/ui/src/types/status-types-and-constants.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+// All statuses reported either by ORT Runs or the individual jobs within them
+export type Status =
+  | 'CREATED'
+  | 'SCHEDULED'
+  | 'RUNNING'
+  | 'ACTIVE'
+  | 'FAILED'
+  | 'FINISHED'
+  | undefined;
+
+// Note: all color classes need to be defined as they are here, as they are formed
+// in compilation time and cannot be interpolated in runtime
+
+// Map statuses to TailwindCSS font colors
+export const STATUS_FONT_COLOR: { [K in Exclude<Status, undefined>]: string } =
+  {
+    CREATED: 'text-gray-500',
+    SCHEDULED: 'text-yellow-500',
+    RUNNING: 'text-blue-500',
+    ACTIVE: 'text-blue-500',
+    FAILED: 'text-red-500',
+    FINISHED: 'text-green-500',
+  } as const;
+
+// Map statuses to TailwindCSS background colors
+export const STATUS_BACKGROUND_COLOR: {
+  [K in Exclude<Status, undefined>]: string;
+} = {
+  CREATED: 'bg-gray-500',
+  SCHEDULED: 'bg-yellow-500',
+  RUNNING: 'bg-blue-500',
+  ACTIVE: 'bg-blue-500',
+  FAILED: 'bg-red-500',
+  FINISHED: 'bg-green-500',
+} as const;


### PR DESCRIPTION
This PR brings in some UI improvements for logging the statuses of ORT runs and their respective job statuses, concentrating mainly on the repository index page:
- all statuses are now polled periodically and the UI is updated accordingly
- runs are shown in reversed order of creation ie. newest runs are shown on top of the list/page
- run statuses are shown with coloured badges to more clearly indicate the general status of a run
- job statuses of a run are shown in the page with a "traffic lights" type of component

Please see the individual commits for details.