### PR TITLE
build(Gradle): Ignore K2's `.kotlin` directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .gradle/
 .idea/
+.kotlin/
 build/
 out/
 /*.iml


### PR DESCRIPTION
See [1]. This is a fixup for 4f98209.

[1]: https://kotlinlang.org/docs/whatsnew20.html#new-directory-for-kotlin-data-in-gradle-projects