### PR TITLE
fix(Analyzer): Change the default user and group ID in Docker file

### DIFF
--- a/workers/analyzer/docker/Analyzer.Dockerfile
+++ b/workers/analyzer/docker/Analyzer.Dockerfile
@@ -101,7 +101,7 @@ RUN echo $LANG > /etc/locale.gen \
     && update-locale LANG=$LANG
 
 ARG USERNAME=ort
-ARG USER_ID=1000
+ARG USER_ID=1001
 ARG USER_GID=$USER_ID
 ARG HOMEDIR=/home/ort
 ENV HOME=$HOMEDIR


### PR DESCRIPTION
The Docker build for Analyzer images was failing when it tried to add the non-privileged user and the associated group. The exit code '4' seems to indicate a conflict with an already existing user and group. So, use another user ID to circumvent the conflict.

In our CI the build was failing as well. I could verify that this fix actually solves the problem.