### PR TITLE
ui: Add parameters, labels and job config context to ORT Run

### DIFF
--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.create-run.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.create-run.tsx
@@ -83,6 +83,7 @@ const formSchema = z.object({
       formats: z.array(z.string()),
     }),
   }),
+  jobConfigContext: z.string().optional(),
 });
 
 const advisors = [
@@ -233,6 +234,7 @@ const CreateRunPage = () => {
         formats: ['ortresult', 'WebApp'],
       },
     },
+    jobConfigContext: 'main',
   };
 
   // Default values for the form are either taken from "baseDefaults" or,
@@ -292,6 +294,8 @@ const CreateRunPage = () => {
               baseDefaults.jobConfigs.reporter.formats,
           },
         },
+        jobConfigContext:
+          ortRun.jobConfigContext || baseDefaults.jobConfigContext,
       }
     : baseDefaults;
 
@@ -348,6 +352,7 @@ const CreateRunPage = () => {
           evaluator: evaluatorConfig,
           reporter: reporterConfig,
         },
+        jobConfigContext: values.jobConfigContext,
       },
     });
   }
@@ -369,7 +374,28 @@ const CreateRunPage = () => {
                   <FormControl>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>Revision to run ORT on</FormDescription>
+                  <FormDescription>
+                    The repository revision used by this run
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name='jobConfigContext'
+              render={({ field }) => (
+                <FormItem className='pt-4'>
+                  <FormLabel>Job configuration context</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    An optional context to be used when obtaining configuration
+                    for this run. The meaning of the context is up for
+                    interpretation by the implementation of the configuration
+                    provider.
+                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.runs.$runIndex.index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.runs.$runIndex.index.tsx
@@ -121,7 +121,7 @@ const RunComponent = () => {
           </TableHeader>
           <TableBody>
             <TableRow>
-              <TableCell>Created At</TableCell>
+              <TableCell>Created at</TableCell>
               <TableCell>
                 <div className='font-medium'>
                   {new Date(ortRun.createdAt).toLocaleString()}
@@ -130,7 +130,7 @@ const RunComponent = () => {
             </TableRow>
             {ortRun.finishedAt && (
               <TableRow>
-                <TableCell>Finished At</TableCell>
+                <TableCell>Finished at</TableCell>
                 <TableCell>
                   <div className='font-medium'>
                     {new Date(ortRun.finishedAt).toLocaleString()}

--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.runs.$runIndex.index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.runs.$runIndex.index.tsx
@@ -115,8 +115,7 @@ const RunComponent = () => {
         <Table>
           <TableHeader>
             <TableRow>
-              <TableHead>Run parameter</TableHead>
-              <TableHead>Value</TableHead>
+              <TableHead>Run details</TableHead>
               <TableHead className='sr-only'>Actions</TableHead>
             </TableRow>
           </TableHeader>
@@ -145,12 +144,22 @@ const RunComponent = () => {
                 <div className='font-medium'>{ortRun.revision}</div>
               </TableCell>
             </TableRow>
-            <TableRow>
-              <TableCell>Path</TableCell>
-              <TableCell>
-                <div className='font-medium'>{ortRun.path}</div>
-              </TableCell>
-            </TableRow>
+            {ortRun.jobConfigContext && (
+              <TableRow>
+                <TableCell>Job configuration context</TableCell>
+                <TableCell>
+                  <div className='font-medium'>{ortRun.jobConfigContext}</div>
+                </TableCell>
+              </TableRow>
+            )}
+            {ortRun.path && (
+              <TableRow>
+                <TableCell>Path</TableCell>
+                <TableCell>
+                  <div className='font-medium'>{ortRun.path}</div>
+                </TableCell>
+              </TableRow>
+            )}
             {ortRun.jobs.reporter?.reportFilenames && (
               <TableRow>
                 <TableCell>Reports</TableCell>
@@ -177,6 +186,44 @@ const RunComponent = () => {
                   <pre>{JSON.stringify(ortRun.issues, null, 2)}</pre>
                 </TableCell>
               </TableRow>
+            )}
+            {ortRun.jobConfigs.parameters && (
+              <>
+                <TableRow>
+                  <TableCell
+                    colSpan={2}
+                    className='font-semibold text-blue-400'
+                  >
+                    Parameters:
+                  </TableCell>
+                </TableRow>
+                {Object.entries(ortRun.jobConfigs.parameters).map(
+                  ([key, value]) => (
+                    <TableRow key={key}>
+                      <TableCell>{key}</TableCell>
+                      <TableCell>{value}</TableCell>
+                    </TableRow>
+                  )
+                )}
+              </>
+            )}
+            {ortRun.labels && (
+              <>
+                <TableRow>
+                  <TableCell
+                    colSpan={2}
+                    className='font-semibold text-blue-400'
+                  >
+                    Labels:
+                  </TableCell>
+                </TableRow>
+                {Object.entries(ortRun.labels).map(([key, value]) => (
+                  <TableRow key={key}>
+                    <TableCell>{key}</TableCell>
+                    <TableCell>{value}</TableCell>
+                  </TableRow>
+                ))}
+              </>
             )}
           </TableBody>
         </Table>


### PR DESCRIPTION
With this PR, parameters and labels can be added to an ORT run. If Rerun functionality for an old ORT run is used, the parameters and labels used for the old run are also pre-populated in the run creation form.

In anticipation of future implementation, job configuration context is also added to the run creation form.

![Capture1](https://github.com/eclipse-apoapsis/ort-server/assets/599904/bd414c71-3f73-4b4f-9137-14ec3e8be29e)

All added properties of the ORT run are shown in the run details page.

![Capture2](https://github.com/eclipse-apoapsis/ort-server/assets/599904/65561cd7-9890-4318-80eb-0cefb7678c6f)

This resolves #312.