### PR TITLE
ui: Use secrets as defaults in ORT run creation form

### DIFF
--- a/ui/src/helpers/defaults-helpers.ts
+++ b/ui/src/helpers/defaults-helpers.ts
@@ -1,0 +1,192 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import {
+  ZodArray,
+  ZodBoolean,
+  ZodEnum,
+  ZodNullable,
+  ZodNumber,
+  ZodObject,
+  ZodOptional,
+  ZodString,
+  ZodType,
+} from 'zod';
+
+type PropertyPathWithType = {
+  path: string;
+  type: string;
+};
+
+/**
+ * Check if a path is excluded based on the provided excluded paths.
+ *
+ * @param path The path to check.
+ * @param excludedPaths The array of paths to be excluded.
+ * @returns True if the path is excluded, otherwise false.
+ */
+const isPathExcluded = (path: string, excludedPaths: string[]): boolean => {
+  return excludedPaths.some(
+    (excludedPath) =>
+      path === excludedPath || path.startsWith(`${excludedPath}.`)
+  );
+};
+
+/**
+ * Get the type of a Zod schema
+ *
+ * @param schema The Zod schema.
+ * @returns The type as a string.
+ */
+const getType = (schema: ZodType): string => {
+  if (schema instanceof ZodString) {
+    return 'string';
+  } else if (schema instanceof ZodNumber) {
+    return 'number';
+  } else if (schema instanceof ZodBoolean) {
+    return 'boolean';
+  } else if (schema instanceof ZodEnum) {
+    return 'enum';
+  } else if (schema instanceof ZodArray) {
+    return `array<${getType(schema.element)}>`;
+  } else if (schema instanceof ZodObject) {
+    return 'object';
+  } else if (schema instanceof ZodNullable || schema instanceof ZodOptional) {
+    return `${getType(schema.unwrap())} | null`;
+  } else {
+    return 'unknown';
+  }
+};
+
+/**
+ * Get the property paths and their types from a Zod schema, excluding specified paths.
+ *
+ * @param schema The Zod schema.
+ * @param excludedPaths Paths to exclude from the result.
+ * @returns The property paths and their types.
+ */
+export const getPropertyPaths = (
+  schema: ZodType,
+  excludedPaths: string[] = []
+): PropertyPathWithType[] => {
+  // Check if schema is nullable or optional
+  if (schema instanceof ZodNullable || schema instanceof ZodOptional) {
+    return getPropertyPaths(schema.unwrap(), excludedPaths);
+  }
+
+  // Check if schema is an array
+  if (schema instanceof ZodArray) {
+    return getPropertyPaths(schema.element, excludedPaths);
+  }
+
+  // Check if schema is an object
+  if (schema instanceof ZodObject) {
+    // Get key/value pairs from schema
+    const entries = Object.entries<ZodType>(schema.shape);
+
+    // Loop through key/value pairs
+    const paths = entries.flatMap(([key, value]) => {
+      // Get nested keys and types
+      const nestedPaths = getPropertyPaths(value, excludedPaths).map(
+        (subPath) => ({
+          path: subPath.path ? `${key}.${subPath.path}` : key,
+          type: subPath.type,
+        })
+      );
+      // Construct the full paths and types
+      const fullPaths = nestedPaths.length
+        ? nestedPaths
+        : [{ path: key, type: getType(value) }];
+
+      // Filter out excluded paths
+      return fullPaths.filter(
+        (subPath) => !isPathExcluded(subPath.path, excludedPaths)
+      );
+    });
+
+    // Sort paths by length and then alphabetically
+    return paths.sort((a, b) => {
+      const lenDiff = a.path.split('.').length - b.path.split('.').length;
+      return lenDiff !== 0 ? lenDiff : a.path.localeCompare(b.path);
+    });
+  }
+
+  // For primitive types and other unsupported types, return the path with its type
+  return [{ path: '', type: getType(schema) }].filter(
+    (subPath) => subPath.path !== ''
+  );
+};
+
+/**
+ * Encode the property path based on the locked status.
+ *
+ * @param property The property path to encode.
+ * @param locked The locked status.
+ * @returns The encoded string.
+ */
+export const encodePropertyPath = (
+  property: string,
+  locked: boolean
+): string => {
+  // Replace dots with hyphens
+  const encodedProperty = property.replace(/\./g, '-');
+  // Prefix based on locked status
+  const prefix = locked ? '-DEFLOCK-' : '-DEF-';
+  return `${prefix}${encodedProperty}`;
+};
+
+/**
+ * Decode the encoded property path to the original path and locked status.
+ *
+ * @param encoded The encoded property path.
+ * @returns An object containing the original property path and locked status.
+ */
+export const decodePropertyPath = (
+  encoded: string
+): { property: string; locked: boolean } => {
+  // Determine the prefix and locked status
+  let prefix: string;
+  let locked: boolean;
+
+  if (encoded.startsWith('-DEFLOCK-')) {
+    prefix = '-DEFLOCK-';
+    locked = true;
+  } else if (encoded.startsWith('-DEF-')) {
+    prefix = '-DEF-';
+    locked = false;
+  } else {
+    throw new Error('Invalid encoded property path');
+  }
+
+  // Remove the prefix and replace hyphens with dots
+  const property = encoded.substring(prefix.length).replace(/-/g, '.');
+
+  return { property, locked };
+};
+
+/**
+ * Check if the given secret name is a default.
+ *
+ * @param name The secret name.
+ * @returns True if the name has a default prefix, otherwise false.
+ */
+export const isDefault = (name: string): boolean => {
+  const defaultPrefixes = ['-DEF-', '-DEFLOCK-'];
+  return defaultPrefixes.some((prefix) => name.startsWith(prefix));
+};

--- a/ui/src/helpers/defaults-helpers.ts
+++ b/ui/src/helpers/defaults-helpers.ts
@@ -29,6 +29,8 @@ import {
   ZodType,
 } from 'zod';
 
