### PR TITLE
feat(api): Add an endpoint to return the ORT-Server version

### DIFF
--- a/core/src/main/kotlin/api/VersionsRoute.kt
+++ b/core/src/main/kotlin/api/VersionsRoute.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.core.api
+
+import io.github.smiley4.ktorswaggerui.dsl.get
+
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getVersions
+import org.eclipse.apoapsis.ortserver.model.ORT_SERVER_VERSION
+
+fun Route.versions() = get("versions", getVersions) {
+    call.respond(
+        mapOf(
+            "ORT Server" to ORT_SERVER_VERSION
+        )
+    )
+}

--- a/core/src/main/kotlin/apiDocs/VersionsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/VersionsDocs.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.core.apiDocs
+
+import io.github.smiley4.ktorswaggerui.dsl.OpenApiRoute
+
+import io.ktor.http.HttpStatusCode
+
+val getVersions: OpenApiRoute.() -> Unit = {
+    operationId = "getVersions"
+    summary = "Get the versions of the ORT server and other components."
+    tags = listOf("Versions")
+
+    response {
+        HttpStatusCode.OK to {
+            description = "Success"
+            jsonBody<Map<String, String>> {
+                example(
+                    name = "Versions",
+                    value = mapOf(
+                        "ORT Server" to "1.0.0"
+                    )
+                )
+            }
+        }
+    }
+}

--- a/core/src/main/kotlin/plugins/Routing.kt
+++ b/core/src/main/kotlin/plugins/Routing.kt
@@ -30,6 +30,7 @@ import org.eclipse.apoapsis.ortserver.core.api.organizations
 import org.eclipse.apoapsis.ortserver.core.api.products
 import org.eclipse.apoapsis.ortserver.core.api.repositories
 import org.eclipse.apoapsis.ortserver.core.api.runs
+import org.eclipse.apoapsis.ortserver.core.api.versions
 
 fun Application.configureRouting() {
     routing {
@@ -41,6 +42,7 @@ fun Application.configureRouting() {
                 products()
                 repositories()
                 runs()
+                versions()
             }
         }
     }

--- a/core/src/test/kotlin/api/VersionsIntegrationTest.kt
+++ b/core/src/test/kotlin/api/VersionsIntegrationTest.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.core.api
+
+import io.kotest.assertions.ktor.client.shouldHaveStatus
+
+import io.ktor.client.request.get
+
+import org.eclipse.apoapsis.ortserver.core.shouldHaveBody
+import org.eclipse.apoapsis.ortserver.model.ORT_SERVER_VERSION
+import org.eclipse.apoapsis.ortserver.utils.test.Integration
+
+class VersionsIntegrationTest : AbstractIntegrationTest({
+    tags(Integration)
+
+    "/versions" should {
+        "respond with the correct versions" {
+            integrationTestApplication {
+                val response = testUserClient.get("/api/v1/versions")
+
+                response shouldHaveStatus 200
+                response shouldHaveBody mapOf("ORT Server" to ORT_SERVER_VERSION)
+            }
+        }
+
+        "require authentication" {
+            requestShouldRequireAuthentication {
+                get("/api/v1/versions")
+            }
+        }
+    }
+})


### PR DESCRIPTION
Add an endpoint `/versions` to return the ORT-Server version. The endpoint returns a map as later on more tool versions will be returned, for example, the version of ORT that is in use.

The endpoint requires authentication to not expose the version to arbitrary clients for security reasons.

Fixes #95.