### PR TITLE
refactor(transport): Use Kotest's new `infix` version of `shouldNotBeNull`

### DIFF
--- a/transport/sqs/src/test/kotlin/SqsMessageSenderFactoryTest.kt
+++ b/transport/sqs/src/test/kotlin/SqsMessageSenderFactoryTest.kt
@@ -91,14 +91,14 @@ class SqsMessageSenderFactoryTest : StringSpec({
 
         val receiveResponse = client.receiveMessage(receiveRequest)
 
-        receiveResponse.messages.shouldNotBeNull().run {
+        receiveResponse.messages shouldNotBeNull {
             shouldHaveSize(1)
 
-            first().messageAttributes.shouldNotBeNull().run {
+            first().messageAttributes shouldNotBeNull {
                 toMessageHeader() shouldBe header
             }
 
-            first().body.shouldNotBeNull().run {
+            first().body shouldNotBeNull {
                 serializer.fromJson(this) shouldBe payload
             }
         }


### PR DESCRIPTION
This was contributed from the ORT core code base and is available since Kotest 5.9.1.