### PR TITLE
Store the trace ID together with the ORT run

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
@@ -282,7 +282,8 @@ fun OrtRun.mapToApi(jobs: ApiJobs) =
         labels,
         issues = issues.map { it.mapToApi() },
         jobConfigContext,
-        resolvedJobConfigContext
+        resolvedJobConfigContext,
+        traceId
     )
 
 fun OrtRun.mapToApiSummary(jobs: ApiJobSummaries) =

--- a/api/v1/model/src/commonMain/kotlin/OrtRun.kt
+++ b/api/v1/model/src/commonMain/kotlin/OrtRun.kt
@@ -114,7 +114,13 @@ data class OrtRun(
      * The resolved configuration context. When an ORT run is started, the configuration context is resolved once and
      * then stored, so that all workers access the same set of configuration properties.
      */
-    val resolvedJobConfigContext: String? = null
+    val resolvedJobConfigContext: String? = null,
+
+    /**
+     * The trace ID that is assigned to this run. This is generated when the run is created. It can be used to
+     * correlate the logs from different components that are taking part in processing of the run.
+     */
+    val traceId: String?
 )
 
 /**

--- a/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
@@ -446,7 +446,8 @@ val postOrtRun: OpenApiRoute.() -> Unit = {
                         labels = mapOf("label key" to "label value"),
                         issues = emptyList(),
                         jobConfigContext = null,
-                        resolvedJobConfigContext = null
+                        resolvedJobConfigContext = null,
+                        traceId = "35b67724-a85b-4cc3-b2a4-60fd914634e7"
                     )
                 }
             }
@@ -490,7 +491,8 @@ val getOrtRunByIndex: OpenApiRoute.() -> Unit = {
                         labels = mapOf("label key" to "label value"),
                         issues = emptyList(),
                         jobConfigContext = null,
-                        resolvedJobConfigContext = "32f955941e94d0a318e1c985903f42af924e9050"
+                        resolvedJobConfigContext = "32f955941e94d0a318e1c985903f42af924e9050",
+                        traceId = "35b67725-a85b-4cc3-b2a4-60fd914634e7"
                     )
                 }
             }

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -62,7 +62,8 @@ val getOrtRunById: OpenApiRoute.() -> Unit = {
                         labels = mapOf("label key" to "label value"),
                         issues = emptyList(),
                         jobConfigContext = null,
-                        resolvedJobConfigContext = "32f955941e94d0a318e1c985903f42af924e9050"
+                        resolvedJobConfigContext = "32f955941e94d0a318e1c985903f42af924e9050",
+                        traceId = "35b67724-a85a-4cc4-b2a4-60fd914634e7"
                     )
                 }
             }

--- a/core/src/main/kotlin/services/OrchestratorService.kt
+++ b/core/src/main/kotlin/services/OrchestratorService.kt
@@ -56,15 +56,25 @@ class OrchestratorService(
         jobConfigContext: String?,
         labels: Map<String, String>?
     ): OrtRun {
+        val traceId = UUID.randomUUID().toString()
+
         val ortRun = db.dbQuery(transactionIsolation = Connection.TRANSACTION_SERIALIZABLE) {
             maxAttempts = 25
-            ortRunRepository.create(repositoryId, revision, path, jobConfig, jobConfigContext, labels.orEmpty())
+            ortRunRepository.create(
+                repositoryId,
+                revision,
+                path,
+                jobConfig,
+                jobConfigContext,
+                labels.orEmpty(),
+                traceId = traceId
+            )
         }
 
         orchestratorSender.send(
             Message(
                 header = MessageHeader(
-                    traceId = UUID.randomUUID().toString(),
+                    traceId = traceId,
                     ortRunId = ortRun.id
                 ),
                 payload = CreateOrtRun(ortRun)

--- a/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
@@ -217,7 +217,8 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     null,
                     JobConfigurations(),
                     "jobConfigContext",
-                    labelsMap
+                    labelsMap,
+                    traceId = "t1"
                 )
 
                 val response = superuserClient.get("/api/v1/runs/${run.id}")
@@ -235,7 +236,8 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     null,
                     JobConfigurations(),
                     "testContext",
-                    labelsMap
+                    labelsMap,
+                    traceId = "trace"
                 )
 
                 val jobs = dbExtension.fixtures.createJobs(run.id).mapToApi()
@@ -248,7 +250,15 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
         }
 
         "require RepositoryPermission.READ_ORT_RUNS" {
-            val run = ortRunRepository.create(repositoryId, "revision", null, JobConfigurations(), null, labelsMap)
+            val run = ortRunRepository.create(
+                repositoryId,
+                "revision",
+                null,
+                JobConfigurations(),
+                null,
+                labelsMap,
+                traceId = "test-trace-id"
+            )
 
             requestShouldRequireRole(RepositoryPermission.READ_ORT_RUNS.roleName(repositoryId)) {
                 get("/api/v1/runs/${run.id}")

--- a/dao/src/main/kotlin/repositories/DaoOrtRunRepository.kt
+++ b/dao/src/main/kotlin/repositories/DaoOrtRunRepository.kt
@@ -60,7 +60,8 @@ class DaoOrtRunRepository(private val db: Database) : OrtRunRepository {
         jobConfigs: JobConfigurations,
         jobConfigContext: String?,
         labels: Map<String, String>,
-        issues: Collection<Issue>
+        issues: Collection<Issue>,
+        traceId: String?
     ): OrtRun = db.blockingQuery {
         val nextIndex = (listForRepository(repositoryId).data.maxByOrNull { it.index }?.index ?: 0) + 1
 
@@ -75,6 +76,7 @@ class DaoOrtRunRepository(private val db: Database) : OrtRunRepository {
             this.status = OrtRunStatus.CREATED
             this.labels = mapAndDeduplicate(labels.entries, ::getLabelDao)
             this.issues = mapAndDeduplicate(issues, IssueDao::createByIssue)
+            this.traceId = traceId
         }.mapToModel()
     }
 

--- a/dao/src/main/kotlin/tables/OrtRunsTable.kt
+++ b/dao/src/main/kotlin/tables/OrtRunsTable.kt
@@ -56,6 +56,7 @@ object OrtRunsTable : SortableTable("ort_runs") {
     val status = enumerationByName<OrtRunStatus>("status", 128)
     val finishedAt = timestamp("finished_at").nullable()
     val path = text("path").nullable()
+    val traceId = text("trace_id").nullable()
 }
 
 class OrtRunDao(id: EntityID<Long>) : LongEntity(id) {
@@ -66,6 +67,7 @@ class OrtRunDao(id: EntityID<Long>) : LongEntity(id) {
     var index by OrtRunsTable.index
     var revision by OrtRunsTable.revision
     var path by OrtRunsTable.path
+    var traceId by OrtRunsTable.traceId
     var createdAt by OrtRunsTable.createdAt.transform({ it.toDatabasePrecision() }, { it })
     var jobConfigs by OrtRunsTable.jobConfigs
     var resolvedJobConfigs by OrtRunsTable.resolvedJobConfigs
@@ -107,6 +109,7 @@ class OrtRunDao(id: EntityID<Long>) : LongEntity(id) {
         repositoryConfigId = repositoryConfig?.id?.value,
         issues = issues.map { it.mapToModel() },
         jobConfigContext = jobConfigContext,
-        resolvedJobConfigContext = resolvedJobConfigContext
+        resolvedJobConfigContext = resolvedJobConfigContext,
+        traceId = traceId
     )
 }

--- a/dao/src/main/resources/db/migration/V69__ortRunTraceId.sql
+++ b/dao/src/main/resources/db/migration/V69__ortRunTraceId.sql
@@ -1,0 +1,2 @@
+ALTER TABLE ort_runs
+    ADD COLUMN trace_id text NULL;

--- a/dao/src/test/kotlin/utils/ListQueryTest.kt
+++ b/dao/src/test/kotlin/utils/ListQueryTest.kt
@@ -139,8 +139,16 @@ class ListQueryTest : StringSpec() {
             val product = productRepository.create("Run Product", null, organization.id)
             val repo =
                 repositoryRepository.create(RepositoryType.GIT, "https://repo.example.org/run.git", product.id)
-            val runs = (1..3).map {
-                ortRunRepository.create(repo.id, "test", null, JobConfigurations(), null, mapOf("label1" to "label1"))
+            val runs = (1..3).map { idx ->
+                ortRunRepository.create(
+                    repo.id,
+                    "test",
+                    null,
+                    JobConfigurations(),
+                    null,
+                    mapOf("label1" to "label1"),
+                    traceId = "trace-$idx"
+                )
             }
 
             val parameters = ListQueryParameters(

--- a/dao/src/testFixtures/kotlin/Fixtures.kt
+++ b/dao/src/testFixtures/kotlin/Fixtures.kt
@@ -142,7 +142,8 @@ class Fixtures(private val db: Database) {
         null,
         jobConfigurations,
         null,
-        mapOf("label key" to "label value")
+        mapOf("label key" to "label value"),
+        traceId = "trace-this-run"
     )
 
     fun createAnalyzerJob(

--- a/model/src/commonMain/kotlin/OrtRun.kt
+++ b/model/src/commonMain/kotlin/OrtRun.kt
@@ -132,7 +132,13 @@ data class OrtRun(
      * The resolved configuration context. When an ORT run is started, the configuration context is resolved once and
      * then stored, so that all workers access the same set of configuration properties.
      */
