### PR TITLE
fix(job-monitor): Include trace ID in lost job msg

### DIFF
--- a/transport/kubernetes-jobmonitor/src/main/kotlin/FailedJobNotifier.kt
+++ b/transport/kubernetes-jobmonitor/src/main/kotlin/FailedJobNotifier.kt
@@ -63,7 +63,7 @@ internal class FailedJobNotifier(
      * Orchestrator about jobs that disappeared in Kubernetes.
      */
     fun sendLostJobNotification(ortRunId: Long, endpoint: Endpoint<*>) {
-        val header = MessageHeader(traceId = "", ortRunId)
+        val header = MessageHeader(traceId = "<lost-job>", ortRunId)
         val message = Message(header, WorkerError(endpoint.configPrefix))
 
         sendToOrchestrator(message)


### PR DESCRIPTION
Previous to this change, using Kubernetes Job Monitor together with SQS transport failed when sending a lost job notification. This happened because trace ID in the message header was left empty. This change adds a dummy trace ID to the header.