### PR TITLE
refactor(config): Migrate from `constructorArgs` to `providedProperties`

### DIFF
--- a/workers/config/src/main/kotlin/ConfigValidator.kt
+++ b/workers/config/src/main/kotlin/ConfigValidator.kt
@@ -20,11 +20,12 @@
 package org.eclipse.apoapsis.ortserver.workers.config
 
 import kotlin.script.experimental.api.ScriptEvaluationConfiguration
-import kotlin.script.experimental.api.constructorArgs
+import kotlin.script.experimental.api.providedProperties
 import kotlin.script.experimental.api.scriptsInstancesSharing
 import kotlin.script.experimental.jvmhost.createJvmCompilationConfigurationFromTemplate
 
 import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
 
 import org.eclipse.apoapsis.ortserver.model.runs.OrtIssue
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
@@ -75,10 +76,12 @@ class ConfigValidator private constructor(private val context: WorkerContext) : 
             }
     }
 
-    override val compConfig = createJvmCompilationConfigurationFromTemplate<ValidationScriptTemplate>()
+    override val compConfig = createJvmCompilationConfigurationFromTemplate<ValidationScriptTemplate> {
+        providedProperties("context" to WorkerContext::class, "time" to Instant::class)
+    }
 
     override val evalConfig = ScriptEvaluationConfiguration {
-        constructorArgs(context, Clock.System.now())
+        providedProperties("context" to context, "time" to Clock.System.now())
         scriptsInstancesSharing(true)
     }
 

--- a/workers/config/src/main/kotlin/ValidationScriptTemplate.kt
+++ b/workers/config/src/main/kotlin/ValidationScriptTemplate.kt
@@ -23,8 +23,6 @@ import kotlin.script.experimental.annotations.KotlinScript
 import kotlin.script.experimental.api.ScriptCompilationConfiguration
 import kotlin.script.experimental.api.defaultImports
 
-import kotlinx.datetime.Instant
-
 import org.eclipse.apoapsis.ortserver.model.JobConfigurations
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
 
@@ -40,13 +38,7 @@ import org.ossreviewtoolkit.utils.scripting.OrtScriptCompilationConfiguration
     fileExtension = "params.kts",
     compilationConfiguration = ValidationScriptCompilationConfiguration::class
 )
-open class ValidationScriptTemplate(
-    /** The context containing the run and the parameters to be validated. */
-    val context: WorkerContext,
-
-    /** The current time. */
-    val time: Instant
-) {
+open class ValidationScriptTemplate {
     var validationResult: ConfigValidationResult = ConfigValidationResultSuccess(JobConfigurations())
 }
 


### PR DESCRIPTION
The `constructorArgs` are deprecated to pass values to scripts. Use the generic `providedProperties` mechanism instead.