### PR TITLE
feat(ui): Add some configuration options to the evaluator job

### DIFF
--- a/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.create-run.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId.products.$productId.repositories.$repoId.create-run.tsx
@@ -83,6 +83,10 @@ const formSchema = z.object({
     }),
     evaluator: z.object({
       enabled: z.boolean(),
+      ruleSet: z.string().optional(),
+      licenseClassificationsFile: z.string().optional(),
+      copyrightGarbageFile: z.string().optional(),
+      resolutionsFile: z.string().optional(),
     }),
     reporter: z.object({
       enabled: z.boolean(),
@@ -292,6 +296,14 @@ const CreateRunPage = () => {
             enabled:
               ortRun.jobConfigs.evaluator !== undefined &&
               ortRun.jobConfigs.evaluator !== null,
+            ruleSet: ortRun.jobConfigs.evaluator?.ruleSet || undefined,
+            licenseClassificationsFile:
+              ortRun.jobConfigs.evaluator?.licenseClassificationsFile ||
+              undefined,
+            copyrightGarbageFile:
+              ortRun.jobConfigs.evaluator?.copyrightGarbageFile || undefined,
+            resolutionsFile:
+              ortRun.jobConfigs.evaluator?.resolutionsFile || undefined,
           },
           reporter: {
             enabled:
@@ -373,7 +385,18 @@ const CreateRunPage = () => {
         }
       : undefined;
     const evaluatorConfig = values.jobConfigs.evaluator.enabled
-      ? {}
+      ? {
+          // Only include the config parameter structures if the corresponding form fields are not empty.
+          // In case they are empty, the default path from the config file provider will be used to
+          // resolve the corresponding files.
+          ruleSet: values.jobConfigs.evaluator.ruleSet || undefined,
+          licenseClassificationsFile:
+            values.jobConfigs.evaluator.licenseClassificationsFile || undefined,
+          copyrightGarbageFile:
+            values.jobConfigs.evaluator.copyrightGarbageFile || undefined,
+          resolutionsFile:
+            values.jobConfigs.evaluator.resolutionsFile || undefined,
+        }
       : undefined;
     const reporterConfig = values.jobConfigs.reporter.enabled
       ? {
@@ -987,7 +1010,82 @@ const CreateRunPage = () => {
                 <AccordionItem value='evaluator' className='flex-1'>
                   <AccordionTrigger>Evaluator</AccordionTrigger>
                   <AccordionContent>
-                    No job configurations yet implemented for Evaluator.
+                    <div className='text-sm text-gray-500'>
+                      In case any input field is left empty, the default path
+                      from the config file provider will be used for the
+                      corresponding file.
+                    </div>
+                    <FormField
+                      control={form.control}
+                      name='jobConfigs.evaluator.ruleSet'
+                      render={({ field }) => (
+                        <FormItem className='pt-4'>
+                          <FormLabel>Evaluator rules</FormLabel>
+                          <FormControl>
+                            <Input {...field} />
+                          </FormControl>
+                          <FormDescription>
+                            The path to the rules file to get from the
+                            configuration provider. Note: In case this field is
+                            left empty, the default path of the config file
+                            provider has to include a rules file, otherwise the
+                            Evaluator job will fail.
+                          </FormDescription>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name='jobConfigs.evaluator.licenseClassificationsFile'
+                      render={({ field }) => (
+                        <FormItem className='pt-4'>
+                          <FormLabel>License classifications</FormLabel>
+                          <FormControl>
+                            <Input {...field} />
+                          </FormControl>
+                          <FormDescription>
+                            The path to the license classifications file to get
+                            from the configuration provider.
+                          </FormDescription>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name='jobConfigs.evaluator.copyrightGarbageFile'
+                      render={({ field }) => (
+                        <FormItem className='pt-4'>
+                          <FormLabel>Copyright garbage</FormLabel>
+                          <FormControl>
+                            <Input {...field} />
+                          </FormControl>
+                          <FormDescription>
+                            The path to the copyright garbage file to get from
+                            the configuration provider.
+                          </FormDescription>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name='jobConfigs.evaluator.resolutionsFile'
+                      render={({ field }) => (
+                        <FormItem className='pt-4'>
+                          <FormLabel>Resolutions</FormLabel>
+                          <FormControl>
+                            <Input {...field} />
+                          </FormControl>
+                          <FormDescription>
+                            The path to the resolutions file to get from the
+                            configuration provider.
+                          </FormDescription>
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
                   </AccordionContent>
                 </AccordionItem>
               </div>


### PR DESCRIPTION
Add the possibility to specify evaluator rules, license classifications, copyright garbage, and resolutions files to the evaluator job.  The user can also specify a path within the repository where the configuration file is located.

![Capture](https://github.com/eclipse-apoapsis/ort-server/assets/599904/e2986142-ef3e-4dbb-ba43-2502ab9552cd)

Using `GitHubConfigFileProvider`, it was verified that all files (with their specific paths inside the repository) are properly passed to the Evaluator and Reporter.

By providing fallback files (copied from [oss-review-toolkit/ort-config](https://github.com/oss-review-toolkit/ort-config)) at the root directory of the GitHub config file provider, it was also verified that in case of empty fields, the files from the default directory were taken into the jobs correctly.