### PR TITLE
fix(core): Fix a race condition when creating ORT runs

### DIFF
--- a/core/src/main/kotlin/services/OrchestratorService.kt
+++ b/core/src/main/kotlin/services/OrchestratorService.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.apoapsis.ortserver.core.services
 
+import java.sql.Connection
 import java.util.UUID
 
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
@@ -55,7 +56,7 @@ class OrchestratorService(
         jobConfigContext: String?,
         labels: Map<String, String>?
     ): OrtRun {
-        val ortRun = db.dbQuery {
+        val ortRun = db.dbQuery(transactionIsolation = Connection.TRANSACTION_SERIALIZABLE) {
             ortRunRepository.create(repositoryId, revision, path, jobConfig, jobConfigContext, labels.orEmpty())
         }
 


### PR DESCRIPTION
Creating multiple runs for the same repository concurrently could lead to a unique constraint violation exception because the computation of the run index is not thread-safe. Fix this by setting the transaction isolation level to `TRANSACTION_SERIALIZABLE`. Since runs are not created that frequently, this should not have a major impact on the performance.