### PR TITLE
feat(api): Add endpoints for user management

### DIFF
--- a/api/v1/model/src/commonMain/kotlin/User.kt
+++ b/api/v1/model/src/commonMain/kotlin/User.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.api.v1.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Response object for a user.
+ */
+@Serializable
+data class User(
+    val id: String,
+    val username: String
+)
+
+/**
+ * Request object for identification of a user by username.
+ */
+@Serializable
+data class IdentifyUser(
+    val username: String
+)

--- a/clients/keycloak/src/main/kotlin/DefaultKeycloakClient.kt
+++ b/clients/keycloak/src/main/kotlin/DefaultKeycloakClient.kt
@@ -383,6 +383,43 @@ class DefaultKeycloakClient(
         }.getOrElse {
             throw KeycloakClientException("Failed to load client roles for user '${id.value}'.", it)
         }.body()
+
+    override suspend fun addUserToGroup(username: UserName, groupName: GroupName) {
+        val user = getUser(username)
+        val group = getGroup(groupName)
+
+        runCatching {
+            httpClient.put("$apiUrl/users/${user.id.value}/groups/${group.id.value}")
+        }.onFailure {
+            throw KeycloakClientException(
+                "Failed to add user '{$username.value}' to group '{$groupName}'.",
+                it
+            )
+        }
+    }
+
+    override suspend fun removeUserFromGroup(username: UserName, groupName: GroupName) {
+        val user = getUser(username)
+        val group = getGroup(groupName)
+
+        runCatching {
+            httpClient.delete("$apiUrl/users/${user.id.value}/groups/${group.id.value}")
+        }.onFailure {
+            throw KeycloakClientException(
+                "Failed to remove user '${username.value}' from group {'$groupName.value}'.",
+                it
+            )
+        }
+    }
+
+    override suspend fun getGroupMembers(groupName: GroupName): Set<User> {
+        val group = getGroup(groupName)
+        return runCatching {
+            httpClient.get("$apiUrl/groups/${group.id.value}/members")
+        }.getOrElse {
+            throw KeycloakClientException("Failed to get members of group '${groupName.value}'.", it)
+        }.body()
+    }
 }
 
 /**

--- a/clients/keycloak/src/main/kotlin/KeycloakClient.kt
+++ b/clients/keycloak/src/main/kotlin/KeycloakClient.kt
@@ -157,4 +157,19 @@ interface KeycloakClient {
      * Get all client [roles][Role] for the [user][User] with the given [id].
      */
     suspend fun getUserClientRoles(id: UserId): Set<Role>
+
+    /**
+     * Add a user [username] to the group [groupName].
+     */
+    suspend fun addUserToGroup(username: UserName, groupName: GroupName)
+
+    /**
+     * Remove a user [username] from the group [groupName].
+     */
+    suspend fun removeUserFromGroup(username: UserName, groupName: GroupName)
+
+    /**
+     * Return a set of all [users][User] of a group [GroupName].
+     */
+    suspend fun getGroupMembers(groupName: GroupName): Set<User>
 }

--- a/clients/keycloak/src/testFixtures/kotlin/KeycloakTestClient.kt
+++ b/clients/keycloak/src/testFixtures/kotlin/KeycloakTestClient.kt
@@ -177,6 +177,18 @@ class KeycloakTestClient(
         userClientRoles[id]?.flatMapTo(mutableSetOf()) { getCompositeRolesRecursive(it) + getRole(it) }
             ?: throw KeycloakClientException("")
 
+    override suspend fun addUserToGroup(username: UserName, groupName: GroupName) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun removeUserFromGroup(username: UserName, groupName: GroupName) {
+        TODO("Not yet implemented")
+    }
+
+    override suspend fun getGroupMembers(groupName: GroupName): Set<User> {
+        TODO("Not yet implemented")
+    }
+
     private fun getNextGroupId() = GroupId("group-id-${groupCounter++}")
 
     private fun getNextRoleId() = RoleId("role-id-${roleCounter++}")

--- a/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
@@ -27,6 +27,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.CreateInfrastructureService
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrganization
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateProduct
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateSecret
+import org.eclipse.apoapsis.ortserver.api.v1.model.IdentifyUser
 import org.eclipse.apoapsis.ortserver.api.v1.model.InfrastructureService
 import org.eclipse.apoapsis.ortserver.api.v1.model.Organization
 import org.eclipse.apoapsis.ortserver.api.v1.model.PagedResponse
@@ -531,6 +532,68 @@ val deleteInfrastructureServiceForOrganizationIdAndName: OpenApiRoute.() -> Unit
     response {
         HttpStatusCode.NoContent to {
             description = "Success"
+        }
+    }
+}
+
+val putUserToGroup: OpenApiRoute.() -> Unit = {
+    operationId = "PutUserToGroup"
+    summary = "Add a user to a group on Organization level."
+    tags = listOf("Groups")
+
+    request {
+        pathParameter<Long>("organizationId") {
+            description = "The organization's ID."
+        }
+        pathParameter<String>("groupId") {
+            description = "One of 'readers', 'writers' or 'admins'."
+        }
+
+        jsonBody<IdentifyUser> {
+            example("Add user identified by username 'abc123'.") {
+                value = IdentifyUser(username = "abc123")
+            }
+        }
+    }
+
+    response {
+        HttpStatusCode.NoContent to {
+            description = "Successfully added the user to the group."
+        }
+
+        HttpStatusCode.NotFound to {
+            description = "Organization or group not found."
+        }
+    }
+}
+
+val deleteUserFromGroup: OpenApiRoute.() -> Unit = {
+    operationId = "DeleteUserFromGroup"
+    summary = "Remove a user from a group on Organization level."
+    tags = listOf("Groups")
+
+    request {
+        pathParameter<Long>("organizationId") {
+            description = "The organization's ID."
+        }
+        pathParameter<String>("groupId") {
+            description = "One of 'readers', 'writers' or 'admins'."
+        }
+
+        jsonBody<IdentifyUser> {
+            example("Remove user identified by username 'abc123'.") {
+                value = IdentifyUser(username = "abc123")
+            }
+        }
+    }
+
+    response {
+        HttpStatusCode.NoContent to {
+            description = "Successfully removed the user to the group."
+        }
+
+        HttpStatusCode.NotFound to {
+            description = "Organization or group not found."
         }
     }
 }

