### PR TITLE
Revert "build(detekt): Disable the `RedundantSuspendModifier` rule"

### DIFF
--- a/.detekt.yml
+++ b/.detekt.yml
@@ -42,8 +42,6 @@ complexity:
 coroutines:
   InjectDispatcher:
     active: false
-  RedundantSuspendModifier:
-    active: false
 
 # Formatting rules are implemented via the ktlint plugin. As ktlint does not allow exceptions, we need to disable
 # respective rules completely.


### PR DESCRIPTION
This reverts commit 9df9f85 as the false-positives cannot be reproduced anymore.