### PR TITLE
feat(ui): Increase the limits in API requests

### DIFF
--- a/ui/src/routes/_layout/admin/index.tsx
+++ b/ui/src/routes/_layout/admin/index.tsx
@@ -202,7 +202,7 @@ const DataTable = <TData, TValue>({
 const OverviewContent = () => {
   const { data } = useSuspenseQuery({
     queryKey: [useOrganizationsServiceGetOrganizationsKey],
-    queryFn: () => OrganizationsService.getOrganizations(),
+    queryFn: () => OrganizationsService.getOrganizations({ limit: 1000 }),
   });
 
   return (

--- a/ui/src/routes/_layout/index.tsx
+++ b/ui/src/routes/_layout/index.tsx
@@ -49,7 +49,7 @@ import {
 export const IndexPage = () => {
   const { data } = useSuspenseQuery({
     queryKey: [useOrganizationsServiceGetOrganizationsKey],
-    queryFn: () => OrganizationsService.getOrganizations(),
+    queryFn: () => OrganizationsService.getOrganizations({ limit: 1000 }),
   });
 
   return (
@@ -118,7 +118,7 @@ export const Route = createFileRoute('/_layout/')({
   loader: async ({ context }) => {
     await context.queryClient.ensureQueryData({
       queryKey: [useOrganizationsServiceGetOrganizationsKey],
-      queryFn: () => OrganizationsService.getOrganizations(),
+      queryFn: () => OrganizationsService.getOrganizations({ limit: 1000 }),
     });
   },
   component: IndexPage,

--- a/ui/src/routes/_layout/organizations/$orgId.index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.index.tsx
@@ -86,6 +86,7 @@ const OrganizationComponent = () => {
         queryFn: async () =>
           await ProductsService.getOrganizationProducts({
             organizationId: Number.parseInt(params.orgId),
+            limit: 1000,
           }),
       },
     ],
@@ -252,6 +253,7 @@ export const Route = createFileRoute('/_layout/organizations/$orgId/')({
         queryFn: () =>
           ProductsService.getOrganizationProducts({
             organizationId: Number.parseInt(params.orgId),
+            limit: 1000,
           }),
       }),
     ]);

--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.index.tsx
@@ -85,6 +85,7 @@ const ProductComponent = () => {
         queryFn: async () =>
           await RepositoriesService.getRepositoriesByProductId({
             productId: Number.parseInt(params.productId),
+            limit: 1000,
           }),
       },
     ],
@@ -265,6 +266,7 @@ export const Route = createFileRoute(
         queryFn: () =>
           RepositoriesService.getRepositoriesByProductId({
             productId: Number.parseInt(params.productId),
+            limit: 1000,
           }),
       }),
     ]);

--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.index.tsx
@@ -95,6 +95,7 @@ const RepoComponent = () => {
         queryFn: async () =>
           await RepositoriesService.getOrtRuns({
             repositoryId: Number.parseInt(params.repoId),
+            limit: 1000,
             sort: '-index',
           }),
         refetchInterval: pollInterval,
@@ -321,6 +322,7 @@ export const Route = createFileRoute(
         queryFn: () =>
           RepositoriesService.getOrtRuns({
             repositoryId: Number.parseInt(params.repoId),
+            limit: 1000,
             sort: '-index',
           }),
       }),


### PR DESCRIPTION
Increase the limits when requesting list of organizations, products, repositories, and runs from the default 20 to 1000.

This mitigates the issue that not all entities can be accessed from the UI until #453 is implemented.