### PR TITLE
ci(docker): Enable `latest` tag for published images

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -121,6 +121,7 @@ jobs:
           type=raw,value=${{ env.ORT_SERVER_VERSION }}
           type=ref,event=branch
           type=sha
+          type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Build ${{ matrix.docker.image }} Image
       if: ${{ matrix.docker.dockerfile != '' }}
@@ -143,6 +144,7 @@ jobs:
           type=raw,value=${{ env.ORT_SERVER_VERSION }}
           type=ref,event=branch
           type=sha
+          type=raw,value=latest,enable={{is_default_branch}}
 
     - name: Build ${{ matrix.docker.jibImage }} Image
       if: ${{ matrix.docker.task != '' }}


### PR DESCRIPTION
The `latest` tag is widely used and expected in the Docker ecosystem.
Tag the latest builds from the main branch with the tag.

Signed-off-by: Mikko Murto <mikko.murto@doubleopen.org>