### PR TITLE
fix(scanner): Fix assignments of provenances to nested provenances

### DIFF
--- a/workers/scanner/src/main/kotlin/scanner/OrtServerNestedProvenanceStorage.kt
+++ b/workers/scanner/src/main/kotlin/scanner/OrtServerNestedProvenanceStorage.kt
@@ -106,7 +106,7 @@ class OrtServerNestedProvenanceStorage(
         nestedProvenanceDao: NestedProvenanceDao
     ) {
         runBlocking {
-            packageProvenanceCache.get(provenance)?.let { packageProvenanceId ->
+            packageProvenanceCache.get(provenance).forEach { packageProvenanceId ->
                 PackageProvenanceDao[packageProvenanceId].nestedProvenance = nestedProvenanceDao
             }
         }

--- a/workers/scanner/src/test/kotlin/OrtServerPackageProvenanceStorageTest.kt
+++ b/workers/scanner/src/test/kotlin/OrtServerPackageProvenanceStorageTest.kt
@@ -80,7 +80,7 @@ class OrtServerPackageProvenanceStorageTest : WordSpec() {
                 associatedProvenances.single() shouldBe provenance
 
                 if (provenance is RepositoryProvenance) {
-                    runBlocking { cache.get(provenance) } shouldBe associatedProvenanceDaos.single().id.value
+                    runBlocking { cache.get(provenance).single() } shouldBe associatedProvenanceDaos.single().id.value
                 }
             }
         }

--- a/workers/scanner/src/test/kotlin/scanner/PackageProvenanceCacheTest.kt
+++ b/workers/scanner/src/test/kotlin/scanner/PackageProvenanceCacheTest.kt
@@ -35,19 +35,21 @@ import org.ossreviewtoolkit.model.VcsType
 
 class PackageProvenanceCacheTest : WordSpec({
     "get" should {
-        "return null for an unknown provenance" {
+        "return an empty list for an unknown provenance" {
             val cache = PackageProvenanceCache()
 
-            cache.get(rootProvenance) should beNull()
+            cache.get(rootProvenance) should beEmpty()
         }
 
-        "return the assigned database ID" {
-            val provenanceDaoId = 20240111153515L
+        "return the assigned database IDs" {
+            val provenanceDaoId1 = 20240111153515L
+            val provenanceDaoId2 = 20240617092022L
             val cache = PackageProvenanceCache()
 
-            cache.putAndGetNestedProvenance(rootProvenance, provenanceDaoId)
+            cache.putAndGetNestedProvenance(rootProvenance, provenanceDaoId1)
+            cache.putAndGetNestedProvenance(rootProvenance, provenanceDaoId2)
 
-            cache.get(rootProvenance) shouldBe provenanceDaoId
+            cache.get(rootProvenance) shouldContainExactlyInAnyOrder listOf(provenanceDaoId1, provenanceDaoId2)
         }
     }
 


### PR DESCRIPTION
OrtServerNestedProvenanceStorage did not handle the constellation correctly that there are multiple root projects in a repository. In this case, only the last project was assigned the nested provenance correctly; the others were missed.

To prevent this, extend `PackageProvenanceCache` to store a list of provenance IDs that are found in a repository. Then the assignment can be done for all of these provenances.