### PR TITLE
fix(ui): Redirect back to same path after signing in

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -71,7 +71,9 @@ export const App = () => {
       !auth.isLoading &&
       !hasTriedSignin
     ) {
-      auth.signinRedirect();
+      auth.signinRedirect({
+        redirect_uri: window.location.href,
+      });
       setHasTriedSignin(true);
     }
   }, [auth, hasTriedSignin]);


### PR DESCRIPTION
To sing the users in, the UI briefly redirects the browser to Keycloak when
loading the UI in browser. Keycloak redirects users back to the UI, so use
the current URL as the redirect URI to get the user to the same page they
tried to access before signing in.

Fixes #435.