### PR TITLE
fix(compose): Use `ORT_SERVER_CORE_PORT` also for the UI

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -447,6 +447,8 @@ services:
       retries: 5
     ports:
       - "8082:8080"
+    environment:
+      UI_API_URL: "http://localhost:${ORT_SERVER_CORE_PORT:-8080}"
 
 volumes:
   db:


### PR DESCRIPTION
Use the `ORT_SERVER_CORE_PORT` variable also for configuring the UI service to make sure it expects the API at the correct port.