### PR TITLE
ui: Show the creation time in the ort runs table and run details page

### DIFF
--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/index.tsx
@@ -81,6 +81,7 @@ const RepoComponent = () => {
   const params = Route.useParams();
   const navigate = useNavigate();
   const { toast } = useToast();
+  const locale = navigator.language;
 
   const [{ data: repo }, { data: runs }] = useSuspenseQueries({
     queries: [
@@ -249,7 +250,7 @@ const RepoComponent = () => {
                       </div>
                     </TableCell>
                     <TableCell>
-                      {new Date(run.createdAt).toLocaleString().split(',')[0]}
+                      {new Date(run.createdAt).toLocaleString(locale)}
                     </TableCell>
                     <TableCell>
                       <Badge

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/index.tsx
@@ -46,6 +46,7 @@ import { getStatusBackgroundColor } from '@/helpers/get-status-colors';
 
 const RunComponent = () => {
   const params = Route.useParams();
+  const locale = navigator.language;
 
   const { data: ortRun } = useSuspenseQuery({
     queryKey: [
@@ -131,7 +132,7 @@ const RunComponent = () => {
               <TableCell>Created at</TableCell>
               <TableCell>
                 <div className='font-medium'>
-                  {new Date(ortRun.createdAt).toLocaleString()}
+                  {new Date(ortRun.createdAt).toLocaleString(locale)}
                 </div>
               </TableCell>
             </TableRow>
@@ -140,7 +141,7 @@ const RunComponent = () => {
                 <TableCell>Finished at</TableCell>
                 <TableCell>
                   <div className='font-medium'>
-                    {new Date(ortRun.finishedAt).toLocaleString()}
+                    {new Date(ortRun.finishedAt).toLocaleString(locale)}
                   </div>
                 </TableCell>
               </TableRow>


### PR DESCRIPTION
Use browser language to decide on the exact format. Examples:

English:
![Capture_English](https://github.com/user-attachments/assets/f4ae36b2-d493-4a9d-a64a-1b03bba9eb0b)

Finnish:
![Capture_Finnish](https://github.com/user-attachments/assets/c47cf79b-b3b0-4b29-8829-07c40c86949a)

Run details, English:
![Capture_details_English](https://github.com/user-attachments/assets/d1469fe0-04b0-491c-9f1a-91074a4e2c62)