### PR TITLE
build(Gradle): Use a different syntax to configure common source sets

### DIFF
--- a/api/v1/mapping/build.gradle.kts
+++ b/api/v1/mapping/build.gradle.kts
@@ -28,16 +28,15 @@ group = "org.eclipse.apoapsis.ortserver.api.v1"
 kotlin {
     jvm()
 
-    @Suppress("UnusedPrivateMember")
     sourceSets {
-        val commonMain by getting {
+        commonMain {
             dependencies {
                 api(projects.api.v1.apiV1Model)
                 api(projects.model)
             }
         }
 
-        val commonTest by getting {
+        commonTest {
             dependencies {
                 implementation(projects.utils.test)
             }

--- a/api/v1/model/build.gradle.kts
+++ b/api/v1/model/build.gradle.kts
@@ -29,9 +29,8 @@ group = "org.eclipse.apoapsis.ortserver.api.v1"
 kotlin {
     jvm()
 
-    @Suppress("UnusedPrivateMember")
     sourceSets {
-        val commonMain by getting {
+        commonMain {
             dependencies {
                 api(libs.kotlinxDatetime)
                 api(libs.konform)
@@ -40,7 +39,7 @@ kotlin {
             }
         }
 
-        val commonTest by getting {
+        commonTest {
             dependencies {
                 implementation(projects.utils.test)
             }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -148,8 +148,8 @@ subprojects {
     detekt {
         // Only configure differences to the default.
         buildUponDefaultConfig = true
-        config.setFrom(files("$rootDir/.detekt.yml"))
-        basePath = rootProject.projectDir.path
+        config.from(files("$rootDir/.detekt.yml"))
+        basePath = rootDir.path
         source.from(fileTree(".") { include("*.gradle.kts") }, "src/testFixtures/kotlin")
     }
 

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -29,9 +29,8 @@ group = "org.eclipse.apoapsis.ortserver"
 kotlin {
     jvm()
 
-    @Suppress("UnusedPrivateMember")
     sourceSets {
-        val commonMain by getting {
+        commonMain {
             dependencies {
                 api(libs.kotlinxDatetime)
 
@@ -40,7 +39,7 @@ kotlin {
             }
         }
 
-        val commonTest by getting {
+        commonTest {
             dependencies {
                 implementation(projects.utils.test)
             }

--- a/utils/test/build.gradle.kts
+++ b/utils/test/build.gradle.kts
@@ -26,15 +26,14 @@ group = "org.eclipse.apoapsis.ortserver.utils"
 kotlin {
     jvm()
 
-    @Suppress("UnusedPrivateMember")
     sourceSets {
-        val commonMain by getting {
+        commonMain {
             dependencies {
                 api(libs.kotestFrameworkApi)
             }
         }
 
-        val jvmMain by getting {
+        jvmMain {
             dependencies {
                 // Transitively export this to consumers so they do not have to declare a logger implementation.
                 api(libs.logback)


### PR DESCRIPTION
This way no suppression of "UnusedPrivateMember" is required.