### PR TITLE
Use suspend functions in Transport implementations

### DIFF
--- a/dao/src/testFixtures/kotlin/MockDatabaseModule.kt
+++ b/dao/src/testFixtures/kotlin/MockDatabaseModule.kt
@@ -83,9 +83,10 @@ fun KoinTest.verifyDatabaseModuleIncluded() {
 
 /**
  * Run [block] with a [mocked database module][mockDatabaseModule]. Afterward do cleanup by calling
- * [unmockDatabaseModule].
+ * [unmockDatabaseModule]. Note that this is an *inline* function which makes it possible to invoke *suspend* functions
+ * in [block].
  */
-fun withMockDatabaseModule(block: () -> Unit) {
+inline fun withMockDatabaseModule(block: () -> Unit) {
     mockDatabaseModule()
     try {
         block()

--- a/dao/src/testFixtures/kotlin/MockTransaction.kt
+++ b/dao/src/testFixtures/kotlin/MockTransaction.kt
@@ -63,9 +63,10 @@ fun unmockkTransaction() {
 
 /**
  * Create a static mock for [transaction] that does not actually create a transaction. Can be used to mock database
- * access for functions that call [transaction]. Clears the mock after executing [block].
+ * access for functions that call [transaction]. Clears the mock after executing [block]. Note that this is an
+ * *inline* function which makes it possible to invoke *suspend* functions in [block].
  */
-fun <T> mockkTransaction(block: () -> T): T {
+inline fun <T> mockkTransaction(block: () -> T): T {
     mockkTransaction()
     return try {
         block()

--- a/orchestrator/src/main/kotlin/Entrypoint.kt
+++ b/orchestrator/src/main/kotlin/Entrypoint.kt
@@ -69,7 +69,7 @@ import org.slf4j.LoggerFactory
 
 private val log = LoggerFactory.getLogger("org.eclipse.apoapsis.ortserver.orchestrator.EntrypointKt")
 
-fun main() {
+suspend fun main() {
     log.info("Starting ORT-Server Orchestrator.")
 
     OrchestratorComponent().start()

--- a/orchestrator/src/test/kotlin/OrchestratorEndpointTest.kt
+++ b/orchestrator/src/test/kotlin/OrchestratorEndpointTest.kt
@@ -251,7 +251,7 @@ class OrchestratorEndpointTest : KoinTest, StringSpec() {
      * Run [block] as a test for the Orchestrator endpoint. Start the endpoint with a configuration that selects the
      * testing transport. Then execute the given [block].
      */
-    private fun runEndpointTest(block: () -> Unit) {
+    private suspend fun runEndpointTest(block: suspend () -> Unit) {
         withMockDatabaseModule {
             val environment = mapOf(
                 "ORCHESTRATOR_RECEIVER_TRANSPORT_TYPE" to TEST_TRANSPORT_NAME,

--- a/transport/activemqartemis/src/main/kotlin/ArtemisMessageReceiverFactory.kt
+++ b/transport/activemqartemis/src/main/kotlin/ArtemisMessageReceiverFactory.kt
@@ -54,7 +54,7 @@ class ArtemisMessageReceiverFactory : MessageReceiverFactory {
 
     override val name = ArtemisConfig.TRANSPORT_NAME
 
-    override fun <T : Any> createReceiver(
+    override suspend fun <T : Any> createReceiver(
         from: Endpoint<T>,
         configManager: ConfigManager,
         handler: EndpointHandler<T>

--- a/transport/kubernetes/src/main/kotlin/KubernetesMessageReceiverFactory.kt
+++ b/transport/kubernetes/src/main/kotlin/KubernetesMessageReceiverFactory.kt
@@ -49,7 +49,7 @@ class KubernetesMessageReceiverFactory : MessageReceiverFactory {
 
     override val name = KubernetesSenderConfig.TRANSPORT_NAME
 
-    override fun <T : Any> createReceiver(
+    override suspend fun <T : Any> createReceiver(
         from: Endpoint<T>,
         configManager: ConfigManager,
         handler: EndpointHandler<T>

--- a/transport/rabbitmq/build.gradle.kts
+++ b/transport/rabbitmq/build.gradle.kts
@@ -27,6 +27,7 @@ group = "org.eclipse.apoapsis.ortserver.transport"
 dependencies {
     implementation(projects.transport.transportSpi)
 
+    implementation(libs.kotlinxCoroutines)
     implementation(libs.rabbitMqAmqpClient)
 
     runtimeOnly(libs.logback)

--- a/transport/rabbitmq/src/main/kotlin/RabbitMqMessageReceiverFactory.kt
+++ b/transport/rabbitmq/src/main/kotlin/RabbitMqMessageReceiverFactory.kt
@@ -29,6 +29,8 @@ import com.rabbitmq.client.Envelope
 
 import java.util.concurrent.CountDownLatch
 
+import kotlinx.coroutines.runBlocking
+
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.transport.Endpoint
 import org.eclipse.apoapsis.ortserver.transport.EndpointHandler
@@ -47,7 +49,7 @@ class RabbitMqMessageReceiverFactory : MessageReceiverFactory {
 
     override val name = RabbitMqConfig.TRANSPORT_NAME
 
-    override fun <T : Any> createReceiver(
+    override suspend fun <T : Any> createReceiver(
         from: Endpoint<T>,
         configManager: ConfigManager,
         handler: EndpointHandler<T>
@@ -122,7 +124,8 @@ class RabbitMqMessageReceiverFactory : MessageReceiverFactory {
                         )
                     }
 
-                    handler(message)
+                    // TODO: Find a better alternative to runBlocking().
+                    runBlocking { handler(message) }
                 }.onFailure {
                     logger.error("Error during message processing.", it)
                 }

--- a/transport/spi/src/main/kotlin/EndpointComponent.kt
+++ b/transport/spi/src/main/kotlin/EndpointComponent.kt
@@ -60,7 +60,7 @@ abstract class EndpointComponent<T : Any>(
      * Start this endpoint and perform necessary initialization, so that incoming messages can be received and
      * processed.
      */
-    fun start() {
+    suspend fun start() {
         startKoin {
             modules(baseModule())
             modules(customModules())

--- a/transport/spi/src/main/kotlin/MessageReceiverFactory.kt
+++ b/transport/spi/src/main/kotlin/MessageReceiverFactory.kt
@@ -29,7 +29,7 @@ import org.slf4j.LoggerFactory
 /**
  * Definition of a message handler function of an endpoint. The function is passed the message it should handle.
  */
-typealias EndpointHandler<T> = (Message<T>) -> Unit
+typealias EndpointHandler<T> = suspend (Message<T>) -> Unit
 
 /**
  * Factory interface for setting up a receiver for an [Endpoint].
@@ -68,7 +68,11 @@ interface MessageReceiverFactory {
          * based on the provided [configManager]. The concrete implementation of the [MessageSenderFactory] is
          * determined from the [CONFIG_PREFIX].[TYPE_PROPERTY] configuration using the Java Service Loader mechanism.
          */
-        fun <T : Any> createReceiver(from: Endpoint<T>, configManager: ConfigManager, handler: EndpointHandler<T>) {
+        suspend fun <T : Any> createReceiver(
+            from: Endpoint<T>,
+            configManager: ConfigManager,
+            handler: EndpointHandler<T>
+        ) {
             val receiverConfig = configManager.subConfig(Path("${from.configPrefix}.$CONFIG_PREFIX"))
             val factoryName = receiverConfig.getString(TYPE_PROPERTY)
             log.info("Setting up a MessageReceiver of type '{}' for endpoint '{}'.", factoryName, from.configPrefix)
@@ -92,5 +96,5 @@ interface MessageReceiverFactory {
      * [handler] function with the received messages. Use [configManager] as source of configuration settings for this
      * infrastructure.
      */
-    fun <T : Any> createReceiver(from: Endpoint<T>, configManager: ConfigManager, handler: EndpointHandler<T>)
+    suspend fun <T : Any> createReceiver(from: Endpoint<T>, configManager: ConfigManager, handler: EndpointHandler<T>)
 }

--- a/transport/spi/src/testFixtures/kotlin/TransportForTesting.kt
+++ b/transport/spi/src/testFixtures/kotlin/TransportForTesting.kt
@@ -136,7 +136,7 @@ class MessageReceiverFactoryForTesting : MessageReceiverFactory {
          * Invoke the recorded [EndpointHandler] for the given [endpoint] with the given [message]. Fail if no handler
          * or a handler to a different endpoint was registered.
          */
-        fun <T : Any> receive(endpoint: Endpoint<T>, message: Message<T>) {
+        suspend fun <T : Any> receive(endpoint: Endpoint<T>, message: Message<T>) {
             createdEndpoint shouldBe endpoint
 
             @Suppress("UNCHECKED_CAST")
@@ -147,7 +147,7 @@ class MessageReceiverFactoryForTesting : MessageReceiverFactory {
 
     override val name: String = TEST_TRANSPORT_NAME
 
-    override fun <T : Any> createReceiver(
+    override suspend fun <T : Any> createReceiver(
         from: Endpoint<T>,
         configManager: ConfigManager,
         handler: EndpointHandler<T>

--- a/transport/spi/src/testFixtures/kotlin/Utils.kt
+++ b/transport/spi/src/testFixtures/kotlin/Utils.kt
@@ -28,6 +28,8 @@ import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 
+import kotlinx.coroutines.runBlocking
+
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.model.orchestrator.OrchestratorMessage
 import org.eclipse.apoapsis.ortserver.transport.Message
@@ -69,7 +71,9 @@ fun startReceiver(configManager: ConfigManager): LinkedBlockingQueue<Message<Orc
     }
 
     Thread {
-        MessageReceiverFactory.createReceiver(OrchestratorEndpoint, configManager, ::handler)
+        runBlocking {
+            MessageReceiverFactory.createReceiver(OrchestratorEndpoint, configManager, ::handler)
+        }
     }.start()
 
     return queue

--- a/transport/sqs/src/main/kotlin/SqsMessageReceiverFactory.kt
+++ b/transport/sqs/src/main/kotlin/SqsMessageReceiverFactory.kt
@@ -23,8 +23,9 @@ import aws.sdk.kotlin.services.sqs.model.DeleteMessageRequest
 import aws.sdk.kotlin.services.sqs.model.GetQueueUrlRequest
 import aws.sdk.kotlin.services.sqs.model.ReceiveMessageRequest
 
+import kotlin.coroutines.coroutineContext
+
 import kotlinx.coroutines.isActive
-import kotlinx.coroutines.runBlocking
 
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.transport.Endpoint
@@ -52,7 +53,7 @@ class SqsMessageReceiverFactory : MessageReceiverFactory {
         from: Endpoint<T>,
         configManager: ConfigManager,
         handler: EndpointHandler<T>
-    ) = runBlocking {
+    ) {
         logger.info("Creating SQS receiver for endpoint '${from.configPrefix}'.")
 
         val serializer = JsonSerializer.forClass(from.messageClass)
@@ -79,7 +80,7 @@ class SqsMessageReceiverFactory : MessageReceiverFactory {
             waitTimeSeconds = 20
         }
 
-        while (isActive) {
+        while (coroutineContext.isActive) {
             val receiveResponse = client.receiveMessage(receiveRequest)
 
             receiveResponse.messages?.forEach { sqsMessage ->

--- a/transport/sqs/src/main/kotlin/SqsMessageReceiverFactory.kt
+++ b/transport/sqs/src/main/kotlin/SqsMessageReceiverFactory.kt
@@ -48,7 +48,7 @@ internal val messageAttributeNames = listOf(TRACE_PROPERTY, RUN_ID_PROPERTY)
 class SqsMessageReceiverFactory : MessageReceiverFactory {
     override val name: String = SqsConfig.TRANSPORT_NAME
 
-    override fun <T : Any> createReceiver(
+    override suspend fun <T : Any> createReceiver(
         from: Endpoint<T>,
         configManager: ConfigManager,
         handler: EndpointHandler<T>

--- a/workers/advisor/src/main/kotlin/advisor/Entrypoint.kt
+++ b/workers/advisor/src/main/kotlin/advisor/Entrypoint.kt
@@ -29,7 +29,7 @@ private val logger = LoggerFactory.getLogger(AdvisorComponent::class.java)
  * This is the entry point of the Advisor worker. It calls the Advisor from ORT programmatically by
  * interfacing on its APIs.
  */
-fun main() {
+suspend fun main() {
     logger.info("Starting ORT-Server Advisor endpoint.")
 
     enableOrtStackTraces()

--- a/workers/advisor/src/test/kotlin/AdvisorEndpointTest.kt
+++ b/workers/advisor/src/test/kotlin/AdvisorEndpointTest.kt
@@ -102,13 +102,13 @@ class AdvisorEndpointTest : KoinTest, StringSpec() {
                 declareMock<AdvisorWorker> {
                     every { run(ADVISOR_JOB_ID, TRACE_ID) } returns
                             RunResult.Failed(IllegalStateException("Test exception"))
-
-                    sendAdvisorRequest()
-
-                    val resultMessage = MessageSenderFactoryForTesting.expectMessage(OrchestratorEndpoint)
-                    resultMessage.header shouldBe messageHeader
-                    resultMessage.payload shouldBe AdvisorWorkerError(ADVISOR_JOB_ID)
                 }
+
+                sendAdvisorRequest()
+
+                val resultMessage = MessageSenderFactoryForTesting.expectMessage(OrchestratorEndpoint)
+                resultMessage.header shouldBe messageHeader
+                resultMessage.payload shouldBe AdvisorWorkerError(ADVISOR_JOB_ID)
             }
         }
 
@@ -128,7 +128,7 @@ class AdvisorEndpointTest : KoinTest, StringSpec() {
     /**
      * Simulate an incoming request to advice a project.
      */
-    private fun sendAdvisorRequest() {
+    private suspend fun sendAdvisorRequest() {
         mockkTransaction {
             val message = Message(messageHeader, advisorRequest)
             MessageReceiverFactoryForTesting.receive(AdvisorEndpoint, message)
@@ -139,7 +139,7 @@ class AdvisorEndpointTest : KoinTest, StringSpec() {
      * Run [block] as a test for the Analyzer endpoint. Start the endpoint with a configuration that selects the
      * testing transport. Then execute the given [block].
      */
-    private fun runEndpointTest(block: () -> Unit) {
+    private suspend fun runEndpointTest(block: suspend () -> Unit) {
         withMockDatabaseModule {
             val environment = mapOf(
                 "ADVISOR_RECEIVER_TRANSPORT_TYPE" to TEST_TRANSPORT_NAME,

--- a/workers/analyzer/src/main/kotlin/analyzer/Entrypoint.kt
+++ b/workers/analyzer/src/main/kotlin/analyzer/Entrypoint.kt
@@ -29,7 +29,7 @@ private val logger = LoggerFactory.getLogger(AnalyzerComponent::class.java)
  * This is the entry point of the Analyzer worker. It calls the Analyzer from ORT programmatically by
  * interfacing on its APIs.
  */
-fun main() {
+suspend fun main() {
     logger.info("Starting ORT-Server Analyzer endpoint.")
 
     enableOrtStackTraces()

--- a/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
@@ -21,7 +21,6 @@ package org.eclipse.apoapsis.ortserver.workers.analyzer
 
 import com.typesafe.config.Config
 
-import io.kotest.common.runBlocking
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
@@ -253,7 +252,7 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
     /**
      * Simulate an incoming request to analyze a project.
      */
-    private fun sendAnalyzerRequest() {
+    private suspend fun sendAnalyzerRequest() {
         mockkTransaction {
             val message = Message(messageHeader, analyzerRequest)
             MessageReceiverFactoryForTesting.receive(AnalyzerEndpoint, message)
@@ -264,7 +263,7 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
      * Run [block] as a test for the Analyzer endpoint. Start the endpoint with a configuration that selects the
      * testing transport. Then execute the given [block].
      */
-    private fun runEndpointTest(block: () -> Unit) {
+    private suspend fun runEndpointTest(block: suspend () -> Unit) {
         withMockDatabaseModule {
             val environment = mapOf(
                 "ANALYZER_RECEIVER_TRANSPORT_TYPE" to TEST_TRANSPORT_NAME,
@@ -288,7 +287,7 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
      * should create the configuration files declared for the environment. The specified [test][block] can then
      * check whether these files have been created correctly.
      */
-    private fun runEnvironmentTest(block: (File) -> Unit) {
+    private suspend fun runEnvironmentTest(block: (File) -> Unit) {
         runEndpointTest {
             val organization = Organization(20230627065854L, "Test organization")
             val product = Product(20230627065917L, organization.id, "Test product")
@@ -351,10 +350,8 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
 
             val environmentService by inject<EnvironmentService>()
 
-            runBlocking {
-                withSystemProperties(properties, mode = OverrideMode.SetOrOverride) {
-                    environmentService.setUpEnvironment(context, repositoryFolder, null)
-                }
+            withSystemProperties(properties, mode = OverrideMode.SetOrOverride) {
+                environmentService.setUpEnvironment(context, repositoryFolder, null)
             }
 
             block(homeFolder)

--- a/workers/config/src/main/kotlin/Entrypoint.kt
+++ b/workers/config/src/main/kotlin/Entrypoint.kt
@@ -28,7 +28,7 @@ private val logger = LoggerFactory.getLogger(ConfigComponent::class.java)
  * The worker checks and transforms the configuration/parameters passed to the current ORT run using a validation
  * script.
  */
-fun main() {
+suspend fun main() {
     logger.info("Starting ORT Server Config endpoint.")
 
     ConfigComponent().start()

--- a/workers/config/src/test/kotlin/EndpointTest.kt
+++ b/workers/config/src/test/kotlin/EndpointTest.kt
@@ -103,7 +103,7 @@ class EndpointTest : KoinTest, StringSpec() {
     /**
      * Simulate an incoming request to check the configuration of an ORT run.
      */
-    private fun sendConfigRequest() {
+    private suspend fun sendConfigRequest() {
         mockkTransaction {
             val message = Message(messageHeader, configRequest)
             MessageReceiverFactoryForTesting.receive(ConfigEndpoint, message)
@@ -114,7 +114,7 @@ class EndpointTest : KoinTest, StringSpec() {
      * Run [block] as a test for the Analyzer endpoint. Start the endpoint with a configuration that selects the
      * testing transport. Then execute the given [block].
      */
-    private fun runEndpointTest(block: () -> Unit) {
+    private suspend fun runEndpointTest(block: suspend () -> Unit) {
         withMockDatabaseModule {
             val environment = mapOf(
                 "CONFIG_RECEIVER_TRANSPORT_TYPE" to TEST_TRANSPORT_NAME,

--- a/workers/evaluator/src/main/kotlin/evaluator/Entrypoint.kt
+++ b/workers/evaluator/src/main/kotlin/evaluator/Entrypoint.kt
@@ -29,7 +29,7 @@ private val logger = LoggerFactory.getLogger(EvaluatorComponent::class.java)
  * This is the entry point of the Evaluator worker. It calls the Evaluator from ORT programmatically by
  * interfacing on its APIs.
  */
-fun main() {
+suspend fun main() {
     logger.info("Starting ORT-Server Evaluator endpoint.")
 
     enableOrtStackTraces()

--- a/workers/evaluator/src/test/kotlin/EvaluatorEndpointTest.kt
+++ b/workers/evaluator/src/test/kotlin/EvaluatorEndpointTest.kt
@@ -125,7 +125,7 @@ class EvaluatorEndpointTest : KoinTest, StringSpec() {
     /**
      * Simulate an incoming request to evaluate a project.
      */
-    private fun sendEvaluatorRequest() {
+    private suspend fun sendEvaluatorRequest() {
         mockkTransaction {
             val message = Message(messageHeader, evaluatorRequest)
             MessageReceiverFactoryForTesting.receive(EvaluatorEndpoint, message)
@@ -136,7 +136,7 @@ class EvaluatorEndpointTest : KoinTest, StringSpec() {
      * Run [block] as a test for the Evaluator endpoint. Start the endpoint with a configuration that selects the
      * testing transport. Then execute the given [block].
      */
-    private fun runEndpointTest(block: () -> Unit) {
+    private suspend fun runEndpointTest(block: suspend () -> Unit) {
         withMockDatabaseModule {
             val environment = mapOf(
                 "EVALUATOR_RECEIVER_TRANSPORT_TYPE" to TEST_TRANSPORT_NAME,

--- a/workers/notifier/src/main/kotlin/notifier/Entrypoint.kt
+++ b/workers/notifier/src/main/kotlin/notifier/Entrypoint.kt
@@ -29,7 +29,7 @@ private val logger = LoggerFactory.getLogger(NotifierComponent::class.java)
  * This is the entry point of the Notifier worker. It calls the Notifier from ORT programmatically by
  * interfacing on its APIs.
  */
-fun main() {
+suspend fun main() {
     logger.info("Starting ORT-Server Notifier endpoint.")
 
     enableOrtStackTraces()

--- a/workers/notifier/src/test/kotlin/NotifierEndpointTest.kt
+++ b/workers/notifier/src/test/kotlin/NotifierEndpointTest.kt
@@ -122,14 +122,14 @@ class NotifierEndpointTest : KoinTest, StringSpec() {
         }
     }
 
-    private fun sendNotifierRequest() {
+    private suspend fun sendNotifierRequest() {
         mockkTransaction {
             val message = Message(messageHeader, notifierRequest)
             MessageReceiverFactoryForTesting.receive(NotifierEndpoint, message)
         }
     }
 
-    private fun runEndpointTest(block: () -> Unit) {
+    private suspend fun runEndpointTest(block: suspend () -> Unit) {
         withMockDatabaseModule {
             val environment = mapOf(
                 "NOTIFIER_RECEIVER_TRANSPORT_TYPE" to TEST_TRANSPORT_NAME,

--- a/workers/reporter/src/main/kotlin/reporter/Entrypoint.kt
+++ b/workers/reporter/src/main/kotlin/reporter/Entrypoint.kt
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory
 
 private val logger = LoggerFactory.getLogger(::main::class.java)
 
-fun main() {
+suspend fun main() {
     logger.info("Starting ORT-Server Reporter endpoint.")
 
     enableOrtStackTraces()

--- a/workers/reporter/src/test/kotlin/reporter/ReporterComponentTest.kt
+++ b/workers/reporter/src/test/kotlin/reporter/ReporterComponentTest.kt
@@ -139,7 +139,7 @@ class ReporterComponentTest : KoinTest, StringSpec() {
     /**
      * Simulate an incoming request to create a project report.
      */
-    private fun sendReporterRequest() {
+    private suspend fun sendReporterRequest() {
         val message = Message(messageHeader, reporterRequest)
         MessageReceiverFactoryForTesting.receive(ReporterEndpoint, message)
     }
@@ -148,7 +148,7 @@ class ReporterComponentTest : KoinTest, StringSpec() {
      * Run [block] as a test for the Reporter endpoint. Start the endpoint with a configuration that selects the
      * testing transport. Then execute the [block].
      */
-    private fun runEndpointTest(block: () -> Unit) {
+    private suspend fun runEndpointTest(block: suspend () -> Unit) {
         withMockDatabaseModule {
             val environment = mapOf(
                 "REPORTER_RECEIVER_TRANSPORT_TYPE" to TEST_TRANSPORT_NAME,

--- a/workers/scanner/src/main/kotlin/scanner/Entrypoint.kt
+++ b/workers/scanner/src/main/kotlin/scanner/Entrypoint.kt
@@ -29,7 +29,7 @@ private val logger = LoggerFactory.getLogger(ScannerComponent::class.java)
  * This is the entry point of the Scanner worker. It calls the Scanner from ORT programmatically by
  * interfacing on its APIs.
  */
-fun main() {
+suspend fun main() {
     logger.info("Starting ORT-Server Scanner endpoint.")
 
     enableOrtStackTraces()

--- a/workers/scanner/src/test/kotlin/ScannerEndpointTest.kt
+++ b/workers/scanner/src/test/kotlin/ScannerEndpointTest.kt
@@ -127,7 +127,7 @@ class ScannerEndpointTest : KoinTest, StringSpec() {
     /**
      * Simulate an incoming request to scan a project.
      */
-    private fun sendScannerRequest() {
+    private suspend fun sendScannerRequest() {
         mockkTransaction {
             val message = Message(messageHeader, scannerRequest)
             MessageReceiverFactoryForTesting.receive(ScannerEndpoint, message)
@@ -138,7 +138,7 @@ class ScannerEndpointTest : KoinTest, StringSpec() {
      * Run [block] as a test for the Scanner endpoint. Start the endpoint with a configuration that selects the
      * testing transport. Then execute the given [block].
      */
-    private fun runEndpointTest(block: () -> Unit) {
+    private suspend fun runEndpointTest(block: suspend () -> Unit) {
         withMockDatabaseModule {
             val environment = mapOf(
                 "SCANNER_RECEIVER_TRANSPORT_TYPE" to TEST_TRANSPORT_NAME,


### PR DESCRIPTION
Change the entry points into ORT Server components to use suspend functions, so that further usage of coroutines does not require additional effort.