### PR TITLE
style: Use a more compact formatting for several tests

### DIFF
--- a/config/github/src/test/kotlin/GitHubConfigFileProviderFactoryTest.kt
+++ b/config/github/src/test/kotlin/GitHubConfigFileProviderFactoryTest.kt
@@ -23,8 +23,6 @@ import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 
 import io.kotest.core.spec.style.WordSpec
-import io.kotest.core.test.TestCase
-import io.kotest.core.test.TestResult
 import io.kotest.matchers.shouldBe
 
 import io.mockk.every
@@ -38,46 +36,38 @@ import org.eclipse.apoapsis.ortserver.config.ConfigSecretProviderFactoryForTesti
 import org.eclipse.apoapsis.ortserver.config.Context
 import org.eclipse.apoapsis.ortserver.config.Path
 
-class GitHubConfigFileProviderFactoryTest : WordSpec() {
-    override suspend fun afterEach(testCase: TestCase, result: TestResult) {
+class GitHubConfigFileProviderFactoryTest : WordSpec({
+    afterEach {
         unmockkAll()
     }
 
-    init {
-        "A correctly initialized provider instance" should {
-            "be created" {
-                mockkConstructor(GitHubConfigFileProvider::class)
-                every { anyConstructed<GitHubConfigFileProvider>().getFile(any(), any()) } returns ByteArrayInputStream(
-                    CONTENT.toByteArray()
-                )
+    "A correctly initialized provider instance" should {
+        "be created" {
+            mockkConstructor(GitHubConfigFileProvider::class)
+            every { anyConstructed<GitHubConfigFileProvider>().getFile(any(), any()) } returns ByteArrayInputStream(
+                CONTENT.toByteArray()
+            )
 
-                val manager = createConfigManager()
-                manager.getFile(Context(REVISION), Path(CONFIG_PATH)).bufferedReader(Charsets.UTF_8)
-                    .use { it.readText() } shouldBe CONTENT
-            }
+            val manager = ConfigManager.create(createProviderConfig())
+            manager.getFile(Context(REVISION), Path(CONFIG_PATH)).bufferedReader(Charsets.UTF_8)
+                .use { it.readText() } shouldBe CONTENT
         }
     }
+})
 
-    /**
-     * Create a [ConfigManager] object that uses a [GitHubConfigFileProvider] which reads secrets from the provided
-     * [server].
-     */
-    private fun createConfigManager(): ConfigManager = ConfigManager.create(createProviderConfig())
+/**
+ * Create a [Config] that can be used to instantiate a [ConfigManager] which uses a [GitHubConfigFileProvider] to
+ * query config files. The files are read from the given [server].
+ */
+private fun createProviderConfig(): Config {
+    val providerMap = mapOf(
+        ConfigManager.FILE_PROVIDER_NAME_PROPERTY to GitHubConfigFileProviderFactory.NAME,
+        ConfigManager.SECRET_PROVIDER_NAME_PROPERTY to ConfigSecretProviderFactoryForTesting.NAME,
+        GitHubConfigFileProvider.GITHUB_API_URL to "http://localhost:8080",
+        GitHubConfigFileProvider.REPOSITORY_OWNER to OWNER,
+        GitHubConfigFileProvider.REPOSITORY_NAME to REPOSITORY
+    )
+    val configMap = mapOf(ConfigManager.CONFIG_MANAGER_SECTION to providerMap)
 
-    /**
-     * Create a [Config] that can be used to instantiate a [ConfigManager] which uses a [GitHubConfigFileProvider] to
-     * query config files. The files are read from the given [server].
-     */
-    private fun createProviderConfig(): Config {
-        val providerMap = mapOf(
-            ConfigManager.FILE_PROVIDER_NAME_PROPERTY to GitHubConfigFileProviderFactory.NAME,
-            ConfigManager.SECRET_PROVIDER_NAME_PROPERTY to ConfigSecretProviderFactoryForTesting.NAME,
-            GitHubConfigFileProvider.GITHUB_API_URL to "http://localhost:8080",
-            GitHubConfigFileProvider.REPOSITORY_OWNER to OWNER,
-            GitHubConfigFileProvider.REPOSITORY_NAME to REPOSITORY
-        )
-        val configMap = mapOf(ConfigManager.CONFIG_MANAGER_SECTION to providerMap)
-
-        return ConfigFactory.parseMap(configMap)
-    }
+    return ConfigFactory.parseMap(configMap)
 }


### PR DESCRIPTION
Reduce indentation and minify overridden function signatures for a better overview. While at it, inline the only use of the `createConfigManager()` function.