### PR TITLE
refactor(transport): Move message property constants to a central place

### DIFF
--- a/transport/activemqartemis/src/main/kotlin/ArtemisMessageConverter.kt
+++ b/transport/activemqartemis/src/main/kotlin/ArtemisMessageConverter.kt
@@ -24,6 +24,9 @@ import jakarta.jms.TextMessage
 
 import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessageHeader
+import org.eclipse.apoapsis.ortserver.transport.RUN_ID_PROPERTY
+import org.eclipse.apoapsis.ortserver.transport.TOKEN_PROPERTY
+import org.eclipse.apoapsis.ortserver.transport.TRACE_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.json.JsonSerializer
 
 /**
@@ -31,15 +34,6 @@ import org.eclipse.apoapsis.ortserver.transport.json.JsonSerializer
  * This is used by both the Artemis-based sender and receiver implementations.
  */
 internal object ArtemisMessageConverter {
-    /** Name of the message property that stores the access token. */
-    private const val TOKEN_PROPERTY = "token"
-
-    /** Name of the message property that stores the trace ID. */
-    private const val TRACE_PROPERTY = "traceId"
-
-    /** Name of the message property that stores the ORT run ID. */
-    private const val RUN_ID_PROPERTY = "runId"
-
     /**
      * Convert the given [message] to a JMS [TextMessage] using the provided [serializer] and [session].
      */

--- a/transport/activemqartemis/src/test/kotlin/ArtemisMessageReceiverFactoryTest.kt
+++ b/transport/activemqartemis/src/test/kotlin/ArtemisMessageReceiverFactoryTest.kt
@@ -39,6 +39,9 @@ import org.eclipse.apoapsis.ortserver.model.orchestrator.OrchestratorMessage
 import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessageReceiverFactory
 import org.eclipse.apoapsis.ortserver.transport.OrchestratorEndpoint
+import org.eclipse.apoapsis.ortserver.transport.RUN_ID_PROPERTY
+import org.eclipse.apoapsis.ortserver.transport.TOKEN_PROPERTY
+import org.eclipse.apoapsis.ortserver.transport.TRACE_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.json.JsonSerializer
 
 class ArtemisMessageReceiverFactoryTest : StringSpec({
@@ -126,9 +129,9 @@ private fun <T> JsonSerializer<T>.createMessage(
     payload: T
 ): TextMessage =
     session.createTextMessage(toJson(payload)).apply {
-        setStringProperty("token", token)
-        setStringProperty("traceId", traceId)
-        setLongProperty("runId", runId)
+        setStringProperty(TOKEN_PROPERTY, token)
+        setStringProperty(TRACE_PROPERTY, traceId)
+        setLongProperty(RUN_ID_PROPERTY, runId)
     }
 
 /**

--- a/transport/activemqartemis/src/test/kotlin/ArtemisMessageSenderFactoryTest.kt
+++ b/transport/activemqartemis/src/test/kotlin/ArtemisMessageSenderFactoryTest.kt
@@ -42,6 +42,9 @@ import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessageHeader
 import org.eclipse.apoapsis.ortserver.transport.MessageSenderFactory
 import org.eclipse.apoapsis.ortserver.transport.OrchestratorEndpoint
+import org.eclipse.apoapsis.ortserver.transport.RUN_ID_PROPERTY
+import org.eclipse.apoapsis.ortserver.transport.TOKEN_PROPERTY
+import org.eclipse.apoapsis.ortserver.transport.TRACE_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.json.JsonSerializer
 
 class ArtemisMessageSenderFactoryTest : StringSpec({
@@ -63,9 +66,9 @@ class ArtemisMessageSenderFactoryTest : StringSpec({
 
             connection.start()
             val receivedMessage = consumer.receive(5000) as TextMessage
-            receivedMessage.getStringProperty("token") shouldBe header.token
-            receivedMessage.getStringProperty("traceId") shouldBe header.traceId
-            receivedMessage.getLongProperty("runId") shouldBe header.ortRunId
+            receivedMessage.getStringProperty(TOKEN_PROPERTY) shouldBe header.token
+            receivedMessage.getStringProperty(TRACE_PROPERTY) shouldBe header.traceId
+            receivedMessage.getLongProperty(RUN_ID_PROPERTY) shouldBe header.ortRunId
 
             val serializer = JsonSerializer.forType<OrchestratorMessage>()
             val payload2 = serializer.fromJson(receivedMessage.text)

--- a/transport/kubernetes/src/main/kotlin/KubernetesMessageReceiverFactory.kt
+++ b/transport/kubernetes/src/main/kotlin/KubernetesMessageReceiverFactory.kt
@@ -29,6 +29,9 @@ import org.eclipse.apoapsis.ortserver.transport.EndpointHandler
 import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessageHeader
 import org.eclipse.apoapsis.ortserver.transport.MessageReceiverFactory
+import org.eclipse.apoapsis.ortserver.transport.RUN_ID_PROPERTY
+import org.eclipse.apoapsis.ortserver.transport.TOKEN_PROPERTY
+import org.eclipse.apoapsis.ortserver.transport.TRACE_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.json.JsonSerializer
 
 import org.slf4j.LoggerFactory
@@ -56,9 +59,9 @@ class KubernetesMessageReceiverFactory : MessageReceiverFactory {
 
         logger.info("Starting Kubernetes message receiver for endpoint '{}'.", from.configPrefix)
 
-        val token = System.getenv("token")
-        val traceId = System.getenv("traceId")
-        val runId = System.getenv("runId").toLong()
+        val token = System.getenv(TOKEN_PROPERTY)
+        val traceId = System.getenv(TRACE_PROPERTY)
+        val runId = System.getenv(RUN_ID_PROPERTY).toLong()
         val payload = System.getenv("payload")
 
         val msg = Message(MessageHeader(token, traceId, runId), serializer.fromJson(payload))

--- a/transport/kubernetes/src/main/kotlin/KubernetesMessageSender.kt
+++ b/transport/kubernetes/src/main/kotlin/KubernetesMessageSender.kt
@@ -34,6 +34,9 @@ import io.kubernetes.client.openapi.models.V1VolumeMount
 import org.eclipse.apoapsis.ortserver.transport.Endpoint
 import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessageSender
+import org.eclipse.apoapsis.ortserver.transport.RUN_ID_PROPERTY
+import org.eclipse.apoapsis.ortserver.transport.TOKEN_PROPERTY
+import org.eclipse.apoapsis.ortserver.transport.TRACE_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.json.JsonSerializer
 
 /** A prefix for the name of a label storing a part of the trace ID. */
@@ -87,9 +90,9 @@ internal class KubernetesMessageSender<T : Any>(
 
     override fun send(message: Message<T>) {
         val msgMap = mapOf(
-            "token" to message.header.token,
-            "traceId" to message.header.traceId,
-            "runId" to message.header.ortRunId.toString(),
+            TOKEN_PROPERTY to message.header.token,
+            TRACE_PROPERTY to message.header.traceId,
+            RUN_ID_PROPERTY to message.header.ortRunId.toString(),
             "payload" to serializer.toJson(message.payload)
         )
 

--- a/transport/kubernetes/src/test/kotlin/KubernetesMessageReceiverFactoryTest.kt
+++ b/transport/kubernetes/src/test/kotlin/KubernetesMessageReceiverFactoryTest.kt
@@ -37,6 +37,9 @@ import org.eclipse.apoapsis.ortserver.model.orchestrator.AnalyzerRequest
 import org.eclipse.apoapsis.ortserver.transport.AnalyzerEndpoint
 import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessageHeader
+import org.eclipse.apoapsis.ortserver.transport.RUN_ID_PROPERTY
+import org.eclipse.apoapsis.ortserver.transport.TOKEN_PROPERTY
+import org.eclipse.apoapsis.ortserver.transport.TRACE_PROPERTY
 
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
@@ -55,9 +58,9 @@ class KubernetesMessageReceiverFactoryTest : StringSpec({
         val header = MessageHeader(token = "testToken", traceId = "testTraceId", ortRunId = 33)
 
         val env = mapOf(
-            "token" to header.token,
-            "traceId" to header.traceId,
-            "runId" to header.ortRunId.toString(),
+            TOKEN_PROPERTY to header.token,
+            TRACE_PROPERTY to header.traceId,
+            RUN_ID_PROPERTY to header.ortRunId.toString(),
             "payload" to "{\"analyzerJobId\":${payload.analyzerJobId}}"
         )
 
@@ -93,9 +96,9 @@ class KubernetesMessageReceiverFactoryTest : StringSpec({
         val header = MessageHeader(token = "testToken", traceId = "testTraceId", ortRunId = 7)
 
         val env = mapOf(
-            "token" to header.token,
-            "traceId" to header.traceId,
-            "runId" to header.ortRunId.toString(),
+            TOKEN_PROPERTY to header.token,
+            TRACE_PROPERTY to header.traceId,
+            RUN_ID_PROPERTY to header.ortRunId.toString(),
             "payload" to "{\"analyzerJobId\":${payload.analyzerJobId}}"
         )
 

--- a/transport/kubernetes/src/test/kotlin/KubernetesMessageSenderTest.kt
+++ b/transport/kubernetes/src/test/kotlin/KubernetesMessageSenderTest.kt
@@ -46,6 +46,9 @@ import org.eclipse.apoapsis.ortserver.model.orchestrator.AnalyzerRequest
 import org.eclipse.apoapsis.ortserver.transport.AnalyzerEndpoint
 import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessageHeader
+import org.eclipse.apoapsis.ortserver.transport.RUN_ID_PROPERTY
+import org.eclipse.apoapsis.ortserver.transport.TOKEN_PROPERTY
+import org.eclipse.apoapsis.ortserver.transport.TRACE_PROPERTY
 
 import org.ossreviewtoolkit.utils.test.shouldNotBeNull
 
@@ -53,7 +56,7 @@ class KubernetesMessageSenderTest : StringSpec({
     "Kubernetes jobs are created via the sender" {
         val expectedEnvVars = envVars.toMutableMap()
         expectedEnvVars["SPECIFIC_PROPERTY"] = "foo"
-        expectedEnvVars["runId"] = message.header.ortRunId.toString()
+        expectedEnvVars[RUN_ID_PROPERTY] = message.header.ortRunId.toString()
         expectedEnvVars -= "ANALYZER_SPECIFIC_PROPERTY"
         val senderConfig = createConfig()
 
@@ -187,8 +190,8 @@ private val message = Message(header, payload)
 private val envVars = mapOf(
     "SPECIFIC_PROPERTY" to "bar",
     "SHELL" to "/bin/bash",
-    "token" to header.token,
-    "traceId" to header.traceId,
+    TOKEN_PROPERTY to header.token,
+    TRACE_PROPERTY to header.traceId,
     "payload" to "{\"analyzerJobId\":${payload.analyzerJobId}}",
     "ANALYZER_SPECIFIC_PROPERTY" to "foo"
 )

--- a/transport/rabbitmq/src/main/kotlin/RabbitMqMessageConverter.kt
+++ b/transport/rabbitmq/src/main/kotlin/RabbitMqMessageConverter.kt
@@ -24,18 +24,12 @@ import com.rabbitmq.client.Delivery
 
 import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessageHeader
+import org.eclipse.apoapsis.ortserver.transport.RUN_ID_PROPERTY
+import org.eclipse.apoapsis.ortserver.transport.TOKEN_PROPERTY
+import org.eclipse.apoapsis.ortserver.transport.TRACE_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.json.JsonSerializer
 
 internal object RabbitMqMessageConverter {
-    /** Name of the message property that stores the access token. */
-    private const val TOKEN_PROPERTY = "token"
-
-    /** Name of the message property that stores the trace ID. */
-    private const val TRACE_PROPERTY = "traceId"
-
-    /** Name of the message property that stores the ORT run ID. */
-    private const val RUN_ID_PROPERTY = "runId"
-
     /**
      * Convert the [message headers][this] to the AMQP compatible [BasicProperties].
      */

--- a/transport/rabbitmq/src/test/kotlin/RabbitMqMessageSenderFactoryTest.kt
+++ b/transport/rabbitmq/src/test/kotlin/RabbitMqMessageSenderFactoryTest.kt
@@ -52,6 +52,9 @@ import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessageHeader
 import org.eclipse.apoapsis.ortserver.transport.MessageSenderFactory
 import org.eclipse.apoapsis.ortserver.transport.OrchestratorEndpoint
+import org.eclipse.apoapsis.ortserver.transport.RUN_ID_PROPERTY
+import org.eclipse.apoapsis.ortserver.transport.TOKEN_PROPERTY
+import org.eclipse.apoapsis.ortserver.transport.TRACE_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.json.JsonSerializer
 
 import org.testcontainers.containers.RabbitMQContainer
@@ -102,9 +105,9 @@ class RabbitMqMessageSenderFactoryTest : StringSpec() {
                     { _: String, delivery: Delivery ->
                         val receivedMessage = String(delivery.body)
 
-                        delivery.properties.headers["token"].toString() shouldBe header.token
-                        delivery.properties.headers["traceId"].toString() shouldBe header.traceId
-                        delivery.properties.headers["runId"].toString() shouldBe header.ortRunId.toString()
+                        delivery.properties.headers[TOKEN_PROPERTY].toString() shouldBe header.token
+                        delivery.properties.headers[TRACE_PROPERTY].toString() shouldBe header.traceId
+                        delivery.properties.headers[RUN_ID_PROPERTY].toString() shouldBe header.ortRunId.toString()
 
                         val serializer = JsonSerializer.forType<OrchestratorMessage>()
                         val receivedPayload = serializer.fromJson(receivedMessage)

--- a/transport/spi/src/main/kotlin/Message.kt
+++ b/transport/spi/src/main/kotlin/Message.kt
@@ -19,6 +19,15 @@
 
 package org.eclipse.apoapsis.ortserver.transport
 
+/** Name of the message property that stores the access token. */
+const val TOKEN_PROPERTY = "token"
+
+/** Name of the message property that stores the trace ID. */
+const val TRACE_PROPERTY = "traceId"
+
+/** Name of the message property that stores the ORT run ID. */
+const val RUN_ID_PROPERTY = "runId"
+
 /**
  * A data class representing the header of messages passed between internal ORT server endpoints. Via the properties
  * defined here, additional metadata about messages is provided.


### PR DESCRIPTION
These properties name the properties of the `Message` class, so move them next to that class for general reuse.