+const PREFIX = '-DEF-';
+
 type PropertyPathWithType = {
   path: string;
   type: string;
@@ -134,50 +136,27 @@ export const getPropertyPaths = (
 };
 
 /**
- * Encode the property path based on the locked status.
+ * Encode the property path.
  *
  * @param property The property path to encode.
- * @param locked The locked status.
  * @returns The encoded string.
  */
-export const encodePropertyPath = (
-  property: string,
-  locked: boolean
-): string => {
+export const encodePropertyPath = (property: string): string => {
   // Replace dots with hyphens
   const encodedProperty = property.replace(/\./g, '-');
-  // Prefix based on locked status
-  const prefix = locked ? '-DEFLOCK-' : '-DEF-';
-  return `${prefix}${encodedProperty}`;
+  // Add prefix
+  return `${PREFIX}${encodedProperty}`;
 };
 
 /**
- * Decode the encoded property path to the original path and locked status.
+ * Decode the encoded property path to the original path.
  *
  * @param encoded The encoded property path.
- * @returns An object containing the original property path and locked status.
+ * @returns The original property path.
  */
-export const decodePropertyPath = (
-  encoded: string
-): { property: string; locked: boolean } => {
-  // Determine the prefix and locked status
-  let prefix: string;
-  let locked: boolean;
-
-  if (encoded.startsWith('-DEFLOCK-')) {
-    prefix = '-DEFLOCK-';
-    locked = true;
-  } else if (encoded.startsWith('-DEF-')) {
-    prefix = '-DEF-';
-    locked = false;
-  } else {
-    throw new Error('Invalid encoded property path');
-  }
-
+export const decodePropertyPath = (encoded: string): string => {
   // Remove the prefix and replace hyphens with dots
-  const property = encoded.substring(prefix.length).replace(/-/g, '.');
-
-  return { property, locked };
+  return encoded.substring(PREFIX.length).replace(/-/g, '.');
 };
 
 /**
@@ -187,6 +166,5 @@ export const decodePropertyPath = (
  * @returns True if the name has a default prefix, otherwise false.
  */
 export const isDefault = (name: string): boolean => {
-  const defaultPrefixes = ['-DEF-', '-DEFLOCK-'];
-  return defaultPrefixes.some((prefix) => name.startsWith(prefix));
+  return name.startsWith(PREFIX);
 };

--- a/ui/src/helpers/get-defaults.ts
+++ b/ui/src/helpers/get-defaults.ts
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+// Search the secrets hierarchically for default values.
+
+// TypeScript gets confused when accessing nested properties dynamically, so we ensure type
+// safety of the input of updateBaseDefaults() while letting 'any' types for internal processing.
+
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+
+import { PagedResponse_Secret_, Secret } from '@/api/requests';
+import { CreateRunFormValues } from '@/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/create-run';
+import { decodePropertyPath } from './defaults-helpers';
+
+/**
+ * Get the default values from the secrets.
+ *
+ * @param defaults All defaults.
+ * @returns The default values as a map.
+ */
+function getDefaultValues(defaults: Secret[]): { [key: string]: string } {
+  const defaultValuesMap: { [key: string]: string } = {};
+
+  defaults.forEach((def) => {
+    const decoded = decodePropertyPath(def.name).property;
+    if (def.description !== undefined) {
+      defaultValuesMap[decoded] = def.description;
+    }
+  });
+
+  return defaultValuesMap;
+}
+
+/**
+ * A helper function to get the nested value from an object by path.
+ *
+ * @param obj The object to retrieve the value from.
+ * @param path The path of the nested value.
+ * @returns The value at the specified path.
+ */
+function getNestedValue(obj: any, path: string): any {
+  return path.split('.').reduce((o, p) => (o ? o[p] : undefined), obj);
+}
+
+/**
+ * A helper function to set a nested value in an object by path.
+ *
+ * @param obj The object to update.
+ * @param path The path of the nested value.
+ * @param value The value to set.
+ */
+function setNestedValue(obj: any, path: string, value: any): void {
+  const keys = path.split('.');
+  const lastKey = keys.pop();
+  const lastObj = keys.reduce((o, p) => (o[p] = o[p] || {}), obj);
+  if (lastKey) lastObj[lastKey] = value;
+}
+
+/**
+ * Update the base defaults with the default values from the secrets.
+ *
+ * @param baseDefaults The form's base defaults to update.
+ * @param defaults All defaults.
+ * @returns The updated defaults.
+ */
+export function updateBaseDefaults(
+  baseDefaults: CreateRunFormValues,
+  defaults: Secret[]
+): any {
+  const defaultValues = getDefaultValues(defaults);
+  const updatedDefaults = { ...baseDefaults };
+
+  Object.entries(defaultValues).forEach(([key, value]) => {
+    // Extract the expected type from baseDefaults
+    const currentValue = getNestedValue(updatedDefaults, key);
+
+    // Determine the type and convert the string value back to its appropriate type
+    let typedValue: any;
+    if (typeof currentValue === 'boolean') {
+      typedValue = value.toLowerCase() === 'true';
+    } else if (typeof currentValue === 'number') {
+      typedValue = Number(value);
+    } else {
+      typedValue = value; // Already a string
+    }
+
+    // Update the value in updatedDefaults
+    setNestedValue(updatedDefaults, key, typedValue);
+  });
+
+  return updatedDefaults;
+}
+
+/**
+ * Get the default parameters from the secrets.
+ *
+ * @param orgSecrets The organization secrets.
+ * @param prodSecrets The product secrets.
+ * @param repoSecrets The repository secrets.
+ * @returns The default parameters as a key-value array.
+ */
+// TODO: Change this when parameters are supported
+export function getDefaultParameters(
+  orgSecrets: PagedResponse_Secret_,
+  prodSecrets: PagedResponse_Secret_,
+  repoSecrets: PagedResponse_Secret_
+): { key: string; value: string }[] {
+  const defaultValuesMap: { [key: string]: string } = {};
+
+  // Helper function to add secrets to the map
+  const addSecrets = (secrets: PagedResponse_Secret_) => {
+    secrets.data.forEach((secret) => {
+      if (secret.name.endsWith('DEFAULT-PARAMETER') && secret.description) {
+        const nameWithoutDefault = secret.name
+          .slice(0, -'DEFAULT-PARAMETER'.length)
+          .trim();
+        // Add or update the default value in the map
+        defaultValuesMap[nameWithoutDefault] = secret.description;
+      }
+    });
+  };
+
+  // Add secrets with precedence: repo > prod > org
+  addSecrets(orgSecrets);
+  addSecrets(prodSecrets);
+  addSecrets(repoSecrets);
+
+  // Convert the map to the required output format
+  const defaultKeyValueArray: { key: string; value: string }[] = Object.entries(
+    defaultValuesMap
+  ).map(([key, value]) => ({ key, value }));
+
+  return defaultKeyValueArray;
+}

--- a/ui/src/helpers/get-defaults.ts
+++ b/ui/src/helpers/get-defaults.ts
@@ -38,7 +38,7 @@ function getDefaultValues(defaults: Secret[]): { [key: string]: string } {
   const defaultValuesMap: { [key: string]: string } = {};
 
   defaults.forEach((def) => {
-    const decoded = decodePropertyPath(def.name).property;
+    const decoded = decodePropertyPath(def.name);
     if (def.description !== undefined) {
       defaultValuesMap[decoded] = def.description;
     }

--- a/ui/src/routes/_layout/organizations/$orgId/defaults/$defaultName/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/defaults/$defaultName/edit.tsx
@@ -1,0 +1,288 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { Loader2 } from 'lucide-react';
+import { useForm } from 'react-hook-form';
+import z from 'zod';
+
+import {
+  useSecretsServiceGetSecretByOrganizationIdAndNameKey,
+  useSecretsServicePatchSecretByOrganizationIdAndName,
+} from '@/api/queries';
+import { ApiError, SecretsService } from '@/api/requests';
+import { LoadingIndicator } from '@/components/loading-indicator';
+import { ToastError } from '@/components/toast-error';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+} from '@/components/ui/card';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
+import { useToast } from '@/components/ui/use-toast';
+import {
+  decodePropertyPath,
+  getPropertyPaths,
+} from '@/helpers/defaults-helpers';
+import { formSchema as runFormSchema } from '@/schemas';
+
+const paths = getPropertyPaths(runFormSchema, [
+  'labels',
+  'jobConfigs.parameters',
+]).filter((path) => path.type !== 'array<string>');
+
+const editDefaultFormSchema = z.object({
+  property: z.string().optional(),
+  value: z.string().min(1).or(z.number()).or(z.boolean()),
+  locked: z.boolean(),
+});
+
+export type EditDefaultFormValues = z.infer<typeof editDefaultFormSchema>;
+
+const EditOrganizationDefaultPage = () => {
+  const params = Route.useParams();
+  const navigate = useNavigate();
+  const { toast } = useToast();
+
+  const { data: secret } = useSuspenseQuery({
+    queryKey: [
+      useSecretsServiceGetSecretByOrganizationIdAndNameKey,
+      params.orgId,
+      params.defaultName,
+    ],
+    queryFn: () =>
+      SecretsService.getSecretByOrganizationIdAndName({
+        organizationId: Number.parseInt(params.orgId),
+        secretName: params.defaultName,
+      }),
+  });
+
+  const selectionType = paths.find(
+    (path) => path.path === decodePropertyPath(secret.name).property
+  )?.type;
+
+  const form = useForm<EditDefaultFormValues>({
+    resolver: zodResolver(editDefaultFormSchema),
+    values: {
+      property: decodePropertyPath(secret.name).property,
+      value: secret.description || '',
+      locked: decodePropertyPath(secret.name).locked,
+    },
+  });
+
+  const { mutateAsync: editSecret, isPending } =
+    useSecretsServicePatchSecretByOrganizationIdAndName({
+      onSuccess(data) {
+        toast({
+          title: 'Edit organization default property',
+          description: `Default property "${decodePropertyPath(data.name).property}" updated successfully.`,
+        });
+        navigate({
+          to: '/organizations/$orgId/defaults',
+          params: { orgId: params.orgId },
+        });
+      },
+      onError(error: ApiError) {
+        toast({
+          title: error.message,
+          description: <ToastError error={error} />,
+          variant: 'destructive',
+        });
+      },
+    });
+
+  const onSubmit = (values: EditDefaultFormValues) => {
+    editSecret({
+      organizationId: Number.parseInt(params.orgId),
+      secretName: secret.name,
+      requestBody: {
+        name: values.property,
+        value: 'xyz',
+        description: values.value,
+      },
+    });
+  };
+
+  return (
+    <Card className='mx-auto w-full max-w-4xl'>
+      <CardHeader>Edit Default Run Property</CardHeader>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>
+          <CardContent className='space-y-4'>
+            <FormField
+              control={form.control}
+              name='property'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Run Property</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    The name of the run property (cannot be changed)
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+              disabled
+            />
+            {selectionType && (
+              <FormField
+                control={form.control}
+                name='value'
+                render={({ field }) =>
+                  selectionType === 'string' ||
+                  selectionType === 'string | null' ? (
+                    <FormItem>
+                      <FormLabel>Value (text)</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type='text'
+                          value={field.value.toString()}
+                        />
+                      </FormControl>
+                      <FormDescription>Value of the property</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  ) : selectionType === 'number' ? (
+                    <FormItem>
+                      <FormLabel>Value (number)</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type='number'
+                          value={Number(field.value)}
+                        />
+                      </FormControl>
+                      <FormDescription>Value of the property</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  ) : selectionType === 'boolean' ? (
+                    <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
+                      <div className='space-y-0.5'>
+                        <FormLabel>True/false</FormLabel>
+                        <FormDescription>Boolean value</FormDescription>
+                      </div>
+                      <FormControl>
+                        <Switch
+                          checked={field.value === true}
+                          onCheckedChange={(checked) =>
+                            field.onChange(checked ? true : false)
+                          }
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  ) : (
+                    <></>
+                  )
+                }
+              />
+            )}
+            <FormField
+              control={form.control}
+              name='locked'
+              render={({ field }) => (
+                <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
+                  <div className='space-y-0.5'>
+                    <FormLabel>Lock the value</FormLabel>
+                    <FormDescription>
+                      Lock the value of the property to prevent changing it in
+                      ORT run creation form (cannot be changed)
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                      disabled
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          </CardContent>
+          <CardFooter>
+            <Button
+              className='m-1'
+              variant='outline'
+              onClick={() =>
+                navigate({
+                  to: '/organizations/$orgId/defaults',
+                  params: { orgId: params.orgId },
+                })
+              }
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button type='submit' disabled={isPending}>
+              {isPending ? (
+                <>
+                  <span className='sr-only'>Editing default property...</span>
+                  <Loader2 size={16} className='mx-3 animate-spin' />
+                </>
+              ) : (
+                'Submit'
+              )}
+            </Button>
+          </CardFooter>
+        </form>
+      </Form>
+    </Card>
+  );
+};
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/defaults/$defaultName/edit'
+)({
+  loader: async ({ context, params }) => {
+    await Promise.allSettled([
+      context.queryClient.ensureQueryData({
+        queryKey: [
+          useSecretsServiceGetSecretByOrganizationIdAndNameKey,
+          params.orgId,
+          params.defaultName,
+        ],
+        queryFn: () =>
+          SecretsService.getSecretByOrganizationIdAndName({
+            organizationId: Number.parseInt(params.orgId),
+            secretName: params.defaultName,
+          }),
+      }),
+    ]);
+  },
+  component: EditOrganizationDefaultPage,
+  pendingComponent: LoadingIndicator,
+});

--- a/ui/src/routes/_layout/organizations/$orgId/defaults/$defaultName/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/defaults/$defaultName/edit.tsx
@@ -64,7 +64,6 @@ const paths = getPropertyPaths(runFormSchema, [
 const editDefaultFormSchema = z.object({
   property: z.string().optional(),
   value: z.string().min(1).or(z.number()).or(z.boolean()),
-  locked: z.boolean(),
 });
 
 export type EditDefaultFormValues = z.infer<typeof editDefaultFormSchema>;
@@ -88,15 +87,14 @@ const EditOrganizationDefaultPage = () => {
   });
 
   const selectionType = paths.find(
-    (path) => path.path === decodePropertyPath(secret.name).property
+    (path) => path.path === decodePropertyPath(secret.name)
   )?.type;
 
   const form = useForm<EditDefaultFormValues>({
     resolver: zodResolver(editDefaultFormSchema),
     values: {
-      property: decodePropertyPath(secret.name).property,
+      property: decodePropertyPath(secret.name),
       value: secret.description || '',
-      locked: decodePropertyPath(secret.name).locked,
     },
   });
 
@@ -105,7 +103,7 @@ const EditOrganizationDefaultPage = () => {
       onSuccess(data) {
         toast({
           title: 'Edit organization default property',
-          description: `Default property "${decodePropertyPath(data.name).property}" updated successfully.`,
+          description: `Default property "${decodePropertyPath(data.name)}" updated successfully.`,
         });
         navigate({
           to: '/organizations/$orgId/defaults',
@@ -210,28 +208,6 @@ const EditOrganizationDefaultPage = () => {
                 }
               />
             )}
-            <FormField
-              control={form.control}
-              name='locked'
-              render={({ field }) => (
-                <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
-                  <div className='space-y-0.5'>
-                    <FormLabel>Lock the value</FormLabel>
-                    <FormDescription>
-                      Lock the value of the property to prevent changing it in
-                      ORT run creation form (cannot be changed)
-                    </FormDescription>
-                  </div>
-                  <FormControl>
-                    <Switch
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                      disabled
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
           </CardContent>
           <CardFooter>
             <Button

--- a/ui/src/routes/_layout/organizations/$orgId/defaults/create-default.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/defaults/create-default.tsx
@@ -71,7 +71,6 @@ const paths = getPropertyPaths(runFormSchema, [
 const formSchema = z.object({
   property: z.string().min(1),
   value: z.string().min(1).or(z.number()).or(z.boolean()),
-  locked: z.boolean(),
 });
 
 const CreateOrganizationDefaultPage = () => {
@@ -85,7 +84,7 @@ const CreateOrganizationDefaultPage = () => {
       onSuccess(data) {
         toast({
           title: 'Create default run property',
-          description: `New organization default run property "${decodePropertyPath(data.name).property}" created successfully.`,
+          description: `New organization default run property "${decodePropertyPath(data.name)}" created successfully.`,
         });
         navigate({
           to: '/organizations/$orgId/defaults',
@@ -107,7 +106,6 @@ const CreateOrganizationDefaultPage = () => {
     defaultValues: {
       property: '',
       value: true,
-      locked: false,
     },
   });
 
@@ -115,7 +113,7 @@ const CreateOrganizationDefaultPage = () => {
     await mutateAsync({
       organizationId: Number.parseInt(params.orgId),
       requestBody: {
-        name: encodePropertyPath(values.property, values.locked),
+        name: encodePropertyPath(values.property),
         value: 'xyx',
         description: values.value.toString(),
       },
@@ -220,27 +218,6 @@ const CreateOrganizationDefaultPage = () => {
                 }
               />
             )}
-            <FormField
-              control={form.control}
-              name='locked'
-              render={({ field }) => (
-                <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
-                  <div className='space-y-0.5'>
-                    <FormLabel>Lock the value</FormLabel>
-                    <FormDescription>
-                      Lock the value of the property to prevent changing it in
-                      ORT run creation form
-                    </FormDescription>
-                  </div>
-                  <FormControl>
-                    <Switch
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
           </CardContent>
           <CardFooter>
             <Button type='submit' disabled={isPending}>

--- a/ui/src/routes/_layout/organizations/$orgId/defaults/create-default.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/defaults/create-default.tsx
@@ -1,0 +1,269 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import { useSecretsServicePostSecretForOrganization } from '@/api/queries';
+import { ApiError } from '@/api/requests';
+import { ToastError } from '@/components/toast-error';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+} from '@/components/ui/card';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { useToast } from '@/components/ui/use-toast';
+import {
+  decodePropertyPath,
+  encodePropertyPath,
+  getPropertyPaths,
+} from '@/helpers/defaults-helpers';
+import { formSchema as runFormSchema } from '@/schemas';
+
+// First implementation only supports primitive types (string, number, boolean)
+// for the default run properties.
+const paths = getPropertyPaths(runFormSchema, [
+  'labels',
+  'jobConfigs.parameters',
+  'jobConfigs.analyzer.enabled',
+]).filter((path) => path.type !== 'array<string>');
+
+const formSchema = z.object({
+  property: z.string().min(1),
+  value: z.string().min(1).or(z.number()).or(z.boolean()),
+  locked: z.boolean(),
+});
+
+const CreateOrganizationDefaultPage = () => {
+  const navigate = useNavigate();
+  const params = Route.useParams();
+  const { toast } = useToast();
+  const [selectionType, setSelectionType] = useState<string | undefined>();
+
+  const { mutateAsync, isPending } = useSecretsServicePostSecretForOrganization(
+    {
+      onSuccess(data) {
+        toast({
+          title: 'Create default run property',
+          description: `New organization default run property "${decodePropertyPath(data.name).property}" created successfully.`,
+        });
+        navigate({
+          to: '/organizations/$orgId/defaults',
+          params: { orgId: params.orgId },
+        });
+      },
+      onError(error: ApiError) {
+        toast({
+          title: error.message,
+          description: <ToastError error={error} />,
+          variant: 'destructive',
+        });
+      },
+    }
+  );
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      property: '',
+      value: true,
+      locked: false,
+    },
+  });
+
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    await mutateAsync({
+      organizationId: Number.parseInt(params.orgId),
+      requestBody: {
+        name: encodePropertyPath(values.property, values.locked),
+        value: 'xyx',
+        description: values.value.toString(),
+      },
+    });
+  }
+
+  return (
+    <Card className='mx-auto w-full max-w-4xl'>
+      <CardHeader>Create Default Run Property</CardHeader>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>
+          <CardContent className='space-y-4'>
+            <FormField
+              control={form.control}
+              name='property'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Run property</FormLabel>
+                  <Select
+                    onValueChange={(value) => {
+                      field.onChange;
+                      form.setValue('property', value);
+                      setSelectionType(
+                        paths.find((path) => path.path === value)?.type
+                      );
+                    }}
+                    defaultValue={field.value}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder='Select a run property' />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {Object.values(paths).map((path) => (
+                        <SelectItem key={path.path} value={path.path}>
+                          {path.path}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormDescription>
+                    Name and path of the run property you want to default
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            {selectionType && (
+              <FormField
+                control={form.control}
+                name='value'
+                render={({ field }) =>
+                  selectionType === 'string' ||
+                  selectionType === 'string | null' ? (
+                    <FormItem>
+                      <FormLabel>Value (text)</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type='text'
+                          placeholder='Input text'
+                          value={field.value.toString()}
+                        />
+                      </FormControl>
+                      <FormDescription>Value of the property</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  ) : selectionType === 'number' ? (
+                    <FormItem>
+                      <FormLabel>Value (number)</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type='number'
+                          placeholder='Input number'
+                          value={Number(field.value)}
+                        />
+                      </FormControl>
+                      <FormDescription>Value of the property</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  ) : selectionType === 'boolean' ? (
+                    <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
+                      <div className='space-y-0.5'>
+                        <FormLabel>True/false</FormLabel>
+                        <FormDescription>Boolean value</FormDescription>
+                      </div>
+                      <FormControl>
+                        <Switch
+                          checked={field.value === true}
+                          onCheckedChange={(checked) =>
+                            field.onChange(checked ? true : false)
+                          }
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  ) : (
+                    <></>
+                  )
+                }
+              />
+            )}
+            <FormField
+              control={form.control}
+              name='locked'
+              render={({ field }) => (
+                <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
+                  <div className='space-y-0.5'>
+                    <FormLabel>Lock the value</FormLabel>
+                    <FormDescription>
+                      Lock the value of the property to prevent changing it in
+                      ORT run creation form
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          </CardContent>
+          <CardFooter>
+            <Button type='submit' disabled={isPending}>
+              {isPending ? (
+                <>
+                  <span className='sr-only'>
+                    Creating default run property...
+                  </span>
+                  <Loader2 size={16} className='mx-3 animate-spin' />
+                </>
+              ) : (
+                'Create'
+              )}
+            </Button>
+          </CardFooter>
+        </form>
+      </Form>
+    </Card>
+  );
+};
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/defaults/create-default'
+)({
+  component: CreateOrganizationDefaultPage,
+});

--- a/ui/src/routes/_layout/organizations/$orgId/defaults/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/defaults/index.tsx
@@ -89,7 +89,7 @@ const ActionCell = ({ row }: CellContext<Secret, unknown>) => {
         setOpenDelDialog(false);
         toast({
           title: 'Delete Default',
-          description: `Default value "${decodePropertyPath(row.original.name).property}" deleted successfully.`,
+          description: `Default value "${decodePropertyPath(row.original.name)}" deleted successfully.`,
         });
         queryClient.invalidateQueries({
           queryKey: [useSecretsServiceGetSecretsByOrganizationId],
@@ -126,7 +126,7 @@ const ActionCell = ({ row }: CellContext<Secret, unknown>) => {
         setOpen={setOpenDelDialog}
         item={{
           descriptor: 'default run property',
-          name: decodePropertyPath(row.original.name).property,
+          name: decodePropertyPath(row.original.name),
         }}
         onDelete={() =>
           delSecret({
@@ -145,17 +145,11 @@ const columns: ColumnDef<Secret>[] = [
     accessorKey: 'name',
     header: 'Run property',
     // Do not show the property encoding prefix in the table
-    cell: ({ row }) => decodePropertyPath(row.original.name).property,
+    cell: ({ row }) => decodePropertyPath(row.original.name),
   },
   {
     accessorKey: 'description',
     header: 'Value',
-  },
-  {
-    accessorKey: 'locked',
-    header: 'Locked?',
-    cell: ({ row }) =>
-      decodePropertyPath(row.original.name).locked ? 'Yes' : 'No',
   },
   {
     id: 'actions',

--- a/ui/src/routes/_layout/organizations/$orgId/defaults/route.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/defaults/route.tsx
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/_layout/organizations/$orgId/defaults')({
+  component: () => <Outlet />,
+  beforeLoad: ({ context, params }) => {
+    if (
+      !context.auth.hasRole([
+        'superuser',
+        `permission_organization_${params.orgId}_write_secrets`,
+      ])
+    ) {
+      throw redirect({
+        to: '/403',
+      });
+    }
+  },
+});

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/defaults/$defaultName/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/defaults/$defaultName/edit.tsx
@@ -1,0 +1,289 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { Loader2 } from 'lucide-react';
+import { useForm } from 'react-hook-form';
+import z from 'zod';
+
+import {
+  useSecretsServiceGetSecretByProductIdAndNameKey,
+  useSecretsServicePatchSecretByProductIdAndName,
+} from '@/api/queries';
+import { ApiError, SecretsService } from '@/api/requests';
+import { LoadingIndicator } from '@/components/loading-indicator';
+import { ToastError } from '@/components/toast-error';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+} from '@/components/ui/card';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
+import { useToast } from '@/components/ui/use-toast';
+import {
+  decodePropertyPath,
+  getPropertyPaths,
+} from '@/helpers/defaults-helpers';
+import { formSchema as runFormSchema } from '@/schemas';
+
+const paths = getPropertyPaths(runFormSchema, [
+  'labels',
+  'jobConfigs.parameters',
+]).filter((path) => path.type !== 'array<string>');
+
+const editDefaultFormSchema = z.object({
+  property: z.string().optional(),
+  value: z.string().min(1).or(z.number()).or(z.boolean()),
+  locked: z.boolean(),
+});
+
+export type EditDefaultFormValues = z.infer<typeof editDefaultFormSchema>;
+
+const EditProductDefaultPage = () => {
+  const params = Route.useParams();
+  const navigate = useNavigate();
+  const { toast } = useToast();
+
+  const { data: secret } = useSuspenseQuery({
+    queryKey: [
+      useSecretsServiceGetSecretByProductIdAndNameKey,
+      params.productId,
+      params.defaultName,
+    ],
+    queryFn: () =>
+      SecretsService.getSecretByProductIdAndName({
+        productId: Number.parseInt(params.productId),
+        secretName: params.defaultName,
+      }),
+  });
+
+  const selectionType = paths.find(
+    (path) => path.path === decodePropertyPath(secret.name).property
+  )?.type;
+
+  const form = useForm<EditDefaultFormValues>({
+    resolver: zodResolver(editDefaultFormSchema),
+    values: {
+      property: decodePropertyPath(secret.name).property,
+      value: secret.description || '',
+      locked: decodePropertyPath(secret.name).locked,
+    },
+  });
+
+  const { mutateAsync: editSecret, isPending } =
+    useSecretsServicePatchSecretByProductIdAndName({
+      onSuccess(data) {
+        toast({
+          title: 'Edit product default property',
+          description: `Default property "${decodePropertyPath(data.name).property}" updated successfully.`,
+        });
+        navigate({
+          to: '/organizations/$orgId/products/$productId/defaults',
+          params: { orgId: params.orgId, productId: params.productId },
+        });
+      },
+      onError(error: ApiError) {
+        toast({
+          title: error.message,
+          description: <ToastError error={error} />,
+          variant: 'destructive',
+        });
+      },
+    });
+
+  const onSubmit = (values: EditDefaultFormValues) => {
+    editSecret({
+      productId: Number.parseInt(params.productId),
+      secretName: secret.name,
+      requestBody: {
+        name: values.property,
+        value: 'xyz',
+        description: values.value,
+      },
+    });
+  };
+
+  return (
+    <Card className='mx-auto w-full max-w-4xl'>
+      <CardHeader>Edit Default Run Property</CardHeader>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>
+          <CardContent className='space-y-4'>
+            <FormField
+              control={form.control}
+              name='property'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Run Property</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    The name of the run property (cannot be changed)
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+              disabled
+            />
+            {selectionType && (
+              <FormField
+                control={form.control}
+                name='value'
+                render={({ field }) =>
+                  selectionType === 'string' ||
+                  selectionType === 'string | null' ? (
+                    <FormItem>
+                      <FormLabel>Value (text)</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type='text'
+                          placeholder='Input text'
+                          value={field.value.toString()}
+                        />
+                      </FormControl>
+                      <FormDescription>Value of the property</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  ) : selectionType === 'number' ? (
+                    <FormItem>
+                      <FormLabel>Value (number)</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type='number'
+                          value={Number(field.value)}
+                        />
+                      </FormControl>
+                      <FormDescription>Value of the property</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  ) : selectionType === 'boolean' ? (
+                    <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
+                      <div className='space-y-0.5'>
+                        <FormLabel>True/false</FormLabel>
+                        <FormDescription>Boolean value</FormDescription>
+                      </div>
+                      <FormControl>
+                        <Switch
+                          checked={field.value === true}
+                          onCheckedChange={(checked) =>
+                            field.onChange(checked ? true : false)
+                          }
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  ) : (
+                    <></>
+                  )
+                }
+              />
+            )}
+            <FormField
+              control={form.control}
+              name='locked'
+              render={({ field }) => (
+                <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
+                  <div className='space-y-0.5'>
+                    <FormLabel>Lock the value</FormLabel>
+                    <FormDescription>
+                      Lock the value of the property to prevent changing it in
+                      ORT run creation form (cannot be changed)
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                      disabled
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          </CardContent>
+          <CardFooter>
+            <Button
+              className='m-1'
+              variant='outline'
+              onClick={() =>
+                navigate({
+                  to: '/organizations/$orgId/products/$productId/defaults',
+                  params: { orgId: params.orgId, productId: params.productId },
+                })
+              }
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button type='submit' disabled={isPending}>
+              {isPending ? (
+                <>
+                  <span className='sr-only'>Editing default property...</span>
+                  <Loader2 size={16} className='mx-3 animate-spin' />
+                </>
+              ) : (
+                'Submit'
+              )}
+            </Button>
+          </CardFooter>
+        </form>
+      </Form>
+    </Card>
+  );
+};
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/products/$productId/defaults/$defaultName/edit'
+)({
+  loader: async ({ context, params }) => {
+    await Promise.allSettled([
+      context.queryClient.ensureQueryData({
+        queryKey: [
+          useSecretsServiceGetSecretByProductIdAndNameKey,
+          params.productId,
+          params.defaultName,
+        ],
+        queryFn: () =>
+          SecretsService.getSecretByProductIdAndName({
+            productId: Number.parseInt(params.orgId),
+            secretName: params.defaultName,
+          }),
+      }),
+    ]);
+  },
+  component: EditProductDefaultPage,
+  pendingComponent: LoadingIndicator,
+});

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/defaults/$defaultName/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/defaults/$defaultName/edit.tsx
@@ -64,7 +64,6 @@ const paths = getPropertyPaths(runFormSchema, [
 const editDefaultFormSchema = z.object({
   property: z.string().optional(),
   value: z.string().min(1).or(z.number()).or(z.boolean()),
-  locked: z.boolean(),
 });
 
 export type EditDefaultFormValues = z.infer<typeof editDefaultFormSchema>;
@@ -88,15 +87,14 @@ const EditProductDefaultPage = () => {
   });
 
   const selectionType = paths.find(
-    (path) => path.path === decodePropertyPath(secret.name).property
+    (path) => path.path === decodePropertyPath(secret.name)
   )?.type;
 
   const form = useForm<EditDefaultFormValues>({
     resolver: zodResolver(editDefaultFormSchema),
     values: {
-      property: decodePropertyPath(secret.name).property,
+      property: decodePropertyPath(secret.name),
       value: secret.description || '',
-      locked: decodePropertyPath(secret.name).locked,
     },
   });
 
@@ -105,7 +103,7 @@ const EditProductDefaultPage = () => {
       onSuccess(data) {
         toast({
           title: 'Edit product default property',
-          description: `Default property "${decodePropertyPath(data.name).property}" updated successfully.`,
+          description: `Default property "${decodePropertyPath(data.name)}" updated successfully.`,
         });
         navigate({
           to: '/organizations/$orgId/products/$productId/defaults',
@@ -211,28 +209,6 @@ const EditProductDefaultPage = () => {
                 }
               />
             )}
-            <FormField
-              control={form.control}
-              name='locked'
-              render={({ field }) => (
-                <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
-                  <div className='space-y-0.5'>
-                    <FormLabel>Lock the value</FormLabel>
-                    <FormDescription>
-                      Lock the value of the property to prevent changing it in
-                      ORT run creation form (cannot be changed)
-                    </FormDescription>
-                  </div>
-                  <FormControl>
-                    <Switch
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                      disabled
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
           </CardContent>
           <CardFooter>
             <Button

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/defaults/create-default.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/defaults/create-default.tsx
@@ -1,0 +1,267 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import { useSecretsServicePostSecretForProduct } from '@/api/queries';
+import { ApiError } from '@/api/requests';
+import { ToastError } from '@/components/toast-error';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+} from '@/components/ui/card';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { useToast } from '@/components/ui/use-toast';
+import {
+  decodePropertyPath,
+  encodePropertyPath,
+  getPropertyPaths,
+} from '@/helpers/defaults-helpers';
+import { formSchema as runFormSchema } from '@/schemas';
+
+// First implementation only supports primitive types (string, number, boolean)
+// for the default run properties.
+const paths = getPropertyPaths(runFormSchema, [
+  'labels',
+  'jobConfigs.parameters',
+  'jobConfigs.analyzer.enabled',
+]).filter((path) => path.type !== 'array<string>');
+
+const formSchema = z.object({
+  property: z.string().min(1),
+  value: z.string().min(1).or(z.number()).or(z.boolean()),
+  locked: z.boolean(),
+});
+
+const CreateProductDefaultPage = () => {
+  const navigate = useNavigate();
+  const params = Route.useParams();
+  const { toast } = useToast();
+  const [selectionType, setSelectionType] = useState<string | undefined>();
+
+  const { mutateAsync, isPending } = useSecretsServicePostSecretForProduct({
+    onSuccess(data) {
+      toast({
+        title: 'Create default run property',
+        description: `New product default run property "${decodePropertyPath(data.name).property}" created successfully.`,
+      });
+      navigate({
+        to: '/organizations/$orgId/products/$productId/defaults',
+        params: { orgId: params.orgId, productId: params.productId },
+      });
+    },
+    onError(error: ApiError) {
+      toast({
+        title: error.message,
+        description: <ToastError error={error} />,
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      property: '',
+      value: true,
+      locked: false,
+    },
+  });
+
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    await mutateAsync({
+      productId: Number.parseInt(params.productId),
+      requestBody: {
+        name: encodePropertyPath(values.property, values.locked),
+        value: 'xyx',
+        description: values.value.toString(),
+      },
+    });
+  }
+
+  return (
+    <Card className='mx-auto w-full max-w-4xl'>
+      <CardHeader>Create Default Run Property</CardHeader>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>
+          <CardContent className='space-y-4'>
+            <FormField
+              control={form.control}
+              name='property'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Run property</FormLabel>
+                  <Select
+                    onValueChange={(value) => {
+                      field.onChange;
+                      form.setValue('property', value);
+                      setSelectionType(
+                        paths.find((path) => path.path === value)?.type
+                      );
+                    }}
+                    defaultValue={field.value}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder='Select a run property' />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {Object.values(paths).map((path) => (
+                        <SelectItem key={path.path} value={path.path}>
+                          {path.path}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormDescription>
+                    Name and path of the run property you want to default
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            {selectionType && (
+              <FormField
+                control={form.control}
+                name='value'
+                render={({ field }) =>
+                  selectionType === 'string' ||
+                  selectionType === 'string | null' ? (
+                    <FormItem>
+                      <FormLabel>Value (text)</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type='text'
+                          placeholder='Input text'
+                          value={field.value.toString()}
+                        />
+                      </FormControl>
+                      <FormDescription>Value of the property</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  ) : selectionType === 'number' ? (
+                    <FormItem>
+                      <FormLabel>Value (number)</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type='number'
+                          placeholder='Input number'
+                          value={Number(field.value)}
+                        />
+                      </FormControl>
+                      <FormDescription>Value of the property</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  ) : selectionType === 'boolean' ? (
+                    <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
+                      <div className='space-y-0.5'>
+                        <FormLabel>True/false</FormLabel>
+                        <FormDescription>Boolean value</FormDescription>
+                      </div>
+                      <FormControl>
+                        <Switch
+                          checked={field.value === true}
+                          onCheckedChange={(checked) =>
+                            field.onChange(checked ? true : false)
+                          }
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  ) : (
+                    <></>
+                  )
+                }
+              />
+            )}
+            <FormField
+              control={form.control}
+              name='locked'
+              render={({ field }) => (
+                <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
+                  <div className='space-y-0.5'>
+                    <FormLabel>Lock the value</FormLabel>
+                    <FormDescription>
+                      Lock the value of the property to prevent changing it in
+                      ORT run creation form
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          </CardContent>
+          <CardFooter>
+            <Button type='submit' disabled={isPending}>
+              {isPending ? (
+                <>
+                  <span className='sr-only'>
+                    Creating default run property...
+                  </span>
+                  <Loader2 size={16} className='mx-3 animate-spin' />
+                </>
+              ) : (
+                'Create'
+              )}
+            </Button>
+          </CardFooter>
+        </form>
+      </Form>
+    </Card>
+  );
+};
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/products/$productId/defaults/create-default'
+)({
+  component: CreateProductDefaultPage,
+});

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/defaults/create-default.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/defaults/create-default.tsx
@@ -71,7 +71,6 @@ const paths = getPropertyPaths(runFormSchema, [
 const formSchema = z.object({
   property: z.string().min(1),
   value: z.string().min(1).or(z.number()).or(z.boolean()),
-  locked: z.boolean(),
 });
 
 const CreateProductDefaultPage = () => {
@@ -84,7 +83,7 @@ const CreateProductDefaultPage = () => {
     onSuccess(data) {
       toast({
         title: 'Create default run property',
-        description: `New product default run property "${decodePropertyPath(data.name).property}" created successfully.`,
+        description: `New product default run property "${decodePropertyPath(data.name)}" created successfully.`,
       });
       navigate({
         to: '/organizations/$orgId/products/$productId/defaults',
@@ -105,7 +104,6 @@ const CreateProductDefaultPage = () => {
     defaultValues: {
       property: '',
       value: true,
-      locked: false,
     },
   });
 
@@ -113,7 +111,7 @@ const CreateProductDefaultPage = () => {
     await mutateAsync({
       productId: Number.parseInt(params.productId),
       requestBody: {
-        name: encodePropertyPath(values.property, values.locked),
+        name: encodePropertyPath(values.property),
         value: 'xyx',
         description: values.value.toString(),
       },
@@ -218,27 +216,6 @@ const CreateProductDefaultPage = () => {
                 }
               />
             )}
-            <FormField
-              control={form.control}
-              name='locked'
-              render={({ field }) => (
-                <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
-                  <div className='space-y-0.5'>
-                    <FormLabel>Lock the value</FormLabel>
-                    <FormDescription>
-                      Lock the value of the property to prevent changing it in
-                      ORT run creation form
-                    </FormDescription>
-                  </div>
-                  <FormControl>
-                    <Switch
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
           </CardContent>
           <CardFooter>
             <Button type='submit' disabled={isPending}>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/defaults/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/defaults/index.tsx
@@ -1,0 +1,294 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import {
+  useQueryClient,
+  useSuspenseQueries,
+  useSuspenseQuery,
+} from '@tanstack/react-query';
+import { createFileRoute, Link } from '@tanstack/react-router';
+import {
+  CellContext,
+  ColumnDef,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import { EditIcon, PlusIcon } from 'lucide-react';
+import { useState } from 'react';
+
+import {
+  useProductsServiceGetProductByIdKey,
+  useSecretsServiceDeleteSecretByProductIdAndName,
+  useSecretsServiceGetSecretsByProductId,
+} from '@/api/queries';
+import {
+  ApiError,
+  ProductsService,
+  Secret,
+  SecretsService,
+} from '@/api/requests';
+import { DataTable } from '@/components/data-table/data-table';
+import { DeleteDialog } from '@/components/delete-dialog';
+import { LoadingIndicator } from '@/components/loading-indicator';
+import { ToastError } from '@/components/toast-error';
+import { Button } from '@/components/ui/button';
+import { buttonVariants } from '@/components/ui/button-variants';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { useToast } from '@/components/ui/use-toast';
+import { decodePropertyPath, isDefault } from '@/helpers/defaults-helpers';
+import { cn } from '@/lib/utils';
+import { paginationSchema } from '@/schemas';
+
+const defaultPageSize = 10;
+
+const ActionCell = ({ row }: CellContext<Secret, unknown>) => {
+  const params = Route.useParams();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [openDelDialog, setOpenDelDialog] = useState(false);
+
+  const { data: product } = useSuspenseQuery({
+    queryKey: [useProductsServiceGetProductByIdKey, params.productId],
+    queryFn: async () =>
+      await ProductsService.getProductById({
+        productId: Number.parseInt(params.productId),
+      }),
+  });
+
+  const { mutateAsync: delSecret, isPending: delIsPending } =
+    useSecretsServiceDeleteSecretByProductIdAndName({
+      onSuccess() {
+        setOpenDelDialog(false);
+        toast({
+          title: 'Delete Default',
+          description: `Default value "${decodePropertyPath(row.original.name).property}" deleted successfully.`,
+        });
+        queryClient.invalidateQueries({
+          queryKey: [useSecretsServiceGetSecretsByProductId],
+        });
+      },
+      onError(error: ApiError) {
+        toast({
+          title: error.message,
+          description: <ToastError error={error} />,
+          variant: 'destructive',
+        });
+      },
+    });
+
+  return (
+    <div className='flex justify-end gap-1'>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Link
+              to='/organizations/$orgId/products/$productId/defaults/$defaultName/edit'
+              params={{
+                orgId: params.orgId,
+                productId: params.productId,
+                defaultName: row.original.name,
+              }}
+              className={cn(buttonVariants({ variant: 'outline' }), 'h-9 px-2')}
+            >
+              <span className='sr-only'>Edit</span>
+              <EditIcon size={16} />
+            </Link>
+          </TooltipTrigger>
+          <TooltipContent>Edit this default run property</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <DeleteDialog
+        open={openDelDialog}
+        setOpen={setOpenDelDialog}
+        item={{
+          descriptor: 'default run property',
+          name: decodePropertyPath(row.original.name).property,
+        }}
+        onDelete={() =>
+          delSecret({
+            productId: product.id,
+            secretName: row.original.name,
+          })
+        }
+        isPending={delIsPending}
+      />
+    </div>
+  );
+};
+
+const columns: ColumnDef<Secret>[] = [
+  {
+    accessorKey: 'name',
+    header: 'Run property',
+    // Do not show the property encoding prefix in the table
+    cell: ({ row }) => decodePropertyPath(row.original.name).property,
+  },
+  {
+    accessorKey: 'description',
+    header: 'Value',
+  },
+  {
+    accessorKey: 'locked',
+    header: 'Locked?',
+    cell: ({ row }) =>
+      decodePropertyPath(row.original.name).locked ? 'Yes' : 'No',
+  },
+  {
+    id: 'actions',
+    cell: ActionCell,
+  },
+];
+
+const ProductDefaults = () => {
+  const params = Route.useParams();
+  const search = Route.useSearch();
+  const pageIndex = search.page ? search.page - 1 : 0;
+  const pageSize = search.pageSize ? search.pageSize : defaultPageSize;
+
+  const [{ data: product }, { data: secrets }] = useSuspenseQueries({
+    queries: [
+      {
+        queryKey: [useProductsServiceGetProductByIdKey, params.orgId],
+        queryFn: async () =>
+          await ProductsService.getProductById({
+            productId: Number.parseInt(params.productId),
+          }),
+      },
+      {
+        queryKey: [
+          useSecretsServiceGetSecretsByProductId,
+          params.productId,
+          pageIndex,
+          pageSize,
+        ],
+        queryFn: async () =>
+          await SecretsService.getSecretsByProductId({
+            productId: Number.parseInt(params.productId),
+            limit: pageSize,
+            offset: pageIndex * pageSize,
+          }),
+      },
+    ],
+  });
+
+  // Only show secrets which are encoded as default properties
+  const tableData = secrets?.data.filter((secret) => isDefault(secret.name));
+
+  const table = useReactTable({
+    data: tableData || [],
+    columns,
+    pageCount: Math.ceil(secrets.pagination.totalCount / pageSize),
+    state: {
+      pagination: {
+        pageIndex,
+        pageSize,
+      },
+    },
+    getCoreRowModel: getCoreRowModel(),
+    manualPagination: true,
+  });
+
+  return (
+    <TooltipProvider>
+      <Card className='mx-auto w-full max-w-4xl'>
+        <CardHeader>
+          <CardTitle>Default Run Properties</CardTitle>
+          <CardDescription>
+            Manage default run properties for {product.name}
+          </CardDescription>
+          <div className='py-2'>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button asChild size='sm' className='ml-auto gap-1'>
+                  <Link
+                    to='/organizations/$orgId/products/$productId/defaults/create-default'
+                    params={{
+                      orgId: params.orgId,
+                      productId: params.productId,
+                    }}
+                  >
+                    New default property
+                    <PlusIcon className='h-4 w-4' />
+                  </Link>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                Create a new default run property for this product
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <DataTable table={table} />
+        </CardContent>
+      </Card>
+    </TooltipProvider>
+  );
+};
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/products/$productId/defaults/'
+)({
+  validateSearch: paginationSchema,
+  loaderDeps: ({ search: { page, pageSize } }) => ({ page, pageSize }),
+  loader: async ({ context, params, deps: { page, pageSize } }) => {
+    await Promise.allSettled([
+      context.queryClient.ensureQueryData({
+        queryKey: [
+          useProductsServiceGetProductByIdKey,
+          params.orgId,
+          params.productId,
+        ],
+        queryFn: () =>
+          ProductsService.getProductById({
+            productId: Number.parseInt(params.productId),
+          }),
+      }),
+      context.queryClient.ensureQueryData({
+        queryKey: [
+          useSecretsServiceGetSecretsByProductId,
+          params.orgId,
+          params.productId,
+          page,
+          pageSize,
+        ],
+        queryFn: () =>
+          SecretsService.getSecretsByProductId({
+            productId: Number.parseInt(params.productId),
+            limit: pageSize || defaultPageSize,
+            offset: page ? (page - 1) * (pageSize || defaultPageSize) : 0,
+          }),
+      }),
+    ]);
+  },
+  component: ProductDefaults,
+  pendingComponent: LoadingIndicator,
+});

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/defaults/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/defaults/index.tsx
@@ -89,7 +89,7 @@ const ActionCell = ({ row }: CellContext<Secret, unknown>) => {
         setOpenDelDialog(false);
         toast({
           title: 'Delete Default',
-          description: `Default value "${decodePropertyPath(row.original.name).property}" deleted successfully.`,
+          description: `Default value "${decodePropertyPath(row.original.name)}" deleted successfully.`,
         });
         queryClient.invalidateQueries({
           queryKey: [useSecretsServiceGetSecretsByProductId],
@@ -130,7 +130,7 @@ const ActionCell = ({ row }: CellContext<Secret, unknown>) => {
         setOpen={setOpenDelDialog}
         item={{
           descriptor: 'default run property',
-          name: decodePropertyPath(row.original.name).property,
+          name: decodePropertyPath(row.original.name),
         }}
         onDelete={() =>
           delSecret({
@@ -149,17 +149,11 @@ const columns: ColumnDef<Secret>[] = [
     accessorKey: 'name',
     header: 'Run property',
     // Do not show the property encoding prefix in the table
-    cell: ({ row }) => decodePropertyPath(row.original.name).property,
+    cell: ({ row }) => decodePropertyPath(row.original.name),
   },
   {
     accessorKey: 'description',
     header: 'Value',
-  },
-  {
-    accessorKey: 'locked',
-    header: 'Locked?',
-    cell: ({ row }) =>
-      decodePropertyPath(row.original.name).locked ? 'Yes' : 'No',
   },
   {
     id: 'actions',

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/defaults/route.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/defaults/route.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/products/$productId/defaults'
+)({
+  component: () => <Outlet />,
+  beforeLoad: ({ context, params }) => {
+    if (
+      !context.auth.hasRole([
+        'superuser',
+        `permission_organization_${params.productId}_write_secrets`,
+      ])
+    ) {
+      throw redirect({
+        to: '/403',
+      });
+    }
+  },
+});

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-components/display-defaults.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-components/display-defaults.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { Secret } from '@/api/requests';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+
+type DisplayDefaultsProps = {
+  orgDefaults: Secret[];
+  prodDefaults: Secret[];
+  repoDefaults: Secret[];
+};
+
+export const DisplayDefaults = ({
+  orgDefaults,
+  prodDefaults,
+  repoDefaults,
+}: DisplayDefaultsProps) => {
+  return (
+    <Accordion type='multiple'>
+      {orgDefaults.length > 0 && (
+        <AccordionItem value='org-secrets'>
+          <AccordionTrigger className='font-semibold text-blue-400'>
+            From Organization
+          </AccordionTrigger>
+          <AccordionContent>
+            <div className='flex justify-between gap-2 pb-2'>
+              <div className='w-1/2 font-semibold'>Property</div>
+              <div className='flex-1 font-semibold'>Value</div>
+            </div>
+            {orgDefaults.map((def) => (
+              <div key={def.name} className='flex justify-between gap-2 pb-2'>
+                <div className='w-1/2 break-all'>{def.name}</div>
+                <div className='flex-1'>{def.description}</div>
+              </div>
+            ))}
+          </AccordionContent>
+        </AccordionItem>
+      )}
+      {prodDefaults.length > 0 && (
+        <AccordionItem value='prod-secrets'>
+          <AccordionTrigger className='font-semibold text-blue-400'>
+            From Product
+          </AccordionTrigger>
+          <AccordionContent>
+            <div className='flex justify-between gap-2 pb-2'>
+              <div className='w-1/2 font-semibold'>Property</div>
+              <div className='flex-1 font-semibold'>Value</div>
+            </div>
+            {prodDefaults.map((def) => (
+              <div key={def.name} className='flex justify-between gap-2 pb-2'>
+                <div className='w-1/2 break-all'>{def.name}</div>
+                <div className='flex-1'>{def.description}</div>
+              </div>
+            ))}
+          </AccordionContent>
+        </AccordionItem>
+      )}
+      {repoDefaults.length > 0 && (
+        <AccordionItem value='repo-secrets'>
+          <AccordionTrigger className='font-semibold text-blue-400'>
+            From Repository
+          </AccordionTrigger>
+          <AccordionContent>
+            <div className='flex justify-between gap-2 pb-2'>
+              <div className='w-1/2 font-semibold'>Property</div>
+              <div className='flex-1 font-semibold'>Value</div>
+            </div>
+            {repoDefaults.map((def) => (
+              <div key={def.name} className='flex justify-between gap-2 pb-2'>
+                <div className='w-1/2 break-all'>{def.name}</div>
+                <div className='flex-1'>{def.description}</div>
+              </div>
+            ))}
+          </AccordionContent>
+        </AccordionItem>
+      )}
+    </Accordion>
+  );
+};

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/create-run.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/create-run.tsx
@@ -46,6 +46,7 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { useToast } from '@/components/ui/use-toast';
+import { formSchema } from '@/schemas';
 import { AdvisorFields } from './-components/advisor-fields';
 import { AnalyzerFields } from './-components/analyzer-fields';
 import { EvaluatorFields } from './-components/evaluator-fields';
@@ -53,71 +54,6 @@ import { NotifierFields } from './-components/notifier-fields';
 import { ReporterFields } from './-components/reporter-fields';
 import { ScannerFields } from './-components/scanner-fields';
 import { packageManagers } from './-types';
-
-const keyValueSchema = z.object({
-  key: z.string().min(1),
-  value: z.string(), // Allow empty values for now
-});
-
-const formSchema = z.object({
-  revision: z.string(),
-  path: z.string(),
-  jobConfigs: z.object({
-    analyzer: z.object({
-      enabled: z.boolean(),
-      allowDynamicVersions: z.boolean(),
-      skipExcluded: z.boolean(),
-      enabledPackageManagers: z.array(z.string()),
-    }),
-    advisor: z.object({
-      enabled: z.boolean(),
-      skipExcluded: z.boolean(),
-      advisors: z.array(z.string()),
-    }),
-    scanner: z.object({
-      enabled: z.boolean(),
-      skipConcluded: z.boolean(),
-      skipExcluded: z.boolean(),
-    }),
-    evaluator: z.object({
-      enabled: z.boolean(),
-      ruleSet: z.string().optional(),
-      licenseClassificationsFile: z.string().optional(),
-      copyrightGarbageFile: z.string().optional(),
-      resolutionsFile: z.string().optional(),
-    }),
-    reporter: z.object({
-      enabled: z.boolean(),
-      formats: z.array(z.string()),
-    }),
-    notifier: z.object({
-      enabled: z.boolean(),
-      notifierRules: z.string().optional(),
-      resolutionsFile: z.string().optional(),
-      mail: z.object({
-        recipientAddresses: z.array(z.object({ email: z.string() })).optional(),
-        mailServerConfiguration: z.object({
-          hostName: z.string(),
-          port: z.coerce.number().int(),
-          username: z.string(),
-          password: z.string(),
-          useSsl: z.boolean(),
-          fromAddress: z.string(),
-        }),
-      }),
-      jira: z.object({
-        jiraRestClientConfiguration: z.object({
-          serverUrl: z.string(),
-          username: z.string(),
-          password: z.string(),
-        }),
-      }),
-    }),
-    parameters: z.array(keyValueSchema).optional(),
-  }),
-  labels: z.array(keyValueSchema).optional(),
-  jobConfigContext: z.string().optional(),
-});
 
 export type CreateRunFormValues = ReturnType<typeof formSchema.parse>;
 

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/defaults/$defaultName/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/defaults/$defaultName/edit.tsx
@@ -1,0 +1,297 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { Loader2 } from 'lucide-react';
+import { useForm } from 'react-hook-form';
+import z from 'zod';
+
+import {
+  useSecretsServiceGetSecretByRepositoryIdAndNameKey,
+  useSecretsServicePatchSecretByRepositoryIdAndName,
+} from '@/api/queries';
+import { ApiError, SecretsService } from '@/api/requests';
+import { LoadingIndicator } from '@/components/loading-indicator';
+import { ToastError } from '@/components/toast-error';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+} from '@/components/ui/card';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
+import { useToast } from '@/components/ui/use-toast';
+import {
+  decodePropertyPath,
+  getPropertyPaths,
+} from '@/helpers/defaults-helpers';
+import { formSchema as runFormSchema } from '@/schemas';
+
+const paths = getPropertyPaths(runFormSchema, [
+  'labels',
+  'jobConfigs.parameters',
+]).filter((path) => path.type !== 'array<string>');
+
+const editDefaultFormSchema = z.object({
+  property: z.string().optional(),
+  value: z.string().min(1).or(z.number()).or(z.boolean()),
+  locked: z.boolean(),
+});
+
+export type EditDefaultFormValues = z.infer<typeof editDefaultFormSchema>;
+
+const EditRepositoryDefaultPage = () => {
+  const params = Route.useParams();
+  const navigate = useNavigate();
+  const { toast } = useToast();
+
+  const { data: secret } = useSuspenseQuery({
+    queryKey: [
+      useSecretsServiceGetSecretByRepositoryIdAndNameKey,
+      params.repoId,
+      params.defaultName,
+    ],
+    queryFn: () =>
+      SecretsService.getSecretByRepositoryIdAndName({
+        repositoryId: Number.parseInt(params.repoId),
+        secretName: params.defaultName,
+      }),
+  });
+
+  const selectionType = paths.find(
+    (path) => path.path === decodePropertyPath(secret.name).property
+  )?.type;
+
+  const form = useForm<EditDefaultFormValues>({
+    resolver: zodResolver(editDefaultFormSchema),
+    values: {
+      property: decodePropertyPath(secret.name).property,
+      value: secret.description || '',
+      locked: decodePropertyPath(secret.name).locked,
+    },
+  });
+
+  const { mutateAsync: editSecret, isPending } =
+    useSecretsServicePatchSecretByRepositoryIdAndName({
+      onSuccess(data) {
+        toast({
+          title: 'Edit repository default property',
+          description: `Default property "${decodePropertyPath(data.name).property}" updated successfully.`,
+        });
+        navigate({
+          to: '/organizations/$orgId/products/$productId/repositories/$repoId/defaults',
+          params: {
+            orgId: params.orgId,
+            productId: params.productId,
+            repoId: params.repoId,
+          },
+        });
+      },
+      onError(error: ApiError) {
+        toast({
+          title: error.message,
+          description: <ToastError error={error} />,
+          variant: 'destructive',
+        });
+      },
+    });
+
+  const onSubmit = (values: EditDefaultFormValues) => {
+    editSecret({
+      repositoryId: Number.parseInt(params.repoId),
+      secretName: secret.name,
+      requestBody: {
+        name: values.property,
+        value: 'xyz',
+        description: values.value,
+      },
+    });
+  };
+
+  return (
+    <Card className='mx-auto w-full max-w-4xl'>
+      <CardHeader>Edit Default Run Property</CardHeader>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>
+          <CardContent className='space-y-4'>
+            <FormField
+              control={form.control}
+              name='property'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Run Property</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    The name of the run property (cannot be changed)
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+              disabled
+            />
+            {selectionType && (
+              <FormField
+                control={form.control}
+                name='value'
+                render={({ field }) =>
+                  selectionType === 'string' ||
+                  selectionType === 'string | null' ? (
+                    <FormItem>
+                      <FormLabel>Value (text)</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type='text'
+                          placeholder='Input text'
+                          value={field.value.toString()}
+                        />
+                      </FormControl>
+                      <FormDescription>Value of the property</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  ) : selectionType === 'number' ? (
+                    <FormItem>
+                      <FormLabel>Value (number)</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type='number'
+                          value={Number(field.value)}
+                        />
+                      </FormControl>
+                      <FormDescription>Value of the property</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  ) : selectionType === 'boolean' ? (
+                    <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
+                      <div className='space-y-0.5'>
+                        <FormLabel>True/false</FormLabel>
+                        <FormDescription>Boolean value</FormDescription>
+                      </div>
+                      <FormControl>
+                        <Switch
+                          checked={field.value === true}
+                          onCheckedChange={(checked) =>
+                            field.onChange(checked ? true : false)
+                          }
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  ) : (
+                    <></>
+                  )
+                }
+              />
+            )}
+            <FormField
+              control={form.control}
+              name='locked'
+              render={({ field }) => (
+                <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
+                  <div className='space-y-0.5'>
+                    <FormLabel>Lock the value</FormLabel>
+                    <FormDescription>
+                      Lock the value of the property to prevent changing it in
+                      ORT run creation form (cannot be changed)
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                      disabled
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          </CardContent>
+          <CardFooter>
+            <Button
+              className='m-1'
+              variant='outline'
+              onClick={() =>
+                navigate({
+                  to: '/organizations/$orgId/products/$productId/repositories/$repoId/defaults',
+                  params: {
+                    orgId: params.orgId,
+                    productId: params.productId,
+                    repoId: params.repoId,
+                  },
+                })
+              }
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button type='submit' disabled={isPending}>
+              {isPending ? (
+                <>
+                  <span className='sr-only'>Editing default property...</span>
+                  <Loader2 size={16} className='mx-3 animate-spin' />
+                </>
+              ) : (
+                'Submit'
+              )}
+            </Button>
+          </CardFooter>
+        </form>
+      </Form>
+    </Card>
+  );
+};
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/defaults/$defaultName/edit'
+)({
+  loader: async ({ context, params }) => {
+    await Promise.allSettled([
+      context.queryClient.ensureQueryData({
+        queryKey: [
+          useSecretsServiceGetSecretByRepositoryIdAndNameKey,
+          params.repoId,
+          params.defaultName,
+        ],
+        queryFn: () =>
+          SecretsService.getSecretByRepositoryIdAndName({
+            repositoryId: Number.parseInt(params.repoId),
+            secretName: params.defaultName,
+          }),
+      }),
+    ]);
+  },
+  component: EditRepositoryDefaultPage,
+  pendingComponent: LoadingIndicator,
+});

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/defaults/$defaultName/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/defaults/$defaultName/edit.tsx
@@ -64,7 +64,6 @@ const paths = getPropertyPaths(runFormSchema, [
 const editDefaultFormSchema = z.object({
   property: z.string().optional(),
   value: z.string().min(1).or(z.number()).or(z.boolean()),
-  locked: z.boolean(),
 });
 
 export type EditDefaultFormValues = z.infer<typeof editDefaultFormSchema>;
@@ -88,15 +87,14 @@ const EditRepositoryDefaultPage = () => {
   });
 
   const selectionType = paths.find(
-    (path) => path.path === decodePropertyPath(secret.name).property
+    (path) => path.path === decodePropertyPath(secret.name)
   )?.type;
 
   const form = useForm<EditDefaultFormValues>({
     resolver: zodResolver(editDefaultFormSchema),
     values: {
-      property: decodePropertyPath(secret.name).property,
+      property: decodePropertyPath(secret.name),
       value: secret.description || '',
-      locked: decodePropertyPath(secret.name).locked,
     },
   });
 
@@ -105,7 +103,7 @@ const EditRepositoryDefaultPage = () => {
       onSuccess(data) {
         toast({
           title: 'Edit repository default property',
-          description: `Default property "${decodePropertyPath(data.name).property}" updated successfully.`,
+          description: `Default property "${decodePropertyPath(data.name)}" updated successfully.`,
         });
         navigate({
           to: '/organizations/$orgId/products/$productId/repositories/$repoId/defaults',
@@ -215,28 +213,6 @@ const EditRepositoryDefaultPage = () => {
                 }
               />
             )}
-            <FormField
-              control={form.control}
-              name='locked'
-              render={({ field }) => (
-                <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
-                  <div className='space-y-0.5'>
-                    <FormLabel>Lock the value</FormLabel>
-                    <FormDescription>
-                      Lock the value of the property to prevent changing it in
-                      ORT run creation form (cannot be changed)
-                    </FormDescription>
-                  </div>
-                  <FormControl>
-                    <Switch
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                      disabled
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
           </CardContent>
           <CardFooter>
             <Button

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/defaults/create-default.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/defaults/create-default.tsx
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { Loader2 } from 'lucide-react';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import { useSecretsServicePostSecretForRepository } from '@/api/queries';
+import { ApiError } from '@/api/requests';
+import { ToastError } from '@/components/toast-error';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+} from '@/components/ui/card';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { useToast } from '@/components/ui/use-toast';
+import {
+  decodePropertyPath,
+  encodePropertyPath,
+  getPropertyPaths,
+} from '@/helpers/defaults-helpers';
+import { formSchema as runFormSchema } from '@/schemas';
+
+// First implementation only supports primitive types (string, number, boolean)
+// for the default run properties.
+const paths = getPropertyPaths(runFormSchema, [
+  'labels',
+  'jobConfigs.parameters',
+  'jobConfigs.analyzer.enabled',
+]).filter((path) => path.type !== 'array<string>');
+
+const formSchema = z.object({
+  property: z.string().min(1),
+  value: z.string().min(1).or(z.number()).or(z.boolean()),
+  locked: z.boolean(),
+});
+
+const CreateRepositoryDefaultPage = () => {
+  const navigate = useNavigate();
+  const params = Route.useParams();
+  const { toast } = useToast();
+  const [selectionType, setSelectionType] = useState<string | undefined>();
+
+  const { mutateAsync, isPending } = useSecretsServicePostSecretForRepository({
+    onSuccess(data) {
+      toast({
+        title: 'Create default run property',
+        description: `New repository default run property "${decodePropertyPath(data.name).property}" created successfully.`,
+      });
+      navigate({
+        to: '/organizations/$orgId/products/$productId/repositories/$repoId/defaults',
+        params: {
+          orgId: params.orgId,
+          productId: params.productId,
+          repoId: params.repoId,
+        },
+      });
+    },
+    onError(error: ApiError) {
+      toast({
+        title: error.message,
+        description: <ToastError error={error} />,
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      property: '',
+      value: true,
+      locked: false,
+    },
+  });
+
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    await mutateAsync({
+      repositoryId: Number.parseInt(params.repoId),
+      requestBody: {
+        name: encodePropertyPath(values.property, values.locked),
+        value: 'xyx',
+        description: values.value.toString(),
+      },
+    });
+  }
+
+  return (
+    <Card className='mx-auto w-full max-w-4xl'>
+      <CardHeader>Create Default Run Property</CardHeader>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>
+          <CardContent className='space-y-4'>
+            <FormField
+              control={form.control}
+              name='property'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Run property</FormLabel>
+                  <Select
+                    onValueChange={(value) => {
+                      field.onChange;
+                      form.setValue('property', value);
+                      setSelectionType(
+                        paths.find((path) => path.path === value)?.type
+                      );
+                    }}
+                    defaultValue={field.value}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder='Select a run property' />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {Object.values(paths).map((path) => (
+                        <SelectItem key={path.path} value={path.path}>
+                          {path.path}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormDescription>
+                    Name and path of the run property you want to default
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            {selectionType && (
+              <FormField
+                control={form.control}
+                name='value'
+                render={({ field }) =>
+                  selectionType === 'string' ||
+                  selectionType === 'string | null' ? (
+                    <FormItem>
+                      <FormLabel>Value (text)</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type='text'
+                          placeholder='Input text'
+                          value={field.value.toString()}
+                        />
+                      </FormControl>
+                      <FormDescription>Value of the property</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  ) : selectionType === 'number' ? (
+                    <FormItem>
+                      <FormLabel>Value (number)</FormLabel>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          type='number'
+                          placeholder='Input number'
+                          value={Number(field.value)}
+                        />
+                      </FormControl>
+                      <FormDescription>Value of the property</FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  ) : selectionType === 'boolean' ? (
+                    <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
+                      <div className='space-y-0.5'>
+                        <FormLabel>True/false</FormLabel>
+                        <FormDescription>Boolean value</FormDescription>
+                      </div>
+                      <FormControl>
+                        <Switch
+                          checked={field.value === true}
+                          onCheckedChange={(checked) =>
+                            field.onChange(checked ? true : false)
+                          }
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  ) : (
+                    <></>
+                  )
+                }
+              />
+            )}
+            <FormField
+              control={form.control}
+              name='locked'
+              render={({ field }) => (
+                <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
+                  <div className='space-y-0.5'>
+                    <FormLabel>Lock the value</FormLabel>
+                    <FormDescription>
+                      Lock the value of the property to prevent changing it in
+                      ORT run creation form
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          </CardContent>
+          <CardFooter>
+            <Button type='submit' disabled={isPending}>
+              {isPending ? (
+                <>
+                  <span className='sr-only'>
+                    Creating default run property...
+                  </span>
+                  <Loader2 size={16} className='mx-3 animate-spin' />
+                </>
+              ) : (
+                'Create'
+              )}
+            </Button>
+          </CardFooter>
+        </form>
+      </Form>
+    </Card>
+  );
+};
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/defaults/create-default'
+)({
+  component: CreateRepositoryDefaultPage,
+});

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/defaults/create-default.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/defaults/create-default.tsx
@@ -71,7 +71,6 @@ const paths = getPropertyPaths(runFormSchema, [
 const formSchema = z.object({
   property: z.string().min(1),
   value: z.string().min(1).or(z.number()).or(z.boolean()),
-  locked: z.boolean(),
 });
 
 const CreateRepositoryDefaultPage = () => {
@@ -84,7 +83,7 @@ const CreateRepositoryDefaultPage = () => {
     onSuccess(data) {
       toast({
         title: 'Create default run property',
-        description: `New repository default run property "${decodePropertyPath(data.name).property}" created successfully.`,
+        description: `New repository default run property "${decodePropertyPath(data.name)}" created successfully.`,
       });
       navigate({
         to: '/organizations/$orgId/products/$productId/repositories/$repoId/defaults',
@@ -109,7 +108,6 @@ const CreateRepositoryDefaultPage = () => {
     defaultValues: {
       property: '',
       value: true,
-      locked: false,
     },
   });
 
@@ -117,7 +115,7 @@ const CreateRepositoryDefaultPage = () => {
     await mutateAsync({
       repositoryId: Number.parseInt(params.repoId),
       requestBody: {
-        name: encodePropertyPath(values.property, values.locked),
+        name: encodePropertyPath(values.property),
         value: 'xyx',
         description: values.value.toString(),
       },
@@ -222,27 +220,6 @@ const CreateRepositoryDefaultPage = () => {
                 }
               />
             )}
-            <FormField
-              control={form.control}
-              name='locked'
-              render={({ field }) => (
-                <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
-                  <div className='space-y-0.5'>
-                    <FormLabel>Lock the value</FormLabel>
-                    <FormDescription>
-                      Lock the value of the property to prevent changing it in
-                      ORT run creation form
-                    </FormDescription>
-                  </div>
-                  <FormControl>
-                    <Switch
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
           </CardContent>
           <CardFooter>
             <Button type='submit' disabled={isPending}>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/defaults/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/defaults/index.tsx
@@ -1,0 +1,298 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import {
+  useQueryClient,
+  useSuspenseQueries,
+  useSuspenseQuery,
+} from '@tanstack/react-query';
+import { createFileRoute, Link } from '@tanstack/react-router';
+import {
+  CellContext,
+  ColumnDef,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import { EditIcon, PlusIcon } from 'lucide-react';
+import { useState } from 'react';
+
+import {
+  useRepositoriesServiceGetRepositoryByIdKey,
+  useSecretsServiceDeleteSecretByRepositoryIdAndName,
+  useSecretsServiceGetSecretsByRepositoryId,
+} from '@/api/queries';
+import {
+  ApiError,
+  RepositoriesService,
+  Secret,
+  SecretsService,
+} from '@/api/requests';
+import { DataTable } from '@/components/data-table/data-table';
+import { DeleteDialog } from '@/components/delete-dialog';
+import { LoadingIndicator } from '@/components/loading-indicator';
+import { ToastError } from '@/components/toast-error';
+import { Button } from '@/components/ui/button';
+import { buttonVariants } from '@/components/ui/button-variants';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { useToast } from '@/components/ui/use-toast';
+import { decodePropertyPath, isDefault } from '@/helpers/defaults-helpers';
+import { cn } from '@/lib/utils';
+import { paginationSchema } from '@/schemas';
+
+const defaultPageSize = 10;
+
+const ActionCell = ({ row }: CellContext<Secret, unknown>) => {
+  const params = Route.useParams();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const [openDelDialog, setOpenDelDialog] = useState(false);
+
+  const { data: repository } = useSuspenseQuery({
+    queryKey: [useRepositoriesServiceGetRepositoryByIdKey, params.repoId],
+    queryFn: async () =>
+      await RepositoriesService.getRepositoryById({
+        repositoryId: Number.parseInt(params.repoId),
+      }),
+  });
+
+  const { mutateAsync: delSecret, isPending: delIsPending } =
+    useSecretsServiceDeleteSecretByRepositoryIdAndName({
+      onSuccess() {
+        setOpenDelDialog(false);
+        toast({
+          title: 'Delete Default',
+          description: `Default value "${decodePropertyPath(row.original.name).property}" deleted successfully.`,
+        });
+        queryClient.invalidateQueries({
+          queryKey: [useSecretsServiceGetSecretsByRepositoryId],
+        });
+      },
+      onError(error: ApiError) {
+        toast({
+          title: error.message,
+          description: <ToastError error={error} />,
+          variant: 'destructive',
+        });
+      },
+    });
+
+  return (
+    <div className='flex justify-end gap-1'>
+      <TooltipProvider>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Link
+              to='/organizations/$orgId/products/$productId/repositories/$repoId/defaults/$defaultName/edit'
+              params={{
+                orgId: params.orgId,
+                productId: params.productId,
+                repoId: params.repoId,
+                defaultName: row.original.name,
+              }}
+              className={cn(buttonVariants({ variant: 'outline' }), 'h-9 px-2')}
+            >
+              <span className='sr-only'>Edit</span>
+              <EditIcon size={16} />
+            </Link>
+          </TooltipTrigger>
+          <TooltipContent>Edit this default run property</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+      <DeleteDialog
+        open={openDelDialog}
+        setOpen={setOpenDelDialog}
+        item={{
+          descriptor: 'default run property',
+          name: decodePropertyPath(row.original.name).property,
+        }}
+        onDelete={() =>
+          delSecret({
+            repositoryId: repository.id,
+            secretName: row.original.name,
+          })
+        }
+        isPending={delIsPending}
+      />
+    </div>
+  );
+};
+
+const columns: ColumnDef<Secret>[] = [
+  {
+    accessorKey: 'name',
+    header: 'Run property',
+    // Do not show the property encoding prefix in the table
+    cell: ({ row }) => decodePropertyPath(row.original.name).property,
+  },
+  {
+    accessorKey: 'description',
+    header: 'Value',
+  },
+  {
+    accessorKey: 'locked',
+    header: 'Locked?',
+    cell: ({ row }) =>
+      decodePropertyPath(row.original.name).locked ? 'Yes' : 'No',
+  },
+  {
+    id: 'actions',
+    cell: ActionCell,
+  },
+];
+
+const RepositoryDefaults = () => {
+  const params = Route.useParams();
+  const search = Route.useSearch();
+  const pageIndex = search.page ? search.page - 1 : 0;
+  const pageSize = search.pageSize ? search.pageSize : defaultPageSize;
+
+  const [{ data: repository }, { data: secrets }] = useSuspenseQueries({
+    queries: [
+      {
+        queryKey: [useRepositoriesServiceGetRepositoryByIdKey, params.repoId],
+        queryFn: async () =>
+          await RepositoriesService.getRepositoryById({
+            repositoryId: Number.parseInt(params.repoId),
+          }),
+      },
+      {
+        queryKey: [
+          useSecretsServiceGetSecretsByRepositoryId,
+          params.repoId,
+          pageIndex,
+          pageSize,
+        ],
+        queryFn: async () =>
+          await SecretsService.getSecretsByRepositoryId({
+            repositoryId: Number.parseInt(params.repoId),
+            limit: pageSize,
+            offset: pageIndex * pageSize,
+          }),
+      },
+    ],
+  });
+
+  // Only show secrets which are encoded as default properties
+  const tableData = secrets?.data.filter((secret) => isDefault(secret.name));
+
+  const table = useReactTable({
+    data: tableData || [],
+    columns,
+    pageCount: Math.ceil(secrets.pagination.totalCount / pageSize),
+    state: {
+      pagination: {
+        pageIndex,
+        pageSize,
+      },
+    },
+    getCoreRowModel: getCoreRowModel(),
+    manualPagination: true,
+  });
+
+  return (
+    <TooltipProvider>
+      <Card className='mx-auto w-full max-w-4xl'>
+        <CardHeader>
+          <CardTitle>Default Run Properties</CardTitle>
+          <CardDescription>
+            Manage default run properties for {repository.url}
+          </CardDescription>
+          <div className='py-2'>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button asChild size='sm' className='ml-auto gap-1'>
+                  <Link
+                    to='/organizations/$orgId/products/$productId/repositories/$repoId/defaults/create-default'
+                    params={{
+                      orgId: params.orgId,
+                      productId: params.productId,
+                      repoId: params.repoId,
+                    }}
+                  >
+                    New default property
+                    <PlusIcon className='h-4 w-4' />
+                  </Link>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                Create a new default run property for this repository
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        </CardHeader>
+        <CardContent>
+          <DataTable table={table} />
+        </CardContent>
+      </Card>
+    </TooltipProvider>
+  );
+};
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/defaults/'
+)({
+  validateSearch: paginationSchema,
+  loaderDeps: ({ search: { page, pageSize } }) => ({ page, pageSize }),
+  loader: async ({ context, params, deps: { page, pageSize } }) => {
+    await Promise.allSettled([
+      context.queryClient.ensureQueryData({
+        queryKey: [
+          useRepositoriesServiceGetRepositoryByIdKey,
+          params.orgId,
+          params.productId,
+          params.repoId,
+        ],
+        queryFn: () =>
+          RepositoriesService.getRepositoryById({
+            repositoryId: Number.parseInt(params.repoId),
+          }),
+      }),
+      context.queryClient.ensureQueryData({
+        queryKey: [
+          useSecretsServiceGetSecretsByRepositoryId,
+          params.orgId,
+          params.productId,
+          params.repoId,
+          page,
+          pageSize,
+        ],
+        queryFn: () =>
+          SecretsService.getSecretsByRepositoryId({
+            repositoryId: Number.parseInt(params.repoId),
+            limit: pageSize || defaultPageSize,
+            offset: page ? (page - 1) * (pageSize || defaultPageSize) : 0,
+          }),
+      }),
+    ]);
+  },
+  component: RepositoryDefaults,
+  pendingComponent: LoadingIndicator,
+});

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/defaults/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/defaults/index.tsx
@@ -89,7 +89,7 @@ const ActionCell = ({ row }: CellContext<Secret, unknown>) => {
         setOpenDelDialog(false);
         toast({
           title: 'Delete Default',
-          description: `Default value "${decodePropertyPath(row.original.name).property}" deleted successfully.`,
+          description: `Default value "${decodePropertyPath(row.original.name)}" deleted successfully.`,
         });
         queryClient.invalidateQueries({
           queryKey: [useSecretsServiceGetSecretsByRepositoryId],
@@ -131,7 +131,7 @@ const ActionCell = ({ row }: CellContext<Secret, unknown>) => {
         setOpen={setOpenDelDialog}
         item={{
           descriptor: 'default run property',
-          name: decodePropertyPath(row.original.name).property,
+          name: decodePropertyPath(row.original.name),
         }}
         onDelete={() =>
           delSecret({
@@ -150,17 +150,11 @@ const columns: ColumnDef<Secret>[] = [
     accessorKey: 'name',
     header: 'Run property',
     // Do not show the property encoding prefix in the table
-    cell: ({ row }) => decodePropertyPath(row.original.name).property,
+    cell: ({ row }) => decodePropertyPath(row.original.name),
   },
   {
     accessorKey: 'description',
     header: 'Value',
-  },
-  {
-    accessorKey: 'locked',
-    header: 'Locked?',
-    cell: ({ row }) =>
-      decodePropertyPath(row.original.name).locked ? 'Yes' : 'No',
   },
   {
     id: 'actions',

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/defaults/route.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/defaults/route.tsx
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/defaults'
+)({
+  component: () => <Outlet />,
+  beforeLoad: ({ context, params }) => {
+    if (
+      !context.auth.hasRole([
+        'superuser',
+        `permission_organization_${params.repoId}_write_secrets`,
+      ])
+    ) {
+      throw redirect({
+        to: '/403',
+      });
+    }
+  },
+});

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/route.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/route.tsx
@@ -35,6 +35,14 @@ const Layout = () => {
       to: '/organizations/$orgId/products/$productId/repositories/$repoId',
     },
     {
+      title: 'Default Run Properties',
+      to: '/organizations/$orgId/products/$productId/repositories/$repoId/defaults',
+      visible: user.hasRole([
+        'superuser',
+        `permission_organization_${repoId}_write_secrets`,
+      ]),
+    },
+    {
       title: 'Secrets',
       to: '/organizations/$orgId//products/$productId/repositories/$repoId/secrets',
       visible: user.hasRole([

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/route.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/route.tsx
@@ -35,6 +35,14 @@ const Layout = () => {
       to: '/organizations/$orgId/products/$productId',
     },
     {
+      title: 'Default Run Properties',
+      to: '/organizations/$orgId/products/$productId/defaults',
+      visible: user.hasRole([
+        'superuser',
+        `permission_organization_${productId}_write_secrets`,
+      ]),
+    },
+    {
       title: 'Secrets',
       to: '/organizations/$orgId//products/$productId/secrets',
       visible: user.hasRole([

--- a/ui/src/routes/_layout/organizations/$orgId/route.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/route.tsx
@@ -35,6 +35,14 @@ const Layout = () => {
       to: '/organizations/$orgId',
     },
     {
+      title: 'Default Run Properties',
+      to: '/organizations/$orgId/defaults',
+      visible: user.hasRole([
+        'superuser',
+        `permission_organization_${orgId}_write_secrets`,
+      ]),
+    },
+    {
       title: 'Secrets',
       to: '/organizations/$orgId/secrets',
       visible: user.hasRole([

--- a/ui/src/schemas/index.ts
+++ b/ui/src/schemas/index.ts
@@ -24,3 +24,68 @@ export const paginationSchema = z.object({
   page: z.number().optional(),
   pageSize: z.number().optional(),
 });
+
+const keyValueSchema = z.object({
+  key: z.string().min(1),
+  value: z.string(), // Allow empty values for now
+});
+
+export const formSchema = z.object({
+  revision: z.string(),
+  path: z.string(),
+  jobConfigs: z.object({
+    analyzer: z.object({
+      enabled: z.boolean(),
+      allowDynamicVersions: z.boolean(),
+      skipExcluded: z.boolean(),
+      enabledPackageManagers: z.array(z.string()),
+    }),
+    advisor: z.object({
+      enabled: z.boolean(),
+      skipExcluded: z.boolean(),
+      advisors: z.array(z.string()),
+    }),
+    scanner: z.object({
+      enabled: z.boolean(),
+      skipConcluded: z.boolean(),
+      skipExcluded: z.boolean(),
+    }),
+    evaluator: z.object({
+      enabled: z.boolean(),
+      ruleSet: z.string().optional(),
+      licenseClassificationsFile: z.string().optional(),
+      copyrightGarbageFile: z.string().optional(),
+      resolutionsFile: z.string().optional(),
+    }),
+    reporter: z.object({
+      enabled: z.boolean(),
+      formats: z.array(z.string()),
+    }),
+    notifier: z.object({
+      enabled: z.boolean(),
+      notifierRules: z.string().optional(),
+      resolutionsFile: z.string().optional(),
+      mail: z.object({
+        recipientAddresses: z.array(z.object({ email: z.string() })).optional(),
+        mailServerConfiguration: z.object({
+          hostName: z.string(),
+          port: z.coerce.number().int(),
+          username: z.string(),
+          password: z.string(),
+          useSsl: z.boolean(),
+          fromAddress: z.string(),
+        }),
+      }),
+      jira: z.object({
+        jiraRestClientConfiguration: z.object({
+          serverUrl: z.string(),
+          username: z.string(),
+          password: z.string(),
+        }),
+      }),
+    }),
+    parameters: z.array(keyValueSchema).optional(),
+  }),
+  labels: z.array(keyValueSchema).optional(),
+  jobConfigContext: z.string().optional(),
+});


### PR DESCRIPTION
With #719 and #736 we now have full CRUD support for handling secrets on organization, product and repository levels. This PR adds support for organization, product and repository admins to set up (and possibly enforce) some default values to ORT run creation form.