### PR TITLE
Add total counts to organization endpoints that return lists

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
@@ -51,6 +51,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRun as ApiOrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatus as ApiOrtRunStatus
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunSummary as ApiOrtRunSummary
 import org.eclipse.apoapsis.ortserver.api.v1.model.PackageManagerConfiguration as ApiPackageManagerConfiguration
+import org.eclipse.apoapsis.ortserver.api.v1.model.PagedResponse2 as ApiPagedResponse2
 import org.eclipse.apoapsis.ortserver.api.v1.model.PagingOptions as ApiPagingOptions
 import org.eclipse.apoapsis.ortserver.api.v1.model.PluginConfiguration as ApiPluginConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.Product as ApiProduct
@@ -104,6 +105,7 @@ import org.eclipse.apoapsis.ortserver.model.SourceCodeOrigin
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
 import org.eclipse.apoapsis.ortserver.model.runs.PackageManagerConfiguration
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
+import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
 import org.eclipse.apoapsis.ortserver.model.util.OptionalValue
 import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
 import org.eclipse.apoapsis.ortserver.model.util.OrderField
@@ -361,7 +363,7 @@ fun NotifierJob.mapToApi() =
         finishedAt,
         configuration.mapToApi(),
         status.mapToApi()
-      )
+    )
 
 fun NotifierJobConfiguration.mapToApi() =
     ApiNotifierJobConfiguration(
@@ -586,12 +588,33 @@ fun ApiPagingOptions.mapToModel() =
         offset = offset
     )
 
+fun <T, E> ListQueryResult<T>.mapToApi(mapValues: (T) -> E) =
+    ApiPagedResponse2(
+        data = data.map(mapValues),
+        pagination = params.mapToApi().toPagingData(totalCount)
+    )
+
+fun ListQueryParameters.mapToApi() =
+    ApiPagingOptions(
+        limit = limit,
+        offset = offset,
+        sortProperties = sortFields.map { it.mapToApi() }
+    )
+
 fun ApiSortProperty.mapToModel() = OrderField(name, direction.mapToModel())
+
+fun OrderField.mapToApi() = ApiSortProperty(name, direction.mapToApi())
 
 fun ApiSortDirection.mapToModel() =
     when (this) {
         ApiSortDirection.ASCENDING -> OrderDirection.ASCENDING
         ApiSortDirection.DESCENDING -> OrderDirection.DESCENDING
+    }
+
+fun OrderDirection.mapToApi() =
+    when (this) {
+        OrderDirection.ASCENDING -> ApiSortDirection.ASCENDING
+        OrderDirection.DESCENDING -> ApiSortDirection.DESCENDING
     }
 
 fun SourceCodeOrigin.mapToApi() =

--- a/api/v1/model/src/commonMain/kotlin/PagedResponse.kt
+++ b/api/v1/model/src/commonMain/kotlin/PagedResponse.kt
@@ -33,6 +33,18 @@ data class PagedResponse<E>(
     val options: PagingOptions
 )
 
