### PR TITLE
fix(workers): Use ORT's function to fix the `user.home` system property

### DIFF
--- a/workers/advisor/src/main/kotlin/advisor/Entrypoint.kt
+++ b/workers/advisor/src/main/kotlin/advisor/Entrypoint.kt
@@ -21,6 +21,8 @@ package org.eclipse.apoapsis.ortserver.workers.advisor
 
 import org.eclipse.apoapsis.ortserver.workers.common.enableOrtStackTraces
 
+import org.ossreviewtoolkit.utils.common.Os
+
 import org.slf4j.LoggerFactory
 
 private val logger = LoggerFactory.getLogger(AdvisorComponent::class.java)
@@ -33,5 +35,6 @@ suspend fun main() {
     logger.info("Starting ORT-Server Advisor endpoint.")
 
     enableOrtStackTraces()
+    Os.fixupUserHomeProperty()
     AdvisorComponent().start()
 }

--- a/workers/analyzer/src/main/kotlin/analyzer/Entrypoint.kt
+++ b/workers/analyzer/src/main/kotlin/analyzer/Entrypoint.kt
@@ -21,6 +21,8 @@ package org.eclipse.apoapsis.ortserver.workers.analyzer
 
 import org.eclipse.apoapsis.ortserver.workers.common.enableOrtStackTraces
 
+import org.ossreviewtoolkit.utils.common.Os
+
 import org.slf4j.LoggerFactory
 
 private val logger = LoggerFactory.getLogger(AnalyzerComponent::class.java)
@@ -33,5 +35,6 @@ suspend fun main() {
     logger.info("Starting ORT-Server Analyzer endpoint.")
 
     enableOrtStackTraces()
+    Os.fixupUserHomeProperty()
     AnalyzerComponent().start()
 }

--- a/workers/evaluator/src/main/kotlin/evaluator/Entrypoint.kt
+++ b/workers/evaluator/src/main/kotlin/evaluator/Entrypoint.kt
@@ -21,6 +21,8 @@ package org.eclipse.apoapsis.ortserver.workers.evaluator
 
 import org.eclipse.apoapsis.ortserver.workers.common.enableOrtStackTraces
 
+import org.ossreviewtoolkit.utils.common.Os
+
 import org.slf4j.LoggerFactory
 
 private val logger = LoggerFactory.getLogger(EvaluatorComponent::class.java)
@@ -33,5 +35,6 @@ suspend fun main() {
     logger.info("Starting ORT-Server Evaluator endpoint.")
 
     enableOrtStackTraces()
+    Os.fixupUserHomeProperty()
     EvaluatorComponent().start()
 }

--- a/workers/notifier/src/main/kotlin/notifier/Entrypoint.kt
+++ b/workers/notifier/src/main/kotlin/notifier/Entrypoint.kt
@@ -21,6 +21,8 @@ package org.eclipse.apoapsis.ortserver.workers.notifier
 
 import org.eclipse.apoapsis.ortserver.workers.common.enableOrtStackTraces
 
+import org.ossreviewtoolkit.utils.common.Os
+
 import org.slf4j.LoggerFactory
 
 private val logger = LoggerFactory.getLogger(NotifierComponent::class.java)
@@ -33,5 +35,6 @@ suspend fun main() {
     logger.info("Starting ORT-Server Notifier endpoint.")
 
     enableOrtStackTraces()
+    Os.fixupUserHomeProperty()
     NotifierComponent().start()
 }

--- a/workers/reporter/src/main/kotlin/reporter/Entrypoint.kt
+++ b/workers/reporter/src/main/kotlin/reporter/Entrypoint.kt
@@ -21,6 +21,8 @@ package org.eclipse.apoapsis.ortserver.workers.reporter
 
 import org.eclipse.apoapsis.ortserver.workers.common.enableOrtStackTraces
 
+import org.ossreviewtoolkit.utils.common.Os
+
 import org.slf4j.LoggerFactory
 
 private val logger = LoggerFactory.getLogger(::main::class.java)
@@ -29,5 +31,6 @@ suspend fun main() {
     logger.info("Starting ORT-Server Reporter endpoint.")
 
     enableOrtStackTraces()
+    Os.fixupUserHomeProperty()
     ReporterComponent().start()
 }

--- a/workers/scanner/src/main/kotlin/scanner/Entrypoint.kt
+++ b/workers/scanner/src/main/kotlin/scanner/Entrypoint.kt
@@ -21,6 +21,8 @@ package org.eclipse.apoapsis.ortserver.workers.scanner
 
 import org.eclipse.apoapsis.ortserver.workers.common.enableOrtStackTraces
 
+import org.ossreviewtoolkit.utils.common.Os
+
 import org.slf4j.LoggerFactory
 
 private val logger = LoggerFactory.getLogger(ScannerComponent::class.java)
@@ -33,5 +35,6 @@ suspend fun main() {
     logger.info("Starting ORT-Server Scanner endpoint.")
 
     enableOrtStackTraces()
+    Os.fixupUserHomeProperty()
     ScannerComponent().start()
 }


### PR DESCRIPTION
Under some scenarios the property can be set to "?". Use ORT's helper function to fix that based on environment variables. See [1] for some background information.

[1]: https://bugs.openjdk.java.net/browse/JDK-8193433