### PR TITLE
refactor(workers)!: Make the `getConfigFileWithDefault()` helper internal

### DIFF
--- a/workers/common/src/main/kotlin/common/Extensions.kt
+++ b/workers/common/src/main/kotlin/common/Extensions.kt
@@ -75,7 +75,8 @@ fun ConfigManager.readConfigFileWithDefault(
  * This function realizes the contract that if a specific config file is requested, not being able to read it leads to
  * an exception, but the default file is allowed to not exist.
  */
-inline fun <reified T> getConfigFileWithDefault(
+@PublishedApi
+internal inline fun <reified T> getConfigFileWithDefault(
     path: String?,
     defaultPath: String,
     fallbackValue: T,


### PR DESCRIPTION
Still allow this inline function to be used from public API via the `@PublishedApi` annotation [1].

[1]: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/-published-api/