### PR TITLE
ci(renovate): Configure schedule for all `aws.sdk.kotlin` packages

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,7 +17,7 @@
       "enabled": false
     },
     {
-      "matchPackageNames": ["aws.sdk.kotlin:s3"],
+      "matchPackagePrefixes": ["aws.sdk.kotlin:"],
       "schedule": ["after 9pm on sunday"]
     },
     {


### PR DESCRIPTION
Change the configuration to schedule weekly updates for all `aws.sdk.kotlin` packages instead of only `aws.sdk.kotlin:s3`.