### PR TITLE
feat(core): Set Swagger UI server URL from config

### DIFF
--- a/core/src/main/kotlin/plugins/OpenApi.kt
+++ b/core/src/main/kotlin/plugins/OpenApi.kt
@@ -79,7 +79,10 @@ fun Application.configureOpenApi() {
         }
 
         server {
-            url = "http://localhost:8080"
+            val scheme = config.property("ktor.deployment.publicScheme").getString()
+            val fqdn = config.property("ktor.deployment.publicFqdn").getString()
+            val port = config.property("ktor.deployment.publicPort").getString()
+            url = "$scheme://$fqdn:$port"
             description = "Local ORT server"
         }
 

--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -23,6 +23,12 @@ configManager {
 
 ktor {
   deployment {
+    publicScheme = "http"
+    publicScheme = ${?PUBLIC_SCHEME}
+    publicFqdn = "localhost"
+    publicFqdn = ${?PUBLIC_FQDN}
+    publicPort = 8080
+    publicPort = ${?PUBLIC_PORT}
     port = 8080
     port = ${?PORT}
     watch = [ classes ]

--- a/core/src/test/resources/application-test-auth.conf
+++ b/core/src/test/resources/application-test-auth.conf
@@ -17,6 +17,9 @@
 
 ktor {
   deployment {
+    publicScheme = "http"
+    publicFqdn = "localhost"
+    publicPort = 8080
     port = 8080
     port = ${?PORT}
     watch = [ classes ]

--- a/core/src/test/resources/application-test.conf
+++ b/core/src/test/resources/application-test.conf
@@ -17,6 +17,9 @@
 
 ktor {
   deployment {
+    publicScheme = "http"
+    publicFqdn = "localhost"
+    publicPort = 8080
     port = 8080
     port = ${?PORT}
     watch = [ classes ]


### PR DESCRIPTION
This change introduces three new configuration variables that are used for setting the "server" value in the Swagger UI configuration. The new variables have default values that keep the existing behaviour.

This enables using Swagger UI in environments with some kind of proxy or load balancer in front of the ORT Server API.