### PR TITLE
ci(renovate): Update lucide-react once a week

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -29,6 +29,10 @@
       "rangeStrategy": "in-range-only"
     },
     {
+      "matchPackageNames": ["lucide-react"],
+      "schedule": ["after 9pm on sunday"]
+    },
+    {
       "matchPackageNames": ["node"],
       "schedule": ["after 9pm on sunday"]
     }


### PR DESCRIPTION
The lucide icon library is updated very often. As most updates do not affect the icons used by the ui, limit the updates to once a week.