### PR TITLE
ci: Make the Docker build a callable workflow

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,6 +6,7 @@ on:
       - main
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
+  workflow_call:
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Hence, users can reuse this workflow in their (private) repositories. Workflow inputs will be added in a future commit.