-    val resolvedJobConfigContext: String?
+    val resolvedJobConfigContext: String?,
+
+    /**
+     * The trace ID that is assigned to this run. This is generated when the run is created. It can be used to
+     * correlate the logs from different components that are taking part in processing of the run.
+     */
+    val traceId: String?
 )
 
 enum class OrtRunStatus(

--- a/model/src/commonMain/kotlin/repositories/OrtRunRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/OrtRunRepository.kt
@@ -41,7 +41,8 @@ interface OrtRunRepository {
         jobConfigs: JobConfigurations,
         jobConfigContext: String? = null,
         labels: Map<String, String>,
-        issues: Collection<Issue> = emptyList()
+        issues: Collection<Issue> = emptyList(),
+        traceId: String?
     ): OrtRun
 
     /**

--- a/orchestrator/src/main/kotlin/WorkerScheduleContext.kt
+++ b/orchestrator/src/main/kotlin/WorkerScheduleContext.kt
@@ -71,10 +71,14 @@ internal class WorkerScheduleContext(
     /**
      * Create a message based on the given [payload] and publish it to the given [endpoint].
      * Make sure that the header contains the correct transport properties. These are obtained from the labels of the
-     * current ORT run.
+     * current ORT run. Also make sure that a trace ID is available.
      */
     fun <T : Any> publish(endpoint: Endpoint<T>, payload: T) {
-        val headerWithProperties = header.copy(transportProperties = ortRun.labels.selectByPrefix("transport"))
+        val traceId = header.traceId.takeUnless { it.isEmpty() } ?: ortRun.traceId.orEmpty()
+        val headerWithProperties = header.copy(
+            traceId = traceId,
+            transportProperties = ortRun.labels.selectByPrefix("transport")
+        )
 
         publisher.publish(to = endpoint, message = Message(headerWithProperties, payload))
     }

--- a/orchestrator/src/test/kotlin/OrchestratorEndpointTest.kt
+++ b/orchestrator/src/test/kotlin/OrchestratorEndpointTest.kt
@@ -108,7 +108,8 @@ class OrchestratorEndpointTest : KoinTest, StringSpec() {
                     null,
                     emptyList(),
                     null,
-                    null
+                    null,
+                    "trace-id"
                 )
             )
             val message = Message(msgHeader, createOrtRun)

