### PR TITLE
Add `/runs/{id}` endpoint

### DIFF
--- a/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
@@ -69,7 +69,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateRepository
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateSecret
 import org.eclipse.apoapsis.ortserver.api.v1.model.asPresent
 
-private val fullJobConfigurations = JobConfigurations(
+internal val fullJobConfigurations = JobConfigurations(
     analyzer = AnalyzerJobConfiguration(
         allowDynamicVersions = true,
         disabledPackageManagers = listOf("NPM", "SBT"),

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -23,8 +23,51 @@ import io.github.smiley4.ktorswaggerui.dsl.OpenApiRoute
 
 import io.ktor.http.HttpStatusCode
 
+import kotlinx.datetime.Clock
+
+import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRun
+import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatus
 import org.eclipse.apoapsis.ortserver.logaccess.LogLevel
 import org.eclipse.apoapsis.ortserver.logaccess.LogSource
+
+val getOrtRunById: OpenApiRoute.() -> Unit = {
+    operationId = "getOrtRunById"
+    summary = "Get details of an ORT run."
+    tags = listOf("Runs")
+
+    request {
+        pathParameter<Long>("runId") {
+            description = "The run's ID."
+        }
+    }
+
+    response {
+        HttpStatusCode.OK to {
+            description = "Success"
+            jsonBody<OrtRun> {
+                example(
+                    name = "Get ORT run",
+                    value = OrtRun(
+                        id = 1,
+                        index = 2,
+                        repositoryId = 1,
+                        revision = "main",
+                        createdAt = Clock.System.now(),
+                        jobConfigs = fullJobConfigurations,
+                        resolvedJobConfigs = fullJobConfigurations,
+                        jobs = jobs,
+                        status = OrtRunStatus.ACTIVE,
+                        finishedAt = null,
+                        labels = mapOf("label key" to "label value"),
+                        issues = emptyList(),
+                        jobConfigContext = null,
+                        resolvedJobConfigContext = "32f955941e94d0a318e1c985903f42af924e9050"
+                    )
+                )
+            }
+        }
+    }
+}
 
 val getReportByRunIdAndFileName: OpenApiRoute.() -> Unit = {
     operationId = "GetReportByRunIdAndFileName"

--- a/core/src/main/kotlin/plugins/OpenApi.kt
+++ b/core/src/main/kotlin/plugins/OpenApi.kt
@@ -91,32 +91,15 @@ fun Application.configureOpenApi() {
         // of the tags on root level also defines the order of appearance of the operations
         // (belonging to these tags) in the Swagger UI.
         // See https://swagger.io/docs/specification/grouping-operations-with-tags/ for details.
-        tag("Health") {
-        }
-
-        tag("Organizations") {
-        }
-
-        tag("Products") {
-        }
-
-        tag("Repositories") {
-        }
-
-        tag("Runs") {
-        }
-
-        tag("Secrets") {
-        }
-
-        tag("Infrastructure services") {
-        }
-
-        tag("Reports") {
-        }
-
-        tag("Logs") {
-        }
+        tag("Health") { }
+        tag("Organizations") { }
+        tag("Products") { }
+        tag("Repositories") { }
+        tag("Runs") { }
+        tag("Secrets") { }
+        tag("Infrastructure services") { }
+        tag("Reports") { }
+        tag("Logs") { }
 
         encoding {
             schemaEncoder { type ->

--- a/core/src/main/kotlin/plugins/OpenApi.kt
+++ b/core/src/main/kotlin/plugins/OpenApi.kt
@@ -103,6 +103,9 @@ fun Application.configureOpenApi() {
         tag("Repositories") {
         }
 
+        tag("Runs") {
+        }
+
         tag("Secrets") {
         }
 

--- a/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
@@ -143,14 +143,7 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
         prodId: Long = productId
     ) = productService.createRepository(type, url, prodId)
 
-    fun createJobSummaries(ortRunId: Long): JobSummaries {
-        val analyzerJob = dbExtension.fixtures.createAnalyzerJob(ortRunId).mapToApiSummary()
-        val advisorJob = dbExtension.fixtures.createAdvisorJob(ortRunId).mapToApiSummary()
-        val scannerJob = dbExtension.fixtures.createScannerJob(ortRunId).mapToApiSummary()
-        val evaluatorJob = dbExtension.fixtures.createEvaluatorJob(ortRunId).mapToApiSummary()
-        val reporterJob = dbExtension.fixtures.createReporterJob(ortRunId).mapToApiSummary()
-        return JobSummaries(analyzerJob, advisorJob, scannerJob, evaluatorJob, reporterJob)
-    }
+    fun createJobSummaries(ortRunId: Long) = dbExtension.fixtures.createJobs(ortRunId).mapToApiSummary()
 
     val secretPath = "path"
     val secretName = "name"

--- a/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
@@ -442,10 +442,12 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                     labelsMap
                 )
 
+                val jobs = dbExtension.fixtures.createJobs(run.id).mapToApi()
+
                 val response = superuserClient.get("/api/v1/repositories/${createdRepository.id}/runs/${run.index}")
 
                 response shouldHaveStatus HttpStatusCode.OK
-                response shouldHaveBody run.mapToApi(Jobs())
+                response shouldHaveBody run.mapToApi(jobs)
             }
         }
 

--- a/dao/src/testFixtures/kotlin/Fixtures.kt
+++ b/dao/src/testFixtures/kotlin/Fixtures.kt
@@ -46,6 +46,7 @@ import org.eclipse.apoapsis.ortserver.model.AnalyzerJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.EvaluatorJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.JiraNotificationConfiguration
 import org.eclipse.apoapsis.ortserver.model.JobConfigurations
+import org.eclipse.apoapsis.ortserver.model.Jobs
 import org.eclipse.apoapsis.ortserver.model.MailNotificationConfiguration
 import org.eclipse.apoapsis.ortserver.model.NotifierJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.ReporterJobConfiguration
@@ -173,6 +174,17 @@ class Fixtures(private val db: Database) {
         ortRunId: Long = ortRun.id,
         configuration: NotifierJobConfiguration = jobConfigurations.notifier!!
     ) = notifierJobRepository.create(ortRunId, configuration)
+
+    fun createJobs(ortRunId: Long): Jobs {
+        val analyzerJob = createAnalyzerJob(ortRunId)
+        val advisorJob = createAdvisorJob(ortRunId)
+        val scannerJob = createScannerJob(ortRunId)
+        val evaluatorJob = createEvaluatorJob(ortRunId)
+        val reporterJob = createReporterJob(ortRunId)
+        val notifierJob = createNotifierJob(ortRunId)
+
+        return Jobs(analyzerJob, advisorJob, scannerJob, evaluatorJob, reporterJob, notifierJob)
+    }
 
     fun createIdentifier() = db.blockingQuery {
         IdentifierDao.new {


### PR DESCRIPTION
Add an endpoint to get the details of an ORT run at `/runs/{id}`.

For context see #406.