### PR TITLE
deps: Downgrade Vite to 5.3.5

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -70,7 +70,7 @@
     "tailwindcss": "^3.4.1",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.2.2",
-    "vite": "^5.1.6",
+    "vite": "5.3.5",
     "vitest": "^2.0.2"
   }
 }

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -116,7 +116,7 @@ importers:
         version: 1.47.0
       '@tanstack/router-vite-plugin':
         specifier: ^1.32.17
-        version: 1.47.0(vite@5.4.0(@types/node@20.14.15))
+        version: 1.47.0(vite@5.3.5(@types/node@20.14.15))
       '@types/node':
         specifier: ^20.11.30
         version: 20.14.15
@@ -134,7 +134,7 @@ importers:
         version: 7.18.0(eslint@8.57.0)(typescript@5.5.4)
       '@vitejs/plugin-react':
         specifier: ^4.2.1
-        version: 4.3.1(vite@5.4.0(@types/node@20.14.15))
+        version: 4.3.1(vite@5.3.5(@types/node@20.14.15))
       autoprefixer:
         specifier: ^10.4.19
         version: 10.4.20(postcss@8.4.41)
@@ -166,8 +166,8 @@ importers:
         specifier: ^5.2.2
         version: 5.5.4
       vite:
-        specifier: ^5.1.6
-        version: 5.4.0(@types/node@20.14.15)
+        specifier: 5.3.5
+        version: 5.3.5(@types/node@20.14.15)
       vitest:
         specifier: ^2.0.2
         version: 2.0.5(@types/node@20.14.15)
@@ -2832,8 +2832,8 @@ packages:
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
 
-  vite@5.4.0:
-    resolution: {integrity: sha512-5xokfMX0PIiwCMCMb9ZJcMyh5wbBun0zUzKib+L65vAZ8GY9ePZMXxFrHbr/Kyll2+LSCY7xtERPpxkBDKngwg==}
+  vite@5.3.5:
+    resolution: {integrity: sha512-MdjglKR6AQXQb9JGiS7Rc2wC6uMjcm7Go/NHNO63EwiJXfuk9PgqiP/n5IDJCziMkfw9n4Ubp7lttNwz+8ZVKA==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
     peerDependencies:
@@ -2841,7 +2841,6 @@ packages:
       less: '*'
       lightningcss: ^1.21.0
       sass: '*'
-      sass-embedded: '*'
       stylus: '*'
       sugarss: '*'
       terser: ^5.4.0
@@ -2853,8 +2852,6 @@ packages:
       lightningcss:
         optional: true
       sass:
-        optional: true
-      sass-embedded:
         optional: true
       stylus:
         optional: true
@@ -4206,7 +4203,7 @@ snapshots:
       prettier: 3.3.3
       zod: 3.23.8
 
-  '@tanstack/router-plugin@1.47.0(vite@5.4.0(@types/node@20.14.15))':
+  '@tanstack/router-plugin@1.47.0(vite@5.3.5(@types/node@20.14.15))':
     dependencies:
       '@babel/core': 7.25.2
       '@babel/generator': 7.25.0
@@ -4226,13 +4223,13 @@ snapshots:
       unplugin: 1.12.1
       zod: 3.23.8
     optionalDependencies:
-      vite: 5.4.0(@types/node@20.14.15)
+      vite: 5.3.5(@types/node@20.14.15)
     transitivePeerDependencies:
       - supports-color
 
-  '@tanstack/router-vite-plugin@1.47.0(vite@5.4.0(@types/node@20.14.15))':
+  '@tanstack/router-vite-plugin@1.47.0(vite@5.3.5(@types/node@20.14.15))':
     dependencies:
-      '@tanstack/router-plugin': 1.47.0(vite@5.4.0(@types/node@20.14.15))
+      '@tanstack/router-plugin': 1.47.0(vite@5.3.5(@types/node@20.14.15))
     transitivePeerDependencies:
       - '@rsbuild/core'
       - supports-color
@@ -4373,14 +4370,14 @@ snapshots:
 
   '@ungap/structured-clone@1.2.0': {}
 
-  '@vitejs/plugin-react@4.3.1(vite@5.4.0(@types/node@20.14.15))':
+  '@vitejs/plugin-react@4.3.1(vite@5.3.5(@types/node@20.14.15))':
     dependencies:
       '@babel/core': 7.24.7
       '@babel/plugin-transform-react-jsx-self': 7.24.7(@babel/core@7.24.7)
       '@babel/plugin-transform-react-jsx-source': 7.24.7(@babel/core@7.24.7)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.2
-      vite: 5.4.0(@types/node@20.14.15)
+      vite: 5.3.5(@types/node@20.14.15)
     transitivePeerDependencies:
       - supports-color
 
@@ -5601,19 +5598,18 @@ snapshots:
       debug: 4.3.6
       pathe: 1.1.2
       tinyrainbow: 1.2.0
-      vite: 5.4.0(@types/node@20.14.15)
+      vite: 5.3.5(@types/node@20.14.15)
     transitivePeerDependencies:
       - '@types/node'
       - less
       - lightningcss
       - sass
-      - sass-embedded
       - stylus
       - sugarss
       - supports-color
       - terser
 
-  vite@5.4.0(@types/node@20.14.15):
+  vite@5.3.5(@types/node@20.14.15):
     dependencies:
       esbuild: 0.21.5
       postcss: 8.4.41
@@ -5640,7 +5636,7 @@ snapshots:
       tinybench: 2.8.0
       tinypool: 1.0.0
       tinyrainbow: 1.2.0
-      vite: 5.4.0(@types/node@20.14.15)
+      vite: 5.3.5(@types/node@20.14.15)
       vite-node: 2.0.5(@types/node@20.14.15)
       why-is-node-running: 2.3.0
     optionalDependencies:
@@ -5649,7 +5645,6 @@ snapshots:
       - less
       - lightningcss
       - sass
-      - sass-embedded
       - stylus
       - sugarss
       - supports-color


### PR DESCRIPTION
With Vite 5.4.0 the `VITE_` configuration variables do not appear anymore in the built JS file. For example, instead of:

    Pe.BASE=nd.VITE_API_URL||"http://localhost:8080";

the output file now contains only:

    Pe.BASE="http://localhost:8080";

This breaks the entrypoint script for the UI Docker image which makes it impossible to use the image with other than the default values.

Downgrade Vite to 5.3.5 until a proper solution is found.