### PR TITLE
Caching for GitHubConfigFileProvider

### DIFF
--- a/config/github/build.gradle.kts
+++ b/config/github/build.gradle.kts
@@ -29,6 +29,7 @@ dependencies {
     implementation(projects.config.configSpi)
     implementation(projects.utils.config)
 
+    implementation(libs.kotlinxDatetime)
     implementation(libs.ktorClientOkHttp)
     implementation(libs.ktorKotlinxSerialization)
 

--- a/config/github/src/main/kotlin/GitHubConfigCache.kt
+++ b/config/github/src/main/kotlin/GitHubConfigCache.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.config.github
+
+import io.ktor.utils.io.ByteReadChannel
+
+import java.io.InputStream
+
+/**
+ * Definition of an interface for a cache to store GitHub configuration data.
+ *
+ * During an ORT run, [GitHubConfigFileProvider] typically loads many configuration files from the configured GitHub
+ * repository. This can be problematic for multiple reasons:
+ * - The GitHub API has a rate limit of 5000 requests per hour, which can be exceeded quickly.
+ * - There is a strong dependency to the availability of the GitHub API.
+ * - The same data is requested multiple times during an ORT run, which is inefficient.
+ *
+ * To address these issues, this caching interface is introduced. Currently, it is not intended to support custom
+ * implementations, but there will be a default implementation using a file-based cache and a no-op implementation for
+ * turning off caching.
+ */
+interface GitHubConfigCache {
+    /**
+     * Return an [InputStream] to access the file at the given [path] from the given [revision]. Use the given [load]
+     * function to obtain the file content if necessary. The [load] function returns a channel with the content of the
+     * file to be cached; this is typically obtained via an HTTP request to the GitHub API. A concrete cache
+     * implementation persists this data and returns an [InputStream] to access it (which is also the return type
+     * for files requested from a config file provider).
+     */
+    suspend fun getOrPutFile(revision: String, path: String, load: suspend () -> ByteReadChannel): InputStream
+}

--- a/config/github/src/main/kotlin/GitHubConfigFileCache.kt
+++ b/config/github/src/main/kotlin/GitHubConfigFileCache.kt
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.config.github
+
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.core.isEmpty
+import io.ktor.utils.io.core.readByteBuffer
+
+import java.io.File
+import java.io.FileInputStream
+import java.io.InputStream
+import java.io.RandomAccessFile
+import java.nio.channels.FileLock
+
+import kotlin.time.Duration
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withContext
+
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger(GitHubConfigFileCache::class.java)
+
+/**
+ * The path under which files downloaded from GitHub are stored in the cache. This is a subdirectory of the folder for
+ * the specific revision.
+ */
+private const val FILES_PATH = "tree"
+
+/**
+ * A class implementing a file cache for data fetched from the GitHub configuration repository.
+ *
+ * Caching of content downloaded from GitHub should be rather effective, as the revision can be used as a criterion to
+ * construct cache keys. It is guaranteed that the data of a specific revision does not change. By applying caching,
+ * the number of requests sent to the GitHub REST API can be reduced significantly. This is especially important since
+ * there is a rate limit in place (which is by default 5000 API requests per hour).
+ *
+ * The implementation has to deal with some race conditions. Since the cache is used by multiple JVMs, it has to be
+ * ensured that concurrent access does not cause any problems. For instance, if a file which is not yet present in the
+ * cache is requested by two JVM instances at the same time, it should be requested from GitHub only once, and it can
+ * be read only after it has been fully downloaded. The implementation achieves this by using exclusive and shared
+ * locks on the accessed files.
+ *
+ * Note: This implementation focuses on the specific requirements of [GitHubConfigFileProvider]. It may be possible to
+ * extract common functionality of a file-based cache for more generic use cases later.
+ */
+internal class GitHubConfigFileCache(
+    /** The root directory of the file cache. */
+    private val cacheDir: File,
+
+    /**
+     * An interval in which the implementation should check for the availability of a read lock. Read locks are used to
+     * make sure that a file is fully written before it is read. Instead of doing a blocking wait for the lock, the
+     * implementation suspends and checks periodically if the lock is available. So, the thread can be used more
+     * effectively.
+     */
+    private val lockCheckInterval: Duration
+) : GitHubConfigCache {
+    /**
+     * Return an [InputStream] to access the file at the given [path] from the given [revision]. If the file is already
+     * contained in the cache, a stream to its content can be returned directly. Otherwise, the specified [load]
+     * function is called to obtain the file and copy its data into the cache.
+     */
+    override suspend fun getOrPutFile(
+        revision: String,
+        path: String,
+        load: suspend () -> ByteReadChannel
+    ): InputStream =
+        withContext(Dispatchers.IO) {
+            logger.info("Request for file '{}' at revision '{}'.", path, revision)
+
+            val revisionDir = cacheDir.resolve(revision)
+            val dataFile = revisionDir.resolve(FILES_PATH).resolve(path)
+
+            val needRetry = if (!dataFile.isFile) {
+                logger.info(
+                    "File '{}' at revision '{}' not found in cache, downloading it to '{}'.",
+                    path,
+                    revision,
+                    dataFile
+                )
+                downloadFile(dataFile, load)
+            } else {
+                false
+            }
+
+            if (needRetry) {
+                getOrPutFile(revision, path, load)
+            } else {
+                dataFile.inputStream().waitForReadLock()
+            }
+        }
+
+    /**
+     * Download a file using the given [load] function and write it into the cache as [dataFile]. Return a flag
+     * whether this was successful. A return value of *false* means that the same file is currently downloaded by
+     * a different process. Then the operation needs to be retried.
+     */
+    private suspend fun downloadFile(dataFile: File, load: suspend () -> ByteReadChannel): Boolean =
+        withContext(Dispatchers.IO) {
+            dataFile.parentFile.mkdirs()
+
+            RandomAccessFile(dataFile, "rw").use { file ->
+                file.channel.use { writeChannel ->
+                    val lock = runCatching { writeChannel.tryLock() }.getOrNull()
+
+                    // If no write lock can be acquired, the file is currently downloaded by another process. In this
+                    // case, simply retry the operation.
+                    lock?.use {
+                        if (dataFile.length() <= 0L) {
+                            val readChannel = load()
+
+                            while (!readChannel.isClosedForRead) {
+                                val packet = readChannel.readRemaining()
+                                while (!packet.isEmpty) {
+                                    val data = packet.readByteBuffer()
+                                    writeChannel.write(data)
+                                }
+                            }
+                        } else {
+                            logger.info("File '{}' already exists, skipping download.", dataFile)
+                        }
+                        false
+                    } ?: true
+                }
+            }
+        }
+
+    /**
+     * Wait until a read lock is available for the given [FileInputStream]. This is needed to ensure that a file has
+     * been fully downloaded until a stream to it is returned from the cache.
+     */
+    private suspend fun FileInputStream.waitForReadLock(): FileInputStream =
+        withContext(Dispatchers.IO) {
+            var lock: FileLock?
+
+            do {
+                lock = runCatching {
+                    this@waitForReadLock.channel.tryLock(0, Long.MAX_VALUE, true)
+                }.getOrNull()
+
+                if (lock == null) {
+                    delay(lockCheckInterval)
+                }
+            } while (lock == null)
+
+            lock.close()
+            this@waitForReadLock
+        }
+}

--- a/config/github/src/main/kotlin/GitHubConfigNoCache.kt
+++ b/config/github/src/main/kotlin/GitHubConfigNoCache.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.config.github
+
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.jvm.javaio.copyTo
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.io.InputStream
+
+/**
+ * An implementation of [GitHubConfigCache] that does not cache anything, but always delegates to the function that
+ * fetches the requested data.
+ */
+internal class GitHubConfigNoCache : GitHubConfigCache {
+    /**
+     * This implementation ignores the passed in [revision] and [path] and always delegates to the [load] function.
+     * Note that the whole content of the file is loaded into memory, which should be fine for configuration files.
+     * (This is also in-line with the original implementation of [GitHubConfigFileProvider].)
+     */
+    override suspend fun getOrPutFile(
+        revision: String,
+        path: String,
+        load: suspend () -> ByteReadChannel
+    ): InputStream {
+        val bos = ByteArrayOutputStream()
+        load().copyTo(bos)
+
+        return ByteArrayInputStream(bos.toByteArray())
+    }
+}

--- a/config/github/src/test/kotlin/GitHubConfigFileCacheTest.kt
+++ b/config/github/src/test/kotlin/GitHubConfigFileCacheTest.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.config.github
+
+import io.kotest.core.TestConfiguration
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.engine.spec.tempdir
+import io.kotest.matchers.shouldBe
+
+import io.ktor.utils.io.ByteReadChannel
+
+import java.io.InputStream
+import java.util.concurrent.atomic.AtomicInteger
+
+import kotlin.time.Duration.Companion.milliseconds
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+
+class GitHubConfigFileCacheTest : WordSpec({
+    "getOrPutFile" should {
+        "return the correct content of a file not yet present in the cache" {
+            val cache = createCache()
+
+            val stream = cache.getOrPutFile(revision(1), TEST_PATH, loadFunc())
+
+            stream.verifyContent()
+        }
+
+        "return the correct content of a file already present in the cache" {
+            val cache = createCache()
+            val loadFunc = loadFunc()
+            cache.getOrPutFile(revision(1), TEST_PATH, loadFunc).close()
+
+            val stream = cache.getOrPutFile(revision(1), TEST_PATH, loadFunc)
+
+            stream.verifyContent()
+        }
+
+        "support different revisions of a file" {
+            val prefix = "otherRevision:\n"
+            val cache = createCache()
+            cache.getOrPutFile(revision(1), TEST_PATH, loadFunc()).close()
+
+            val stream = cache.getOrPutFile(revision(2), TEST_PATH, loadFunc(prefix))
+
+            stream.verifyContent(prefix)
+        }
+
+        "handle concurrent access" {
+            val revisionCount = 4
+            val accessCount = 16
+            val cache = createCache()
+
+            repeat(revisionCount) { revisionIndex ->
+                val prefix = "rev$revisionIndex:\n"
+                val loadFunc = loadFunc(prefix)
+
+                repeat(accessCount) {
+                    launch(Dispatchers.IO) {
+                        val stream = cache.getOrPutFile(revision(revisionIndex), TEST_PATH, loadFunc)
+
+                        stream.verifyContent(prefix)
+                    }
+                }
+            }
+        }
+    }
+})
+
+/** The interval to check for the availability of read locks. */
+private val lockCheckInterval = 10.milliseconds
+
+/** The content of the test file to be loaded from the cache. */
+private const val TEST_CONTENT = """
+    Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore
+    et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum.
+    Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+    consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed
+    diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+    takimata sanctus est Lorem ipsum dolor sit amet.
+"""
+
+/** Default path of the test file to be loaded from the cache. */
+private const val TEST_PATH = "test/config/test.txt"
+
+/**
+ * Return a function that simulates loading a test file from GitHub. The function returns the test content with an
+ * optional [prefix]. It checks that it is only invoked once.
+ */
+private fun loadFunc(prefix: String? = null): suspend () -> ByteReadChannel {
+    val counter = AtomicInteger()
+
+    return {
+        require(counter.getAndIncrement() == 0) {
+            "The load function must be called only once for '$prefix'."
+        }
+
+        ByteReadChannel(testFileContent(prefix))
+    }
+}
+
+/**
+ * Generate the content of a test file with an optional [prefix].
+ */
+private fun testFileContent(prefix: String? = null) = prefix.orEmpty() + TEST_CONTENT
+
+/**
+ * Verify that this [InputStream] contains the expected content with the given [prefix]. Also close the stream.
+ */
+private fun InputStream.verifyContent(prefix: String? = null) {
+    use {
+        String(readAllBytes()) shouldBe testFileContent(prefix)
+    }
+}
+
+/**
+ * Generate a revision based on the given [index].
+ */
+private fun revision(index: Int): String = "rev$index"
+
+/**
+ * Return a test instance of [GitHubConfigFileCache] backed by a managed temporary directory.
+ */
+private fun TestConfiguration.createCache(): GitHubConfigFileCache =
+    GitHubConfigFileCache(tempdir(), lockCheckInterval)

--- a/config/github/src/test/kotlin/GitHubConfigNoCacheTest.kt
+++ b/config/github/src/test/kotlin/GitHubConfigNoCacheTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.config.github
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import io.ktor.utils.io.ByteReadChannel
+
+class GitHubConfigNoCacheTest : WordSpec({
+    "getOrPutFile" should {
+        "return the data obtained from the load function" {
+            val data = "test configuration data".toByteArray()
+            val cache = GitHubConfigNoCache()
+
+            val stream = cache.getOrPutFile("foo", "bar") {
+                ByteReadChannel(data)
+            }
+
+            stream.readAllBytes() shouldBe data
+        }
+    }
+})

--- a/workers/advisor/src/main/resources/application.conf
+++ b/workers/advisor/src/main/resources/application.conf
@@ -23,6 +23,9 @@ configManager {
   fileProvider = ${?ADVISOR_CONFIG_FILE_PROVIDER}
   gitHubRepositoryOwner = ${?ADVISOR_CONFIG_GITHUB_REPOSITORY_OWNER}
   gitHubRepositoryName = ${?ADVISOR_CONFIG_GITHUB_REPOSITORY_NAME}
+  gitHubCacheDirectory = ${?ADVISOR_CONFIG_GITHUB_CACHE_DIRECTORY}
+  gitHubCacheLockCheckIntervalSec = 5
+  gitHubCacheLockCheckIntervalSec = ${?ADVISOR_CONFIG_GITHUB_CACHE_LOCK_CHECK_INTERVAL}
   gitUrl = ${?ADVISOR_CONFIG_GIT_URL}
   localConfigDir = ${?ADVISOR_CONFIG_LOCAL_CONFIG_DIR}
 }

--- a/workers/analyzer/src/main/resources/application.conf
+++ b/workers/analyzer/src/main/resources/application.conf
@@ -23,6 +23,9 @@ configManager {
   fileProvider = ${?ANALYZER_CONFIG_FILE_PROVIDER}
   gitHubRepositoryOwner = ${?ANALYZER_CONFIG_GITHUB_REPOSITORY_OWNER}
   gitHubRepositoryName = ${?ANALYZER_CONFIG_GITHUB_REPOSITORY_NAME}
+  gitHubCacheDirectory = ${?ANALYZER_CONFIG_GITHUB_CACHE_DIRECTORY}
+  gitHubCacheLockCheckIntervalSec = 5
+  gitHubCacheLockCheckIntervalSec = ${?ANALYZER_CONFIG_GITHUB_CACHE_LOCK_CHECK_INTERVAL}
   gitUrl = ${?ANALYZER_CONFIG_GIT_URL}
   localConfigDir = ${?ANALYZER_CONFIG_LOCAL_CONFIG_DIR}
 }

--- a/workers/config/src/main/resources/application.conf
+++ b/workers/config/src/main/resources/application.conf
@@ -23,6 +23,9 @@ configManager {
   fileProvider = ${?CONFIG_CONFIG_FILE_PROVIDER}
   gitHubRepositoryOwner = ${?CONFIG_CONFIG_GITHUB_REPOSITORY_OWNER}
   gitHubRepositoryName = ${?CONFIG_CONFIG_GITHUB_REPOSITORY_NAME}
+  gitHubCacheDirectory = ${?CONFIG_CONFIG_GITHUB_CACHE_DIRECTORY}
+  gitHubCacheLockCheckIntervalSec = 5
+  gitHubCacheLockCheckIntervalSec = ${?CONFIG_CONFIG_GITHUB_CACHE_LOCK_CHECK_INTERVAL}
   gitUrl = ${?CONFIG_CONFIG_GIT_URL}
   localConfigDir = ${?CONFIG_CONFIG_LOCAL_CONFIG_DIR}
 }

--- a/workers/evaluator/src/main/resources/application.conf
+++ b/workers/evaluator/src/main/resources/application.conf
@@ -23,6 +23,9 @@ configManager {
   fileProvider = ${?EVALUATOR_CONFIG_FILE_PROVIDER}
   gitHubRepositoryOwner = ${?EVALUATOR_CONFIG_GITHUB_REPOSITORY_OWNER}
   gitHubRepositoryName = ${?EVALUATOR_CONFIG_GITHUB_REPOSITORY_NAME}
+  gitHubCacheDirectory = ${?EVALUATOR_CONFIG_GITHUB_CACHE_DIRECTORY}
+  gitHubCacheLockCheckIntervalSec = 5
+  gitHubCacheLockCheckIntervalSec = ${?EVALUATOR_CONFIG_GITHUB_CACHE_LOCK_CHECK_INTERVAL}
   gitUrl = ${?EVALUATOR_CONFIG_GIT_URL}
   localConfigDir = ${?EVALUATOR_CONFIG_LOCAL_CONFIG_DIR}
 }

--- a/workers/notifier/src/main/resources/application.conf
+++ b/workers/notifier/src/main/resources/application.conf
@@ -23,6 +23,9 @@ configManager {
   fileProvider = ${?NOTIFIER_CONFIG_FILE_PROVIDER}
   gitHubRepositoryOwner = ${?NOTIFIER_CONFIG_GITHUB_REPOSITORY_OWNER}
   gitHubRepositoryName = ${?NOTIFIER_CONFIG_GITHUB_REPOSITORY_NAME}
+  gitHubCacheDirectory = ${?NOTIFIER_CONFIG_GITHUB_CACHE_DIRECTORY}
+  gitHubCacheLockCheckIntervalSec = 5
+  gitHubCacheLockCheckIntervalSec = ${?NOTIFIER_CONFIG_GITHUB_CACHE_LOCK_CHECK_INTERVAL}
   gitUrl = ${?NOTIFIER_CONFIG_GIT_URL}
   localConfigDir = ${?NOTIFIER_CONFIG_LOCAL_CONFIG_DIR}
 }

--- a/workers/reporter/src/main/resources/application.conf
+++ b/workers/reporter/src/main/resources/application.conf
@@ -23,6 +23,9 @@ configManager {
   fileProvider = ${?REPORTER_CONFIG_FILE_PROVIDER}
   gitHubRepositoryOwner = ${?REPORTER_CONFIG_GITHUB_REPOSITORY_OWNER}
   gitHubRepositoryName = ${?REPORTER_CONFIG_GITHUB_REPOSITORY_NAME}
+  gitHubCacheDirectory = ${?REPORTER_CONFIG_GITHUB_CACHE_DIRECTORY}
+  gitHubCacheLockCheckIntervalSec = 5
+  gitHubCacheLockCheckIntervalSec = ${?REPORTER_CONFIG_GITHUB_CACHE_LOCK_CHECK_INTERVAL}
   gitUrl = ${?REPORTER_CONFIG_GIT_URL}
   localConfigDir = ${?REPORTER_CONFIG_LOCAL_CONFIG_DIR}
 }

--- a/workers/scanner/src/main/resources/application.conf
+++ b/workers/scanner/src/main/resources/application.conf
@@ -23,6 +23,9 @@ configManager {
   fileProvider = ${?SCANNER_CONFIG_FILE_PROVIDER}
   gitHubRepositoryOwner = ${?SCANNER_CONFIG_GITHUB_REPOSITORY_OWNER}
   gitHubRepositoryName = ${?SCANNER_CONFIG_GITHUB_REPOSITORY_NAME}
+  gitHubCacheDirectory = ${?SCANNER_CONFIG_GITHUB_CACHE_DIRECTORY}
+  gitHubCacheLockCheckIntervalSec = 5
+  gitHubCacheLockCheckIntervalSec = ${?SCANNER_CONFIG_GITHUB_CACHE_LOCK_CHECK_INTERVAL}
   gitUrl = ${?SCANNER_CONFIG_GIT_URL}
   localConfigDir = ${?SCANNER_CONFIG_LOCAL_CONFIG_DIR}
 }


### PR DESCRIPTION
`GitHubConfigFileProvider` downloads multiple configuration files from a configurable GitHub repository during an ORT run. When there are many ORT runs, this can be an issue, since the GitHub REST API has some rate limiting applied (5000 requests per hour).

This PR therefore adds support for caching to this provider. This is rather effective for this use case, as files under a specific revision are immutable.

For now, configuration files are cached in a local directory, which can be a network share. This is going to be extended by also caching the content of folders and also by an automatic clean-up of old entries in the cache.