### PR TITLE
build(test-utils): Enable logging when running tests

### DIFF
--- a/utils/test/build.gradle.kts
+++ b/utils/test/build.gradle.kts
@@ -33,5 +33,12 @@ kotlin {
                 api(libs.kotestFrameworkApi)
             }
         }
+
+        val jvmMain by getting {
+            dependencies {
+                // Transitively export this to consumers so they do not have to declare a logger implementation.
+                api(libs.logback)
+            }
+        }
     }
 }

--- a/utils/test/src/commonMain/resources/logback.xml
+++ b/utils/test/src/commonMain/resources/logback.xml
@@ -1,0 +1,34 @@
+<!--
+  ~ Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ License-Filename: LICENSE
+  -->
+
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="DEBUG">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.apache.http.headers" level="ERROR"/>
+    <logger name="org.apache.http.wire" level="ERROR"/>
+    <logger name="org.eclipse.jgit.internal.storage.file.FileSnapshot" level="ERROR"/>
+</configuration>


### PR DESCRIPTION
Set a logger and the default log level to "debug" when running tests.