### PR TITLE
test: Disable scanning for Kotest project config in third-party JARs

### DIFF
--- a/utils/test/src/commonMain/resources/kotest.properties
+++ b/utils/test/src/commonMain/resources/kotest.properties
@@ -17,3 +17,4 @@
 
 kotest.framework.classpath.scanning.autoscan.disable = true
 kotest.framework.classpath.scanning.config.disable = true
+kotest.framework.discovery.jar.scan.disable = true


### PR DESCRIPTION
This should reduce test startup times yet more, see [1].

[1]: https://kantis.github.io/posts/Faster-Kotest-startup/