--- a/orchestrator/src/test/kotlin/OrchestratorTest.kt
+++ b/orchestrator/src/test/kotlin/OrchestratorTest.kt
@@ -206,7 +206,8 @@ class OrchestratorTest : WordSpec() {
         null,
         emptyList(),
         null,
-        null
+        null,
+        traceId = "test-trace-id"
     )
 
     private val ortRunAnalyzerAndReporter = OrtRun(
@@ -235,7 +236,8 @@ class OrchestratorTest : WordSpec() {
         null,
         emptyList(),
         null,
-        null
+        null,
+        traceId = null
     )
 
     init {

--- a/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
@@ -338,7 +338,8 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
                     null,
                     emptyList(),
                     null,
-                    null
+                    null,
+                    "trace-id"
                 )
             }
 

--- a/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
@@ -93,7 +93,8 @@ private val ortRun = OrtRun(
     repositoryConfigId = 1L,
     issues = emptyList(),
     jobConfigContext = "context",
-    resolvedJobConfigContext = "context"
+    resolvedJobConfigContext = "context",
+    traceId = "trace-id"
 )
 
 private val analyzerJob = AnalyzerJob(

--- a/workers/common/src/test/kotlin/OrtServerMappingsTest.kt
+++ b/workers/common/src/test/kotlin/OrtServerMappingsTest.kt
@@ -143,7 +143,8 @@ class OrtServerMappingsTest : WordSpec({
                 null,
                 listOf(runIssue),
                 "default",
-                "c80ef3bcd2bec428da923a188dd0870b1153995c"
+                "c80ef3bcd2bec428da923a188dd0870b1153995c",
+                "trace-4321"
             )
 
             val analyzerJob = AnalyzerJob(

--- a/workers/config/src/test/kotlin/ConfigWorkerTest.kt
+++ b/workers/config/src/test/kotlin/ConfigWorkerTest.kt
@@ -275,7 +275,8 @@ private fun mockContext(orgConfigContext: String? = ORIGINAL_CONTEXT): Pair<Work
         repositoryConfigId = null,
         issues = emptyList(),
         jobConfigContext = orgConfigContext,
-        resolvedJobConfigContext = null
+        resolvedJobConfigContext = null,
+        traceId = "trace-id"
     )
 
     val context = mockk<WorkerContext> {


### PR DESCRIPTION
This is required to handle certain scenarios with fatal worker crashes correctly. The functionality will also be needed if we were to support external trace IDs.

Refer to the single commits for further information.