### PR TITLE
feat: Make source code origin priority configurable

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
@@ -65,6 +65,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.ScannerJobConfiguration as Ap
 import org.eclipse.apoapsis.ortserver.api.v1.model.Secret as ApiSecret
 import org.eclipse.apoapsis.ortserver.api.v1.model.SortDirection as ApiSortDirection
 import org.eclipse.apoapsis.ortserver.api.v1.model.SortProperty as ApiSortProperty
+import org.eclipse.apoapsis.ortserver.api.v1.model.SourceCodeOrigin as ApiSourceCodeOrigin
 import org.eclipse.apoapsis.ortserver.model.AdvisorJob
 import org.eclipse.apoapsis.ortserver.model.AdvisorJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.AnalyzerJob
@@ -99,6 +100,7 @@ import org.eclipse.apoapsis.ortserver.model.RepositoryType
 import org.eclipse.apoapsis.ortserver.model.ScannerJob
 import org.eclipse.apoapsis.ortserver.model.ScannerJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.Secret
+import org.eclipse.apoapsis.ortserver.model.SourceCodeOrigin
 import org.eclipse.apoapsis.ortserver.model.runs.OrtIssue
 import org.eclipse.apoapsis.ortserver.model.runs.PackageManagerConfiguration
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
@@ -413,6 +415,7 @@ fun ScannerJobConfiguration.mapToApi() = ApiScannerJobConfiguration(
     scanners,
     skipConcluded,
     skipExcluded,
+    sourceCodeOrigins?.map { it.mapToApi() },
     config?.mapValues { it.value.mapToApi() }
 )
 
@@ -423,6 +426,7 @@ fun ApiScannerJobConfiguration.mapToModel() = ScannerJobConfiguration(
     scanners,
     skipConcluded,
     skipExcluded,
+    sourceCodeOrigins?.map { it.mapToModel() },
     config?.mapValues { it.value.mapToModel() }
 )
 
@@ -584,4 +588,16 @@ fun ApiSortDirection.mapToModel() =
     when (this) {
         ApiSortDirection.ASCENDING -> OrderDirection.ASCENDING
         ApiSortDirection.DESCENDING -> OrderDirection.DESCENDING
+    }
+
+fun SourceCodeOrigin.mapToApi() =
+    when (this) {
+        SourceCodeOrigin.ARTIFACT -> ApiSourceCodeOrigin.ARTIFACT
+        SourceCodeOrigin.VCS -> ApiSourceCodeOrigin.VCS
+    }
+
+fun ApiSourceCodeOrigin.mapToModel() =
+    when (this) {
+        ApiSourceCodeOrigin.ARTIFACT -> SourceCodeOrigin.ARTIFACT
+        ApiSourceCodeOrigin.VCS -> SourceCodeOrigin.VCS
     }

