### PR TITLE
feat(workers): Log the ORT Server version when a worker starts

### DIFF
--- a/transport/spi/src/main/kotlin/EndpointComponent.kt
+++ b/transport/spi/src/main/kotlin/EndpointComponent.kt
@@ -30,6 +30,9 @@ import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
 /**
  * An abstract base class providing functionality useful for components implementing endpoints in the ORT server.
  *
@@ -50,6 +53,8 @@ abstract class EndpointComponent<T : Any>(
     val configManager: ConfigManager = ConfigManager.create(ConfigFactory.load())
 ) : KoinComponent {
     abstract val endpointHandler: EndpointHandler<T>
+
+    protected val logger: Logger = LoggerFactory.getLogger(this::class.java)
 
     /**
      * Start this endpoint and perform necessary initialization, so that incoming messages can be received and

--- a/transport/spi/src/main/kotlin/EndpointComponent.kt
+++ b/transport/spi/src/main/kotlin/EndpointComponent.kt
@@ -66,6 +66,7 @@ abstract class EndpointComponent<T : Any>(
             modules(customModules())
         }
 
+        logger.logVersion()
         MessageReceiverFactory.createReceiver(endpoint, configManager, endpointHandler)
     }
 

--- a/transport/spi/src/main/kotlin/Utils.kt
+++ b/transport/spi/src/main/kotlin/Utils.kt
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.transport
+
+import org.eclipse.apoapsis.ortserver.model.ORT_SERVER_VERSION
+
+import org.slf4j.Logger
+
+private val ORT_SERVER_BANNER = """
+  ___    ____    _____           ____                                       
+ / _ \  |  _ \  |_   _|         / ___|    ___   _ __  __   __   ___   _ __  
+| | | | | |_) |   | |    _____  \___ \   / _ \ | '__| \ \ / /  / _ \ | '__| 
+| |_| | |  _ <    | |   |_____|  ___) | |  __/ | |     \ V /  |  __/ | |    
+ \___/  |_| \_\   |_|           |____/   \___| |_|      \_/    \___| |_|    
+ --------------------------------------------------------------------------
+ ORT Server version: $ORT_SERVER_VERSION
+"""
+
+/**
+ * Log the ORT Server version including the commit hash. Also display a pretty Ascii art banner.
+ */
+fun Logger.logVersion() {
+    info(ORT_SERVER_BANNER)
+}

--- a/workers/advisor/src/main/kotlin/advisor/AdvisorComponent.kt
+++ b/workers/advisor/src/main/kotlin/advisor/AdvisorComponent.kt
@@ -49,10 +49,6 @@ import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
-import org.slf4j.LoggerFactory
-
-private val logger = LoggerFactory.getLogger(AdvisorComponent::class.java)
-
 class AdvisorComponent : EndpointComponent<AdvisorRequest>(AdvisorEndpoint) {
     override val endpointHandler: EndpointHandler<AdvisorRequest> = { message ->
         val advisorWorker by inject<AdvisorWorker>()

--- a/workers/analyzer/src/main/kotlin/analyzer/AnalyzerComponent.kt
+++ b/workers/analyzer/src/main/kotlin/analyzer/AnalyzerComponent.kt
@@ -41,10 +41,6 @@ import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
-import org.slf4j.LoggerFactory
-
-private val logger = LoggerFactory.getLogger(AnalyzerComponent::class.java)
-
 /**
  * The central entry point into the Analyzer service. The class processes messages to analyze repositories by
  * delegating to helper objects.

--- a/workers/config/src/main/kotlin/ConfigComponent.kt
+++ b/workers/config/src/main/kotlin/ConfigComponent.kt
@@ -39,10 +39,6 @@ import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
-import org.slf4j.LoggerFactory
-
-private val logger = LoggerFactory.getLogger(ConfigComponent::class.java)
-
 /**
  * The central entry point into the Config worker. The class sets up the dependency injection framework and processes
  * incoming messages by delegating them to a [ConfigWorker] instance.

--- a/workers/evaluator/src/main/kotlin/evaluator/EvaluatorComponent.kt
+++ b/workers/evaluator/src/main/kotlin/evaluator/EvaluatorComponent.kt
@@ -43,10 +43,6 @@ import org.koin.dsl.module
 import org.ossreviewtoolkit.model.config.LicenseFilePatterns
 import org.ossreviewtoolkit.model.utils.FileArchiver
 
-import org.slf4j.LoggerFactory
-
-private val logger = LoggerFactory.getLogger(EvaluatorComponent::class.java)
-
 class EvaluatorComponent : EndpointComponent<EvaluatorRequest>(EvaluatorEndpoint) {
     override val endpointHandler: EndpointHandler<EvaluatorRequest> = { message ->
         val evaluatorWorker by inject<EvaluatorWorker>()

--- a/workers/notifier/src/main/kotlin/notifier/NotifierComponent.kt
+++ b/workers/notifier/src/main/kotlin/notifier/NotifierComponent.kt
@@ -37,10 +37,6 @@ import org.koin.core.component.inject
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
-import org.slf4j.LoggerFactory
-
-private val logger = LoggerFactory.getLogger(NotifierComponent::class.java)
-
 class NotifierComponent : EndpointComponent<NotifierRequest>(NotifierEndpoint) {
     override val endpointHandler: EndpointHandler<NotifierRequest> = { message ->
         val notifierWorker by inject<NotifierWorker>()

--- a/workers/reporter/src/main/kotlin/reporter/ReporterComponent.kt
+++ b/workers/reporter/src/main/kotlin/reporter/ReporterComponent.kt
@@ -47,10 +47,6 @@ import org.koin.dsl.module
 import org.ossreviewtoolkit.model.config.LicenseFilePatterns
 import org.ossreviewtoolkit.model.utils.FileArchiver
 
-import org.slf4j.LoggerFactory
-
-private val logger = LoggerFactory.getLogger(ReporterComponent::class.java)
-
 class ReporterComponent : EndpointComponent<ReporterRequest>(ReporterEndpoint) {
     companion object {
         /**

--- a/workers/scanner/src/main/kotlin/scanner/ScannerComponent.kt
+++ b/workers/scanner/src/main/kotlin/scanner/ScannerComponent.kt
@@ -44,10 +44,6 @@ import org.koin.dsl.module
 import org.ossreviewtoolkit.model.config.LicenseFilePatterns
 import org.ossreviewtoolkit.model.utils.FileArchiver
 
-import org.slf4j.LoggerFactory
-
-private val logger = LoggerFactory.getLogger(ScannerComponent::class.java)
-
 class ScannerComponent : EndpointComponent<ScannerRequest>(ScannerEndpoint) {
     override val endpointHandler: EndpointHandler<ScannerRequest> = { message ->
         val scannerWorker by inject<ScannerWorker>()


### PR DESCRIPTION
![image](https://github.com/eclipse-apoapsis/ort-server/assets/66427221/714f0780-1a8f-48e2-b3ba-7c6c1d924646)

The Ascii art uses a library from a small project "Kotlin Ink":
https://github.com/Derrick-Mwendwa/kotlin-ink

Is it ok to use it in ORT Server ? I reviewed the source code and it seems clean.

I also opened an issue for better integration:
https://github.com/Derrick-Mwendwa/kotlin-ink/issues/3