### PR TITLE
ui: First skeleton version of new ORT run details page

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -29,6 +29,7 @@
     "@radix-ui/react-separator": "^1.0.3",
     "@radix-ui/react-slot": "^1.0.2",
     "@radix-ui/react-switch": "^1.0.3",
+    "@radix-ui/react-tabs": "^1.1.0",
     "@radix-ui/react-toast": "^1.1.5",
     "@radix-ui/react-tooltip": "^1.0.7",
     "@tanstack/react-query": "^5.29.2",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@radix-ui/react-switch':
         specifier: ^1.0.3
         version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-tabs':
+        specifier: ^1.1.0
+        version: 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-toast':
         specifier: ^1.1.5
         version: 1.2.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -1071,6 +1074,19 @@ packages:
 
   '@radix-ui/react-switch@1.1.0':
     resolution: {integrity: sha512-OBzy5WAj641k0AOSpKQtreDMe+isX0MQJ1IVyF03ucdF3DunOnROVrjWs8zsXUxC3zfZ6JL9HFVCUlMghz9dJw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-tabs@1.1.0':
+    resolution: {integrity: sha512-bZgOKB/LtZIij75FSuPzyEti/XBhJH52ExgtdVqjCIh+Nx/FW+LhnbXtbCzIi34ccyMsyOja8T0thCzoHFXNKA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3870,6 +3886,22 @@ snapshots:
       '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.3)(react@18.3.1)
       '@radix-ui/react-use-previous': 1.1.0(@types/react@18.3.3)(react@18.3.1)
       '@radix-ui/react-use-size': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-tabs@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.3)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     optionalDependencies:

--- a/ui/src/components/header.tsx
+++ b/ui/src/components/header.tsx
@@ -91,6 +91,12 @@ export const Header = () => {
       '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex'
   );
 
+  const run2Match = matches.find(
+    (match) =>
+      match.routeId ===
+      '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex'
+  );
+
   return (
     <header className='sticky top-0 z-50 flex h-16 justify-between gap-4 border-b bg-background px-4 md:px-6'>
       <div className='flex flex-row items-center gap-4'>
@@ -168,6 +174,18 @@ export const Header = () => {
                   <BreadcrumbLink asChild>
                     <Link to={runMatch.pathname}>
                       {runMatch.context.breadcrumbs.run}
+                    </Link>
+                  </BreadcrumbLink>
+                </BreadcrumbItem>
+              </>
+            )}
+            {run2Match?.context && (
+              <>
+                <BreadcrumbSeparator />
+                <BreadcrumbItem>
+                  <BreadcrumbLink asChild>
+                    <Link to={run2Match.pathname}>
+                      {run2Match.context.breadcrumbs.run}
                     </Link>
                   </BreadcrumbLink>
                 </BreadcrumbItem>

--- a/ui/src/components/ui/tabs.tsx
+++ b/ui/src/components/ui/tabs.tsx
@@ -1,0 +1,62 @@
+/*
+ * The component is originally a part of the shadcn/ui library at https://github.com/shadcn-ui/ui.
+ * The library is licensed as set out below:
+ *
+ * Copyright (c) 2023 shadcn
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import * as TabsPrimitive from '@radix-ui/react-tabs';
+import * as React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Tabs = TabsPrimitive.Root;
+
+const TabsList = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.List>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.List
+    ref={ref}
+    className={cn(
+      'inline-flex h-9 items-center justify-center rounded-lg bg-muted p-1 text-muted-foreground',
+      className
+    )}
+    {...props}
+  />
+));
+TabsList.displayName = TabsPrimitive.List.displayName;
+
+const TabsTrigger = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Trigger>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Trigger
+    ref={ref}
+    className={cn(
+      'inline-flex items-center justify-center whitespace-nowrap rounded-md px-3 py-1 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow',
+      className
+    )}
+    {...props}
+  />
+));
+TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
+
+const TabsContent = React.forwardRef<
+  React.ElementRef<typeof TabsPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>
+>(({ className, ...props }, ref) => (
+  <TabsPrimitive.Content
+    ref={ref}
+    className={cn(
+      'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      className
+    )}
+    {...props}
+  />
+));
+TabsContent.displayName = TabsPrimitive.Content.displayName;
+
+export { Tabs, TabsList, TabsTrigger, TabsContent };

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/route.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/route.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { createFileRoute, Outlet } from '@tanstack/react-router';
+
+import { Sidebar } from './runs2/$runIndex/-components/sidebar';
+
+const Layout = () => {
+  return (
+    <div className='flex h-full w-full flex-row gap-2'>
+      <Sidebar />
+      <Outlet />
+    </div>
+  );
+};
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout'
+)({
+  component: Layout,
+});

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/route.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/route.tsx
@@ -23,7 +23,7 @@ import { Sidebar } from './runs2/$runIndex/-components/sidebar';
 
 const Layout = () => {
   return (
-    <div className='flex h-full w-full flex-row gap-2'>
+    <div className='flex h-[calc(100vh-4rem-2rem)] w-full gap-2 md:h-[calc(100vh-4rem-4rem)]'>
       <Sidebar />
       <Outlet />
     </div>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/-components/advisor-job-details.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/-components/advisor-job-details.tsx
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { OrtRun } from '@/api/requests';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { calculateDuration } from '@/helpers/get-run-duration';
+import { getStatusBackgroundColor } from '@/helpers/get-status-colors';
+
+type AdvisorJobDetailsProps = {
+  run: OrtRun;
+};
+
+export const AdvisorJobDetails = ({ run }: AdvisorJobDetailsProps) => {
+  const job = run.jobs.advisor;
+  const jobConfigs = run.resolvedJobConfigs?.advisor;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          <Badge className={`border ${getStatusBackgroundColor(job?.status)}`}>
+            {job?.status || 'NOT RUN'}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className='space-y-2 text-sm'>
+          <div>
+            <Label className='font-semibold'>Duration: </Label>
+            {job?.startedAt && job?.finishedAt
+              ? calculateDuration(job.startedAt, job.finishedAt)
+              : 'N/A'}
+          </div>
+          {jobConfigs && (
+            <div className='space-y-2'>
+              <Label className='font-semibold'>
+                Resolved job configuration:
+              </Label>
+              <div className='ml-2 space-y-2'>
+                {jobConfigs?.skipExcluded && (
+                  <div>
+                    <Label className='font-semibold'>Skip excluded: </Label>
+                    {jobConfigs.skipExcluded.toString()}
+                  </div>
+                )}
+                {jobConfigs?.advisors && (
+                  <div>
+                    <Label className='font-semibold'>Advisors:</Label>{' '}
+                    {jobConfigs.advisors.join(', ')}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/-components/analyzer-job-details.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/-components/analyzer-job-details.tsx
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { OrtRun } from '@/api/requests';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { calculateDuration } from '@/helpers/get-run-duration';
+import { getStatusBackgroundColor } from '@/helpers/get-status-colors';
+
+type AnalyzerJobDetailsProps = {
+  run: OrtRun;
+};
+
+export const AnalyzerJobDetails = ({ run }: AnalyzerJobDetailsProps) => {
+  const job = run.jobs.analyzer;
+  const jobConfigs = run.resolvedJobConfigs?.analyzer;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          <Badge className={`border ${getStatusBackgroundColor(job?.status)}`}>
+            {job?.status || 'NOT RUN'}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className='space-y-2 text-sm'>
+          <div>
+            <Label className='font-semibold'>Duration: </Label>
+            {job?.startedAt && job?.finishedAt
+              ? calculateDuration(job.startedAt, job.finishedAt)
+              : 'N/A'}
+          </div>
+          {jobConfigs && (
+            <div className='space-y-2'>
+              <Label className='font-semibold'>
+                Resolved job configuration:
+              </Label>
+              <div className='ml-2 space-y-2'>
+                {jobConfigs?.allowDynamicVersions && (
+                  <div>
+                    <Label className='font-semibold'>
+                      Allow dynamic versions:
+                    </Label>{' '}
+                    {jobConfigs.allowDynamicVersions.toString()}
+                  </div>
+                )}
+                {jobConfigs?.skipExcluded && (
+                  <div>
+                    <Label className='font-semibold'>Skip excluded: </Label>
+                    {jobConfigs.skipExcluded.toString()}
+                  </div>
+                )}
+                {jobConfigs?.enabledPackageManagers && (
+                  <div>
+                    <Label className='font-semibold'>
+                      Enabled package managers:
+                    </Label>{' '}
+                    {jobConfigs.enabledPackageManagers.join(', ')}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/-components/evaluator-job-details.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/-components/evaluator-job-details.tsx
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { OrtRun } from '@/api/requests';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { calculateDuration } from '@/helpers/get-run-duration';
+import { getStatusBackgroundColor } from '@/helpers/get-status-colors';
+
+type EvaluatorJobDetailsProps = {
+  run: OrtRun;
+};
+
+export const EvaluatorJobDetails = ({ run }: EvaluatorJobDetailsProps) => {
+  const job = run.jobs.evaluator;
+  const jobConfigs = run.resolvedJobConfigs?.evaluator;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          <Badge className={`border ${getStatusBackgroundColor(job?.status)}`}>
+            {job?.status || 'NOT RUN'}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className='space-y-2 text-sm'>
+          <div>
+            <Label className='font-semibold'>Duration: </Label>
+            {job?.startedAt && job?.finishedAt
+              ? calculateDuration(job.startedAt, job.finishedAt)
+              : 'N/A'}
+          </div>
+          {jobConfigs && (
+            <div className='space-y-2'>
+              <Label className='font-semibold'>
+                Resolved job configuration:
+              </Label>
+              <div className='ml-2 space-y-2'>
+                {jobConfigs?.ruleSet && (
+                  <div>
+                    <Label className='font-semibold'>Ruleset:</Label>{' '}
+                    {jobConfigs.ruleSet}
+                  </div>
+                )}
+                {jobConfigs?.licenseClassificationsFile && (
+                  <div>
+                    <Label className='font-semibold'>
+                      License classifications:
+                    </Label>{' '}
+                    {jobConfigs.licenseClassificationsFile}
+                  </div>
+                )}
+                {jobConfigs?.copyrightGarbageFile && (
+                  <div>
+                    <Label className='font-semibold'>Copyright garbage:</Label>{' '}
+                    {jobConfigs.copyrightGarbageFile}
+                  </div>
+                )}
+                {jobConfigs?.resolutionsFile && (
+                  <div>
+                    <Label className='font-semibold'>Resolutions:</Label>{' '}
+                    {jobConfigs.resolutionsFile}
+                  </div>
+                )}
+                {jobConfigs?.packageConfigurationProviders && (
+                  <div className='space-y-2'>
+                    <Label className='font-semibold'>
+                      Package configuration providers:
+                    </Label>{' '}
+                    {jobConfigs.packageConfigurationProviders.map(
+                      (provider) => (
+                        <div className='ml-2' key={provider.id}>
+                          <Label className='font-semibold'>
+                            {provider.type}
+                          </Label>
+                          {provider.id && (
+                            <div className='ml-2'>
+                              <Label className='font-semibold'>Id:</Label>{' '}
+                              {provider.id.toString()}
+                            </div>
+                          )}
+                          {provider.enabled && (
+                            <div className='ml-2'>
+                              <Label className='font-semibold'>Enabled:</Label>{' '}
+                              {provider.enabled.toString()}
+                            </div>
+                          )}
+                          {provider.options && (
+                            <div className='ml-2'>
+                              <Label className='font-semibold'>Options:</Label>{' '}
+                              <div className='ml-2'>
+                                {Object.entries(provider.options).map(
+                                  ([key, value]) => (
+                                    <div key={key}>
+                                      <Label className='font-semibold'>
+                                        {key}:
+                                      </Label>{' '}
+                                      {value.toString()}
+                                    </div>
+                                  )
+                                )}
+                              </div>
+                            </div>
+                          )}
+                          {provider.secrets && (
+                            <div className='ml-2'>
+                              <Label className='font-semibold'>Secrets:</Label>{' '}
+                              <div className='ml-2'>
+                                {Object.entries(provider.secrets).map(
+                                  ([key, value]) => (
+                                    <div key={key}>
+                                      <Label className='font-semibold'>
+                                        {key}:
+                                      </Label>{' '}
+                                      {value.toString()}
+                                    </div>
+                                  )
+                                )}
+                              </div>
+                            </div>
+                          )}
+                        </div>
+                      )
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/-components/notifier-job-details.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/-components/notifier-job-details.tsx
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { OrtRun } from '@/api/requests';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { calculateDuration } from '@/helpers/get-run-duration';
+import { getStatusBackgroundColor } from '@/helpers/get-status-colors';
+
+type NotifierJobDetailsProps = {
+  run: OrtRun;
+};
+
+export const NotifierJobDetails = ({ run }: NotifierJobDetailsProps) => {
+  const job = run.jobs.notifier;
+  const jobConfigs = run.resolvedJobConfigs?.notifier;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          <Badge className={`border ${getStatusBackgroundColor(job?.status)}`}>
+            {job?.status || 'NOT RUN'}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className='space-y-2 text-sm'>
+          <div>
+            <Label className='font-semibold'>Duration: </Label>
+            {job?.startedAt && job?.finishedAt
+              ? calculateDuration(job.startedAt, job.finishedAt)
+              : 'N/A'}
+          </div>
+          {jobConfigs && (
+            <div className='space-y-2'>
+              <Label className='font-semibold'>
+                Resolved job configuration:
+              </Label>
+              <div className='ml-2 space-y-2'>
+                {jobConfigs?.notifierRules && (
+                  <div>
+                    <Label className='font-semibold'>Rules:</Label>{' '}
+                    {jobConfigs.notifierRules}
+                  </div>
+                )}
+                {jobConfigs?.resolutionsFile && (
+                  <div>
+                    <Label className='font-semibold'>Resolutions:</Label>{' '}
+                    {jobConfigs.resolutionsFile}
+                  </div>
+                )}
+                {jobConfigs?.mail && (
+                  <div className='space-y-2'>
+                    <Label className='font-semibold'>Mail:</Label>{' '}
+                    {jobConfigs.mail.recipientAddresses && (
+                      <div className='ml-2'>
+                        <Label className='font-semibold'>
+                          Recipient addresses:
+                        </Label>{' '}
+                        {jobConfigs.mail.recipientAddresses.join(', ')}
+                      </div>
+                    )}
+                    {jobConfigs.mail.mailServerConfiguration && (
+                      <div className='ml-2'>
+                        <Label className='font-semibold'>
+                          Mail server configuration:
+                        </Label>{' '}
+                        <div className='ml-2'>
+                          <div>
+                            <Label className='font-semibold'>Host name: </Label>
+                            {jobConfigs.mail.mailServerConfiguration.hostName}
+                          </div>
+                          <div>
+                            <Label className='font-semibold'>Port: </Label>
+                            {jobConfigs.mail.mailServerConfiguration.port}
+                          </div>
+                          <div>
+                            <Label className='font-semibold'>Username: </Label>
+                            {jobConfigs.mail.mailServerConfiguration.username}
+                          </div>
+                          <div>
+                            <Label className='font-semibold'>Password: </Label>
+                            {jobConfigs.mail.mailServerConfiguration.password}
+                          </div>
+                          <div>
+                            <Label className='font-semibold'>Use SSL: </Label>
+                            {jobConfigs.mail.mailServerConfiguration.useSsl.toString()}
+                          </div>
+                          <div>
+                            <Label className='font-semibold'>
+                              From address:{' '}
+                            </Label>
+                            {
+                              jobConfigs.mail.mailServerConfiguration
+                                .fromAddress
+                            }
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
+                {jobConfigs?.jira && (
+                  <div className='space-y-2'>
+                    <Label className='font-semibold'>Jira:</Label>{' '}
+                    {jobConfigs.jira.jiraRestClientConfiguration && (
+                      <div className='ml-2'>
+                        <Label className='font-semibold'>
+                          Jira REST client configuration:
+                        </Label>{' '}
+                        <div className='ml-2'>
+                          <div>
+                            <Label className='font-semibold'>
+                              Server URL:{' '}
+                            </Label>
+                            {
+                              jobConfigs.jira.jiraRestClientConfiguration
+                                .serverUrl
+                            }
+                          </div>
+                          <div>
+                            <Label className='font-semibold'>Username: </Label>
+                            {
+                              jobConfigs.jira.jiraRestClientConfiguration
+                                .username
+                            }
+                          </div>
+                          <div>
+                            <Label className='font-semibold'>Password: </Label>
+                            {
+                              jobConfigs.jira.jiraRestClientConfiguration
+                                .password
+                            }
+                          </div>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/-components/reporter-job-details.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/-components/reporter-job-details.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { OrtRun } from '@/api/requests';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { calculateDuration } from '@/helpers/get-run-duration';
+import { getStatusBackgroundColor } from '@/helpers/get-status-colors';
+
+type ReporterJobDetailsProps = {
+  run: OrtRun;
+};
+
+export const ReporterJobDetails = ({ run }: ReporterJobDetailsProps) => {
+  const job = run.jobs.reporter;
+  const jobConfigs = run.resolvedJobConfigs?.reporter;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          <Badge className={`border ${getStatusBackgroundColor(job?.status)}`}>
+            {run.jobs.reporter?.status || 'NOT RUN'}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className='space-y-2 text-sm'>
+          <div>
+            <Label className='font-semibold'>Duration: </Label>
+            {job?.startedAt && job?.finishedAt
+              ? calculateDuration(job.startedAt, job.finishedAt)
+              : 'N/A'}
+          </div>
+          {jobConfigs && (
+            <div className='space-y-2'>
+              <Label className='font-semibold'>
+                Resolved job configuration:
+              </Label>
+              <div className='ml-2'>
+                {jobConfigs?.formats && (
+                  <div>
+                    <Label className='font-semibold'>Report formats:</Label>{' '}
+                    {jobConfigs.formats.join(', ')}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/-components/scanner-job-details.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/-components/scanner-job-details.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { OrtRun } from '@/api/requests';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { calculateDuration } from '@/helpers/get-run-duration';
+import { getStatusBackgroundColor } from '@/helpers/get-status-colors';
+
+type ScannerJobDetailsProps = {
+  run: OrtRun;
+};
+
+export const ScannerJobDetails = ({ run }: ScannerJobDetailsProps) => {
+  const job = run.jobs.scanner;
+  const jobConfigs = run.resolvedJobConfigs?.scanner;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>
+          <Badge className={`border ${getStatusBackgroundColor(job?.status)}`}>
+            {job?.status || 'NOT RUN'}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className='space-y-2 text-sm'>
+          <div>
+            <Label className='font-semibold'>Duration: </Label>
+            {job?.startedAt && job?.finishedAt
+              ? calculateDuration(job.startedAt, job.finishedAt)
+              : 'N/A'}
+          </div>
+          {jobConfigs && (
+            <div className='space-y-2'>
+              <Label className='font-semibold'>
+                Resolved job configuration:
+              </Label>
+              <div className='ml-2 space-y-2'>
+                {jobConfigs?.skipConcluded && (
+                  <div>
+                    <Label className='font-semibold'>Skip concluded: </Label>
+                    {jobConfigs.skipConcluded.toString()}
+                  </div>
+                )}
+                {jobConfigs?.skipExcluded && (
+                  <div>
+                    <Label className='font-semibold'>Skip excluded: </Label>
+                    {jobConfigs.skipExcluded.toString()}
+                  </div>
+                )}
+                {jobConfigs?.scanners && (
+                  <div className='space-y-2'>
+                    <Label className='font-semibold'>Scanners:</Label>{' '}
+                    {jobConfigs.scanners.map((scanner) => (
+                      <div className='ml-2' key={scanner}>
+                        <Label className='font-semibold'>{scanner}</Label>
+                        {jobConfigs?.config?.[scanner] && (
+                          <div className='ml-2'>
+                            <Label className='font-semibold'>
+                              Configuration:
+                            </Label>
+                            {jobConfigs.config?.[scanner].options && (
+                              <div className='ml-2'>
+                                <Label className='font-semibold'>
+                                  Options:
+                                </Label>
+                                <div className='ml-2'>
+                                  {Object.entries(
+                                    jobConfigs.config[scanner].options
+                                  ).map(([key, value]) => (
+                                    <div key={key}>
+                                      <Label className='font-semibold'>
+                                        {key}:
+                                      </Label>{' '}
+                                      {value.toString()}
+                                    </div>
+                                  ))}
+                                </div>
+                              </div>
+                            )}
+                            {jobConfigs.config?.[scanner].secrets && (
+                              <div className='ml-2'>
+                                <Label className='font-semibold'>
+                                  Secrets:
+                                </Label>
+                                <div className='ml-2'>
+                                  {Object.entries(
+                                    jobConfigs.config[scanner].secrets
+                                  ).map(([key, value]) => (
+                                    <div key={key}>
+                                      <Label className='font-semibold'>
+                                        {key}:
+                                      </Label>{' '}
+                                      {value.toString()}
+                                    </div>
+                                  ))}
+                                </div>
+                              </div>
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+};

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/-components/sidebar.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/-components/sidebar.tsx
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+export const Sidebar = () => {
+  return (
+    <div className='flex w-40 flex-col border'>
+      <div>Overview</div>
+      <div>Logs</div>
+      <div>Results</div>
+    </div>
+  );
+};

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/index.tsx
@@ -1,0 +1,305 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { createFileRoute, Link } from '@tanstack/react-router';
+import { Redo2 } from 'lucide-react';
+import { z } from 'zod';
+
+import { useRepositoriesServiceGetOrtRunByIndexKey } from '@/api/queries';
+import { RepositoriesService } from '@/api/requests';
+import { LoadingIndicator } from '@/components/loading-indicator';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { calculateDuration } from '@/helpers/get-run-duration';
+import { getStatusBackgroundColor } from '@/helpers/get-status-colors';
+import { AdvisorJobDetails } from './-components/advisor-job-details';
+import { AnalyzerJobDetails } from './-components/analyzer-job-details';
+import { EvaluatorJobDetails } from './-components/evaluator-job-details';
+import { NotifierJobDetails } from './-components/notifier-job-details';
+import { ReporterJobDetails } from './-components/reporter-job-details';
+import { ScannerJobDetails } from './-components/scanner-job-details';
+
+const RunComponent = () => {
+  const params = Route.useParams();
+  const searchParams = Route.useSearch();
+  const locale = navigator.language;
+
+  const { data: ortRun } = useSuspenseQuery({
+    queryKey: [
+      useRepositoriesServiceGetOrtRunByIndexKey,
+      params.orgId,
+      params.productId,
+      params.repoId,
+      params.runIndex,
+    ],
+    queryFn: async () =>
+      await RepositoriesService.getOrtRunByIndex({
+        repositoryId: Number.parseInt(params.repoId),
+        ortRunIndex: Number.parseInt(params.runIndex),
+      }),
+  });
+
+  return (
+    <>
+      <div className='flex flex-1 flex-col gap-2'>
+        <div className='flex flex-row gap-2'>
+          <Card>
+            <CardHeader>
+              <CardTitle className='flex flex-row items-center justify-between'>
+                <Badge
+                  className={`border ${getStatusBackgroundColor(ortRun.status)}`}
+                >
+                  {ortRun.status}
+                </Badge>
+                <Button variant='outline' asChild size='sm'>
+                  <Link
+                    to='/organizations/$orgId/products/$productId/repositories/$repoId/create-run'
+                    params={{
+                      orgId: params.orgId,
+                      productId: params.productId,
+                      repoId: params.repoId,
+                    }}
+                    search={{
+                      rerunIndex: ortRun.index,
+                    }}
+                  >
+                    Rerun
+                    <Redo2 className='ml-1 h-4 w-4' />
+                  </Link>
+                </Button>
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className='text-sm'>
+                <Label className='font-semibold'>Run index:</Label>{' '}
+                {ortRun.index}
+              </div>
+              <div className='text-sm'>
+                <Label className='font-semibold'>Global id:</Label> {ortRun.id}
+              </div>
+              <div className='text-sm'>
+                <Label className='font-semibold'>Created at:</Label>{' '}
+                {new Date(ortRun.createdAt).toLocaleString(locale)}
+              </div>
+              {ortRun.finishedAt && (
+                <div>
+                  <div className='text-sm'>
+                    <Label className='font-semibold'>Finished at:</Label>{' '}
+                    {new Date(ortRun.finishedAt).toLocaleString(locale)}
+                  </div>
+                  <div className='text-sm'>
+                    <Label className='font-semibold'>Duration:</Label>{' '}
+                    {calculateDuration(ortRun.createdAt, ortRun.finishedAt)}
+                  </div>
+                </div>
+              )}
+            </CardContent>
+          </Card>
+          <Card className='flex-1'>
+            <CardHeader>
+              <CardTitle>Context information</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className='text-sm'>
+                <Label className='font-semibold'>Revision:</Label>{' '}
+                {ortRun.revision}
+              </div>
+              {ortRun.path && (
+                <div className='text-sm'>
+                  <Label className='font-semibold'>Path:</Label> {ortRun.path}
+                </div>
+              )}
+              {ortRun.jobConfigContext && (
+                <div className='text-sm'>
+                  <Label className='font-semibold'>
+                    Job configuration context:
+                  </Label>{' '}
+                  {ortRun.jobConfigContext}
+                </div>
+              )}
+              {ortRun.resolvedJobConfigContext && (
+                <div className='text-sm'>
+                  <Label className='font-semibold'>Resolved to:</Label>{' '}
+                  {ortRun.resolvedJobConfigContext}
+                </div>
+              )}
+              {Object.keys(ortRun.labels).length > 0 && (
+                <div className='text-sm'>
+                  <Label className='font-semibold'>Labels:</Label>{' '}
+                  {Object.entries(ortRun.labels).map(([key, value]) => (
+                    <span key={key}>
+                      {key} = {value},{' '}
+                    </span>
+                  ))}
+                </div>
+              )}
+              {ortRun.jobConfigs.parameters && (
+                <div className='text-sm'>
+                  <Label className='font-semibold'>Parameters:</Label>{' '}
+                  {Object.entries(ortRun.jobConfigs.parameters).map(
+                    ([key, value]) => (
+                      <span key={key}>
+                        {key} = {value},{' '}
+                      </span>
+                    )
+                  )}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </div>
+        <div className='flex flex-1'>
+          <Card className='flex-1'>
+            <CardHeader>
+              <CardTitle>Issues</CardTitle>
+              <CardContent className='space-y-2'>
+                <p>
+                  Lorem ipsum dolor, sit amet consectetur adipisicing elit.
+                  Possimus nobis necessitatibus amet deleniti quia quis
+                  consequuntur cumque impedit accusantium dolorem, eos inventore
+                  in sed magni dolorum nemo repellendus voluptates velit.
+                </p>
+                <p>
+                  Lorem ipsum dolor, sit amet consectetur adipisicing elit.
+                  Possimus nobis necessitatibus amet deleniti quia quis
+                  consequuntur cumque impedit accusantium dolorem, eos inventore
+                  in sed magni dolorum nemo repellendus voluptates velit.
+                </p>
+                <p>
+                  Lorem ipsum dolor, sit amet consectetur adipisicing elit.
+                  Possimus nobis necessitatibus amet deleniti quia quis
+                  consequuntur cumque impedit accusantium dolorem, eos inventore
+                  in sed magni dolorum nemo repellendus voluptates velit.
+                </p>
+                <p>
+                  Lorem ipsum dolor, sit amet consectetur adipisicing elit.
+                  Possimus nobis necessitatibus amet deleniti quia quis
+                  consequuntur cumque impedit accusantium dolorem, eos inventore
+                  in sed magni dolorum nemo repellendus voluptates velit.
+                </p>
+              </CardContent>
+            </CardHeader>
+          </Card>
+        </div>
+      </div>
+      <div className='flex w-4/12'>
+        <Tabs defaultValue={searchParams.job}>
+          <TabsList className='flex-wrap justify-start bg-white'>
+            <TabsTrigger
+              value='analyzer'
+              className={`border font-semibold text-white ${getStatusBackgroundColor(ortRun.jobs.analyzer?.status)}`}
+            >
+              <Link search={() => ({ job: 'analyzer' })}>Analyzer</Link>
+            </TabsTrigger>
+            <TabsTrigger
+              value='advisor'
+              className={`border font-semibold text-white ${getStatusBackgroundColor(ortRun.jobs.advisor?.status)}`}
+            >
+              <Link search={() => ({ job: 'advisor' })}>Advisor</Link>
+            </TabsTrigger>
+            <TabsTrigger
+              value='scanner'
+              className={`border font-semibold text-white ${getStatusBackgroundColor(ortRun.jobs.scanner?.status)}`}
+            >
+              <Link search={() => ({ job: 'scanner' })}>Scanner</Link>
+            </TabsTrigger>
+            <TabsTrigger
+              value='evaluator'
+              className={`border font-semibold text-white ${getStatusBackgroundColor(ortRun.jobs.evaluator?.status)}`}
+            >
+              <Link search={() => ({ job: 'evaluator' })}>Evaluator</Link>
+            </TabsTrigger>
+            <TabsTrigger
+              value='reporter'
+              className={`border font-semibold text-white ${getStatusBackgroundColor(ortRun.jobs.reporter?.status)}`}
+            >
+              <Link search={() => ({ job: 'reporter' })}>Reporter</Link>
+            </TabsTrigger>
+            <TabsTrigger
+              value='notifier'
+              className={`border font-semibold text-white ${getStatusBackgroundColor(ortRun.jobs.notifier?.status)}`}
+            >
+              <Link search={() => ({ job: 'notifier' })}>Notifier</Link>
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value='analyzer' className='mt-10'>
+            <AnalyzerJobDetails run={ortRun} />
+          </TabsContent>
+          <TabsContent value='advisor' className='mt-10'>
+            <AdvisorJobDetails run={ortRun} />
+          </TabsContent>
+          <TabsContent value='scanner' className='mt-10'>
+            <ScannerJobDetails run={ortRun} />
+          </TabsContent>
+          <TabsContent value='evaluator' className='mt-10'>
+            <EvaluatorJobDetails run={ortRun} />
+          </TabsContent>
+          <TabsContent value='reporter' className='mt-10'>
+            <ReporterJobDetails run={ortRun} />
+          </TabsContent>
+          <TabsContent value='notifier' className='mt-10'>
+            <NotifierJobDetails run={ortRun} />
+          </TabsContent>
+        </Tabs>
+      </div>
+    </>
+  );
+};
+
+// These are the only valid search parameters for this route.
+const jobSearchSchema = z.object({
+  job: z
+    .enum([
+      'analyzer',
+      'advisor',
+      'scanner',
+      'evaluator',
+      'reporter',
+      'notifier',
+    ])
+    .catch('analyzer'),
+});
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/'
+)({
+  loader: async ({ context, params }) => {
+    await context.queryClient.ensureQueryData({
+      queryKey: [
+        useRepositoriesServiceGetOrtRunByIndexKey,
+        params.orgId,
+        params.productId,
+        params.repoId,
+        params.runIndex,
+      ],
+      queryFn: () =>
+        RepositoriesService.getOrtRunByIndex({
+          repositoryId: Number.parseInt(params.repoId),
+          ortRunIndex: Number.parseInt(params.runIndex),
+        }),
+    });
+  },
+  component: RunComponent,
+  pendingComponent: LoadingIndicator,
+  validateSearch: jobSearchSchema,
+});

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/index.tsx
@@ -168,39 +168,55 @@ const RunComponent = () => {
             </CardContent>
           </Card>
         </div>
-        <div className='flex flex-1'>
-          <Card className='flex-1'>
-            <CardHeader>
-              <CardTitle>Issues</CardTitle>
-              <CardContent className='space-y-2'>
-                <p>
-                  Lorem ipsum dolor, sit amet consectetur adipisicing elit.
-                  Possimus nobis necessitatibus amet deleniti quia quis
-                  consequuntur cumque impedit accusantium dolorem, eos inventore
-                  in sed magni dolorum nemo repellendus voluptates velit.
-                </p>
-                <p>
-                  Lorem ipsum dolor, sit amet consectetur adipisicing elit.
-                  Possimus nobis necessitatibus amet deleniti quia quis
-                  consequuntur cumque impedit accusantium dolorem, eos inventore
-                  in sed magni dolorum nemo repellendus voluptates velit.
-                </p>
-                <p>
-                  Lorem ipsum dolor, sit amet consectetur adipisicing elit.
-                  Possimus nobis necessitatibus amet deleniti quia quis
-                  consequuntur cumque impedit accusantium dolorem, eos inventore
-                  in sed magni dolorum nemo repellendus voluptates velit.
-                </p>
-                <p>
-                  Lorem ipsum dolor, sit amet consectetur adipisicing elit.
-                  Possimus nobis necessitatibus amet deleniti quia quis
-                  consequuntur cumque impedit accusantium dolorem, eos inventore
-                  in sed magni dolorum nemo repellendus voluptates velit.
-                </p>
-              </CardContent>
-            </CardHeader>
-          </Card>
-        </div>
+        <Card className='flex flex-1 overflow-hidden'>
+          <CardHeader>
+            <CardTitle>Issues</CardTitle>
+            <CardContent className='space-y-2 overflow-auto'>
+              <p>
+                Lorem ipsum dolor, sit amet consectetur adipisicing elit.
+                Possimus nobis necessitatibus amet deleniti quia quis
+                consequuntur cumque impedit accusantium dolorem, eos inventore
+                in sed magni dolorum nemo repellendus voluptates velit.
+              </p>
+              <p>
+                Lorem ipsum dolor, sit amet consectetur adipisicing elit.
+                Possimus nobis necessitatibus amet deleniti quia quis
+                consequuntur cumque impedit accusantium dolorem, eos inventore
+                in sed magni dolorum nemo repellendus voluptates velit.
+              </p>
+              <p>
+                Lorem ipsum dolor, sit amet consectetur adipisicing elit.
+                Possimus nobis necessitatibus amet deleniti quia quis
+                consequuntur cumque impedit accusantium dolorem, eos inventore
+                in sed magni dolorum nemo repellendus voluptates velit.
+              </p>
+              <p>
+                Lorem ipsum dolor, sit amet consectetur adipisicing elit.
+                Possimus nobis necessitatibus amet deleniti quia quis
+                consequuntur cumque impedit accusantium dolorem, eos inventore
+                in sed magni dolorum nemo repellendus voluptates velit.
+              </p>
+              <p>
+                Lorem ipsum dolor, sit amet consectetur adipisicing elit.
+                Possimus nobis necessitatibus amet deleniti quia quis
+                consequuntur cumque impedit accusantium dolorem, eos inventore
+                in sed magni dolorum nemo repellendus voluptates velit.
+              </p>
+              <p>
+                Lorem ipsum dolor, sit amet consectetur adipisicing elit.
+                Possimus nobis necessitatibus amet deleniti quia quis
+                consequuntur cumque impedit accusantium dolorem, eos inventore
+                in sed magni dolorum nemo repellendus voluptates velit.
+              </p>
+              <p>
+                Lorem ipsum dolor, sit amet consectetur adipisicing elit.
+                Possimus nobis necessitatibus amet deleniti quia quis
+                consequuntur cumque impedit accusantium dolorem, eos inventore
+                in sed magni dolorum nemo repellendus voluptates velit.
+              </p>
+            </CardContent>
+          </CardHeader>
+        </Card>
       </div>
       <div className='flex w-4/12'>
         <Tabs defaultValue={searchParams.job}>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/route.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/route.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { createFileRoute, Outlet } from '@tanstack/react-router';
+import { Suspense } from 'react';
+
+import { useRepositoriesServiceGetOrtRunByIndexKey } from '@/api/queries';
+import { RepositoriesService } from '@/api/requests';
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex'
+)({
+  loader: async ({ context, params }) => {
+    const run = await context.queryClient.ensureQueryData({
+      queryKey: [
+        useRepositoriesServiceGetOrtRunByIndexKey,
+        params.orgId,
+        params.productId,
+        params.repoId,
+        params.runIndex,
+      ],
+      queryFn: () =>
+        RepositoriesService.getOrtRunByIndex({
+          repositoryId: Number.parseInt(params.repoId),
+          ortRunIndex: Number.parseInt(params.runIndex),
+        }),
+    });
+    context.breadcrumbs.run = run.index.toString();
+  },
+  component: () => (
+    <Suspense fallback={<div>Loading...</div>}>
+      <Outlet />
+    </Suspense>
+  ),
+});

--- a/ui/src/routes/_layout/route.tsx
+++ b/ui/src/routes/_layout/route.tsx
@@ -25,11 +25,9 @@ const Layout = () => {
   return (
     <div className='flex min-h-screen w-full flex-col'>
       <Header />
-      <div>
-        <main className='flex flex-col gap-4 p-4 md:w-full md:gap-8 md:p-8'>
-          <Outlet />
-        </main>
-      </div>
+      <main className='flex h-full flex-col gap-4 p-4 md:w-full md:gap-8 md:p-8'>
+        <Outlet />
+      </main>
     </div>
   );
 };


### PR DESCRIPTION
This PR adds a temporary route `.../runs2/` that will be used for pages and (upcoming) subpages for viewing ORT run details results. The PR touches existing implementation very minimally:
- root layout has one added Tailwind class
- header has an additional (temporary) breadcrumb item, to make the breadcrumb show identical information as for the current run details page

As there already are ongoing discussions about the philosophy for showing the ORT run results, the purpose of this PR is to be more of a basis for discussion, rather than a polished and finalized way to show the results. (Think of it more like a Figma skeleton of a part of the UI.)

No links in the current UI lead directly to the new page, so should the users want to see it, it can be done by replacing `.../runs/...` in the URL with `.../runs2/...`.