### PR TITLE
chore(ui): Use the Lucide "Repeat" icon instead of "Redo2"

### DIFF
--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs2/$runIndex/index.tsx
@@ -19,7 +19,7 @@
 
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { Redo2 } from 'lucide-react';
+import { Repeat } from 'lucide-react';
 import { z } from 'zod';
 
 import { useRepositoriesServiceGetOrtRunByIndexKey } from '@/api/queries';
@@ -82,7 +82,7 @@ const RunComponent = () => {
                     }}
                   >
                     Rerun
-                    <Redo2 className='ml-1 h-4 w-4' />
+                    <Repeat className='ml-1 h-4 w-4' />
                   </Link>
                 </Button>
               </CardTitle>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/index.tsx
@@ -24,7 +24,7 @@ import {
   getCoreRowModel,
   useReactTable,
 } from '@tanstack/react-table';
-import { EditIcon, PlusIcon, Redo2 } from 'lucide-react';
+import { EditIcon, PlusIcon, Repeat } from 'lucide-react';
 
 import {
   useRepositoriesServiceDeleteRepositoryById,
@@ -140,7 +140,7 @@ const columns: ColumnDef<GetOrtRunsResponse['data'][number]>[] = [
               }}
             >
               Rerun
-              <Redo2 className='ml-1 h-4 w-4' />
+              <Repeat className='ml-1 h-4 w-4' />
             </Link>
           </Button>
         </TooltipTrigger>


### PR DESCRIPTION
The "Redo2" icon [1] is supposed to be used in the context of "undo" operations, so use the better fitting "Repeat" icon [2] instead.

[1]: https://lucide.dev/icons/redo-2
[2]: https://lucide.dev/icons/repeat