+/**
+ * A response object for returning paged lists of entities.
+ */
+@Serializable
+data class PagedResponse2<E>(
+    /** The list of returned entities. */
+    val data: List<E>,
+
+    /** The pagination information for the result set. */
+    val pagination: PagingData
+)
+
 @Serializable
 data class PagingOptions(
     /** An optional limit for the number of items to return. */

--- a/api/v1/model/src/commonMain/kotlin/PagedResponse.kt
+++ b/api/v1/model/src/commonMain/kotlin/PagedResponse.kt
@@ -60,7 +60,19 @@ data class PagingOptions(
      * An optional list of properties by which the result set should be sorted.
      */
     val sortProperties: List<SortProperty>? = null
-)
+) {
+    /**
+     * Convert this object to [PagingData] with the provided [totalCount]. This requires that all properties of this
+     * object are not `null`, an exception is thrown otherwise.
+     */
+    fun toPagingData(totalCount: Long): PagingData {
+        checkNotNull(limit)
+        checkNotNull(offset)
+        checkNotNull(sortProperties)
+
+        return PagingData(limit, offset, totalCount, sortProperties)
+    }
+}
 
 @Serializable
 data class PagingData(

--- a/api/v1/model/src/commonMain/kotlin/PagedResponse.kt
+++ b/api/v1/model/src/commonMain/kotlin/PagedResponse.kt
@@ -51,6 +51,21 @@ data class PagingOptions(
 )
 
 @Serializable
+data class PagingData(
+    /** The limit for the number of items to return. */
+    val limit: Int,
+
+    /** The offset for the items to return. */
+    val offset: Long,
+
+    /** The total count of items. */
+    val totalCount: Long,
+
+    /** The properties by which the result set was sorted. */
+    val sortProperties: List<SortProperty>
+)
+
+@Serializable
 /**
  * A data class defining a property by which a query result should be sorted.
  */

--- a/core/src/main/kotlin/api/OrganizationsRoute.kt
+++ b/core/src/main/kotlin/api/OrganizationsRoute.kt
@@ -67,6 +67,7 @@ import org.eclipse.apoapsis.ortserver.core.utils.paginate
 import org.eclipse.apoapsis.ortserver.core.utils.pagingOptions
 import org.eclipse.apoapsis.ortserver.core.utils.requireIdParameter
 import org.eclipse.apoapsis.ortserver.core.utils.requireParameter
+import org.eclipse.apoapsis.ortserver.model.Product
 import org.eclipse.apoapsis.ortserver.model.authorization.OrganizationPermission
 import org.eclipse.apoapsis.ortserver.services.InfrastructureServiceService
 import org.eclipse.apoapsis.ortserver.services.OrganizationService
@@ -154,10 +155,8 @@ fun Route.organizations() = route("organizations") {
 
             val productsForOrganization =
                 organizationService.listProductsForOrganization(orgId, pagingOptions.mapToModel())
-            val pagedResponse = PagedResponse(
-                productsForOrganization.map { it.mapToApi() },
-                pagingOptions
-            )
+
+            val pagedResponse = productsForOrganization.mapToApi(Product::mapToApi)
 
             call.respond(HttpStatusCode.OK, pagedResponse)
         }

--- a/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
@@ -554,14 +554,15 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                 val response = superuserClient.get("/api/v1/organizations/$orgId/products")
 
                 response shouldHaveStatus HttpStatusCode.OK
-                response shouldHaveBody PagedResponse(
+                response shouldHaveBody PagedResponse2(
                     listOf(
                         Product(createdProduct1.id, orgId, name1, description),
                         Product(createdProduct2.id, orgId, name2, description)
                     ),
-                    PagingOptions(
+                    PagingData(
                         limit = DEFAULT_LIMIT,
                         offset = 0,
+                        totalCount = 2,
                         sortProperties = listOf(SortProperty("name", SortDirection.ASCENDING))
                     )
                 )
@@ -583,11 +584,12 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                 val response = superuserClient.get("/api/v1/organizations/$orgId/products?sort=-name&limit=1")
 
                 response shouldHaveStatus HttpStatusCode.OK
-                response shouldHaveBody PagedResponse(
+                response shouldHaveBody PagedResponse2(
                     listOf(Product(createdProduct2.id, orgId, name2, description)),
-                    PagingOptions(
+                    PagingData(
                         limit = 1,
                         offset = 0,
+                        totalCount = 2,
                         sortProperties = listOf(SortProperty("name", SortDirection.DESCENDING))
                     )
                 )

--- a/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
@@ -52,6 +52,8 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.InfrastructureService as ApiI
 import org.eclipse.apoapsis.ortserver.api.v1.model.OptionalValue
 import org.eclipse.apoapsis.ortserver.api.v1.model.Organization
 import org.eclipse.apoapsis.ortserver.api.v1.model.PagedResponse
+import org.eclipse.apoapsis.ortserver.api.v1.model.PagedResponse2
+import org.eclipse.apoapsis.ortserver.api.v1.model.PagingData
 import org.eclipse.apoapsis.ortserver.api.v1.model.PagingOptions
 import org.eclipse.apoapsis.ortserver.api.v1.model.Product
 import org.eclipse.apoapsis.ortserver.api.v1.model.Secret
@@ -144,12 +146,13 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                 val response = superuserClient.get("/api/v1/organizations")
 
                 response shouldHaveStatus HttpStatusCode.OK
-                response shouldHaveBody PagedResponse(
+                response shouldHaveBody PagedResponse2(
                     listOf(org1.mapToApi(), org2.mapToApi()),
-                    PagingOptions(
+                    PagingData(
                         limit = DEFAULT_LIMIT,
                         offset = 0,
-                        sortProperties = listOf(SortProperty("name", SortDirection.ASCENDING)),
+                        totalCount = 2,
+                        sortProperties = listOf(SortProperty("name", SortDirection.ASCENDING))
                     )
                 )
             }
@@ -175,11 +178,12 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                 val response = testUserClient.get("/api/v1/organizations")
 
                 response shouldHaveStatus HttpStatusCode.OK
-                response shouldHaveBody PagedResponse(
+                response shouldHaveBody PagedResponse2(
                     listOf(org2.mapToApi(), org4.mapToApi()),
-                    PagingOptions(
+                    PagingData(
                         limit = DEFAULT_LIMIT,
                         offset = 0,
+                        totalCount = 2,
                         sortProperties = listOf(SortProperty("name", SortDirection.ASCENDING)),
                     )
                 )
@@ -194,11 +198,12 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                 val response = superuserClient.get("/api/v1/organizations?sort=-name&limit=1")
 
                 response shouldHaveStatus HttpStatusCode.OK
-                response shouldHaveBody PagedResponse(
+                response shouldHaveBody PagedResponse2(
                     listOf(org2.mapToApi()),
-                    PagingOptions(
+                    PagingData(
                         limit = 1,
                         offset = 0,
+                        totalCount = 2,
                         sortProperties = listOf(SortProperty("name", SortDirection.DESCENDING)),
                     )
                 )

--- a/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
@@ -210,7 +210,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 superuserClient.delete("/api/v1/products/${createdProduct.id}") shouldHaveStatus
                         HttpStatusCode.NoContent
 
-                organizationService.listProductsForOrganization(orgId) shouldBe emptyList()
+                organizationService.listProductsForOrganization(orgId).data shouldBe emptyList()
             }
         }
 

--- a/dao/src/test/kotlin/repositories/DaoProductRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/DaoProductRepositoryTest.kt
@@ -33,6 +33,7 @@ import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
 import org.eclipse.apoapsis.ortserver.dao.test.Fixtures
 import org.eclipse.apoapsis.ortserver.model.Product
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
+import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
 import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
 import org.eclipse.apoapsis.ortserver.model.util.OrderField
 import org.eclipse.apoapsis.ortserver.model.util.asPresent
@@ -111,9 +112,13 @@ class DaoProductRepositoryTest : StringSpec({
         val createdProduct2 = productRepository.create(name2, description2, orgId)
         productRepository.create(name1, description1, otherOrgId)
 
-        productRepository.listForOrganization(orgId) shouldBe listOf(
-            Product(createdProduct1.id, orgId, name1, description1),
-            Product(createdProduct2.id, orgId, name2, description2)
+        productRepository.listForOrganization(orgId) shouldBe ListQueryResult(
+            data = listOf(
+                Product(createdProduct1.id, orgId, name1, description1),
+                Product(createdProduct2.id, orgId, name2, description2)
+            ),
+            params = ListQueryParameters.DEFAULT,
+            totalCount = 2
         )
     }
 
@@ -135,8 +140,10 @@ class DaoProductRepositoryTest : StringSpec({
         val createdProduct2 = productRepository.create(name2, description2, orgId)
         productRepository.create(name1, description1, otherOrgId)
 
-        productRepository.listForOrganization(orgId, parameters) shouldBe listOf(
-            Product(createdProduct2.id, orgId, name2, description2)
+        productRepository.listForOrganization(orgId, parameters) shouldBe ListQueryResult(
+            data = listOf(Product(createdProduct2.id, orgId, name2, description2)),
+            params = parameters,
+            totalCount = 2
         )
     }
 
@@ -168,7 +175,11 @@ class DaoProductRepositoryTest : StringSpec({
 
         productRepository.delete(createdProduct.id)
 
-        productRepository.listForOrganization(orgId) shouldBe emptyList()
+        productRepository.listForOrganization(orgId) shouldBe ListQueryResult(
+            data = emptyList(),
+            params = ListQueryParameters.DEFAULT,
+            totalCount = 0
+        )
     }
 
     "get should return null" {

--- a/model/src/commonMain/kotlin/repositories/ProductRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/ProductRepository.kt
@@ -21,6 +21,7 @@ package org.eclipse.apoapsis.ortserver.model.repositories
 
 import org.eclipse.apoapsis.ortserver.model.Product
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
+import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
 import org.eclipse.apoapsis.ortserver.model.util.OptionalValue
 
 /**
@@ -48,7 +49,7 @@ interface ProductRepository {
     fun listForOrganization(
         organizationId: Long,
         parameters: ListQueryParameters = ListQueryParameters.DEFAULT
-    ): List<Product>
+    ): ListQueryResult<Product>
 
     /**
      * Update a product by [id] with the [present][OptionalValue.Present] values.

--- a/model/src/commonMain/kotlin/util/ListQueryResult.kt
+++ b/model/src/commonMain/kotlin/util/ListQueryResult.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.model.util
+
+/**
+ * A class to capture the result of a [parameterized][params] list query.
+ */
+data class ListQueryResult<T>(
+    /** The data returned by the query. */
+    val data: List<T>,
+
+    /** The parameters used for the query. */
+    val params: ListQueryParameters,
+
+    /** The total number of items, without applying the [params]. */
+    val totalCount: Long
+)


### PR DESCRIPTION
Add the total entity counts to organization endpoints to enable proper pagination in the UI. Please see the commit messages for details.

This is a first step to implement the requirements for #453, the remaining endpoints will be aligned in separate PRs.