### PR TITLE
fix(reporter): Add Git to the Reporter base image

### DIFF
--- a/workers/reporter/docker/Reporter.Dockerfile
+++ b/workers/reporter/docker/Reporter.Dockerfile
@@ -22,6 +22,13 @@
 # When updating this version make sure to keep it in sync with the other worker Dockerfiles and libs.version.toml.
 FROM eclipse-temurin:17.0.11_9-jdk-jammy@sha256:d81254b2550895a5d978d43f22baa606fc6699ee5475292378263a5b33241b87
 
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,target=/var/lib/apt,sharing=locked \
+    apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    git \
+    && rm -rf /var/lib/apt/lists/*
+
 ARG USERNAME=ort
 ARG USER_ID=1000
 ARG USER_GID=$USER_ID


### PR DESCRIPTION
This is required for the special source code bundle reporter which may download artifacts to be included into the bundle from their VCS location.

Note that this is a quick fix. It is also not complete, since not all version control systems supported by ORT are added. For the long run, a more generic solution needs to be found.