### PR TITLE
Job Monitor: Detect and delete jobs that exceed a timeout

### DIFF
--- a/transport/kubernetes-jobmonitor/src/main/kotlin/JobHandler.kt
+++ b/transport/kubernetes-jobmonitor/src/main/kotlin/JobHandler.kt
@@ -91,6 +91,13 @@ internal class JobHandler(
                     status?.conditions.orEmpty().any { it.type in COMPLETED_CONDITIONS }
 
         /**
+         * Return a flag whether this job has run into a timeout according to the given [threshold]. This means that
+         * the job was started before the given date and is not yet completed.
+         */
+        fun V1Job.isTimeout(threshold: OffsetDateTime): Boolean =
+            !isCompleted() && status?.startTime?.isBefore(threshold) == true
+
+        /**
          * Obtain the ID of the ORT run from this job from the label used for this purpose. If the label is not set,
          * return *null*.
          */

--- a/transport/kubernetes-jobmonitor/src/main/kotlin/JobHandler.kt
+++ b/transport/kubernetes-jobmonitor/src/main/kotlin/JobHandler.kt
@@ -176,7 +176,7 @@ internal class JobHandler(
     /**
      * Delete the job with the given [jobName]. Log occurring exceptions, but ignore them otherwise.
      */
-    private fun deleteJob(jobName: String) {
+    fun deleteJob(jobName: String) {
         runCatching {
             jobApi.deleteNamespacedJob(jobName, config.namespace, null, null, null, null, null, null)
         }.onFailure { e ->

--- a/transport/kubernetes-jobmonitor/src/main/kotlin/JobWatchHelper.kt
+++ b/transport/kubernetes-jobmonitor/src/main/kotlin/JobWatchHelper.kt
@@ -55,12 +55,12 @@ internal class JobWatchHelper(
         val JOB_TYPE = object : TypeToken<Watch.Response<V1Job>>() {}
 
         /**
-         * Create a new [JobWatchHelper] instance that watches jobs in the given [namespace] using the given
-         * [jobApi]. Watching starts at the provided [resourceVersion] if it is defined. Otherwise, the initial
-         * resource version is obtained by listing the current job state.
+         * Create a new [JobWatchHelper] instance based on the given [config] using the given [jobApi]. Watching starts
+         * at the provided [resourceVersion] if it is defined. Otherwise, the initial resource version is obtained by
+         * listing the current job state.
          */
-        fun create(jobApi: BatchV1Api, namespace: String, resourceVersion: String? = null): JobWatchHelper =
-            JobWatchHelper(jobApi, namespace, resourceVersion)
+        fun create(jobApi: BatchV1Api, config: MonitorConfig, resourceVersion: String? = null): JobWatchHelper =
+            JobWatchHelper(jobApi, config.namespace, resourceVersion)
 
         /**
          * Obtain the current resource version for starting watching on [namespace] by querying the list of current

--- a/transport/kubernetes-jobmonitor/src/main/kotlin/LongRunningJobsFinder.kt
+++ b/transport/kubernetes-jobmonitor/src/main/kotlin/LongRunningJobsFinder.kt
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.transport.kubernetes.jobmonitor
+
+import kotlin.time.Duration
+
+import org.eclipse.apoapsis.ortserver.transport.AdvisorEndpoint
+import org.eclipse.apoapsis.ortserver.transport.AnalyzerEndpoint
+import org.eclipse.apoapsis.ortserver.transport.ConfigEndpoint
+import org.eclipse.apoapsis.ortserver.transport.Endpoint
+import org.eclipse.apoapsis.ortserver.transport.EvaluatorEndpoint
+import org.eclipse.apoapsis.ortserver.transport.NotifierEndpoint
+import org.eclipse.apoapsis.ortserver.transport.ReporterEndpoint
+import org.eclipse.apoapsis.ortserver.transport.ScannerEndpoint
+import org.eclipse.apoapsis.ortserver.transport.kubernetes.jobmonitor.JobHandler.Companion.isTimeout
+
+import org.slf4j.LoggerFactory
+
+/**
+ * A class that periodically checks for jobs that are running longer than a configured timeout.
+ *
+ * The purpose of this class is to detect jobs that hang or encounter other problems that prevent their proper
+ * execution. Such jobs are then terminated. If the [LostJobsFinder] component is active, it will find out that jobs
+ * are missing and notify the Orchestrator to mark the ORT run as failed.
+ *
+ * Since worker jobs of different types typically have different execution times, the timeouts can be configured
+ * separately for each worker type.
+ */
+internal class LongRunningJobsFinder(
+    /** The object to query and manipulate jobs. */
+    private val jobHandler: JobHandler,
+
+    /** The configuration. */
+    private val monitorConfig: MonitorConfig,
+
+    /** The object for time calculations. */
+    private val timeHelper: TimeHelper
+) {
+    companion object {
+        private val logger = LoggerFactory.getLogger(LongRunningJobsFinder::class.java)
+    }
+
+    /**
+     * Schedule an action to periodically check for long-running jobs on the given [scheduler] according to the
+     * configuration.
+     */
+    fun run(scheduler: Scheduler) {
+        scheduler.schedule(monitorConfig.longRunningJobsInterval, this::checkForLongRunningJobs)
+    }
+
+    /**
+     * Perform a check for long-running jobs.
+     */
+    private fun checkForLongRunningJobs() {
+        checkForLongRunningJobsForEndpoint(ConfigEndpoint, monitorConfig.timeoutConfig.configTimeout)
+        checkForLongRunningJobsForEndpoint(AnalyzerEndpoint, monitorConfig.timeoutConfig.analyzerTimeout)
+        checkForLongRunningJobsForEndpoint(AdvisorEndpoint, monitorConfig.timeoutConfig.advisorTimeout)
+        checkForLongRunningJobsForEndpoint(ScannerEndpoint, monitorConfig.timeoutConfig.scannerTimeout)
+        checkForLongRunningJobsForEndpoint(EvaluatorEndpoint, monitorConfig.timeoutConfig.evaluatorTimeout)
+        checkForLongRunningJobsForEndpoint(ReporterEndpoint, monitorConfig.timeoutConfig.reporterTimeout)
+        checkForLongRunningJobsForEndpoint(NotifierEndpoint, monitorConfig.timeoutConfig.notifierTimeout)
+    }
+
+    /**
+     * Check for long-running worker jobs for the given [endpoint] that have reached the given [timeout]. Delete
+     * such jobs.
+     */
+    private fun checkForLongRunningJobsForEndpoint(endpoint: Endpoint<*>, timeout: Duration) {
+        val threshold = timeHelper.before(timeout)
+        logger.info(
+            "Checking for long-running jobs for endpoint '{}' started before {}.",
+            endpoint.configPrefix,
+            threshold
+        )
+
+        jobHandler.findJobsForWorker(endpoint)
+            .filter { it.isTimeout(threshold) }
+            .mapNotNull { it.metadata?.name }
+            .forEach { job ->
+                logger.info("Deleting long-running job '{}'.", job)
+                jobHandler.deleteJob(job)
+            }
+    }
+}

--- a/transport/kubernetes-jobmonitor/src/main/kotlin/LostJobsFinder.kt
+++ b/transport/kubernetes-jobmonitor/src/main/kotlin/LostJobsFinder.kt
@@ -21,8 +21,6 @@ package org.eclipse.apoapsis.ortserver.transport.kubernetes.jobmonitor
 
 import kotlin.time.Duration
 
-import kotlinx.datetime.Clock
-
 import org.eclipse.apoapsis.ortserver.model.repositories.AdvisorJobRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.AnalyzerJobRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.EvaluatorJobRepository
@@ -85,8 +83,8 @@ internal class LostJobsFinder(
     /** The repository for Notifier jobs. */
     notifierJobRepository: NotifierJobRepository,
 
-    /** The clock to determine the current time and the age of jobs. */
-    private val clock: Clock = Clock.System
+    /** The object to determine the current time and the age of jobs. */
+    private val timeHelper: TimeHelper
 ) {
     companion object {
         private val logger = LoggerFactory.getLogger(LostJobsFinder::class.java)
@@ -123,7 +121,7 @@ internal class LostJobsFinder(
      * Perform a check for lost jobs for the given worker [endpoint] using its [jobRepository].
      */
     private fun checkForLostWorkerJobs(endpoint: Endpoint<*>, jobRepository: WorkerJobRepository<*>) {
-        val currentTime = clock.now()
+        val currentTime = timeHelper.now()
 
         val kubeJobs = jobHandler.findJobsForWorker(endpoint).associateBy { it.ortRunId }
 

--- a/transport/kubernetes-jobmonitor/src/main/kotlin/MonitorComponent.kt
+++ b/transport/kubernetes-jobmonitor/src/main/kotlin/MonitorComponent.kt
@@ -29,7 +29,6 @@ import kotlin.time.Duration.Companion.seconds
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
-import kotlinx.datetime.Clock
 
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.dao.databaseModule
@@ -134,7 +133,7 @@ internal class MonitorComponent(
         val namespace = configManager.getString(NAMESPACE_PROPERTY)
 
         return module {
-            single<Clock> { Clock.System }
+            single { TimeHelper() }
             single { configManager }
             single { ClientBuilder.defaultClient() }
             single { BatchV1Api(get()) }
@@ -154,7 +153,7 @@ internal class MonitorComponent(
             single { JobHandler(get(), get(), get(), namespace) }
             single { FailedJobNotifier(get()) }
             singleOf(::JobMonitor)
-            single { Reaper(get(), configManager.getInt(REAPER_INTERVAL_PROPERTY).seconds) }
+            single { Reaper(get(), configManager.getInt(REAPER_INTERVAL_PROPERTY).seconds, get()) }
             single {
                 LostJobsFinder(
                     get(),

--- a/transport/kubernetes-jobmonitor/src/main/kotlin/MonitorComponent.kt
+++ b/transport/kubernetes-jobmonitor/src/main/kotlin/MonitorComponent.kt
@@ -94,6 +94,14 @@ internal class MonitorComponent(
             lostJobsFinder.run(scheduler)
         }
 
+        if (monitorConfig.longRunningJobsEnabled) {
+            logger.info("Starting long-running jobs detection component.")
+
+            val scheduler by inject<Scheduler>()
+            val longRunningJobsFinder by inject<LongRunningJobsFinder>()
+            longRunningJobsFinder.run(scheduler)
+        }
+
         if (monitorConfig.watchingEnabled) {
             logger.info("Starting watcher component.")
 
@@ -130,6 +138,7 @@ internal class MonitorComponent(
             singleOf(::JobMonitor)
             singleOf(::Reaper)
             singleOf(::LostJobsFinder)
+            singleOf(::LongRunningJobsFinder)
         }
     }
 }

--- a/transport/kubernetes-jobmonitor/src/main/kotlin/MonitorConfig.kt
+++ b/transport/kubernetes-jobmonitor/src/main/kotlin/MonitorConfig.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.transport.kubernetes.jobmonitor
+
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+import org.eclipse.apoapsis.ortserver.config.ConfigManager
+import org.eclipse.apoapsis.ortserver.config.Path
+
+/**
+ * A class collecting the configuration options supported by the Kubernetes Job Monitor component.
+ */
+data class MonitorConfig(
+    /** The name of the Kubernetes namespace this component should monitor. */
+    val namespace: String,
+
+    /** The interval in which the Reaper component should run. */
+    val reaperInterval: Duration,
+
+    /**
+     * The maximum age of a job for being deleted by the Reaper. During a Reaper run, it deletes all completed that
+     * are older than this value.
+     */
+    val reaperMaxAge: Duration,
+
+    /** The interval in which the lost jobs detection should run. */
+    val lostJobsInterval: Duration,
+
+    /**
+     * The minimum age of a job in the database to be taken into account by the lost job finder component. This is
+     * needed to prevent certain race conditions with jobs that have just been added to the database, but are not yet
+     * propagated to Kubernetes.
+     */
+    val lostJobsMinAge: Duration,
+
+    /**
+     * A duration that defines an interval in which a job should be considered as recently processed. The job handler
+     * keeps a list of the jobs that have been deleted during this interval to prevent duplicate processing of jobs.
+     */
+    val recentlyProcessedInterval: Duration,
+
+    /** Flag whether the watcher component should be active. */
+    val watchingEnabled: Boolean,
+
+    /** Flag whether the Reaper component should be active. */
+    val reaperEnabled: Boolean,
+
+    /** Flag whether the lost jobs detection component should be active. */
+    val lostJobsEnabled: Boolean
+) {
+    companion object {
+        /** The prefix for all configuration properties. */
+        private const val CONFIG_PREFIX = "jobMonitor"
+
+        /** The configuration property that selects the namespace to watch. */
+        private const val NAMESPACE_PROPERTY = "namespace"
+
+        /** The configuration property defining the interval in which the reaper should run (in seconds). */
+        private const val REAPER_INTERVAL_PROPERTY = "reaperInterval"
+
+        /**
+         * The configuration property defining the maximum age of a completed job (in seconds) to become subject of
+         * the Reaper. The Reaper deletes jobs that are older than this value.
+         */
+        private const val REAPER_MAX_AGE_PROPERTY = "reaperMaxAge"
+
+        /**
+         * The configuration property defining the interval in which the lost jobs detection should run (in seconds).
+         */
+        private const val LOST_JOBS_INTERVAL_PROPERTY = "lostJobsInterval"
+
+        /** The configuration property defining the minimum age of a job (in seconds) to be considered lost. */
+        private const val LOST_JOBS_MIN_AGE_PROPERTY = "lostJobsMinAge"
+
+        /**
+         * The configuration property defining the interval in which a job should be considered as recently processed
+         * (in seconds).
+         */
+        private const val RECENTLY_PROCESSED_INTERVAL_PROPERTY = "recentlyProcessedInterval"
+
+        /** The configuration property to enable or disable the watcher component. */
+        private const val WATCHING_ENABLED_PROPERTY = "enableWatching"
+
+        /** The configuration property to enable or disable the Reaper component. */
+        private const val REAPER_ENABLED_PROPERTY = "enableReaper"
+
+        /** The configuration property to enable or disable the detection of lost jobs. */
+        private const val LOST_JOBS_ENABLED_PROPERTY = "enableLostJobs"
+
+        /**
+         * Create a [MonitorConfig] from the settings stored in the given [configManager].
+         */
+        fun create(configManager: ConfigManager): MonitorConfig {
+            val config = configManager.subConfig(Path(CONFIG_PREFIX))
+
+            return MonitorConfig(
+                namespace = config.getString(NAMESPACE_PROPERTY),
+                reaperInterval = config.getInt(REAPER_INTERVAL_PROPERTY).seconds,
+                reaperMaxAge = config.getInt(REAPER_MAX_AGE_PROPERTY).seconds,
+                lostJobsInterval = config.getInt(LOST_JOBS_INTERVAL_PROPERTY).seconds,
+                lostJobsMinAge = config.getInt(LOST_JOBS_MIN_AGE_PROPERTY).seconds,
+                recentlyProcessedInterval = config.getInt(RECENTLY_PROCESSED_INTERVAL_PROPERTY).seconds,
+                watchingEnabled = config.getBoolean(WATCHING_ENABLED_PROPERTY),
+                reaperEnabled = config.getBoolean(REAPER_ENABLED_PROPERTY),
+                lostJobsEnabled = config.getBoolean(LOST_JOBS_ENABLED_PROPERTY)
+            )
+        }
+    }
+}

--- a/transport/kubernetes-jobmonitor/src/main/kotlin/Reaper.kt
+++ b/transport/kubernetes-jobmonitor/src/main/kotlin/Reaper.kt
@@ -19,8 +19,6 @@
 
 package org.eclipse.apoapsis.ortserver.transport.kubernetes.jobmonitor
 
-import kotlin.time.Duration
-
 import org.slf4j.LoggerFactory
 
 /**
@@ -34,8 +32,8 @@ internal class Reaper(
     /** The object to query and manipulate jobs. */
     private val jobHandler: JobHandler,
 
-    /** The maximum age of a completed job before it gets removed. */
-    private val maxJobAge: Duration,
+    /** The configuration. */
+    private val config: MonitorConfig,
 
     /** The object for time calculations. */
     private val timeHelper: TimeHelper
@@ -45,17 +43,17 @@ internal class Reaper(
     }
 
     /**
-     * Run reaper jobs periodically in the given [interval] using the provided [scheduler].
+     * Run reaper jobs periodically according to the configuration using the provided [scheduler].
      */
-    fun run(scheduler: Scheduler, interval: Duration) {
-        scheduler.schedule(interval) { reap() }
+    fun run(scheduler: Scheduler) {
+        scheduler.schedule(config.reaperInterval) { reap() }
     }
 
     /**
      * Perform a reap run.
      */
     private suspend fun reap() {
-        val time = timeHelper.before(maxJobAge)
+        val time = timeHelper.before(config.reaperMaxAge)
         logger.info("Starting a Reaper run. Processing completed jobs before {}.", time)
 
         val completeJobs = jobHandler.findJobsCompletedBefore(time)

--- a/transport/kubernetes-jobmonitor/src/main/kotlin/Reaper.kt
+++ b/transport/kubernetes-jobmonitor/src/main/kotlin/Reaper.kt
@@ -19,13 +19,7 @@
 
 package org.eclipse.apoapsis.ortserver.transport.kubernetes.jobmonitor
 
-import java.time.Instant
-import java.time.OffsetDateTime
-import java.time.ZoneOffset
-
 import kotlin.time.Duration
-
-import kotlinx.datetime.Clock
 
 import org.slf4j.LoggerFactory
 
@@ -43,11 +37,8 @@ internal class Reaper(
     /** The maximum age of a completed job before it gets removed. */
     private val maxJobAge: Duration,
 
-    /** The clock to determine the current time and the age of jobs. */
-    private val clock: Clock = Clock.System,
-
-    /** The default zone offset for this system. */
-    private val systemZoneOffset: ZoneOffset = OffsetDateTime.now().offset
+    /** The object for time calculations. */
+    private val timeHelper: TimeHelper
 ) {
     companion object {
         private val logger = LoggerFactory.getLogger(Reaper::class.java)
@@ -64,7 +55,7 @@ internal class Reaper(
      * Perform a reap run.
      */
     private suspend fun reap() {
-        val time = Instant.ofEpochSecond(clock.now().minus(maxJobAge).epochSeconds).atOffset(systemZoneOffset)
+        val time = timeHelper.before(maxJobAge)
         logger.info("Starting a Reaper run. Processing completed jobs before {}.", time)
 
         val completeJobs = jobHandler.findJobsCompletedBefore(time)

--- a/transport/kubernetes-jobmonitor/src/main/kotlin/Reaper.kt
+++ b/transport/kubernetes-jobmonitor/src/main/kotlin/Reaper.kt
@@ -25,9 +25,6 @@ import java.time.ZoneOffset
 
 import kotlin.time.Duration
 
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import kotlinx.datetime.Clock
 
 import org.slf4j.LoggerFactory
@@ -75,16 +72,5 @@ internal class Reaper(
         logger.debug("Found {} completed jobs.", completeJobs.size)
 
         completeJobs.forEach { jobHandler.deleteAndNotifyIfFailed(it) }
-    }
-}
-
-/**
- * Return a [Flow] that produces periodic tick events in the given [interval]. This is used as the timer for triggering
- * [Reaper] runs periodically.
- */
-internal fun tickerFlow(interval: Duration): Flow<Unit> = flow {
-    while (true) {
-        delay(interval)
-        emit(Unit)
     }
 }

--- a/transport/kubernetes-jobmonitor/src/main/kotlin/TimeHelper.kt
+++ b/transport/kubernetes-jobmonitor/src/main/kotlin/TimeHelper.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.transport.kubernetes.jobmonitor
+
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+import kotlin.time.Duration
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+/**
+ * An internally used helper class that provides some functionality related to querying the current time and
+ * computing thresholds for filtering jobs based on their age.
+ */
+internal class TimeHelper(
+    /** The clock to determine the current time and the age of jobs. */
+    private val clock: Clock = Clock.System,
+
+    /** The default zone offset for this system. */
+    private val systemZoneOffset: ZoneOffset = OffsetDateTime.now().offset
+) {
+    /**
+     * Return the current time as an [Instant].
+     */
+    fun now(): Instant = clock.now()
+
+    /**
+     * Return a timestamp that lies the given [duration] before the current time as an [OffsetDateTime]. This format
+     * is used by the Kubernetes API; so it can be used directly to compare against the timestamps of jobs.
+     */
+    fun before(duration: Duration): OffsetDateTime =
+        java.time.Instant.ofEpochSecond(clock.now().minus(duration).epochSeconds).atOffset(systemZoneOffset)
+}

--- a/transport/kubernetes-jobmonitor/src/main/resources/application.conf
+++ b/transport/kubernetes-jobmonitor/src/main/resources/application.conf
@@ -30,6 +30,10 @@ jobMonitor {
   enableReaper = ${?MONITOR_REAPER_ENABLED}
   reaperInterval = 600
   reaperInterval = ${?MONITOR_REAPER_INTERVAL}
+  reaperMaxAge = 600
+  reaperMaxAge = ${?MONITOR_REAPER_MAX_AGE}
+  recentlyProcessedInterval = 60
+  recentlyProcessedInterval = ${?MONITOR_RECENTLY_PROCESSED_INTERVAL}
   enableLostJobs = true
   enableLostJobs = ${?MONITOR_LOST_JOBS_ENABLED}
   lostJobsInterval = 120

--- a/transport/kubernetes-jobmonitor/src/main/resources/application.conf
+++ b/transport/kubernetes-jobmonitor/src/main/resources/application.conf
@@ -40,6 +40,26 @@ jobMonitor {
   lostJobsInterval = ${?MONITOR_LOST_JOBS_INTERVAL}
   lostJobsMinAge = 30
   lostJobsMinAge = ${?MONITOR_LOST_JOBS_MIN_AGE}
+  enableLongRunningJobs = true
+  enableLongRunningJobs = ${?MONITOR_LONG_RUNNING_JOBS_ENABLED}
+  longRunningJobsInterval = 600
+  longRunningJobsInterval = ${?MONITOR_LONG_RUNNING_JOBS_INTERVAL}
+  timeouts {
+    config = 1
+    config = ${?MONITOR_TIMEOUT_CONFIG}
+    analyzer = 120
+    analyzer = ${?MONITOR_TIMEOUT_ANALYZER}
+    advisor = 2
+    advisor = ${?MONITOR_TIMEOUT_ADVISOR}
+    scanner = 1440
+    scanner = ${?MONITOR_TIMEOUT_SCANNER}
+    evaluator = 5
+    evaluator = ${?MONITOR_TIMEOUT_EVALUATOR}
+    reporter = 30
+    reporter = ${?MONITOR_TIMEOUT_REPORTER}
+    notifier = 10
+    notifier = ${?MONITOR_TIMEOUT_NOTIFIER}
+  }
 }
 
 database {

--- a/transport/kubernetes-jobmonitor/src/test/kotlin/JobHandlerTest.kt
+++ b/transport/kubernetes-jobmonitor/src/test/kotlin/JobHandlerTest.kt
@@ -552,7 +552,16 @@ private fun createJobHandler(
     notifier: FailedJobNotifier = mockk(),
     recentlyProcessedInterval: Duration = 30.seconds
 ): JobHandler =
-    JobHandler(jobApi, api, notifier, NAMESPACE, recentlyProcessedInterval)
+    JobHandler(jobApi, api, notifier, createMonitorConfig(recentlyProcessedInterval))
+
+/**
+ * Create a [MonitorConfig] with default values and the given [processedInterval].
+ */
+private fun createMonitorConfig(processedInterval: Duration): MonitorConfig =
+    mockk {
+        every { namespace } returns NAMESPACE
+        every { recentlyProcessedInterval } returns processedInterval
+    }
 
 /**
  * Create a [V1Job] with the given [name] and [status].

--- a/transport/kubernetes-jobmonitor/src/test/kotlin/JobWatchHelperTest.kt
+++ b/transport/kubernetes-jobmonitor/src/test/kotlin/JobWatchHelperTest.kt
@@ -57,7 +57,7 @@ class JobWatchHelperTest : StringSpec({
         val watch = createWatchWithEvents(event)
         mockWatchCreation(jobApi, resourceVersion, watch)
 
-        val helper = JobWatchHelper.create(jobApi, NAMESPACE, resourceVersion)
+        val helper = JobWatchHelper.create(jobApi, createConfig(), resourceVersion)
 
         helper.nextEvent() shouldBe event
     }
@@ -70,7 +70,7 @@ class JobWatchHelperTest : StringSpec({
         val watch = createWatchWithEvents(eventIgnored, event)
         mockWatchCreation(jobApi, resourceVersion, watch)
 
-        val helper = JobWatchHelper.create(jobApi, NAMESPACE, resourceVersion)
+        val helper = JobWatchHelper.create(jobApi, createConfig(), resourceVersion)
 
         helper.nextEvent() shouldBe event
     }
@@ -89,7 +89,7 @@ class JobWatchHelperTest : StringSpec({
         mockWatchCreation(jobApi, resourceVersion1, watch1)
         mockWatchCreation(jobApi, resourceVersion2, watch2)
 
-        val helper = JobWatchHelper.create(jobApi, NAMESPACE, resourceVersion1)
+        val helper = JobWatchHelper.create(jobApi, createConfig(), resourceVersion1)
 
         helper.nextEvent() shouldBe event1
         helper.nextEvent() shouldBe event2
@@ -121,7 +121,7 @@ class JobWatchHelperTest : StringSpec({
         val watch = createWatchWithEvents(event)
         mockWatchCreation(jobApi, resourceVersion2, watch)
 
-        val helper = JobWatchHelper.create(jobApi, NAMESPACE, resourceVersion1)
+        val helper = JobWatchHelper.create(jobApi, createConfig(), resourceVersion1)
 
         helper.nextEvent() shouldBe event
     }
@@ -136,7 +136,7 @@ class JobWatchHelperTest : StringSpec({
         val watch = createWatchWithEvents(event)
         mockWatchCreation(jobApi, initialResourceVersion, watch)
 
-        val helper = JobWatchHelper.create(jobApi, NAMESPACE)
+        val helper = JobWatchHelper.create(jobApi, createConfig())
 
         helper.nextEvent() shouldBe event
     }
@@ -156,11 +156,19 @@ class JobWatchHelperTest : StringSpec({
         val watch2 = createWatchWithEvents(event)
         mockWatchCreation(jobApi, updatedResourceVersion, watch2)
 
-        val helper = JobWatchHelper.create(jobApi, NAMESPACE)
+        val helper = JobWatchHelper.create(jobApi, createConfig())
 
         helper.nextEvent() shouldBe event
     }
 })
+
+/**
+ * Create mock for the [MonitorConfig] that returns the test namespace.
+ */
+private fun createConfig(): MonitorConfig =
+    mockk {
+        every { namespace } returns NAMESPACE
+    }
 
 /**
  * Create a mock for the jobs API.

--- a/transport/kubernetes-jobmonitor/src/test/kotlin/LongRunningJobsFinderTest.kt
+++ b/transport/kubernetes-jobmonitor/src/test/kotlin/LongRunningJobsFinderTest.kt
@@ -1,0 +1,169 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.transport.kubernetes.jobmonitor
+
+import io.kotest.core.spec.style.WordSpec
+
+import io.kubernetes.client.openapi.models.V1Job
+import io.kubernetes.client.openapi.models.V1ObjectMeta
+
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.runs
+import io.mockk.unmockkAll
+import io.mockk.verify
+
+import java.time.Month
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+import kotlin.test.fail
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+
+import org.eclipse.apoapsis.ortserver.transport.AdvisorEndpoint
+import org.eclipse.apoapsis.ortserver.transport.AnalyzerEndpoint
+import org.eclipse.apoapsis.ortserver.transport.ConfigEndpoint
+import org.eclipse.apoapsis.ortserver.transport.Endpoint
+import org.eclipse.apoapsis.ortserver.transport.EvaluatorEndpoint
+import org.eclipse.apoapsis.ortserver.transport.NotifierEndpoint
+import org.eclipse.apoapsis.ortserver.transport.ReporterEndpoint
+import org.eclipse.apoapsis.ortserver.transport.ScannerEndpoint
+import org.eclipse.apoapsis.ortserver.transport.kubernetes.jobmonitor.JobHandler.Companion.isTimeout
+
+class LongRunningJobsFinderTest : WordSpec({
+    beforeTest {
+        mockkObject(JobHandler)
+    }
+
+    afterTest {
+        unmockkAll()
+    }
+
+    "LongRunningJobsFinder" should {
+        "delete long-running Config worker jobs" {
+            testLongRunningJobsDetectionForEndpoint(ConfigEndpoint)
+        }
+
+        "delete long-running Analyzer worker jobs" {
+            testLongRunningJobsDetectionForEndpoint(AnalyzerEndpoint)
+        }
+
+        "delete long-running Advisor worker jobs" {
+            testLongRunningJobsDetectionForEndpoint(AdvisorEndpoint)
+        }
+
+        "delete long-running Scanner worker jobs" {
+            testLongRunningJobsDetectionForEndpoint(ScannerEndpoint)
+        }
+
+        "delete long-running Evaluator worker jobs" {
+            testLongRunningJobsDetectionForEndpoint(EvaluatorEndpoint)
+        }
+
+        "delete long-running Reporter worker jobs" {
+            testLongRunningJobsDetectionForEndpoint(ReporterEndpoint)
+        }
+
+        "delete long-running Notifier worker jobs" {
+            testLongRunningJobsDetectionForEndpoint(NotifierEndpoint)
+        }
+    }
+})
+
+/** The name of the job that runs into a timeout. */
+private const val TIMEOUT_JOB_NAME = "longRunningJob"
+
+/** The timeout configuration for the different worker types. */
+private val testTimeoutConfig = TimeoutConfig(
+    configTimeout = 1.minutes,
+    analyzerTimeout = 120.minutes,
+    advisorTimeout = 2.minutes,
+    scannerTimeout = 24.hours,
+    evaluatorTimeout = 5.minutes,
+    reporterTimeout = 15.minutes,
+    notifierTimeout = 11.minutes
+)
+
+/** The interval for checks for long-running jobs. */
+private val checkInterval = 23.minutes
+
+/**
+ * Determine the timeout for this [Endpoint]. This is explicitly done via a `when` construct to make sure that the
+ * compiler complains when a new endpoint is added.
+ */
+private fun TimeoutConfig.forEndpoint(endpoint: Endpoint<*>): Duration =
+    when (endpoint) {
+     ConfigEndpoint -> configTimeout
+     AnalyzerEndpoint -> analyzerTimeout
+     AdvisorEndpoint -> advisorTimeout
+     ScannerEndpoint -> scannerTimeout
+     EvaluatorEndpoint -> evaluatorTimeout
+     ReporterEndpoint -> reporterTimeout
+     NotifierEndpoint -> notifierTimeout
+    else -> fail("Unknown endpoint type.")
+}
+
+private suspend fun testLongRunningJobsDetectionForEndpoint(endpoint: Endpoint<*>) {
+    val config = mockk<MonitorConfig> {
+        every { longRunningJobsInterval } returns checkInterval
+        every { timeoutConfig } returns testTimeoutConfig
+    }
+
+    val timeout = testTimeoutConfig.forEndpoint(endpoint)
+    val threshold = OffsetDateTime.of(2024, Month.AUGUST.value, 13, 10, 18, 11, 0, ZoneOffset.UTC)
+    val timeHelper = mockk<TimeHelper> {
+        every { before(any()) } returns OffsetDateTime.now()
+        every { before(timeout) } returns threshold
+    }
+
+    val meta = V1ObjectMeta().apply { name = TIMEOUT_JOB_NAME }
+    val timeoutJob = mockk<V1Job> {
+        every { isTimeout(threshold) } returns true
+        every { metadata } returns meta
+    }
+    val otherJobs = (1..5).map {
+        mockk<V1Job> {
+            every { isTimeout(threshold) } returns false
+        }
+    }
+
+    val jobHandler = mockk<JobHandler> {
+        Endpoint.entries().forEach {
+            every { findJobsForWorker(it) } returns emptyList()
+        }
+        every { findJobsForWorker(endpoint) } returns (otherJobs + timeoutJob).shuffled()
+        every { deleteJob(TIMEOUT_JOB_NAME) } just runs
+    }
+
+    val schedulerHelper = SchedulerTestHelper()
+
+    val finder = LongRunningJobsFinder(jobHandler, config, timeHelper)
+    finder.run(schedulerHelper.scheduler)
+
+    schedulerHelper.expectSchedule(checkInterval).triggerAction()
+
+    verify {
+        jobHandler.deleteJob(TIMEOUT_JOB_NAME)
+    }
+}

--- a/transport/kubernetes-jobmonitor/src/test/kotlin/LostJobsFinderTest.kt
+++ b/transport/kubernetes-jobmonitor/src/test/kotlin/LostJobsFinderTest.kt
@@ -33,7 +33,6 @@ import io.mockk.verify
 import kotlin.test.fail
 import kotlin.time.Duration.Companion.minutes
 
-import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
 import org.eclipse.apoapsis.ortserver.model.AdvisorJob
@@ -99,7 +98,7 @@ class LostJobsFinderTest : StringSpec({
             evaluatorJobRepo,
             reporterJobRepo,
             notifierJobRepo,
-            testClock
+            testTimeHelper
         )
 
         val interval = 3.minutes
@@ -131,7 +130,7 @@ private val jobCreationTime = Instant.parse("2024-03-15T12:28:17Z")
 private val minJobAge = 1.minutes
 
 /** The clock used by the component under test. It always returns a constant time. */
-private val testClock = createClock()
+private val testTimeHelper = createTimeHelper()
 
 /**
  * Prepare this [JobHandler] mock to expect a query for the active jobs of the given [endpoint]. For each endpoint,
@@ -182,8 +181,8 @@ private fun createKubernetesJob(runId: Long, name: String): V1Job =
     }
 
 /**
- * Return a mock clock that returns the [currentTime].
+ * Return a mock [TimeHelper] that returns the [currentTime].
  */
-private fun createClock(): Clock = mockk {
+private fun createTimeHelper(): TimeHelper = mockk {
     every { now() } returns currentTime
 }

--- a/transport/kubernetes-jobmonitor/src/test/kotlin/MonitorComponentTest.kt
+++ b/transport/kubernetes-jobmonitor/src/test/kotlin/MonitorComponentTest.kt
@@ -117,6 +117,7 @@ class MonitorComponentTest : KoinTest, StringSpec() {
                             Duration::class,
                             Function0::class,
                             Function1::class,
+                            TimeoutConfig::class,
                             ZoneOffset::class,
                         )
                     )

--- a/transport/kubernetes-jobmonitor/src/test/kotlin/MonitorComponentTest.kt
+++ b/transport/kubernetes-jobmonitor/src/test/kotlin/MonitorComponentTest.kt
@@ -112,6 +112,7 @@ class MonitorComponentTest : KoinTest, StringSpec() {
                     .verify(
                         extraTypes = listOf(
                             Boolean::class,
+                            Clock::class,
                             Config::class,
                             Duration::class,
                             Function0::class,
@@ -240,7 +241,7 @@ class MonitorComponentTest : KoinTest, StringSpec() {
                 }
 
                 val referenceTime = Instant.parse("2024-03-18T10:04:42Z")
-                declareMock<Clock> {
+                declareMock<TimeHelper> {
                     every { now() } returns referenceTime
                 }
 

--- a/transport/kubernetes-jobmonitor/src/test/kotlin/MonitorConfigTest.kt
+++ b/transport/kubernetes-jobmonitor/src/test/kotlin/MonitorConfigTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.transport.kubernetes.jobmonitor
+
+import com.typesafe.config.ConfigFactory
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.extensions.system.withEnvironment
+import io.kotest.matchers.shouldBe
+
+import kotlin.time.Duration.Companion.seconds
+
+import org.eclipse.apoapsis.ortserver.config.ConfigManager
+
+class MonitorConfigTest : StringSpec({
+    "The configuration should be loaded correctly" {
+        val monitorConfigMap = mapOf(
+            "namespace" to "test-namespace",
+            "reaperInterval" to "333",
+            "reaperMaxAge" to "555",
+            "lostJobsInterval" to "444",
+            "lostJobsMinAge" to "600",
+            "recentlyProcessedInterval" to "66",
+            "enableWatching" to "true",
+            "enableReaper" to "false",
+            "enableLostJobs" to "true"
+        )
+        val configMap = mapOf("jobMonitor" to monitorConfigMap)
+        val configManager = ConfigManager.create(ConfigFactory.parseMap(configMap))
+
+        val monitorConfig = MonitorConfig.create(configManager)
+
+        monitorConfig.namespace shouldBe "test-namespace"
+        monitorConfig.reaperInterval shouldBe 333.seconds
+        monitorConfig.reaperMaxAge shouldBe 555.seconds
+        monitorConfig.lostJobsInterval shouldBe 444.seconds
+        monitorConfig.lostJobsMinAge shouldBe 600.seconds
+        monitorConfig.recentlyProcessedInterval shouldBe 66.seconds
+        monitorConfig.watchingEnabled shouldBe true
+        monitorConfig.reaperEnabled shouldBe false
+        monitorConfig.lostJobsEnabled shouldBe true
+    }
+
+    "The configuration should be loaded from environment variables" {
+        val environment = mapOf(
+            "MONITOR_NAMESPACE" to "test-namespace",
+            "MONITOR_REAPER_INTERVAL" to "333",
+            "MONITOR_REAPER_MAX_AGE" to "555",
+            "MONITOR_LOST_JOBS_INTERVAL" to "444",
+            "MONITOR_LOST_JOBS_MIN_AGE" to "600",
+            "MONITOR_RECENTLY_PROCESSED_INTERVAL" to "66",
+            "MONITOR_WATCHING_ENABLED" to "true",
+            "MONITOR_REAPER_ENABLED" to "false",
+            "MONITOR_LOST_JOBS_ENABLED" to "true"
+        )
+
+        withEnvironment(environment) {
+            ConfigFactory.invalidateCaches()
+            val configManager = ConfigManager.create(ConfigFactory.load())
+
+            val monitorConfig = MonitorConfig.create(configManager)
+
+            monitorConfig.namespace shouldBe "test-namespace"
+            monitorConfig.reaperInterval shouldBe 333.seconds
+            monitorConfig.reaperMaxAge shouldBe 555.seconds
+            monitorConfig.lostJobsInterval shouldBe 444.seconds
+            monitorConfig.lostJobsMinAge shouldBe 600.seconds
+            monitorConfig.recentlyProcessedInterval shouldBe 66.seconds
+            monitorConfig.watchingEnabled shouldBe true
+            monitorConfig.reaperEnabled shouldBe false
+            monitorConfig.lostJobsEnabled shouldBe true
+        }
+    }
+})

--- a/transport/kubernetes-jobmonitor/src/test/kotlin/MonitorConfigTest.kt
+++ b/transport/kubernetes-jobmonitor/src/test/kotlin/MonitorConfigTest.kt
@@ -25,12 +25,22 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.shouldBe
 
+import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 
 class MonitorConfigTest : StringSpec({
     "The configuration should be loaded correctly" {
+        val timeoutMap = mapOf(
+            "config" to "1",
+            "analyzer" to "90",
+            "advisor" to "2",
+            "scanner" to "1440",
+            "evaluator" to "5",
+            "reporter" to "10",
+            "notifier" to "4"
+        )
         val monitorConfigMap = mapOf(
             "namespace" to "test-namespace",
             "reaperInterval" to "333",
@@ -38,9 +48,12 @@ class MonitorConfigTest : StringSpec({
             "lostJobsInterval" to "444",
             "lostJobsMinAge" to "600",
             "recentlyProcessedInterval" to "66",
+            "longRunningJobsInterval" to "77",
+            "timeouts" to timeoutMap,
             "enableWatching" to "true",
             "enableReaper" to "false",
-            "enableLostJobs" to "true"
+            "enableLostJobs" to "true",
+            "enableLongRunningJobs" to "false"
         )
         val configMap = mapOf("jobMonitor" to monitorConfigMap)
         val configManager = ConfigManager.create(ConfigFactory.parseMap(configMap))
@@ -53,6 +66,16 @@ class MonitorConfigTest : StringSpec({
         monitorConfig.lostJobsInterval shouldBe 444.seconds
         monitorConfig.lostJobsMinAge shouldBe 600.seconds
         monitorConfig.recentlyProcessedInterval shouldBe 66.seconds
+        monitorConfig.longRunningJobsInterval shouldBe 77.seconds
+        monitorConfig.timeoutConfig shouldBe TimeoutConfig(
+            configTimeout = 1.minutes,
+            analyzerTimeout = 90.minutes,
+            advisorTimeout = 2.minutes,
+            scannerTimeout = 1440.minutes,
+            evaluatorTimeout = 5.minutes,
+            reporterTimeout = 10.minutes,
+            notifierTimeout = 4.minutes
+        )
         monitorConfig.watchingEnabled shouldBe true
         monitorConfig.reaperEnabled shouldBe false
         monitorConfig.lostJobsEnabled shouldBe true
@@ -66,9 +89,18 @@ class MonitorConfigTest : StringSpec({
             "MONITOR_LOST_JOBS_INTERVAL" to "444",
             "MONITOR_LOST_JOBS_MIN_AGE" to "600",
             "MONITOR_RECENTLY_PROCESSED_INTERVAL" to "66",
+            "MONITOR_LONG_RUNNING_JOBS_INTERVAL" to "77",
+            "MONITOR_TIMEOUT_CONFIG" to "1",
+            "MONITOR_TIMEOUT_ANALYZER" to "90",
+            "MONITOR_TIMEOUT_ADVISOR" to "2",
+            "MONITOR_TIMEOUT_SCANNER" to "1440",
+            "MONITOR_TIMEOUT_EVALUATOR" to "5",
+            "MONITOR_TIMEOUT_REPORTER" to "10",
+            "MONITOR_TIMEOUT_NOTIFIER" to "4",
             "MONITOR_WATCHING_ENABLED" to "true",
             "MONITOR_REAPER_ENABLED" to "false",
-            "MONITOR_LOST_JOBS_ENABLED" to "true"
+            "MONITOR_LOST_JOBS_ENABLED" to "true",
+            "MONITOR_LONG_RUNNING_JOBS_ENABLED" to "false"
         )
 
         withEnvironment(environment) {
@@ -83,6 +115,16 @@ class MonitorConfigTest : StringSpec({
             monitorConfig.lostJobsInterval shouldBe 444.seconds
             monitorConfig.lostJobsMinAge shouldBe 600.seconds
             monitorConfig.recentlyProcessedInterval shouldBe 66.seconds
+            monitorConfig.longRunningJobsInterval shouldBe 77.seconds
+            monitorConfig.timeoutConfig shouldBe TimeoutConfig(
+                configTimeout = 1.minutes,
+                analyzerTimeout = 90.minutes,
+                advisorTimeout = 2.minutes,
+                scannerTimeout = 1440.minutes,
+                evaluatorTimeout = 5.minutes,
+                reporterTimeout = 10.minutes,
+                notifierTimeout = 4.minutes
+            )
             monitorConfig.watchingEnabled shouldBe true
             monitorConfig.reaperEnabled shouldBe false
             monitorConfig.lostJobsEnabled shouldBe true

--- a/transport/kubernetes-jobmonitor/src/test/kotlin/ReaperTest.kt
+++ b/transport/kubernetes-jobmonitor/src/test/kotlin/ReaperTest.kt
@@ -21,7 +21,6 @@ package org.eclipse.apoapsis.ortserver.transport.kubernetes.jobmonitor
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.inspectors.forAll
-import io.kotest.matchers.shouldBe
 
 import io.kubernetes.client.openapi.models.V1Job
 
@@ -38,21 +37,9 @@ import io.mockk.verify
 import java.time.Month
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.LinkedBlockingQueue
-import java.util.concurrent.TimeUnit
 
-import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.minutes
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 
@@ -138,35 +125,6 @@ class ReaperTest : WordSpec({
                     jobHandler.deleteAndNotifyIfFailed(job)
                 }
             }
-        }
-    }
-
-    "tickerFlow" should {
-        "produce a flow with tick events" {
-            val ticker = tickerFlow(10.milliseconds)
-            val queue = LinkedBlockingQueue<String>()
-
-            CoroutineScope(Dispatchers.IO).launch {
-                ticker.take(10)
-                    .map { "tick" }
-                    .onEach(queue::offer)
-                    .collect()
-            }
-
-            (1..10).toList().forAll {
-                queue.poll(100, TimeUnit.MILLISECONDS) shouldBe "tick"
-            }
-        }
-
-        "take the interval into account" {
-            val ticker = tickerFlow(100.milliseconds)
-            val latch = CountDownLatch(1)
-
-            CoroutineScope(Dispatchers.IO).launch {
-                ticker.onEach { latch.countDown() }.first()
-            }
-
-            latch.await(10, TimeUnit.MILLISECONDS) shouldBe false
         }
     }
 })

--- a/transport/kubernetes-jobmonitor/src/test/kotlin/TimeHelperTest.kt
+++ b/transport/kubernetes-jobmonitor/src/test/kotlin/TimeHelperTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.transport.kubernetes.jobmonitor
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.comparables.shouldBeLessThan
+import io.kotest.matchers.shouldBe
+
+import io.mockk.every
+import io.mockk.mockk
+
+import java.time.Month
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+class TimeHelperTest : WordSpec({
+    "now" should {
+        "return the time from the provided clock" {
+            val currentTime = Instant.parse("2024-08-07T10:58:42Z")
+            val clock = mockk<Clock>()
+            every { clock.now() } returns currentTime
+
+            val timeHelper = TimeHelper(clock)
+
+            timeHelper.now() shouldBe currentTime
+        }
+
+        "use the system clock per default" {
+            val timeHelper = TimeHelper()
+
+            val currentTime = timeHelper.now()
+
+            val systemTime = Clock.System.now()
+            systemTime - currentTime shouldBeLessThan 1000.milliseconds
+        }
+    }
+
+    "before" should {
+        "compute a correct timestamp in the past" {
+            val currentTime = Instant.parse("2024-08-07T11:20:38Z")
+            val zoneOffset = ZoneOffset.ofHours(2)
+            val clock = mockk<Clock>()
+            every { clock.now() } returns currentTime
+
+            val timeHelper = TimeHelper(clock, zoneOffset)
+
+            timeHelper.before(10.minutes) shouldBe OffsetDateTime.of(
+                2024,
+                Month.AUGUST.value,
+                7,
+                13,
+                10,
+                38,
+                0,
+                zoneOffset
+            )
+        }
+    }
+})


### PR DESCRIPTION
This PR adds a new "long-running jobs finder" component to Kubernetes Job Monitor. The component detects worker jobs that are running longer than a configured timeout and deletes them. This allows dealing with hanging jobs automatically. Different timeouts can be configured for the different worker types.