### PR TITLE
fix(api): Remove CVS as a repository type

### DIFF
--- a/api/v1/model/src/commonMain/kotlin/Repository.kt
+++ b/api/v1/model/src/commonMain/kotlin/Repository.kt
@@ -110,6 +110,5 @@ enum class RepositoryType {
     GIT,
     GIT_REPO,
     MERCURIAL,
-    SUBVERSION,
-    CVS
+    SUBVERSION
 }


### PR DESCRIPTION
CVS support was removed from ORT core in [1].

[1]: https://github.com/oss-review-toolkit/ort/pull/6932