### PR TITLE
ui: Improvements for ort run details page

### DIFF
--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.runs.$runIndex.index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.runs.$runIndex.index.tsx
@@ -135,6 +135,27 @@ const RunComponent = () => {
                 <div className='font-medium'>{ortRun.revision}</div>
               </TableCell>
             </TableRow>
+            {ortRun.jobs.reporter?.reportFilenames && (
+              <TableRow>
+                <TableCell>Reports</TableCell>
+                <TableCell>
+                  {(
+                    ortRun.jobs.reporter?.reportFilenames as unknown as string[]
+                  ).map((filename) => (
+                    <div key={filename} className='flex flex-col pb-2'>
+                      <Link onClick={() => handleDownload(ortRun.id, filename)}>
+                        <Button
+                          variant='outline'
+                          className='font-semibold text-blue-400'
+                        >
+                          {filename}
+                        </Button>
+                      </Link>
+                    </div>
+                  ))}
+                </TableCell>
+              </TableRow>
+            )}
             <TableRow>
               <TableCell>Job configs</TableCell>
               <TableCell>
@@ -152,27 +173,6 @@ const RunComponent = () => {
                 <TableCell>Issues</TableCell>
                 <TableCell>
                   <pre>{JSON.stringify(ortRun.issues, null, 2)}</pre>
-                </TableCell>
-              </TableRow>
-            )}
-            {ortRun.jobs.reporter?.reportFilenames && (
-              <TableRow>
-                <TableCell>Result files</TableCell>
-                <TableCell>
-                  {(
-                    ortRun.jobs.reporter?.reportFilenames as unknown as string[]
-                  ).map((filename) => (
-                    <div key={filename} className='flex flex-col pb-2'>
-                      <Link onClick={() => handleDownload(ortRun.id, filename)}>
-                        <Button
-                          variant='outline'
-                          className='font-semibold text-blue-400'
-                        >
-                          {filename}
-                        </Button>
-                      </Link>
-                    </div>
-                  ))}
                 </TableCell>
               </TableRow>
             )}

--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.runs.$runIndex.index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.runs.$runIndex.index.tsx
@@ -124,7 +124,9 @@ const RunComponent = () => {
             <TableRow>
               <TableCell>Created At</TableCell>
               <TableCell>
-                <div className='font-medium'>{ortRun.createdAt}</div>
+                <div className='font-medium'>
+                  {new Date(ortRun.createdAt).toLocaleString()}
+                </div>
               </TableCell>
             </TableRow>
             {ortRun.finishedAt && (
@@ -132,7 +134,7 @@ const RunComponent = () => {
                 <TableCell>Finished At</TableCell>
                 <TableCell>
                   <div className='font-medium'>
-                    {ortRun.finishedAt as unknown as string}
+                    {new Date(ortRun.finishedAt).toLocaleString()}
                   </div>
                 </TableCell>
               </TableRow>

--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.runs.$runIndex.index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.runs.$runIndex.index.tsx
@@ -142,12 +142,6 @@ const RunComponent = () => {
               </TableCell>
             </TableRow>
             <TableRow>
-              <TableCell>Resolved job configs</TableCell>
-              <TableCell>
-                <pre>{JSON.stringify(ortRun.resolvedJobConfigs, null, 2)}</pre>
-              </TableCell>
-            </TableRow>
-            <TableRow>
               <TableCell>Jobs</TableCell>
               <TableCell>
                 <pre>{JSON.stringify(ortRun.jobs, null, 2)}</pre>


### PR DESCRIPTION
This PR improves usability and readability of ORT Run results, by providing at first glance a "top-level" view of the run: main run parameters, job statuses and durations. By clicking a job name, the user can see the results of the job (so far implemented as pretty-printed JSON object to still retain some debugging possibilities).

The resulting details page:

![Capture](https://github.com/eclipse-apoapsis/ort-server/assets/599904/ef43dc7b-b327-4233-b94c-337faa2362df)

Apart from downloading and/or streaming logs, this partially resolves #293 