### PR TITLE
chore: Remove unused property from MessageHeader

### DIFF
--- a/core/src/main/kotlin/services/OrchestratorService.kt
+++ b/core/src/main/kotlin/services/OrchestratorService.kt
@@ -59,11 +59,9 @@ class OrchestratorService(
             ortRunRepository.create(repositoryId, revision, path, jobConfig, jobConfigContext, labels.orEmpty())
         }
 
-        // TODO: Set the correct token.
         orchestratorSender.send(
             Message(
                 header = MessageHeader(
-                    token = "",
                     traceId = UUID.randomUUID().toString(),
                     ortRunId = ortRun.id
                 ),

--- a/orchestrator/src/test/kotlin/OrchestratorEndpointTest.kt
+++ b/orchestrator/src/test/kotlin/OrchestratorEndpointTest.kt
@@ -62,7 +62,6 @@ import org.koin.test.mock.declareMock
 
 class OrchestratorEndpointTest : KoinTest, StringSpec() {
     private val msgHeader = MessageHeader(
-        token = "token",
         traceId = "traceId",
         ortRunId = 17
     )

--- a/orchestrator/src/test/kotlin/OrchestratorTest.kt
+++ b/orchestrator/src/test/kotlin/OrchestratorTest.kt
@@ -97,7 +97,6 @@ import org.eclipse.apoapsis.ortserver.transport.ReporterEndpoint
 @Suppress("LargeClass")
 class OrchestratorTest : WordSpec() {
     private val msgHeader = MessageHeader(
-        token = "token",
         traceId = "traceId",
         ortRunId = RUN_ID,
     )

--- a/transport/activemqartemis/src/main/kotlin/ArtemisMessageConverter.kt
+++ b/transport/activemqartemis/src/main/kotlin/ArtemisMessageConverter.kt
@@ -25,7 +25,6 @@ import jakarta.jms.TextMessage
 import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessageHeader
 import org.eclipse.apoapsis.ortserver.transport.RUN_ID_PROPERTY
-import org.eclipse.apoapsis.ortserver.transport.TOKEN_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.TRACE_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.json.JsonSerializer
 
@@ -39,7 +38,6 @@ internal object ArtemisMessageConverter {
      */
     fun <T> toJmsMessage(message: Message<T>, serializer: JsonSerializer<T>, session: Session): TextMessage =
         session.createTextMessage(serializer.toJson(message.payload)).apply {
-            setStringProperty(TOKEN_PROPERTY, message.header.token)
             setStringProperty(TRACE_PROPERTY, message.header.traceId)
             setLongProperty(RUN_ID_PROPERTY, message.header.ortRunId)
         }
@@ -49,7 +47,6 @@ internal object ArtemisMessageConverter {
      */
     fun <T> toTransportMessage(jmsMessage: TextMessage, serializer: JsonSerializer<T>): Message<T> {
         val header = MessageHeader(
-            token = jmsMessage.getStringProperty(TOKEN_PROPERTY),
             traceId = jmsMessage.getStringProperty(TRACE_PROPERTY),
             ortRunId = jmsMessage.getLongProperty(RUN_ID_PROPERTY)
         )

--- a/transport/activemqartemis/src/test/kotlin/ArtemisMessageSenderFactoryTest.kt
+++ b/transport/activemqartemis/src/test/kotlin/ArtemisMessageSenderFactoryTest.kt
@@ -43,7 +43,6 @@ import org.eclipse.apoapsis.ortserver.transport.MessageHeader
 import org.eclipse.apoapsis.ortserver.transport.MessageSenderFactory
 import org.eclipse.apoapsis.ortserver.transport.OrchestratorEndpoint
 import org.eclipse.apoapsis.ortserver.transport.RUN_ID_PROPERTY
-import org.eclipse.apoapsis.ortserver.transport.TOKEN_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.TRACE_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.json.JsonSerializer
 import org.eclipse.apoapsis.ortserver.transport.testing.TEST_QUEUE_NAME
@@ -53,7 +52,7 @@ class ArtemisMessageSenderFactoryTest : StringSpec({
         val config = startArtemisContainer("orchestrator", "sender")
 
         val payload = AnalyzerWorkerResult(42)
-        val header = MessageHeader(token = "1234567890", traceId = "dick.tracy", 11)
+        val header = MessageHeader(traceId = "dick.tracy", 11)
         val message = Message(header, payload)
 
         val connectionFactory = JmsConnectionFactory(config.getString("orchestrator.sender.serverUri"))
@@ -67,7 +66,6 @@ class ArtemisMessageSenderFactoryTest : StringSpec({
 
             connection.start()
             val receivedMessage = consumer.receive(5000) as TextMessage
-            receivedMessage.getStringProperty(TOKEN_PROPERTY) shouldBe header.token
             receivedMessage.getStringProperty(TRACE_PROPERTY) shouldBe header.traceId
             receivedMessage.getLongProperty(RUN_ID_PROPERTY) shouldBe header.ortRunId
 

--- a/transport/kubernetes-jobmonitor/src/main/kotlin/FailedJobNotifier.kt
+++ b/transport/kubernetes-jobmonitor/src/main/kotlin/FailedJobNotifier.kt
@@ -50,7 +50,7 @@ internal class FailedJobNotifier(
             val ortRunId = job.ortRunId
 
             if (traceId.isNotEmpty() && ortRunId != null) {
-                val header = MessageHeader(token = "", traceId = traceId, ortRunId)
+                val header = MessageHeader(traceId = traceId, ortRunId)
                 val message = Message(header, WorkerError(endpointName))
 
                 sendToOrchestrator(message)
@@ -63,7 +63,7 @@ internal class FailedJobNotifier(
      * Orchestrator about jobs that disappeared in Kubernetes.
      */
     fun sendLostJobNotification(ortRunId: Long, endpoint: Endpoint<*>) {
-        val header = MessageHeader(token = "", traceId = "", ortRunId)
+        val header = MessageHeader(traceId = "", ortRunId)
         val message = Message(header, WorkerError(endpoint.configPrefix))
 
         sendToOrchestrator(message)

--- a/transport/kubernetes/src/main/kotlin/KubernetesMessageReceiverFactory.kt
+++ b/transport/kubernetes/src/main/kotlin/KubernetesMessageReceiverFactory.kt
@@ -30,7 +30,6 @@ import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessageHeader
 import org.eclipse.apoapsis.ortserver.transport.MessageReceiverFactory
 import org.eclipse.apoapsis.ortserver.transport.RUN_ID_PROPERTY
-import org.eclipse.apoapsis.ortserver.transport.TOKEN_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.TRACE_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.json.JsonSerializer
 
@@ -59,12 +58,11 @@ class KubernetesMessageReceiverFactory : MessageReceiverFactory {
 
         logger.info("Starting Kubernetes message receiver for endpoint '{}'.", from.configPrefix)
 
-        val token = System.getenv(TOKEN_PROPERTY)
         val traceId = System.getenv(TRACE_PROPERTY)
         val runId = System.getenv(RUN_ID_PROPERTY).toLong()
         val payload = System.getenv("payload")
 
-        val msg = Message(MessageHeader(token, traceId, runId), serializer.fromJson(payload))
+        val msg = Message(MessageHeader(traceId, runId), serializer.fromJson(payload))
 
         @Suppress("TooGenericExceptionCaught")
         try {

--- a/transport/kubernetes/src/main/kotlin/KubernetesMessageSender.kt
+++ b/transport/kubernetes/src/main/kotlin/KubernetesMessageSender.kt
@@ -35,7 +35,6 @@ import org.eclipse.apoapsis.ortserver.transport.Endpoint
 import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessageSender
 import org.eclipse.apoapsis.ortserver.transport.RUN_ID_PROPERTY
-import org.eclipse.apoapsis.ortserver.transport.TOKEN_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.TRACE_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.json.JsonSerializer
 
@@ -90,7 +89,6 @@ internal class KubernetesMessageSender<T : Any>(
 
     override fun send(message: Message<T>) {
         val msgMap = mapOf(
-            TOKEN_PROPERTY to message.header.token,
             TRACE_PROPERTY to message.header.traceId,
             RUN_ID_PROPERTY to message.header.ortRunId.toString(),
             "payload" to serializer.toJson(message.payload)

--- a/transport/kubernetes/src/test/kotlin/KubernetesMessageReceiverFactoryTest.kt
+++ b/transport/kubernetes/src/test/kotlin/KubernetesMessageReceiverFactoryTest.kt
@@ -39,7 +39,6 @@ import org.eclipse.apoapsis.ortserver.transport.AnalyzerEndpoint
 import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessageHeader
 import org.eclipse.apoapsis.ortserver.transport.RUN_ID_PROPERTY
-import org.eclipse.apoapsis.ortserver.transport.TOKEN_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.TRACE_PROPERTY
 
 class KubernetesMessageReceiverFactoryTest : StringSpec({
@@ -54,10 +53,9 @@ class KubernetesMessageReceiverFactoryTest : StringSpec({
 
     "Messages can be received via the Kubernetes transport" {
         val payload = AnalyzerRequest(1)
-        val header = MessageHeader(token = "testToken", traceId = "testTraceId", ortRunId = 33)
+        val header = MessageHeader(traceId = "testTraceId", ortRunId = 33)
 
         val env = mapOf(
-            TOKEN_PROPERTY to header.token,
             TRACE_PROPERTY to header.traceId,
             RUN_ID_PROPERTY to header.ortRunId.toString(),
             "payload" to "{\"analyzerJobId\":${payload.analyzerJobId}}"
@@ -78,7 +76,6 @@ class KubernetesMessageReceiverFactoryTest : StringSpec({
             }
 
             receivedMessage.shouldNotBeNull {
-                this.header.token shouldBe header.token
                 this.header.traceId shouldBe header.traceId
                 this.header.ortRunId shouldBe header.ortRunId
                 this.payload shouldBe payload
@@ -92,10 +89,9 @@ class KubernetesMessageReceiverFactoryTest : StringSpec({
 
     "The process is terminated even if an exception is thrown by the handler" {
         val payload = AnalyzerRequest(1)
-        val header = MessageHeader(token = "testToken", traceId = "testTraceId", ortRunId = 7)
+        val header = MessageHeader(traceId = "testTraceId", ortRunId = 7)
 
         val env = mapOf(
-            TOKEN_PROPERTY to header.token,
             TRACE_PROPERTY to header.traceId,
             RUN_ID_PROPERTY to header.ortRunId.toString(),
             "payload" to "{\"analyzerJobId\":${payload.analyzerJobId}}"

--- a/transport/kubernetes/src/test/kotlin/KubernetesMessageSenderTest.kt
+++ b/transport/kubernetes/src/test/kotlin/KubernetesMessageSenderTest.kt
@@ -48,7 +48,6 @@ import org.eclipse.apoapsis.ortserver.transport.AnalyzerEndpoint
 import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessageHeader
 import org.eclipse.apoapsis.ortserver.transport.RUN_ID_PROPERTY
-import org.eclipse.apoapsis.ortserver.transport.TOKEN_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.TRACE_PROPERTY
 
 class KubernetesMessageSenderTest : StringSpec({
@@ -183,13 +182,12 @@ private val annotationVariables = mapOf(
 
 private val traceId = "0123456789".repeat(20)
 private val payload = AnalyzerRequest(1)
-private val header = MessageHeader(token = "testToken", traceId = traceId, 9)
+private val header = MessageHeader(traceId = traceId, 9)
 private val message = Message(header, payload)
 
 private val envVars = mapOf(
     "SPECIFIC_PROPERTY" to "bar",
     "SHELL" to "/bin/bash",
-    TOKEN_PROPERTY to header.token,
     TRACE_PROPERTY to header.traceId,
     "payload" to "{\"analyzerJobId\":${payload.analyzerJobId}}",
     "ANALYZER_SPECIFIC_PROPERTY" to "foo"

--- a/transport/rabbitmq/src/main/kotlin/RabbitMqMessageConverter.kt
+++ b/transport/rabbitmq/src/main/kotlin/RabbitMqMessageConverter.kt
@@ -25,7 +25,6 @@ import com.rabbitmq.client.Delivery
 import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessageHeader
 import org.eclipse.apoapsis.ortserver.transport.RUN_ID_PROPERTY
-import org.eclipse.apoapsis.ortserver.transport.TOKEN_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.TRACE_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.json.JsonSerializer
 
@@ -38,7 +37,6 @@ internal object RabbitMqMessageConverter {
         .contentEncoding("UTF-8")
         .headers(
             mapOf(
-                TOKEN_PROPERTY to token,
                 TRACE_PROPERTY to traceId,
                 RUN_ID_PROPERTY to ortRunId
             )
@@ -54,7 +52,6 @@ internal object RabbitMqMessageConverter {
      */
     fun <T> toTransportMessage(delivery: Delivery, serializer: JsonSerializer<T>): Message<T> {
         val header = MessageHeader(
-            delivery.properties.headers[TOKEN_PROPERTY].toString(),
             delivery.properties.headers[TRACE_PROPERTY].toString(),
             delivery.properties.headers[RUN_ID_PROPERTY] as Long
         )

--- a/transport/rabbitmq/src/test/kotlin/RabbitMqMessageReceiverFactoryTest.kt
+++ b/transport/rabbitmq/src/test/kotlin/RabbitMqMessageReceiverFactoryTest.kt
@@ -55,11 +55,9 @@ class RabbitMqMessageReceiverFactoryTest : StringSpec({
 
             val messageQueue = startReceiver(config)
 
-            val token1 = "token1"
             val traceId1 = "trace1"
             val runId1 = 1L
             val payload1 = AnalyzerWorkerError(1)
-            val token2 = "token2"
             val traceId2 = "trace2"
             val runId2 = 2L
             val payload2 = AnalyzerWorkerResult(42)
@@ -67,19 +65,19 @@ class RabbitMqMessageReceiverFactoryTest : StringSpec({
             channel.basicPublish(
                 "",
                 TEST_QUEUE_NAME,
-                MessageHeader(token1, traceId1, runId1).toAmqpProperties(),
+                MessageHeader(traceId1, runId1).toAmqpProperties(),
                 serializer.toJson(payload1).toByteArray()
             )
 
             channel.basicPublish(
                 "",
                 TEST_QUEUE_NAME,
-                MessageHeader(token2, traceId2, runId2).toAmqpProperties(),
+                MessageHeader(traceId2, runId2).toAmqpProperties(),
                 serializer.toJson(payload2).toByteArray()
             )
 
-            messageQueue.checkMessage(token1, traceId1, runId1, payload1)
-            messageQueue.checkMessage(token2, traceId2, runId2, payload2)
+            messageQueue.checkMessage(traceId1, runId1, payload1)
+            messageQueue.checkMessage(traceId2, runId2, payload2)
         }
     }
 
@@ -107,22 +105,21 @@ class RabbitMqMessageReceiverFactoryTest : StringSpec({
             channel.basicPublish(
                 "",
                 TEST_QUEUE_NAME,
-                MessageHeader("tokenInvalid", "traceIdInvalid", -1).toAmqpProperties(),
+                MessageHeader("traceIdInvalid", -1).toAmqpProperties(),
                 "Invalid payload".toByteArray()
             )
 
-            val token = "validtoken"
             val traceId = "validtrace"
             val runId = 10L
             val payload = AnalyzerWorkerResult(42)
             channel.basicPublish(
                 "",
                 TEST_QUEUE_NAME,
-                MessageHeader(token, traceId, runId).toAmqpProperties(),
+                MessageHeader(traceId, runId).toAmqpProperties(),
                 serializer.toJson(payload).toByteArray()
             )
 
-            messageQueue.checkMessage(token, traceId, runId, payload)
+            messageQueue.checkMessage(traceId, runId, payload)
         }
     }
 })

--- a/transport/rabbitmq/src/test/kotlin/RabbitMqMessageSenderFactoryTest.kt
+++ b/transport/rabbitmq/src/test/kotlin/RabbitMqMessageSenderFactoryTest.kt
@@ -47,7 +47,6 @@ import org.eclipse.apoapsis.ortserver.transport.MessageHeader
 import org.eclipse.apoapsis.ortserver.transport.MessageSenderFactory
 import org.eclipse.apoapsis.ortserver.transport.OrchestratorEndpoint
 import org.eclipse.apoapsis.ortserver.transport.RUN_ID_PROPERTY
-import org.eclipse.apoapsis.ortserver.transport.TOKEN_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.TRACE_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.json.JsonSerializer
 import org.eclipse.apoapsis.ortserver.transport.testing.TEST_QUEUE_NAME
@@ -57,7 +56,7 @@ class RabbitMqMessageSenderFactoryTest : StringSpec({
         val config = startRabbitMqContainer("orchestrator", "sender")
 
         val payload = AnalyzerWorkerResult(42)
-        val header = MessageHeader(token = "1234567890", traceId = "dick.tracy", ortRunId = 44)
+        val header = MessageHeader(traceId = "dick.tracy", ortRunId = 44)
         val message = Message(header, payload)
 
         val connectionFactory = ConnectionFactory().apply {
@@ -87,7 +86,6 @@ class RabbitMqMessageSenderFactoryTest : StringSpec({
                 { _: String, delivery: Delivery ->
                     val receivedMessage = String(delivery.body)
 
-                    delivery.properties.headers[TOKEN_PROPERTY].toString() shouldBe header.token
                     delivery.properties.headers[TRACE_PROPERTY].toString() shouldBe header.traceId
                     delivery.properties.headers[RUN_ID_PROPERTY].toString() shouldBe header.ortRunId.toString()
 

--- a/transport/spi/src/main/kotlin/Message.kt
+++ b/transport/spi/src/main/kotlin/Message.kt
@@ -19,9 +19,6 @@
 
 package org.eclipse.apoapsis.ortserver.transport
 
-/** Name of the message property that stores the access token. */
-const val TOKEN_PROPERTY = "token"
-
 /** Name of the message property that stores the trace ID. */
 const val TRACE_PROPERTY = "traceId"
 
@@ -33,12 +30,6 @@ const val RUN_ID_PROPERTY = "runId"
  * defined here, additional metadata about messages is provided.
  */
 data class MessageHeader(
-    /**
-     * The access token associated with the current request. This property can be used to get information about the
-     * caller who triggered this request.
-     */
-    val token: String,
-
     /**
      * An identifier for the current request. This purpose of this string is to allow a correlation of multiple
      * messages that are exchanged to handle a single request.

--- a/transport/spi/src/test/kotlin/EndpointComponentTest.kt
+++ b/transport/spi/src/test/kotlin/EndpointComponentTest.kt
@@ -138,4 +138,4 @@ private class CustomProcessingService(
 }
 
 /** A test message header. */
-private val HEADER = MessageHeader("testToken", "testTraceId", 42)
+private val HEADER = MessageHeader("testTraceId", 42)

--- a/transport/spi/src/test/kotlin/MessagePublisherTest.kt
+++ b/transport/spi/src/test/kotlin/MessagePublisherTest.kt
@@ -115,7 +115,7 @@ class MessagePublisherTest : StringSpec({
 })
 
 /** A test message header. */
-private val HEADER = MessageHeader("testToken", "testTraceId", 17)
+private val HEADER = MessageHeader("testTraceId", 17)
 
 /**
  * Create a [ConfigManager] that selects the test transport for the sender to the given [endpoint].

--- a/transport/spi/src/testFixtures/kotlin/Utils.kt
+++ b/transport/spi/src/testFixtures/kotlin/Utils.kt
@@ -76,13 +76,12 @@ fun startReceiver(configManager: ConfigManager): LinkedBlockingQueue<Message<Orc
 }
 
 /**
- * Check that the next message in this queue has the given [token], [traceId], [runId], and [payload].
+ * Check that the next message in this queue has the given [traceId], [runId], and [payload].
  */
-fun <T> BlockingQueue<Message<T>>.checkMessage(token: String, traceId: String, runId: Long, payload: T) {
+fun <T> BlockingQueue<Message<T>>.checkMessage(traceId: String, runId: Long, payload: T) {
     val message = poll(5, TimeUnit.SECONDS)
 
     message.shouldNotBeNull()
-    message.header.token shouldBe token
     message.header.traceId shouldBe traceId
     message.header.ortRunId shouldBe runId
     message.payload shouldBe payload

--- a/transport/sqs/src/main/kotlin/SqsMessageReceiverFactory.kt
+++ b/transport/sqs/src/main/kotlin/SqsMessageReceiverFactory.kt
@@ -34,7 +34,6 @@ import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessageHeader
 import org.eclipse.apoapsis.ortserver.transport.MessageReceiverFactory
 import org.eclipse.apoapsis.ortserver.transport.RUN_ID_PROPERTY
-import org.eclipse.apoapsis.ortserver.transport.TOKEN_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.TRACE_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.json.JsonSerializer
 
@@ -42,7 +41,7 @@ import org.slf4j.LoggerFactory
 
 private val logger = LoggerFactory.getLogger(SqsMessageReceiverFactory::class.java)
 
-internal val messageAttributeNames = listOf(TOKEN_PROPERTY, TRACE_PROPERTY, RUN_ID_PROPERTY)
+internal val messageAttributeNames = listOf(TRACE_PROPERTY, RUN_ID_PROPERTY)
 
 /**
  * A [MessageReceiverFactory] implementation for AWS SQS.
@@ -115,10 +114,6 @@ class SqsMessageReceiverFactory : MessageReceiverFactory {
 }
 
 internal fun Map<String, MessageAttributeValue>.toMessageHeader(): MessageHeader {
-    val token = checkNotNull(get(TOKEN_PROPERTY)?.stringValue) {
-        "The token attribute is not a valid string value."
-    }
-
     val traceId = checkNotNull(get(TRACE_PROPERTY)?.stringValue) {
         "The trace ID attribute is not a valid string value."
     }
@@ -127,5 +122,5 @@ internal fun Map<String, MessageAttributeValue>.toMessageHeader(): MessageHeader
         "The ORT run ID attribute is not a valid long value."
     }
 
-    return MessageHeader(token, traceId, ortRunId)
+    return MessageHeader(traceId, ortRunId)
 }

--- a/transport/sqs/src/main/kotlin/SqsMessageSender.kt
+++ b/transport/sqs/src/main/kotlin/SqsMessageSender.kt
@@ -30,7 +30,6 @@ import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessageHeader
 import org.eclipse.apoapsis.ortserver.transport.MessageSender
 import org.eclipse.apoapsis.ortserver.transport.RUN_ID_PROPERTY
-import org.eclipse.apoapsis.ortserver.transport.TOKEN_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.TRACE_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.json.JsonSerializer
 
@@ -58,10 +57,6 @@ class SqsMessageSender<T : Any>(
 
 internal fun MessageHeader.toMessageAttributes() =
     mapOf(
-        TOKEN_PROPERTY to MessageAttributeValue {
-            stringValue = token
-            dataType = "String"
-        },
         TRACE_PROPERTY to MessageAttributeValue {
             stringValue = traceId
             dataType = "String"

--- a/transport/sqs/src/test/kotlin/SqsMessageSenderFactoryTest.kt
+++ b/transport/sqs/src/test/kotlin/SqsMessageSenderFactoryTest.kt
@@ -67,7 +67,7 @@ class SqsMessageSenderFactoryTest : StringSpec({
     }
 
     "Messages can be sent via the sender" {
-        val header = MessageHeader("token", "traceId", 47)
+        val header = MessageHeader("traceId", 47)
         val payload = AnalyzerWorkerResult(11)
         val message = Message(header, payload)
 

--- a/workers/advisor/src/test/kotlin/AdvisorEndpointTest.kt
+++ b/workers/advisor/src/test/kotlin/AdvisorEndpointTest.kt
@@ -53,11 +53,10 @@ import org.koin.test.mock.MockProvider
 import org.koin.test.mock.declareMock
 
 private const val ADVISOR_JOB_ID = 1L
-private const val TOKEN = "token"
 private const val TRACE_ID = "42"
 private const val VULNERABLE_CODE_API_KEY = "vulnerable_code_api_key"
 
-private val messageHeader = MessageHeader(TOKEN, TRACE_ID, 23)
+private val messageHeader = MessageHeader(TRACE_ID, 23)
 
 private val advisorRequest = AdvisorRequest(
     advisorJobId = ADVISOR_JOB_ID

--- a/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
@@ -82,10 +82,9 @@ import org.koin.test.mock.MockProvider
 import org.koin.test.mock.declareMock
 
 private const val JOB_ID = 1L
-private const val TOKEN = "token"
 private const val TRACE_ID = "42"
 
-private val messageHeader = MessageHeader(TOKEN, TRACE_ID, 24)
+private val messageHeader = MessageHeader(TRACE_ID, 24)
 
 private val analyzerRequest = AnalyzerRequest(
     analyzerJobId = JOB_ID

--- a/workers/config/src/test/kotlin/EndpointTest.kt
+++ b/workers/config/src/test/kotlin/EndpointTest.kt
@@ -134,9 +134,8 @@ class EndpointTest : KoinTest, StringSpec() {
 }
 
 private const val RUN_ID = 20230803092449L
-private const val TOKEN = "token"
 private const val TRACE_ID = "trace-id"
 
-private val messageHeader = MessageHeader(TOKEN, TRACE_ID, 24)
+private val messageHeader = MessageHeader(TRACE_ID, 24)
 
 private val configRequest = ConfigRequest(RUN_ID)

--- a/workers/evaluator/src/test/kotlin/EvaluatorEndpointTest.kt
+++ b/workers/evaluator/src/test/kotlin/EvaluatorEndpointTest.kt
@@ -53,10 +53,9 @@ import org.koin.test.mock.MockProvider
 import org.koin.test.mock.declareMock
 
 private const val EVALUATOR_JOB_ID = 1L
-private const val TOKEN = "token"
 private const val TRACE_ID = "42"
 
-private val messageHeader = MessageHeader(TOKEN, TRACE_ID, 25)
+private val messageHeader = MessageHeader(TRACE_ID, 25)
 
 private val evaluatorRequest = EvaluatorRequest(EVALUATOR_JOB_ID)
 

--- a/workers/notifier/src/test/kotlin/NotifierEndpointTest.kt
+++ b/workers/notifier/src/test/kotlin/NotifierEndpointTest.kt
@@ -53,10 +53,9 @@ import org.koin.test.mock.MockProvider
 import org.koin.test.mock.declareMock
 
 private const val NOTIFIER_JOB_ID = 1L
-private const val TOKEN = "token"
 private const val TRACE_ID = "42"
 
-private val messageHeader = MessageHeader(TOKEN, TRACE_ID, 25)
+private val messageHeader = MessageHeader(TRACE_ID, 25)
 
 private val notifierRequest = NotifierRequest(NOTIFIER_JOB_ID)
 

--- a/workers/reporter/src/test/kotlin/reporter/ReporterComponentTest.kt
+++ b/workers/reporter/src/test/kotlin/reporter/ReporterComponentTest.kt
@@ -54,13 +54,12 @@ import org.koin.test.mock.MockProvider
 import org.koin.test.mock.declareMock
 
 private const val REPORTER_JOB_ID = 1L
-private const val TOKEN = "token"
 private const val TRACE_ID = "42"
 private const val DOWNLOAD_LINK_PREFIX = "https://report.example.org/download/"
 private const val TOKEN_LENGTH = 77
 private const val TOKEN_VALIDITY = 101
 
-private val messageHeader = MessageHeader(TOKEN, TRACE_ID, 26)
+private val messageHeader = MessageHeader(TRACE_ID, 26)
 
 private val reporterRequest = ReporterRequest(REPORTER_JOB_ID)
 

--- a/workers/scanner/src/test/kotlin/ScannerEndpointTest.kt
+++ b/workers/scanner/src/test/kotlin/ScannerEndpointTest.kt
@@ -53,10 +53,9 @@ import org.koin.test.mock.MockProvider
 import org.koin.test.mock.declareMock
 
 private const val SCANNER_JOB_ID = 1L
-private const val TOKEN = "token"
 private const val TRACE_ID = "42"
 
-private val messageHeader = MessageHeader(TOKEN, TRACE_ID, 25)
+private val messageHeader = MessageHeader(TRACE_ID, 25)
 
 private val scannerRequest = ScannerRequest(
     scannerJobId = SCANNER_JOB_ID


### PR DESCRIPTION
<strike>The header of messages exchanged between the various endpoints contains a field called "token". This change sets that field with the JWT from the "Authorization" HTTP header.</strike>

This change removes the "token" property from the header of messages exchanged between the various ORT Server endpoints. It is currently left empty and there are no changes planned that would make use of it.