### PR TITLE
ci(renovate): Check Tanstack updates at most once a week

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,6 +17,10 @@
       "enabled": false
     },
     {
+      "matchPackagePrefixes": ["@tanstack/"],
+      "schedule": ["after 9pm on sunday"]
+    },
+    {
       "matchPackagePrefixes": ["aws.sdk.kotlin:"],
       "schedule": ["after 9pm on sunday"]
     },


### PR DESCRIPTION
The Tanstack router and query dependencies are often updated daily. Limit this to weekly to not be overwhelmed.