### PR TITLE
fix(analyzer): Resolve secrets of package curation providers

### DIFF
--- a/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
@@ -129,7 +129,10 @@ class AnalyzerWorkerTest : StringSpec({
             every { downloadRepository(any(), any()) } returns projectDir
         }
 
-        val context = mockk<WorkerContext>()
+        val context = mockk<WorkerContext> {
+            coEvery { resolveProviderPluginConfigSecrets(any()) } returns mockk(relaxed = true)
+        }
+
         val contextFactory = mockk<WorkerContextFactory> {
             every { createContext(analyzerJob.ortRunId) } returns context
         }
@@ -187,7 +190,10 @@ class AnalyzerWorkerTest : StringSpec({
             every { downloadRepository(any(), any()) } returns projectDir
         }
 
-        val context = mockk<WorkerContext>()
+        val context = mockk<WorkerContext> {
+            coEvery { resolveProviderPluginConfigSecrets(any()) } returns mockk(relaxed = true)
+        }
+
         val contextFactory = mockk<WorkerContextFactory> {
             every { createContext(analyzerJob.ortRunId) } returns context
         }
@@ -244,7 +250,10 @@ class AnalyzerWorkerTest : StringSpec({
             every { downloadRepository(any(), any()) } returns projectDir
         }
 
-        val context = mockk<WorkerContext>()
+        val context = mockk<WorkerContext> {
+            coEvery { resolveProviderPluginConfigSecrets(any()) } returns mockk(relaxed = true)
+        }
+
         val contextFactory = mockk<WorkerContextFactory> {
             every { createContext(analyzerJob.ortRunId) } returns context
         }


### PR DESCRIPTION
Resolve the secrets in the configurations of the package curation providers from the configured secret storage, instead of using the secret values directly.

As the `AnalyzerRunner` does not have access to the worker context when running in a fork, the secrets need to be resolved before creating the fork.