### PR TITLE
Fix deduplication of projects and packages in the database

### DIFF
--- a/dao/src/main/kotlin/Database.kt
+++ b/dao/src/main/kotlin/Database.kt
@@ -218,4 +218,23 @@ fun <T : LongEntity> LongEntityClass<T>.findSingle(condition: ConditionBuilder):
  * makes sure that the result does not contain any duplicates.
  */
 fun <M, D> mapAndDeduplicate(modelObjects: Collection<M>?, mapper: (M) -> D): SizedIterable<D> =
-    SizedCollection(modelObjects?.mapTo(mutableSetOf(), mapper).orEmpty())
+    SizedCollection(mapToSet(modelObjects, mapper).orEmpty())
+
+/**
+ * Map the given [modelObjects] collection to a [Set] using the given [mapper] function and check whether the result
+ * equals to the given [Collection] of [dataObjects]. This is used by _find_ functions in some Dao implementations to
+ * deal with collections of child elements that cannot have duplicates and for which order does not matter.
+ */
+fun <M, D> mapAndCompare(modelObjects: SizedIterable<M>, dataObjects: Collection<D>, mapper: (M) -> D): Boolean {
+    val modelObjectsList = modelObjects.toList()
+    if (modelObjectsList.size != dataObjects.size) return false
+
+    val mapped = mapToSet(modelObjects, mapper).orEmpty()
+    return mapped.containsAll(dataObjects)
+}
+
+/**
+ * Map the given [modelObjects] collection to a [Set] using the given [mapper] function.
+ */
+private fun <D, M> mapToSet(modelObjects: Iterable<M>?, mapper: (M) -> D): Set<D>? =
+    modelObjects?.mapTo(mutableSetOf(), mapper)

--- a/dao/src/main/kotlin/tables/InfrastructureServicesTable.kt
+++ b/dao/src/main/kotlin/tables/InfrastructureServicesTable.kt
@@ -64,7 +64,7 @@ class InfrastructureServicesDao(id: EntityID<Long>) : LongEntity(id) {
                                 ) and
                         (InfrastructureServicesTable.organizationId eq service.organization?.id) and
                         (InfrastructureServicesTable.productId eq service.product?.id)
