### PR TITLE
ci(github): Upgrade to the new Gradle wrapper validation action

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -18,4 +18,4 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Validate Wrapper
-      uses: gradle/wrapper-validation-action@v1
+      uses: gradle/actions/wrapper-validation@v3


### PR DESCRIPTION
This gets rid of a deprecation warning in CI logs.