### PR TITLE
chore(renovate): Update Node once a week

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -27,6 +27,10 @@
     {
       "matchPackageNames": ["eslint"],
       "rangeStrategy": "in-range-only"
+    },
+    {
+      "matchPackageNames": ["node"],
+      "schedule": ["after 9pm on sunday"]
     }
   ],
   "prHourlyLimit": 5


### PR DESCRIPTION
Node Docker image specified in UI's Dockerfile updates very often. It's
only used to build UI before serving it from NGINX, so update it only once
a week to reduce spam from Renovate.

Signed-off-by: Mikko Murto <mikko.murto@doubleopen.org>