### PR TITLE
refactor(ui): Move utility types in create run page to separate file

### DIFF
--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-types.ts
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-types.ts
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+/**
+ * Some input types for creating runs are strings in the API, but they actually take a limited set
+ * of values. Define the possible values here to use in the UI.
+ */
+
+export const advisors = [
+  {
+    id: 'OssIndex',
+    label: 'OSS Index',
+  },
+  {
+    id: 'OSV',
+    label: 'OSV',
+  },
+  {
+    id: 'VulnerableCode',
+    label: 'VulnerableCode',
+  },
+] as const;
+
+export const packageManagers = [
+  {
+    id: 'Bundler',
+    label: 'Bundler (Ruby)',
+  },
+  {
+    id: 'Cargo',
+    label: 'Cargo (Rust)',
+  },
+  {
+    id: 'GoMod',
+    label: 'GoMod (Go)',
+  },
+  {
+    id: 'GradleInspector',
+    label: 'Gradle (Java)',
+  },
+  {
+    id: 'Maven',
+    label: 'Maven (Java)',
+  },
+  {
+    id: 'NPM',
+    label: 'NPM (JavaScript / Node.js)',
+  },
+  {
+    id: 'PIP',
+    label: 'PIP (Python)',
+  },
+  {
+    id: 'Pipenv',
+    label: 'Pipenv (Python)',
+  },
+  {
+    id: 'PNPM',
+    label: 'PNPM (JavaScript / Node.js)',
+  },
+  {
+    id: 'Poetry',
+    label: 'Poetry (Python)',
+  },
+  {
+    id: 'Yarn',
+    label: 'Yarn 1 (JavaScript / Node.js)',
+  },
+  {
+    id: 'Yarn2',
+    label: 'Yarn 2+ (JavaScript / Node.js)',
+  },
+] as const;
+
+export const reportFormats = [
+  {
+    id: 'AsciiDocTemplate',
+    label: 'AsciiDoc Template',
+  },
+  {
+    id: 'ortresult',
+    label: 'ORT Result',
+  },
+  {
+    id: 'PlainTextTemplate',
+    label: 'NOTICE file',
+  },
+  {
+    id: 'SpdxDocument',
+    label: 'SPDX Document',
+  },
+  {
+    id: 'WebApp',
+    label: 'Web App',
+  },
+] as const;

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/create-run.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/create-run.tsx
@@ -55,6 +55,7 @@ import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
 import { Switch } from '@/components/ui/switch';
 import { useToast } from '@/components/ui/use-toast';
+import { advisors, packageManagers, reportFormats } from './-types';
 
 const keyValueSchema = z.object({
   key: z.string().min(1),
@@ -97,95 +98,6 @@ const formSchema = z.object({
   labels: z.array(keyValueSchema).optional(),
   jobConfigContext: z.string().optional(),
 });
-
-const advisors = [
-  {
-    id: 'OssIndex',
-    label: 'OSS Index',
-  },
-  {
-    id: 'OSV',
-    label: 'OSV',
-  },
-  {
-    id: 'VulnerableCode',
-    label: 'VulnerableCode',
-  },
-] as const;
-
-const packageManagers = [
-  {
-    id: 'Bundler',
-    label: 'Bundler (Ruby)',
-  },
-  {
-    id: 'Cargo',
-    label: 'Cargo (Rust)',
-  },
-  {
-    id: 'GoMod',
-    label: 'GoMod (Go)',
-  },
-  {
-    id: 'GradleInspector',
-    label: 'Gradle (Java)',
-  },
-  {
-    id: 'Maven',
-    label: 'Maven (Java)',
-  },
-  {
-    id: 'NPM',
-    label: 'NPM (JavaScript / Node.js)',
-  },
-  {
-    id: 'PIP',
-    label: 'PIP (Python)',
-  },
-  {
-    id: 'Pipenv',
-    label: 'Pipenv (Python)',
-  },
-  {
-    id: 'PNPM',
-    label: 'PNPM (JavaScript / Node.js)',
-  },
-  {
-    id: 'Poetry',
-    label: 'Poetry (Python)',
-  },
-  {
-    id: 'Yarn',
-    label: 'Yarn 1 (JavaScript / Node.js)',
-  },
-  {
-    id: 'Yarn2',
-    label: 'Yarn 2+ (JavaScript / Node.js)',
-  },
-] as const;
-
-const reportFormats = [
-  {
-    id: 'AsciiDocTemplate',
-    label: 'AsciiDoc Template',
-  },
-  {
-    id: 'ortresult',
-    label: 'ORT Result',
-  },
-  {
-    id: 'PlainTextTemplate',
-    label: 'NOTICE file',
-  },
-  {
-    id: 'SpdxDocument',
-    label: 'SPDX Document',
-  },
-  {
-    id: 'WebApp',
-    label: 'Web App',
-  },
-] as const;
 
 const CreateRunPage = () => {
   const navigate = useNavigate();


### PR DESCRIPTION
This helps declutter the page component. The `-` prefix in routes makes
files not create routes even though they're in the routes directory,
allowing to colocate helpers and components not used anywhere else.

Signed-off-by: Mikko Murto <mikko.murto@doubleopen.org>