### PR TITLE
ui: Create page for downloadable reports of ORT Run

### DIFF
--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/route.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/route.tsx
@@ -19,12 +19,23 @@
 
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 
-import { Sidebar } from './runs2/$runIndex/-components/sidebar';
+import { Sidebar } from '@/components/sidebar';
 
 const Layout = () => {
+  const navItems = [
+    {
+      title: 'Overview',
+      to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs2/$runIndex',
+    },
+    {
+      title: 'Reports',
+      to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs2/$runIndex/reports',
+    },
+  ];
+
   return (
     <div className='flex h-[calc(100vh-4rem-2rem)] w-full gap-2 md:h-[calc(100vh-4rem-4rem)]'>
-      <Sidebar />
+      <Sidebar sections={[{ items: navItems }]} />
       <Outlet />
     </div>
   );

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/reports/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/reports/index.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/reports/'
+)({
+  component: () => (
+    <div>
+      Hello
+      /_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/reports/!
+    </div>
+  ),
+});


### PR DESCRIPTION
This PR is for the temporary `.../runs2/...` route, which holds the implementation of the new ORT run details pages. It implements a sub-page, which is used for downloading all reports from the run.

![Capture](https://github.com/user-attachments/assets/67206231-9549-4586-a63d-f0ffc6c5604f)

Please see the individual commits for details.