### PR TITLE
fix(ui): Guard against possible undefined context in header

### DIFF
--- a/ui/src/components/header.tsx
+++ b/ui/src/components/header.tsx
@@ -128,7 +128,7 @@ export const Header = () => {
         </Sheet>
         <Breadcrumb>
           <BreadcrumbList>
-            {organizationMatch && (
+            {organizationMatch?.context && (
               <BreadcrumbItem>
                 <BreadcrumbLink asChild>
                   <Link to={organizationMatch.pathname}>
@@ -137,7 +137,7 @@ export const Header = () => {
                 </BreadcrumbLink>
               </BreadcrumbItem>
             )}
-            {productMatch && (
+            {productMatch?.context && (
               <>
                 <BreadcrumbSeparator />
                 <BreadcrumbItem>
@@ -149,7 +149,7 @@ export const Header = () => {
                 </BreadcrumbItem>
               </>
             )}
-            {repoMatch && (
+            {repoMatch?.context && (
               <>
                 <BreadcrumbSeparator />
                 <BreadcrumbItem>
@@ -161,7 +161,7 @@ export const Header = () => {
                 </BreadcrumbItem>
               </>
             )}
-            {runMatch && (
+            {runMatch?.context && (
               <>
                 <BreadcrumbSeparator />
                 <BreadcrumbItem>


### PR DESCRIPTION
This PR fixes an undefined context error when refreshing the browser on index pages:

![Capture](https://github.com/user-attachments/assets/07a57a89-9ad3-4429-8bc8-61dee416b2ea)

Please see the commit for details.