### PR TITLE
fix(ui): Identify ORT runs by their index instead of id

### DIFF
--- a/ui/src/components/header.tsx
+++ b/ui/src/components/header.tsx
@@ -69,7 +69,7 @@ export const Header = () => {
   const runMatch = matches.find(
     (match) =>
       match.routeId ===
-      '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runId'
+      '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex'
   );
 
   return (

--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.index.tsx
@@ -222,13 +222,13 @@ const RepoComponent = () => {
                       <div>
                         <Link
                           to={
-                            '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runId'
+                            '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex'
                           }
                           params={{
                             orgId: params.orgId,
                             productId: params.productId,
                             repoId: repo.id.toString(),
-                            runId: run.id.toString(),
+                            runIndex: run.index.toString(),
                           }}
                           className='font-semibold text-blue-400 hover:underline'
                         >

--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.runs.$runIndex.index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.runs.$runIndex.index.tsx
@@ -44,12 +44,12 @@ const RunComponent = () => {
       params.orgId,
       params.productId,
       params.repoId,
-      params.runId,
+      params.runIndex,
     ],
     queryFn: async () =>
       await RepositoriesService.getOrtRunByIndex({
         repositoryId: Number.parseInt(params.repoId),
-        ortRunIndex: Number.parseInt(params.runId),
+        ortRunIndex: Number.parseInt(params.runIndex),
       }),
   });
 
@@ -86,9 +86,9 @@ const RunComponent = () => {
     }
   };
 
-  async function handleDownload(filename: string) {
+  async function handleDownload(runId: number, filename: string) {
     await downloadZipFile({
-      runId: Number.parseInt(params.runId),
+      runId: runId,
       fileName: filename,
     });
   }
@@ -97,7 +97,7 @@ const RunComponent = () => {
     <Card className='mx-auto w-full max-w-4xl'>
       <CardHeader className='flex flex-row items-start'>
         <div className='grid gap-2'>
-          <CardTitle>{ortRun.id}</CardTitle>
+          <CardTitle>{ortRun.index}</CardTitle>
         </div>
       </CardHeader>
       <CardContent>
@@ -169,7 +169,7 @@ const RunComponent = () => {
                     ortRun.jobs.reporter?.reportFilenames as unknown as string[]
                   ).map((filename) => (
                     <div key={filename} className='flex flex-col pb-2'>
-                      <Link onClick={() => handleDownload(filename)}>
+                      <Link onClick={() => handleDownload(ortRun.id, filename)}>
                         <Button
                           variant='outline'
                           className='font-semibold text-blue-400'
@@ -190,7 +190,7 @@ const RunComponent = () => {
 };
 
 export const Route = createFileRoute(
-  '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runId/'
+  '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/'
 )({
   loader: async ({ context, params }) => {
     await context.queryClient.ensureQueryData({
@@ -199,12 +199,12 @@ export const Route = createFileRoute(
         params.orgId,
         params.productId,
         params.repoId,
-        params.runId,
+        params.runIndex,
       ],
       queryFn: () =>
         RepositoriesService.getOrtRunByIndex({
           repositoryId: Number.parseInt(params.repoId),
-          ortRunIndex: Number.parseInt(params.runId),
+          ortRunIndex: Number.parseInt(params.runIndex),
         }),
     });
   },

--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.runs.$runIndex.route.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.runs.$runIndex.route.tsx
@@ -24,7 +24,7 @@ import { useRepositoriesServiceGetOrtRunByIndexKey } from '@/api/queries';
 import { RepositoriesService } from '@/api/requests';
 
 export const Route = createFileRoute(
-  '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runId'
+  '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex'
 )({
   loader: async ({ context, params }) => {
     const run = await context.queryClient.ensureQueryData({
@@ -33,15 +33,15 @@ export const Route = createFileRoute(
         params.orgId,
         params.productId,
         params.repoId,
-        params.runId,
+        params.runIndex,
       ],
       queryFn: () =>
         RepositoriesService.getOrtRunByIndex({
           repositoryId: Number.parseInt(params.repoId),
-          ortRunIndex: Number.parseInt(params.runId),
+          ortRunIndex: Number.parseInt(params.runIndex),
         }),
     });
-    context.breadcrumbs.run = run.id.toString();
+    context.breadcrumbs.run = run.index.toString();
   },
   component: () => (
     <Suspense fallback={<div>Loading...</div>}>


### PR DESCRIPTION
ORT runs have a global id and a repository specific index. Use the index instead of the id when navigating to a run, as the index is used by the API endpoint to get ORT run details. For report downloads still the global id has to be used.

This fixes the issue that the links to ORT runs were broken if runs for multiple repositories exist.