-            }.singleOrNull()
+            }.firstOrNull()
 
         /**
          * Return an entity with properties matching the ones of the given [service]. If no such entity exists yet, a

--- a/dao/src/main/kotlin/tables/LabelsTable.kt
+++ b/dao/src/main/kotlin/tables/LabelsTable.kt
@@ -36,7 +36,7 @@ object LabelsTable : LongIdTable("labels") {
 class LabelDao(id: EntityID<Long>) : LongEntity(id) {
     companion object : LongEntityClass<LabelDao>(LabelsTable) {
         private fun findByKeyAndValue(key: String, value: String): LabelDao? =
-            LabelDao.find { LabelsTable.key eq key and (LabelsTable.value eq value) }.singleOrNull()
+            LabelDao.find { LabelsTable.key eq key and (LabelsTable.value eq value) }.firstOrNull()
 
         fun getOrPut(key: String, value: String): LabelDao =
             findByKeyAndValue(key, value) ?: LabelDao.new {

--- a/dao/src/main/kotlin/tables/SnippetsTable.kt
+++ b/dao/src/main/kotlin/tables/SnippetsTable.kt
@@ -62,7 +62,7 @@ class SnippetDao(id: EntityID<Long>) : LongEntity(id) {
                         (SnippetsTable.endLine eq snippet.location.endLine) and
                         (SnippetsTable.license eq snippet.spdxLicense) and
                         (SnippetsTable.score eq snippet.score)
-            }.singleOrNull {
+            }.firstOrNull {
                 it.mapToModel().provenance == snippet.provenance && it.additionalData?.data == snippet.additionalData
             }
 

--- a/dao/src/main/kotlin/tables/runs/advisor/AdvisorConfigurationOptionsTable.kt
+++ b/dao/src/main/kotlin/tables/runs/advisor/AdvisorConfigurationOptionsTable.kt
@@ -41,7 +41,7 @@ class AdvisorConfigurationOptionDao(id: EntityID<Long>) : LongEntity(id) {
                 AdvisorConfigurationOptionsTable.advisor eq advisor and
                         (AdvisorConfigurationOptionsTable.option eq option) and
                         (AdvisorConfigurationOptionsTable.value eq value)
-            }.singleOrNull()
+            }.firstOrNull()
 
         fun getOrPut(advisor: String, option: String, value: String): AdvisorConfigurationOptionDao =
             find(advisor, option, value) ?: new {

--- a/dao/src/main/kotlin/tables/runs/advisor/AdvisorConfigurationSecretsTable.kt
+++ b/dao/src/main/kotlin/tables/runs/advisor/AdvisorConfigurationSecretsTable.kt
@@ -43,7 +43,7 @@ class AdvisorConfigurationSecretDao(id: EntityID<Long>) : LongEntity(id) {
                 AdvisorConfigurationSecretsTable.advisor eq advisor and
                         (AdvisorConfigurationSecretsTable.secret eq secret) and
                         (AdvisorConfigurationSecretsTable.value eq value)
-            }.singleOrNull()
+            }.firstOrNull()
 
         fun getOrPut(advisor: String, secret: String, value: String): AdvisorConfigurationSecretDao =
             find(advisor, secret, value) ?: new {

--- a/dao/src/main/kotlin/tables/runs/advisor/DefectsTable.kt
+++ b/dao/src/main/kotlin/tables/runs/advisor/DefectsTable.kt
@@ -60,7 +60,7 @@ class DefectDao(id: EntityID<Long>) : LongEntity(id) {
                         (DefectsTable.closingTime eq defect.closingTime) and
                         (DefectsTable.fixReleaseVersion eq defect.fixReleaseVersion) and
                         (DefectsTable.fixReleaseUrl eq defect.fixReleaseUrl)
-            }.singleOrNull { dao ->
+            }.firstOrNull { dao ->
                 dao.description == defect.description &&
                         dao.labels.associate { it.key to it.value } == defect.labels
             }

--- a/dao/src/main/kotlin/tables/runs/advisor/VulnerabilitiesTable.kt
+++ b/dao/src/main/kotlin/tables/runs/advisor/VulnerabilitiesTable.kt
@@ -42,7 +42,7 @@ class VulnerabilityDao(id: EntityID<Long>) : LongEntity(id) {
             find {
                 VulnerabilitiesTable.externalId eq vulnerability.externalId and
                         (VulnerabilitiesTable.summary eq vulnerability.summary)
-            }.singleOrNull {
+            }.firstOrNull {
                 it.description == vulnerability.description &&
                         it.references.map(VulnerabilityReferenceDao::mapToModel) == vulnerability.references
             }

--- a/dao/src/main/kotlin/tables/runs/analyzer/AnalyzerRunsTable.kt
+++ b/dao/src/main/kotlin/tables/runs/analyzer/AnalyzerRunsTable.kt
@@ -58,7 +58,7 @@ class AnalyzerRunDao(id: EntityID<Long>) : LongEntity(id) {
     var dependencyGraphsWrapper by AnalyzerRunsTable.dependencyGraphs
 
     val analyzerConfiguration by AnalyzerConfigurationDao backReferencedOn AnalyzerConfigurationsTable.analyzerRunId
-    val projects by ProjectDao referrersOn ProjectsTable.analyzerRunId
+    val projects by ProjectDao via ProjectsAnalyzerRunsTable
     var packages by PackageDao via PackagesAnalyzerRunsTable
     var issues by IdentifierIssueDao via AnalyzerRunsIdentifiersIssuesTable
 

--- a/dao/src/main/kotlin/tables/runs/analyzer/AuthorsTable.kt
+++ b/dao/src/main/kotlin/tables/runs/analyzer/AuthorsTable.kt
@@ -33,7 +33,7 @@ object AuthorsTable : LongIdTable("authors") {
 
 class AuthorDao(id: EntityID<Long>) : LongEntity(id) {
     companion object : LongEntityClass<AuthorDao>(AuthorsTable) {
-        fun findByName(name: String): AuthorDao? = find { AuthorsTable.name eq name }.singleOrNull()
+        fun findByName(name: String): AuthorDao? = find { AuthorsTable.name eq name }.firstOrNull()
 
         fun getOrPut(author: String): AuthorDao = findByName(author) ?: new { name = author }
     }

--- a/dao/src/main/kotlin/tables/runs/analyzer/MappedDeclaredLicensesTable.kt
+++ b/dao/src/main/kotlin/tables/runs/analyzer/MappedDeclaredLicensesTable.kt
@@ -40,7 +40,7 @@ class MappedDeclaredLicenseDao(id: EntityID<Long>) : LongEntity(id) {
             find {
                 MappedDeclaredLicensesTable.declaredLicense eq declaredLicense and
                         (MappedDeclaredLicensesTable.mappedLicense eq mappedLicense)
-            }.singleOrNull()
+            }.firstOrNull()
 
         fun getOrPut(declaredLicense: String, mappedLicense: String): MappedDeclaredLicenseDao =
             findByMapping(declaredLicense, mappedLicense) ?: new {

--- a/dao/src/main/kotlin/tables/runs/analyzer/PackagesTable.kt
+++ b/dao/src/main/kotlin/tables/runs/analyzer/PackagesTable.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.apoapsis.ortserver.dao.tables.runs.analyzer
 
+import org.eclipse.apoapsis.ortserver.dao.mapAndCompare
 import org.eclipse.apoapsis.ortserver.dao.tables.runs.shared.DeclaredLicenseDao
 import org.eclipse.apoapsis.ortserver.dao.tables.runs.shared.IdentifierDao
 import org.eclipse.apoapsis.ortserver.dao.tables.runs.shared.IdentifiersTable
@@ -65,8 +66,8 @@ class PackageDao(id: EntityID<Long>) : LongEntity(id) {
                         (PackagesTable.isModified eq pkg.isModified)
             }.singleOrNull {
                 it.identifier.mapToModel() == pkg.identifier &&
-                        it.authors == pkg.authors &&
-                        it.declaredLicenses == pkg.declaredLicenses &&
+                        mapAndCompare(it.authors, pkg.authors, AuthorDao::name) &&
+                        mapAndCompare(it.declaredLicenses, pkg.declaredLicenses, DeclaredLicenseDao::name) &&
                         it.processedDeclaredLicense.mapToModel() == pkg.processedDeclaredLicense &&
                         it.vcs.mapToModel() == pkg.vcs &&
                         it.vcsProcessed.mapToModel() == pkg.vcsProcessed &&

--- a/dao/src/main/kotlin/tables/runs/analyzer/PackagesTable.kt
+++ b/dao/src/main/kotlin/tables/runs/analyzer/PackagesTable.kt
@@ -64,7 +64,7 @@ class PackageDao(id: EntityID<Long>) : LongEntity(id) {
                         (PackagesTable.homepageUrl eq pkg.homepageUrl) and
                         (PackagesTable.isMetadataOnly eq pkg.isMetadataOnly) and
                         (PackagesTable.isModified eq pkg.isModified)
-            }.singleOrNull {
+            }.firstOrNull {
                 it.identifier.mapToModel() == pkg.identifier &&
                         mapAndCompare(it.authors, pkg.authors, AuthorDao::name) &&
                         mapAndCompare(it.declaredLicenses, pkg.declaredLicenses, DeclaredLicenseDao::name) &&

--- a/dao/src/main/kotlin/tables/runs/analyzer/ProjectsAnalyzerRunsTable.kt
+++ b/dao/src/main/kotlin/tables/runs/analyzer/ProjectsAnalyzerRunsTable.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.dao.tables.runs.analyzer
+
+import org.jetbrains.exposed.sql.Table
+
+/**
+ * An intermediate table to store references from [ProjectsTable] and [AnalyzerRunsTable].
+ */
+object ProjectsAnalyzerRunsTable : Table("projects_analyzer_runs") {
+    val projectId = reference("project_id", ProjectsTable)
+    val analyzerRunId = reference("analyzer_run_id", AnalyzerRunsTable)
+
+    override val primaryKey: PrimaryKey
+        get() = PrimaryKey(projectId, analyzerRunId, name = "${tableName}_pkey")
+}