--- a/core/src/main/kotlin/plugins/StatusPages.kt
+++ b/core/src/main/kotlin/plugins/StatusPages.kt
@@ -36,6 +36,7 @@ import org.eclipse.apoapsis.ortserver.dao.UniqueConstraintException
 import org.eclipse.apoapsis.ortserver.services.InvalidSecretReferenceException
 import org.eclipse.apoapsis.ortserver.services.ReferencedEntityException
 import org.eclipse.apoapsis.ortserver.services.ReportNotFoundException
+import org.eclipse.apoapsis.ortserver.services.ResourceNotFoundException
 
 import org.jetbrains.exposed.dao.exceptions.EntityNotFoundException
 
@@ -76,6 +77,9 @@ fun Application.configureStatusPages() {
         }
         exception<ReportNotFoundException> { call, e ->
             call.respond(HttpStatusCode.NotFound, ErrorResponse("Report could not be resolved.", e.message))
+        }
+        exception<ResourceNotFoundException> { call, e ->
+            call.respond(HttpStatusCode.NotFound, ErrorResponse("Resource not found.", e.message))
         }
         exception<RequestValidationException> { call, e ->
             call.respond(HttpStatusCode.BadRequest, ErrorResponse("Request validation has failed.", e.message))

--- a/services/authorization/src/main/kotlin/AuthorizationService.kt
+++ b/services/authorization/src/main/kotlin/AuthorizationService.kt
@@ -102,4 +102,14 @@ interface AuthorizationService {
      *   database entities are not correct anymore.
      */
     suspend fun synchronizeRoles()
+
+    /**
+     * Add a user [username] to a group for the given [organizationId].
+     */
+    suspend fun addUserToGroup(username: String, organizationId: Long, groupName: String)
+
+    /**
+     * Remove a user [username] from a group for the given [organizationId].
+     */
+    suspend fun removeUserFromGroup(username: String, organizationId: Long, groupName: String)
 }

--- a/services/authorization/src/main/kotlin/DefaultAuthorizationService.kt
+++ b/services/authorization/src/main/kotlin/DefaultAuthorizationService.kt
@@ -25,6 +25,7 @@ import kotlinx.coroutines.withContext
 import org.eclipse.apoapsis.ortserver.clients.keycloak.GroupName
 import org.eclipse.apoapsis.ortserver.clients.keycloak.KeycloakClient
 import org.eclipse.apoapsis.ortserver.clients.keycloak.RoleName
+import org.eclipse.apoapsis.ortserver.clients.keycloak.UserName
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
 import org.eclipse.apoapsis.ortserver.model.authorization.OrganizationPermission
 import org.eclipse.apoapsis.ortserver.model.authorization.OrganizationRole
@@ -730,5 +731,23 @@ class DefaultAuthorizationService(
         actualGroupRoles.filter { it.name.value.startsWith(groupPrefix) }.filter { it.name.value != roleName }.forEach {
             keycloakClient.removeGroupClientRole(group.id, it)
         }
+    }
+
+    override suspend fun addUserToGroup(
+        username: String,
+        organizationId: Long,
+        groupName: String
+    ) {
+        val group = keycloakGroupPrefix + groupName // Allow multiple ORT instances to share the same Keycloak realm
+        keycloakClient.addUserToGroup(UserName(username), GroupName(group))
+    }
+
+    override suspend fun removeUserFromGroup(
+        username: String,
+        organizationId: Long,
+        groupName: String
+    ) {
+        val group = keycloakGroupPrefix + groupName // Allow multiple ORT instances to share the same Keycloak realm
+        keycloakClient.removeUserFromGroup(UserName(username), GroupName(group))
     }
 }

--- a/services/hierarchy/src/main/kotlin/ResourceNotFoundException.kt
+++ b/services/hierarchy/src/main/kotlin/ResourceNotFoundException.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.services
+
+/** Used when a resource (identified by the URL) was not found. */
+class ResourceNotFoundException(message: String, cause: Throwable? = null) : RuntimeException(message, cause)


### PR DESCRIPTION
Add endpoints to add or remove users to groups on the level of an _Organization_ to assign the respective
roles and permissions to them. Available groups are _readers_, _writers_ and _admins_.