--- a/api/v1/model/src/commonMain/kotlin/JobConfigurations.kt
+++ b/api/v1/model/src/commonMain/kotlin/JobConfigurations.kt
@@ -155,6 +155,12 @@ data class ScannerJobConfiguration(
     val skipExcluded: Boolean = false,
 
     /**
+     * The source code origins to use, ordered by priority. The list must not be empty or contain any duplicates. If
+     * `null`, the default order of [SourceCodeOrigin.ARTIFACT] and [SourceCodeOrigin.VCS] is used.
+     */
+    val sourceCodeOrigins: List<SourceCodeOrigin>? = null,
+
+    /**
      * A map of plugin configurations that are specific to a concrete scanner.
      */
     val config: Map<String, PluginConfiguration>? = null

--- a/api/v1/model/src/commonMain/kotlin/SourceCodeOrigin.kt
+++ b/api/v1/model/src/commonMain/kotlin/SourceCodeOrigin.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.api.v1.model
+
+/** An enum for supported source code origins. */
+enum class SourceCodeOrigin {
+    /** The source code comes from a source artifact. */
+    ARTIFACT,
+
+    /** The source code comes from a version control system. */
+    VCS
+}

--- a/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
@@ -65,6 +65,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.ScannerJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.Secret
 import org.eclipse.apoapsis.ortserver.api.v1.model.SortDirection
 import org.eclipse.apoapsis.ortserver.api.v1.model.SortProperty
+import org.eclipse.apoapsis.ortserver.api.v1.model.SourceCodeOrigin
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateRepository
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateSecret
 import org.eclipse.apoapsis.ortserver.api.v1.model.asPresent
@@ -122,7 +123,8 @@ internal val fullJobConfigurations = JobConfigurations(
         projectScanners = listOf("SCANOSS"),
         scanners = listOf("ScanCode"),
         skipConcluded = true,
-        skipExcluded = true
+        skipExcluded = true,
+        sourceCodeOrigins = listOf(SourceCodeOrigin.ARTIFACT, SourceCodeOrigin.VCS)
     ),
     evaluator = EvaluatorJobConfiguration(
         copyrightGarbageFile = "copyright-garbage.yml",

--- a/model/src/commonMain/kotlin/JobConfigurations.kt
+++ b/model/src/commonMain/kotlin/JobConfigurations.kt
@@ -160,6 +160,12 @@ data class ScannerJobConfiguration(
     val skipExcluded: Boolean = false,
 
     /**
+     * The source code origins to use, ordered by priority. The list must not be empty or contain any duplicates. If
+     * `null`, the default order of [SourceCodeOrigin.ARTIFACT] and [SourceCodeOrigin.VCS] is used.
+     */
+    val sourceCodeOrigins: List<SourceCodeOrigin>? = null,
+
+    /**
      * A map of plugin configurations that are specific to a concrete scanner.
      */
     val config: Map<String, PluginConfiguration>? = null

--- a/model/src/commonMain/kotlin/SourceCodeOrigin.kt
+++ b/model/src/commonMain/kotlin/SourceCodeOrigin.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.model
+
+/** An enum for supported source code origins. */
+enum class SourceCodeOrigin {
+    /** The source code comes from a source artifact. */
+    ARTIFACT,
+
+    /** The source code comes from a version control system. */
+    VCS
+}

--- a/workers/common/src/main/kotlin/common/OrtServerMappings.kt
+++ b/workers/common/src/main/kotlin/common/OrtServerMappings.kt
@@ -32,6 +32,7 @@ import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.PluginConfiguration
 import org.eclipse.apoapsis.ortserver.model.ProviderPluginConfiguration
 import org.eclipse.apoapsis.ortserver.model.Repository
+import org.eclipse.apoapsis.ortserver.model.SourceCodeOrigin
 import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.PackageCurationProviderConfig
 import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.ResolvedConfiguration
 import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.ResolvedPackageCurations
@@ -142,6 +143,7 @@ import org.ossreviewtoolkit.model.ScannerRun as OrtScannerRun
 import org.ossreviewtoolkit.model.Severity as OrtSeverity
 import org.ossreviewtoolkit.model.Snippet as OrtSnippet
 import org.ossreviewtoolkit.model.SnippetFinding as OrtSnippetFinding
+import org.ossreviewtoolkit.model.SourceCodeOrigin as OrtSourceCodeOrigin
 import org.ossreviewtoolkit.model.TextLocation as OrtTextLocation
 import org.ossreviewtoolkit.model.UnknownProvenance as OrtUnknownProvenance
 import org.ossreviewtoolkit.model.VcsInfo as OrtVcsInfo
@@ -688,3 +690,9 @@ fun JiraRestClientConfiguration.mapToOrt() =
         username = username,
         password = password
     )
+
+fun SourceCodeOrigin.mapToOrt() =
+    when (this) {
+        SourceCodeOrigin.ARTIFACT -> OrtSourceCodeOrigin.ARTIFACT
+        SourceCodeOrigin.VCS -> OrtSourceCodeOrigin.VCS
+    }

--- a/workers/scanner/src/main/kotlin/scanner/ScannerRunner.kt
+++ b/workers/scanner/src/main/kotlin/scanner/ScannerRunner.kt
@@ -79,8 +79,8 @@ class ScannerRunner(
         )
 
         val downloaderConfig = DownloaderConfiguration(
-            // TODO: Make the source code origin priority configurable via the ScannerJobConfiguration.
-            sourceCodeOrigins = listOf(SourceCodeOrigin.ARTIFACT, SourceCodeOrigin.VCS)
+            sourceCodeOrigins = config.sourceCodeOrigins?.distinct()?.map { it.mapToOrt() }
+                ?: listOf(SourceCodeOrigin.ARTIFACT, SourceCodeOrigin.VCS)
         )
 
         val workingTreeCache = DefaultWorkingTreeCache()


### PR DESCRIPTION
Make the source code origins configurable via the
`ScannerJobConfiguration`. Previsouly, the configuration was hardcoded to prefer `SourceCodeOrigin.ARTIFACT` over `SourceCodeOrigin.VCS`.