### PR TITLE
docs: Correctly link external docs

### DIFF
--- a/logaccess/loki/src/main/kotlin/LokiConfig.kt
+++ b/logaccess/loki/src/main/kotlin/LokiConfig.kt
@@ -27,12 +27,11 @@ import org.eclipse.apoapsis.ortserver.utils.config.getStringOrNull
 /**
  * A data class storing configuration options for accessing a Grafana Loki instance.
  *
- * Note that according to [1] Loki does not support an authentication by itself, but requires a reverse proxy for this
- * purpose. This means that in theory multiple different options for authentication could be supported. This
- * implementation is currently limited to an optional basic authentication: If both a username and password are
- * configured, the corresponding authorization header is set; otherwise, it is skipped.
- *
- * [1] https://grafana.com/docs/loki/latest/operations/authentication/
+ * Note that according to [Grafana docs](https://grafana.com/docs/loki/latest/operations/authentication/), Loki does not
+ * support an authentication by itself, but requires a reverse proxy for this purpose. This means that in theory
+ * multiple different options for authentication could be supported. This implementation is currently limited to an
+ * optional basic authentication: If both a username and password are configured, the corresponding authorization header
+ * is set; otherwise, it is skipped.
  */
 data class LokiConfig(
     /**

--- a/secrets/spi/src/main/kotlin/SecretsProvider.kt
+++ b/secrets/spi/src/main/kotlin/SecretsProvider.kt
@@ -50,8 +50,8 @@ interface SecretsProvider {
     fun removeSecret(path: Path)
 
     /**
-     * Generate a [Path] for the secret basing on [organizationId], [productId] or [repositoryId] they belong to
-     * and [secretName]
+     * Generate a [Path] for the secret belonging to the given [organizationId], [productId] and [repositoryId], as well
+     * as the [secretName].
      */
     fun createPath(organizationId: Long?, productId: Long?, repositoryId: Long?, secretName: String): Path
 }

--- a/secrets/vault/src/main/kotlin/VaultSecretsProvider.kt
+++ b/secrets/vault/src/main/kotlin/VaultSecretsProvider.kt
@@ -68,14 +68,11 @@ private const val SECRET_ACCESS_PREFIX = "data"
 private const val SECRET_DELETE_PREFIX = "metadata"
 
 /**
- * An implementation of the [SecretsProvider] interface based on HashiCorp Vault [1].
+ * An implementation of the [SecretsProvider] interface for [HashiCorp Vault](https://developer.hashicorp.com/vault).
  *
- * This implementation allows accessing secrets managed via the KV Secrets Engine Version 2 [2]. Authentication is
- * done via the AppRole method [3].
- *
- * [1] https://developer.hashicorp.com/vault.
- * [2] https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2
- * [3] https://developer.hashicorp.com/vault/api-docs/auth/approle
+ * This implementation allows accessing secrets managed via the
+ * [KV Secrets Engine Version 2](https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2). Authentication is done
+ * via the [AppRole method](https://developer.hashicorp.com/vault/api-docs/auth/approle).
  */
 class VaultSecretsProvider(
     private val config: VaultConfiguration


### PR DESCRIPTION
KDoc uses Markdown syntax for that purpose [1]. Note that reference-style links are not supported, though [2]. Apply some slight rewording along the way to make text fit better.

[1]: https://kotlinlang.org/docs/kotlin-doc.html#external-links
[2]: https://youtrack.jetbrains.com/issue/KTIJ-21386