### PR TITLE
fix(core): Use the correct product id in tests

### DIFF
--- a/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
@@ -554,7 +554,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 response shouldHaveStatus HttpStatusCode.OK
                 response shouldHaveBody Secret(secret.name, updatedDescription)
 
-                secretRepository.getByProductIdAndName(orgId, updateSecret.name.valueOrThrow)?.mapToApi() shouldBe
+                secretRepository.getByProductIdAndName(productId, updateSecret.name.valueOrThrow)?.mapToApi() shouldBe
                         Secret(secret.name, updatedDescription)
             }
         }
@@ -587,7 +587,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                     setBody(updateSecret)
                 } shouldHaveStatus HttpStatusCode.InternalServerError
 
-                secretRepository.getByProductIdAndName(orgId, secret.name) shouldBe secret
+                secretRepository.getByProductIdAndName(productId, secret.name) shouldBe secret
             }
         }
 


### PR DESCRIPTION
While it did not seem to make a difference regarding the success of the test, semantically the product id is the correct one to use.