--- a/dao/src/main/kotlin/tables/runs/analyzer/ProjectsTable.kt
+++ b/dao/src/main/kotlin/tables/runs/analyzer/ProjectsTable.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.apoapsis.ortserver.dao.tables.runs.analyzer
 
+import org.eclipse.apoapsis.ortserver.dao.mapAndCompare
 import org.eclipse.apoapsis.ortserver.dao.tables.runs.shared.DeclaredLicenseDao
 import org.eclipse.apoapsis.ortserver.dao.tables.runs.shared.IdentifierDao
 import org.eclipse.apoapsis.ortserver.dao.tables.runs.shared.IdentifiersTable
@@ -36,7 +37,6 @@ import org.jetbrains.exposed.sql.and
  * A table to represent a software package as a project.
  */
 object ProjectsTable : LongIdTable("projects") {
-    val analyzerRunId = reference("analyzer_run_id", AnalyzerRunsTable)
     val identifierId = reference("identifier_id", IdentifiersTable)
     val vcsId = reference("vcs_id", VcsInfoTable)
     val vcsProcessedId = reference("vcs_processed_id", VcsInfoTable)
@@ -55,15 +55,15 @@ class ProjectDao(id: EntityID<Long>) : LongEntity(id) {
                         (ProjectsTable.definitionFilePath eq project.definitionFilePath)
             }.firstOrNull {
                 it.identifier.mapToModel() == project.identifier &&
-                        it.authors == project.authors &&
-                        it.declaredLicenses == project.declaredLicenses &&
+                        mapAndCompare(it.authors, project.authors, AuthorDao::name) &&
+                        mapAndCompare(it.declaredLicenses, project.declaredLicenses, DeclaredLicenseDao::name) &&
+                        mapAndCompare(it.scopeNames, project.scopeNames, ProjectScopeDao::name) &&
                         it.processedDeclaredLicense.mapToModel() == project.processedDeclaredLicense &&
                         it.vcs.mapToModel() == project.vcs &&
                         it.vcsProcessed.mapToModel() == project.vcsProcessed
             }
     }
 
-    var analyzerRun by AnalyzerRunDao referencedOn ProjectsTable.analyzerRunId
     var identifier by IdentifierDao referencedOn ProjectsTable.identifierId
     var vcs by VcsInfoDao referencedOn ProjectsTable.vcsId
     var vcsProcessed by VcsInfoDao referencedOn ProjectsTable.vcsProcessedId
