### PR TITLE
ci: Set 1.0.0-SNAPSHOT as fixed version for the Maven artifacts

### DIFF
--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -36,4 +36,4 @@ jobs:
       env:
         ORG_GRADLE_PROJECT_githubPackagesUsername: ${{ env.GITHUB_ACTOR }}
         ORG_GRADLE_PROJECT_githubPackagesPassword: ${{ secrets.GITHUB_TOKEN }}
-      run: ./gradlew publishAllPublicationsToGithubPackagesRepository
+      run: ./gradlew -Pversion=1.0.0-SNAPSHOT publishAllPublicationsToGithubPackagesRepository


### PR DESCRIPTION
Since 6fdc420 the artifacts were published with changing versions based on the revision. Set 1.0.0-SNAPSHOT as the fixed version for those artifacts, as they are only used for testing and not proper releases.