### PR TITLE
ci(renovate): Renovate eslint in-range-only

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,6 +23,10 @@
     {
       "matchPackageNames": ["eclipse-temurin"],
       "allowedVersions": "< 18"
+    },
+    {
+      "matchPackageNames": ["eslint"],
+      "rangeStrategy": "in-range-only"
     }
   ],
   "prHourlyLimit": 5


### PR DESCRIPTION
Stick to major version 8 for now, see [1].

[1]: https://github.com/eclipse-apoapsis/ort-server/pull/195#pullrequestreview-2062428978