### PR TITLE
style(detekt): Align with ORT core about annotation formatting

### DIFF
--- a/.detekt.yml
+++ b/.detekt.yml
@@ -48,6 +48,8 @@ coroutines:
 # Formatting rules are implemented via the ktlint plugin. As ktlint does not allow exceptions, we need to disable
 # respective rules completely.
 formatting:
+  AnnotationOnSeparateLine:
+    active: false
   ChainWrapping:
     active: false
   CommentWrapping:
@@ -65,6 +67,8 @@ formatting:
   NoWildcardImports:
     active: false
   ParameterListWrapping:
+    active: false
+  SpacingBetweenDeclarationsWithAnnotations:
     active: false
 
 naming:


### PR DESCRIPTION
Allow to put annotations in enums on the same line as the enum entry.