### PR TITLE
chore(gitignore): Ignore some directories at the top-level only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
-.gradle/
-.idea/
-.kotlin/
+/.gradle/
+/.idea/
+/.kotlin/
 build/
 out/
 /*.iml


### PR DESCRIPTION
Reduce potential side-effects due to matching in sub-directories.