### PR TITLE
feat(api): Add endpoints for user management

### DIFF
--- a/clients/keycloak/src/main/kotlin/DefaultKeycloakClient.kt
+++ b/clients/keycloak/src/main/kotlin/DefaultKeycloakClient.kt
@@ -383,6 +383,24 @@ class DefaultKeycloakClient(
         }.getOrElse {
             throw KeycloakClientException("Failed to load client roles for user '${id.value}'.", it)
         }.body()
+
+    override suspend fun addUserToGroup(username: UserName, groupName: GroupName) {
+        val user = getUser(username)
+        val group = getGroup(groupName)
+
+        runCatching {
+            httpClient.put("$apiUrl/users/${user.id}/groups/${group.id}")
+        }.onFailure { throw KeycloakClientException("Failed to add user '$username' to group '$groupName'.", it) }
+    }
+
+    override suspend fun removeUserToGroup(username: UserName, groupName: GroupName) {
+        val user = getUser(username)
+        val group = getGroup(groupName)
+
+        runCatching {
+            httpClient.delete("$apiUrl/users/${user.id}/groups/${group.id}")
+        }.onFailure { throw KeycloakClientException("Failed to remove user '$username' from group '$groupName'.", it) }
+    }
 }
 
 /**

--- a/clients/keycloak/src/main/kotlin/KeycloakClient.kt
+++ b/clients/keycloak/src/main/kotlin/KeycloakClient.kt
@@ -157,4 +157,14 @@ interface KeycloakClient {
      * Get all client [roles][Role] for the [user][User] with the given [id].
      */
     suspend fun getUserClientRoles(id: UserId): Set<Role>
+
+    /**
+     * Add a user [username] to the group [groupName].
+     */
+    suspend fun addUserToGroup(username: UserName, groupName: GroupName)
+
+    /**
+     * Remove a user [username] from the group [groupName].
+     */
+    suspend fun removeUserToGroup(username: UserName, groupName: GroupName)
 }

--- a/services/authorization/src/main/kotlin/AuthorizationService.kt
+++ b/services/authorization/src/main/kotlin/AuthorizationService.kt
@@ -102,4 +102,14 @@ interface AuthorizationService {
      *   database entities are not correct anymore.
      */
     suspend fun synchronizeRoles()
+
+    /**
+     * Add a user [username] to a group for the given [organizationId].
+     */
+    suspend fun addUserToGroup(username: String, organizationId: Long, groupName: String)
+
+    /**
+     * Remove a user [username] from a group for the given [organizationId].
+     */
+    suspend fun removeUserFromGroup(username: String, organizationId: Long, groupName: String)
 }

--- a/services/authorization/src/main/kotlin/DefaultAuthorizationService.kt
+++ b/services/authorization/src/main/kotlin/DefaultAuthorizationService.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.withContext
 import org.eclipse.apoapsis.ortserver.clients.keycloak.GroupName
 import org.eclipse.apoapsis.ortserver.clients.keycloak.KeycloakClient
 import org.eclipse.apoapsis.ortserver.clients.keycloak.RoleName
+import org.eclipse.apoapsis.ortserver.clients.keycloak.UserName
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
 import org.eclipse.apoapsis.ortserver.model.authorization.OrganizationPermission
 import org.eclipse.apoapsis.ortserver.model.authorization.OrganizationRole
@@ -61,7 +62,7 @@ class DefaultAuthorizationService(
      * A prefix for Keycloak group names, to be used when multiple instances of ORT Server share the same Keycloak
      * realm.
      */
-    private val keycloakGroupPrefix: String
+    private val     keycloakGroupPrefix: String
 ) : AuthorizationService {
     override suspend fun createOrganizationPermissions(organizationId: Long) {
         OrganizationPermission.getRolesForOrganization(organizationId).forEach { roleName ->
@@ -730,5 +731,31 @@ class DefaultAuthorizationService(
         actualGroupRoles.filter { it.name.value.startsWith(groupPrefix) }.filter { it.name.value != roleName }.forEach {
             keycloakClient.removeGroupClientRole(group.id, it)
         }
+    }
+
+    override suspend fun addUserToGroup(
+        username: String,
+        organizationId: Long,
+        groupName: String
+    ) {
+        val organization = checkNotNull(organizationRepository.get(organizationId))
+        val group = keycloakGroupPrefix + groupName // Allow multiple ORT instances to share the same Keycloak realm
+
+        keycloakClient.addUserToGroup(UserName(username), GroupName(group))
+
+        // TODO: Convert the various exceptions to some standard ones
+    }
+
+    override suspend fun removeUserFromGroup(
+        username: String,
+        organizationId: Long,
+        groupName: String
+    ) {
+        val organization = checkNotNull(organizationRepository.get(organizationId))
+        val group = keycloakGroupPrefix + groupName // Allow multiple ORT instances to share the same Keycloak realm
+
+        keycloakClient.removeUserToGroup(UserName(username), GroupName(group))
+
+        // TODO: Convert the various exceptions to some standard ones
     }
 }

--- a/services/hierarchy/src/main/kotlin/OrganizationService.kt
+++ b/services/hierarchy/src/main/kotlin/OrganizationService.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.services
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
 import org.eclipse.apoapsis.ortserver.dao.dbQueryCatching
 import org.eclipse.apoapsis.ortserver.model.Organization
+import org.eclipse.apoapsis.ortserver.model.authorization.OrganizationRole
 import org.eclipse.apoapsis.ortserver.model.repositories.OrganizationRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.ProductRepository
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
@@ -119,5 +120,21 @@ class OrganizationService(
         description: OptionalValue<String?> = OptionalValue.Absent
     ): Organization = db.dbQuery {
         organizationRepository.update(organizationId, name, description)
+    }
+
+    suspend fun addUserToGroup(
+        username: String,
+        organizationId: Long,
+        organizationRole: OrganizationRole
+    ) {
+        authorizationService.addUserToGroup(username, organizationId, organizationRole.groupName(organizationId))
+    }
+
+    suspend fun removeUserFromGroup(
+        username: String,
+        organizationId: Long,
+        organizationRole: OrganizationRole
+    ) {
+        authorizationService.removeUserFromGroup(username, organizationId, organizationRole.groupName(organizationId))
     }
 }


### PR DESCRIPTION
Add endpoints to add or remove users to groups on entity level of Organizations, Products and Repositories. For each of this entity levels you can have READER, WRITER or ADMIN permissions.