@@ -75,6 +75,7 @@ class ProjectDao(id: EntityID<Long>) : LongEntity(id) {
     var authors by AuthorDao via ProjectsAuthorsTable
     var declaredLicenses by DeclaredLicenseDao via ProjectsDeclaredLicensesTable
     val scopeNames by ProjectScopeDao referrersOn ProjectScopesTable.projectId
+    var analyzerRuns by AnalyzerRunDao via ProjectsAnalyzerRunsTable
 
     val processedDeclaredLicense by ProcessedDeclaredLicenseDao backReferencedOn
             ProcessedDeclaredLicensesTable.projectId

--- a/dao/src/main/kotlin/tables/runs/analyzer/ProjectsTable.kt
+++ b/dao/src/main/kotlin/tables/runs/analyzer/ProjectsTable.kt
@@ -53,7 +53,7 @@ class ProjectDao(id: EntityID<Long>) : LongEntity(id) {
                 ProjectsTable.cpe eq project.cpe and
                         (ProjectsTable.homepageUrl eq project.homepageUrl) and
                         (ProjectsTable.definitionFilePath eq project.definitionFilePath)
-            }.singleOrNull {
+            }.firstOrNull {
                 it.identifier.mapToModel() == project.identifier &&
                         it.authors == project.authors &&
                         it.declaredLicenses == project.declaredLicenses &&

--- a/dao/src/main/kotlin/tables/runs/analyzer/UnmappedDeclaredLicensesTable.kt
+++ b/dao/src/main/kotlin/tables/runs/analyzer/UnmappedDeclaredLicensesTable.kt
@@ -35,7 +35,7 @@ object UnmappedDeclaredLicensesTable : LongIdTable("unmapped_declared_licenses")
 class UnmappedDeclaredLicenseDao(id: EntityID<Long>) : LongEntity(id) {
     companion object : LongEntityClass<UnmappedDeclaredLicenseDao>(UnmappedDeclaredLicensesTable) {
         fun findByLicense(unmappedLicense: String): UnmappedDeclaredLicenseDao? =
-            find { UnmappedDeclaredLicensesTable.unmappedLicense eq unmappedLicense }.singleOrNull()
+            find { UnmappedDeclaredLicensesTable.unmappedLicense eq unmappedLicense }.firstOrNull()
 
         fun getOrPut(unmappedLicense: String): UnmappedDeclaredLicenseDao =
             findByLicense(unmappedLicense) ?: new { this.unmappedLicense = unmappedLicense }

--- a/dao/src/main/kotlin/tables/runs/repository/DeclaredLicenseMappingsTable.kt
+++ b/dao/src/main/kotlin/tables/runs/repository/DeclaredLicenseMappingsTable.kt
@@ -40,7 +40,7 @@ class DeclaredLicenseMappingDao(id: EntityID<Long>) : LongEntity(id) {
             find {
                 DeclaredLicenseMappingsTable.license eq license and
                         (DeclaredLicenseMappingsTable.spdxLicense eq spdxLicense)
-            }.singleOrNull()
+            }.firstOrNull()
 
         fun getOrPut(license: String, spdxLicense: String): DeclaredLicenseMappingDao =
             findByDeclaredLicenseMap(license, spdxLicense) ?: new {

--- a/dao/src/main/kotlin/tables/runs/repository/IssueResolutionsTable.kt
+++ b/dao/src/main/kotlin/tables/runs/repository/IssueResolutionsTable.kt
@@ -43,7 +43,7 @@ class IssueResolutionDao(id: EntityID<Long>) : LongEntity(id) {
                 IssueResolutionsTable.message eq issueResolution.message and
                         (IssueResolutionsTable.reason eq issueResolution.reason) and
                         (IssueResolutionsTable.comment eq issueResolution.comment)
-            }.singleOrNull()
+            }.firstOrNull()
 
         fun getOrPut(issueResolution: IssueResolution): IssueResolutionDao =
             findByIssueResolution(issueResolution) ?: new {

--- a/dao/src/main/kotlin/tables/runs/repository/LicenseFindingCurationsTable.kt
+++ b/dao/src/main/kotlin/tables/runs/repository/LicenseFindingCurationsTable.kt
@@ -58,7 +58,7 @@ class LicenseFindingCurationDao(id: EntityID<Long>) : LongEntity(id) {
                             (reason eq licenseFindingCuration.reason) and
                             (comment eq licenseFindingCuration.comment)
                 }
-            }.singleOrNull()
+            }.firstOrNull()
 
         fun getOrPut(licenseFindingCuration: LicenseFindingCuration): LicenseFindingCurationDao =
             findByLicenseFindingCuration(licenseFindingCuration) ?: new {

--- a/dao/src/main/kotlin/tables/runs/repository/PackageConfigurationsTable.kt
+++ b/dao/src/main/kotlin/tables/runs/repository/PackageConfigurationsTable.kt
@@ -45,7 +45,7 @@ class PackageConfigurationDao(id: EntityID<Long>) : LongEntity(id) {
         fun findByPackageConfiguration(packageConfiguration: PackageConfiguration): PackageConfigurationDao? =
             find {
                 PackageConfigurationsTable.sourceArtifactUrl eq packageConfiguration.sourceArtifactUrl
-            }.singleOrNull {
+            }.firstOrNull {
                 it.identifier.mapToModel() == packageConfiguration.id &&
                         it.vcsMatcher?.mapToModel() == packageConfiguration.vcs &&
                         it.pathExcludes.map(PathExcludeDao::mapToModel) == packageConfiguration.pathExcludes &&

--- a/dao/src/main/kotlin/tables/runs/repository/PackageCurationDataTable.kt
+++ b/dao/src/main/kotlin/tables/runs/repository/PackageCurationDataTable.kt
@@ -64,7 +64,7 @@ class PackageCurationDataDao(id: EntityID<Long>) : LongEntity(id) {
                             (this.isMetadataOnly eq data.isMetadataOnly) and
                             (this.isModified eq data.isModified)
                 }
-            }.singleOrNull {
+            }.firstOrNull {
                 it.binaryArtifact?.mapToModel() == data.binaryArtifact &&
                         it.sourceArtifact?.mapToModel() == data.sourceArtifact &&
                         it.vcsInfoCurationData?.mapToModel() == data.vcs &&

--- a/dao/src/main/kotlin/tables/runs/repository/PathExcludesTable.kt
+++ b/dao/src/main/kotlin/tables/runs/repository/PathExcludesTable.kt
@@ -44,7 +44,7 @@ class PathExcludeDao(id: EntityID<Long>) : LongEntity(id) {
                 PathExcludesTable.pattern eq pathExclude.pattern and
                         (PathExcludesTable.reason eq pathExclude.reason) and
                         (PathExcludesTable.comment eq pathExclude.comment)
-            }.singleOrNull()
+            }.firstOrNull()
 
         fun getOrPut(pathExclude: PathExclude): PathExcludeDao =
             findByPathExclude(pathExclude) ?: new {

--- a/dao/src/main/kotlin/tables/runs/repository/ProvenanceSnippetChoicesTable.kt
+++ b/dao/src/main/kotlin/tables/runs/repository/ProvenanceSnippetChoicesTable.kt
@@ -46,7 +46,7 @@ class SnippetChoicesDao(id: EntityID<Long>) : LongEntity(id) {
                 with(ProvenanceSnippetChoicesTable) {
                     provenance eq provenanceSnippetChoices.provenance.url
                 }
-            }.singleOrNull {
+            }.firstOrNull {
                 it.choices.map(ChoicesDao::mapToModel) == provenanceSnippetChoices.choices
             }
 

--- a/dao/src/main/kotlin/tables/runs/repository/RepositoryAnalyzerConfigurationsTable.kt
+++ b/dao/src/main/kotlin/tables/runs/repository/RepositoryAnalyzerConfigurationsTable.kt
@@ -52,7 +52,7 @@ class RepositoryAnalyzerConfigurationDao(id: EntityID<Long>) : LongEntity(id) {
                         (this.disabledPackageManagers eq config.disabledPackageManagers?.joinToString(",")) and
                         (this.skipExcluded eq config.skipExcluded)
             }
-        }.singleOrNull { dao ->
+        }.firstOrNull { dao ->
             dao.packageManagerConfigurations.associate { it.name to it.mapToModel() } == config.packageManagers
         }
 

--- a/dao/src/main/kotlin/tables/runs/repository/RuleViolationResolutionsTable.kt
+++ b/dao/src/main/kotlin/tables/runs/repository/RuleViolationResolutionsTable.kt
@@ -45,7 +45,7 @@ class RuleViolationResolutionDao(id: EntityID<Long>) : LongEntity(id) {
             RuleViolationResolutionsTable.message eq ruleViolationResolution.message and
                     (RuleViolationResolutionsTable.reason eq ruleViolationResolution.reason) and
                     (RuleViolationResolutionsTable.comment eq ruleViolationResolution.comment)
-        }.singleOrNull()
+        }.firstOrNull()
 
         fun getOrPut(ruleViolationResolution: RuleViolationResolution): RuleViolationResolutionDao =
             findByRuleViolationResolutionDao(ruleViolationResolution) ?: new {

--- a/dao/src/main/kotlin/tables/runs/repository/ScopeExcludesTable.kt
+++ b/dao/src/main/kotlin/tables/runs/repository/ScopeExcludesTable.kt
@@ -43,7 +43,7 @@ class ScopeExcludeDao(id: EntityID<Long>) : LongEntity(id) {
                 ScopeExcludesTable.pattern eq scopeExclude.pattern and
                         (ScopeExcludesTable.reason eq scopeExclude.reason) and
                         (ScopeExcludesTable.comment eq scopeExclude.comment)
-            }.singleOrNull()
+            }.firstOrNull()
 
         fun getOrPut(scopeExclude: ScopeExclude): ScopeExcludeDao =
             findByScopeExclude(scopeExclude) ?: new {

--- a/dao/src/main/kotlin/tables/runs/repository/SnippetChoicesTable.kt
+++ b/dao/src/main/kotlin/tables/runs/repository/SnippetChoicesTable.kt
@@ -63,7 +63,7 @@ class ChoicesDao(id: EntityID<Long>) : LongEntity(id) {
                             (choiceReason eq snippetChoice.choice.reason.name) and
                             (choiceComment eq snippetChoice.choice.comment)
                 }
-            }.singleOrNull()
+            }.firstOrNull()
 
         fun getOrPut(snippetChoice: SnippetChoice): ChoicesDao =
             findBySnippetChoice(snippetChoice) ?: new {

--- a/dao/src/main/kotlin/tables/runs/repository/SpdxLicenseChoicesTable.kt
+++ b/dao/src/main/kotlin/tables/runs/repository/SpdxLicenseChoicesTable.kt
@@ -41,7 +41,7 @@ class SpdxLicenseChoiceDao(id: EntityID<Long>) : LongEntity(id) {
             find {
                 SpdxLicenseChoicesTable.given eq spdxLicenseChoice.given and
                         (SpdxLicenseChoicesTable.choice eq spdxLicenseChoice.choice)
-            }.singleOrNull()
+            }.firstOrNull()
 
         fun getOrPut(spdxLicenseChoice: SpdxLicenseChoice): SpdxLicenseChoiceDao =
             findBySpdxLicenseChoice(spdxLicenseChoice) ?: new {

--- a/dao/src/main/kotlin/tables/runs/repository/VcsInfoCurationDataTable.kt
+++ b/dao/src/main/kotlin/tables/runs/repository/VcsInfoCurationDataTable.kt
@@ -48,7 +48,7 @@ class VcsInfoCurationDataDao(id: EntityID<Long>) : LongEntity(id) {
                             (revision eq vcsCurationData.revision) and
                             (path eq vcsCurationData.path)
                 }
-            }.singleOrNull()
+            }.firstOrNull()
 
         fun getOrPut(vcsCurationData: VcsInfoCurationData): VcsInfoCurationDataDao =
             findByVcsInfoCurationData(vcsCurationData) ?: new {

--- a/dao/src/main/kotlin/tables/runs/repository/VcsMatchersTable.kt
+++ b/dao/src/main/kotlin/tables/runs/repository/VcsMatchersTable.kt
@@ -46,7 +46,7 @@ class VcsMatcherDao(id: EntityID<Long>) : LongEntity(id) {
                             (url eq vcsMatcher.url) and
                             (revision eq vcsMatcher.revision)
                 }
-            }.singleOrNull()
+            }.firstOrNull()
 
         fun getOrPut(vcsMatcher: VcsMatcher): VcsMatcherDao =
             findByVcsMatcher(vcsMatcher) ?: new {

--- a/dao/src/main/kotlin/tables/runs/repository/VulnerabilityResolutionsTable.kt
+++ b/dao/src/main/kotlin/tables/runs/repository/VulnerabilityResolutionsTable.kt
@@ -45,7 +45,7 @@ class VulnerabilityResolutionDao(id: EntityID<Long>) : LongEntity(id) {
             VulnerabilityResolutionsTable.externalId eq vulnerabilityResolution.externalId and
                     (VulnerabilityResolutionsTable.reason eq vulnerabilityResolution.reason) and
                     (VulnerabilityResolutionsTable.comment eq vulnerabilityResolution.comment)
-        }.singleOrNull()
+        }.firstOrNull()
 
         fun getOrPut(vulnerabilityResolution: VulnerabilityResolution): VulnerabilityResolutionDao =
             findByVulnerabilityResolution(vulnerabilityResolution) ?: new {

--- a/dao/src/main/kotlin/tables/runs/scanner/DetectedLicenseMappingsTable.kt
+++ b/dao/src/main/kotlin/tables/runs/scanner/DetectedLicenseMappingsTable.kt
@@ -39,7 +39,7 @@ class DetectedLicenseMappingDao(id: EntityID<Long>) : LongEntity(id) {
             find {
                 DetectedLicenseMappingsTable.license eq licenseMapping.first and
                         (DetectedLicenseMappingsTable.spdxLicense eq licenseMapping.second)
-            }.singleOrNull()
+            }.firstOrNull()
 
         fun getOrPut(licenseMapping: Pair<String, String>): DetectedLicenseMappingDao =
             findByDetectedLicenseMapping(licenseMapping) ?: new {

--- a/dao/src/main/kotlin/tables/runs/scanner/ScannerConfigurationOptionsTable.kt
+++ b/dao/src/main/kotlin/tables/runs/scanner/ScannerConfigurationOptionsTable.kt
@@ -41,7 +41,7 @@ class ScannerConfigurationOptionDao(id: EntityID<Long>) : LongEntity(id) {
                 ScannerConfigurationOptionsTable.scanner eq scanner and
                         (ScannerConfigurationOptionsTable.option eq option) and
                         (ScannerConfigurationOptionsTable.value eq value)
-            }.singleOrNull()
+            }.firstOrNull()
 
         fun getOrPut(scanner: String, option: String, value: String): ScannerConfigurationOptionDao =
             find(scanner, option, value) ?: new {

--- a/dao/src/main/kotlin/tables/runs/scanner/ScannerConfigurationSecretsTable.kt
+++ b/dao/src/main/kotlin/tables/runs/scanner/ScannerConfigurationSecretsTable.kt
@@ -43,7 +43,7 @@ class ScannerConfigurationSecretDao(id: EntityID<Long>) : LongEntity(id) {
                 ScannerConfigurationSecretsTable.scanner eq scanner and
                         (ScannerConfigurationSecretsTable.secret eq secret) and
                         (ScannerConfigurationSecretsTable.value eq value)
-            }.singleOrNull()
+            }.firstOrNull()
 
         fun getOrPut(scanner: String, secret: String, value: String): ScannerConfigurationSecretDao =
             find(scanner, secret, value) ?: new {

--- a/dao/src/main/kotlin/tables/runs/shared/DeclaredLicensesTable.kt
+++ b/dao/src/main/kotlin/tables/runs/shared/DeclaredLicensesTable.kt
@@ -33,7 +33,7 @@ object DeclaredLicensesTable : LongIdTable("declared_licenses") {
 
 class DeclaredLicenseDao(id: EntityID<Long>) : LongEntity(id) {
     companion object : LongEntityClass<DeclaredLicenseDao>(DeclaredLicensesTable) {
-        fun findByName(name: String): DeclaredLicenseDao? = find { DeclaredLicensesTable.name eq name }.singleOrNull()
+        fun findByName(name: String): DeclaredLicenseDao? = find { DeclaredLicensesTable.name eq name }.firstOrNull()
 
         fun getOrPut(declaredLicense: String): DeclaredLicenseDao =
             findByName(declaredLicense) ?: new { name = declaredLicense }

--- a/dao/src/main/kotlin/tables/runs/shared/EnvironmentsTable.kt
+++ b/dao/src/main/kotlin/tables/runs/shared/EnvironmentsTable.kt
@@ -49,7 +49,7 @@ class EnvironmentDao(id: EntityID<Long>) : LongEntity(id) {
                         (EnvironmentsTable.os eq environment.os) and
                         (EnvironmentsTable.processors eq environment.processors) and
                         (EnvironmentsTable.maxMemory eq environment.maxMemory)
-            }.singleOrNull { dao ->
+            }.firstOrNull { dao ->
                 dao.variables.associate { it.name to it.value } == environment.variables &&
                         dao.toolVersions.associate { it.name to it.version } == environment.toolVersions
             }

--- a/dao/src/main/kotlin/tables/runs/shared/IdentifiersIssuesTable.kt
+++ b/dao/src/main/kotlin/tables/runs/shared/IdentifiersIssuesTable.kt
@@ -39,7 +39,7 @@ class IdentifierIssueDao(id: EntityID<Long>) : LongEntity(id) {
             find {
                 IdentifiersIssuesTable.identifierId eq identifier.id and
                         (IdentifiersIssuesTable.issueId eq issue.id)
-            }.singleOrNull()
+            }.firstOrNull()
 
         fun getOrPut(identifier: IdentifierDao, issue: IssueDao): IdentifierIssueDao =
             findByIdentifierAndIssue(identifier, issue) ?: new {

--- a/dao/src/main/kotlin/tables/runs/shared/IdentifiersTable.kt
+++ b/dao/src/main/kotlin/tables/runs/shared/IdentifiersTable.kt
@@ -45,7 +45,7 @@ class IdentifierDao(id: EntityID<Long>) : LongEntity(id) {
                         (IdentifiersTable.namespace eq identifier.namespace) and
                         (IdentifiersTable.name eq identifier.name) and
                         (IdentifiersTable.version eq identifier.version)
-            }.singleOrNull()
+            }.firstOrNull()
 
         fun getOrPut(identifier: Identifier): IdentifierDao =
             findByIdentifier(identifier) ?: new {

--- a/dao/src/main/kotlin/tables/runs/shared/RemoteArtifactsTable.kt
+++ b/dao/src/main/kotlin/tables/runs/shared/RemoteArtifactsTable.kt
@@ -43,7 +43,7 @@ class RemoteArtifactDao(id: EntityID<Long>) : LongEntity(id) {
                 RemoteArtifactsTable.url eq artifact.url and
                         (RemoteArtifactsTable.hashValue eq artifact.hashValue) and
                         (RemoteArtifactsTable.hashAlgorithm eq artifact.hashAlgorithm)
-            }.singleOrNull()
+            }.firstOrNull()
 
         fun getOrPut(artifact: RemoteArtifact): RemoteArtifactDao =
             findByRemoteArtifact(artifact) ?: new {

--- a/dao/src/main/kotlin/tables/runs/shared/ToolVersionsTable.kt
+++ b/dao/src/main/kotlin/tables/runs/shared/ToolVersionsTable.kt
@@ -36,7 +36,7 @@ object ToolVersionsTable : LongIdTable("tool_versions") {
 class ToolVersionDao(id: EntityID<Long>) : LongEntity(id) {
     companion object : LongEntityClass<ToolVersionDao>(ToolVersionsTable) {
         fun findByNameAndVersion(name: String, version: String): ToolVersionDao? =
-            find { ToolVersionsTable.name eq name and (ToolVersionsTable.version eq version) }.singleOrNull()
+            find { ToolVersionsTable.name eq name and (ToolVersionsTable.version eq version) }.firstOrNull()
 
         fun getOrPut(name: String, version: String): ToolVersionDao =
             findByNameAndVersion(name, version) ?: new {

--- a/dao/src/main/kotlin/tables/runs/shared/VariablesTable.kt
+++ b/dao/src/main/kotlin/tables/runs/shared/VariablesTable.kt
@@ -36,7 +36,7 @@ object VariablesTable : LongIdTable("variables") {
 class VariableDao(id: EntityID<Long>) : LongEntity(id) {
     companion object : LongEntityClass<VariableDao>(VariablesTable) {
         fun findByNameAndValue(name: String, value: String): VariableDao? =
-            find { VariablesTable.name eq name and (VariablesTable.value eq value) }.singleOrNull()
+            find { VariablesTable.name eq name and (VariablesTable.value eq value) }.firstOrNull()
 
         fun getOrPut(name: String, value: String): VariableDao =
             findByNameAndValue(name, value) ?: new {

--- a/dao/src/main/kotlin/tables/runs/shared/VcsInfoTable.kt
+++ b/dao/src/main/kotlin/tables/runs/shared/VcsInfoTable.kt
@@ -46,7 +46,7 @@ class VcsInfoDao(id: EntityID<Long>) : LongEntity(id) {
                         (VcsInfoTable.url eq vcsInfo.url) and
                         (VcsInfoTable.revision eq vcsInfo.revision) and
                         (VcsInfoTable.path eq vcsInfo.path)
-            }.singleOrNull()
+            }.firstOrNull()
 
         fun getOrPut(vcsInfo: VcsInfo): VcsInfoDao =
             findByVcsInfo(vcsInfo) ?: new {

--- a/dao/src/main/resources/db/migration/V71__projectsAnalyzerRuns.sql
+++ b/dao/src/main/resources/db/migration/V71__projectsAnalyzerRuns.sql
@@ -1,0 +1,52 @@
+-- This migration converts the 1:n relation between projects and analyzer runs to a n:m relation, so that
+-- project entities can be shared between multiple analyzer runs.
+
+CREATE TABLE projects_analyzer_runs
+(
+    project_id      bigint REFERENCES projects      NOT NULL,
+    analyzer_run_id bigint REFERENCES analyzer_runs NOT NULL,
+
+    PRIMARY KEY (project_id, analyzer_run_id)
+);
+
+INSERT INTO projects_analyzer_runs
+SELECT
+  p.id,
+  p.analyzer_run_id
+FROM
+  projects p;
+
+ALTER TABLE projects
+DROP COLUMN analyzer_run_id;
+
+-- The following statements make sure that all packages and projects are associated with a processed license.
+-- This is necessary for old databases; due to a bug in the past, some packages and projects do not have a processed
+-- license assigned. This causes the de-duplication logic for packages and projects to fail.
+
+INSERT INTO processed_declared_licenses (package_id, project_id, spdx_expression)
+SELECT
+  p.id,
+  NULL,
+  'NOASSERTION'
+FROM
+  packages p, packages_analyzer_runs par, analyzer_runs ar
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM processed_declared_licenses pdl
+  WHERE pdl.package_id = p.id
+)
+AND par.analyzer_run_id = ar.id
+AND par.package_id = p.id;
+
+INSERT INTO processed_declared_licenses (package_id, project_id, spdx_expression)
+SELECT
+  NULL,
+  p.id,
+  'NOASSERTION'
+FROM
+  projects p
+WHERE NOT EXISTS (
+  SELECT 1
+  FROM processed_declared_licenses pdl
+  WHERE pdl.project_id = p.id
+);

--- a/dao/src/test/kotlin/Utils.kt
+++ b/dao/src/test/kotlin/Utils.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.dao
+
+import org.jetbrains.exposed.sql.Transaction
+import org.jetbrains.exposed.sql.transactions.TransactionManager
+
+/**
+ * Disable foreign key constraints for the given [block]. This is useful in testing when otherwise a lot of irrelevant
+ * test data would have to be created to satisfy foreign key constraints.
+ */
+fun <T> Transaction.disableForeignKeyConstraints(block: (Transaction.() -> T)): T {
+    TransactionManager.current().exec("SET session_replication_role = 'replica';")
+    val result = block()
+    TransactionManager.current().exec("SET session_replication_role = 'origin';")
+    return result
+}

--- a/dao/src/test/kotlin/migrations/V71__projectsAnalyzerRunsTest.kt
+++ b/dao/src/test/kotlin/migrations/V71__projectsAnalyzerRunsTest.kt
@@ -1,0 +1,218 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.dao.tables
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.should
+
+import kotlinx.datetime.Clock
+
+import org.eclipse.apoapsis.ortserver.dao.disableForeignKeyConstraints
+import org.eclipse.apoapsis.ortserver.dao.test.DatabaseMigrationTestExtension
+import org.eclipse.apoapsis.ortserver.dao.utils.jsonb
+import org.eclipse.apoapsis.ortserver.model.runs.DependencyGraphsWrapper
+
+import org.jetbrains.exposed.dao.id.LongIdTable
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.insertAndGetId
+import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+
+@Suppress("ClassNaming")
+class V71__projectsAnalyzerRunsTest : WordSpec() {
+    val extension = extension(DatabaseMigrationTestExtension("70", "71"))
+
+    init {
+        "the migration" should {
+            "keep associations between analyzer runs and projects" {
+                /**
+                 * Create five analyzer runs each associated to 5 projects.
+                 */
+                fun createRunAndProjects(): Map<Long, List<Long>> =
+                    (1..5).map { V69AnalyzerRunsTable.create() }.associateWith { runId ->
+                        (1..5).map { V69ProjectsTable.create(runId) }
+                    }
+
+                val expectedRunsAndProjects = transaction {
+                    disableForeignKeyConstraints {
+                        createRunAndProjects()
+                    }
+                }
+
+                extension.testAppliedMigration {
+                    transaction {
+                        val actualRunsAndProjects = V70ProjectsAnalyzerRunsTable.selectAll().map {
+                            it[V70ProjectsAnalyzerRunsTable.analyzerRunId].value to
+                                    it[V70ProjectsAnalyzerRunsTable.projectId].value
+                        }.groupBy { it.first }.mapValues { (_, value) -> value.map { it.second } }
+
+                        actualRunsAndProjects shouldContainExactly expectedRunsAndProjects
+                    }
+                }
+            }
+
+            "add missing processed declared licenses" {
+                var project1: Long = 0
+                var project2: Long = 0
+                var project3: Long = 0
+
+                var package1: Long = 0
+                var package2: Long = 0
+                var package3: Long = 0
+
+                transaction {
+                    disableForeignKeyConstraints {
+                        project1 = V69ProjectsTable.create(V69AnalyzerRunsTable.create())
+                        project2 = V69ProjectsTable.create(V69AnalyzerRunsTable.create())
+                        project3 = V69ProjectsTable.create(V69AnalyzerRunsTable.create())
+
+                        package1 = V69PackagesTable.create(V69AnalyzerRunsTable.create())
+                        package2 = V69PackagesTable.create(V69AnalyzerRunsTable.create())
+                        package3 = V69PackagesTable.create(V69AnalyzerRunsTable.create())
+
+                        V70ProcessedDeclaredLicensesTable.create(projectId = project2, spdxExpression = "Apache-2.0")
+                        V70ProcessedDeclaredLicensesTable.create(packageId = package2, spdxExpression = "Apache-2.0")
+                    }
+                }
+
+                extension.testAppliedMigration {
+                    transaction {
+                        V70ProcessedDeclaredLicensesTable.findLicensesForProject(project1) should
+                                containExactly("NOASSERTION")
+                        V70ProcessedDeclaredLicensesTable.findLicensesForProject(project2) should
+                                containExactly("Apache-2.0")
+                        V70ProcessedDeclaredLicensesTable.findLicensesForProject(project3) should
+                                containExactly("NOASSERTION")
+
+                        V70ProcessedDeclaredLicensesTable.findLicensesForPackage(package1) should
+                                containExactly("NOASSERTION")
+                        V70ProcessedDeclaredLicensesTable.findLicensesForPackage(package2) should
+                                containExactly("Apache-2.0")
+                        V70ProcessedDeclaredLicensesTable.findLicensesForPackage(package3) should
+                                containExactly("NOASSERTION")
+                    }
+                }
+            }
+        }
+    }
+}
+
+private object V69AnalyzerRunsTable : LongIdTable("analyzer_runs") {
+    val analyzerJobId = long("analyzer_job_id")
+    val environmentId = long("environment_id")
+
+    val startTime = timestamp("start_time")
+    val endTime = timestamp("end_time")
+    val dependencyGraphs = jsonb<DependencyGraphsWrapper>("dependency_graphs")
+
+    fun create() = insertAndGetId {
+        it[analyzerJobId] = 1
+        it[environmentId] = 1
+        it[startTime] = Clock.System.now()
+        it[endTime] = Clock.System.now()
+        it[dependencyGraphs] = DependencyGraphsWrapper(emptyMap())
+    }.value
+}
+
+private object V69ProjectsTable : LongIdTable("projects") {
+    val analyzerRunId = reference("analyzer_run_id", V69AnalyzerRunsTable)
+    val identifierId = long("identifier_id")
+    val vcsId = long("vcs_id")
+    val vcsProcessedId = long("vcs_processed_id")
+
+    val definitionFilePath = text("definition_file_path")
+    val homepageUrl = text("homepage_url")
+
+    fun create(analyzerRunId: Long) = insertAndGetId {
+        it[this.analyzerRunId] = analyzerRunId
+        it[identifierId] = 1
+        it[vcsId] = 1
+        it[vcsProcessedId] = 1
+        it[definitionFilePath] = "definitionFilePath"
+        it[homepageUrl] = "homepageUrl"
+    }.value
+}
+
+private object V69PackagesTable : LongIdTable("packages") {
+    val identifierId = long("identifier_id")
+    val vcsId = long("vcs_id")
+    val vcsProcessedId = long("vcs_processed_id")
+    val binaryArtifactId = long("binary_artifact_id")
+    val sourceArtifactId = long("source_artifact_id")
+
+    val purl = text("purl")
+    val description = text("description")
+    val homepageUrl = text("homepage_url")
+
+    fun create(analyzerRunId: Long) = insertAndGetId {
+        it[identifierId] = 1
+        it[vcsId] = 1
+        it[vcsProcessedId] = 1
+        it[binaryArtifactId] = 1
+        it[sourceArtifactId] = 1
+        it[purl] = "purl"
+        it[description] = "description"
+        it[homepageUrl] = "homepageUrl"
+    }.value.also { packageId ->
+        V69PackagesAnalyzerRunsTable.insert {
+            it[V69PackagesAnalyzerRunsTable.packageId] = packageId
+            it[V69PackagesAnalyzerRunsTable.analyzerRunId] = analyzerRunId
+        }
+    }
+}
+
+private object V69PackagesAnalyzerRunsTable : Table("packages_analyzer_runs") {
+    val packageId = reference("package_id", V69PackagesTable)
+    val analyzerRunId = reference("analyzer_run_id", V69AnalyzerRunsTable)
+
+    override val primaryKey: PrimaryKey
+        get() = PrimaryKey(packageId, analyzerRunId, name = "${tableName}_pkey")
+}
+
+private object V70ProjectsAnalyzerRunsTable : Table("projects_analyzer_runs") {
+    val projectId = reference("project_id", V69ProjectsTable)
+    val analyzerRunId = reference("analyzer_run_id", V69AnalyzerRunsTable)
+
+    override val primaryKey: PrimaryKey
+        get() = PrimaryKey(projectId, analyzerRunId, name = "${tableName}_pkey")
+}
+
+private object V70ProcessedDeclaredLicensesTable : LongIdTable("processed_declared_licenses") {
+    val packageId = reference("package_id", V69PackagesTable).nullable()
+    val projectId = reference("project_id", V69ProjectsTable).nullable()
+
+    val spdxExpression = text("spdx_expression").nullable()
+
+    fun create(packageId: Long? = null, projectId: Long? = null, spdxExpression: String? = null) = insertAndGetId {
+        it[this.packageId] = packageId
+        it[this.projectId] = projectId
+        it[this.spdxExpression] = spdxExpression
+    }.value
+
+    fun findLicensesForPackage(packageId: Long) =
+        selectAll().where { V70ProcessedDeclaredLicensesTable.packageId eq packageId }.map { it[spdxExpression] }
+
+    fun findLicensesForProject(projectId: Long) =
+        selectAll().where { V70ProcessedDeclaredLicensesTable.projectId eq projectId }.map { it[spdxExpression] }
+}

--- a/dao/src/test/kotlin/repositories/DaoAnalyzerRunRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/DaoAnalyzerRunRepositoryTest.kt
@@ -28,6 +28,7 @@ import kotlinx.datetime.Clock
 
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
 import org.eclipse.apoapsis.ortserver.dao.tables.runs.analyzer.PackagesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.runs.analyzer.ProjectsTable
 import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
 import org.eclipse.apoapsis.ortserver.dao.utils.toDatabasePrecision
 import org.eclipse.apoapsis.ortserver.model.RepositoryType
@@ -74,6 +75,13 @@ class DaoAnalyzerRunRepositoryTest : StringSpec({
         analyzerRunRepository.create(analyzerJobId, analyzerRun)
 
         dbExtension.db.dbQuery { PackagesTable.selectAll().count() } shouldBe 1
+    }
+
+    "create should deduplicate projects" {
+        analyzerRunRepository.create(analyzerJobId, analyzerRun)
+        analyzerRunRepository.create(analyzerJobId, analyzerRun)
+
+        dbExtension.db.dbQuery { ProjectsTable.selectAll().count() } shouldBe 1
     }
 
     "get should return null" {


### PR DESCRIPTION
Due to bugs in `PackagesTable` and `ProjectsTable` the intended deduplication for packages and projects does not work. Therefore, new entities are created on each ORT run causing the tables to grow continuously.

~This is WIP. So far, the logic in the table classes is fixed. The PR should not be merged before a migration script is available that cleans up the mess in the database.~

This change works without also cleaning up duplicated entities in the database, so the clean up migration can be done in a separate PR.

