### PR TITLE
build(gradle): Move publication logic to a conventions plugin

### DIFF
--- a/api/v1/mapping/build.gradle.kts
+++ b/api/v1/mapping/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-multiplatform-conventions")
+    id("ort-server-publication-conventions")
 }
 
 group = "org.eclipse.apoapsis.ortserver.api.v1"

--- a/api/v1/model/build.gradle.kts
+++ b/api/v1/model/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-multiplatform-conventions")
+    id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
     alias(libs.plugins.kotlinSerialization)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,7 +29,6 @@ plugins {
     alias(libs.plugins.dependencyAnalysis)
     alias(libs.plugins.gitSemver)
     alias(libs.plugins.jib) apply false
-    alias(libs.plugins.mavenPublish)
     alias(libs.plugins.versions)
 }
 
@@ -52,50 +51,6 @@ if (version == Project.DEFAULT_VERSION) {
 }
 
 logger.lifecycle("Building ORT Server version $version.")
-
-allprojects {
-    apply(plugin = rootProject.libs.plugins.mavenPublish.get().pluginId)
-
-    mavenPublishing {
-        pom {
-            name = project.name
-            description = "Part of the ORT Server, the reference implementation of Eclipse Apoapsis."
-            url = "https://projects.eclipse.org/projects/technology.apoapsis"
-
-            developers {
-                developer {
-                    name = "The ORT Server Project Authors"
-                }
-            }
-
-            licenses {
-                license {
-                    name = "Apache-2.0"
-                    url = "https://www.apache.org/licenses/LICENSE-2.0"
-                }
-            }
-        }
-
-        publishing {
-            repositories {
-                maven {
-                    name = "githubPackages"
-
-                    // The owner and repository need to be configured in the `GITHUB_REPOSITORY` environment variable,
-                    // for example "octocat/Hello-Word". This variable is set by default in GitHub actions, see
-                    // https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables.
-                    url = uri("https://maven.pkg.github.com/${System.getenv("GITHUB_REPOSITORY")}")
-
-                    // Username and password (a personal GitHub access token) should be specified as
-                    // `githubPackagesUsername` and `githubPackagesPassword` Gradle properties or alternatively as
-                    // `ORG_GRADLE_PROJECT_githubPackagesUsername` and `ORG_GRADLE_PROJECT_githubPackagesPassword`
-                    // environment variables.
-                    credentials(PasswordCredentials::class)
-                }
-            }
-        }
-    }
-}
 
 tasks.named<DependencyUpdatesTask>("dependencyUpdates").configure {
     gradleReleaseChannel = "current"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -36,4 +36,5 @@ dependencies {
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
     implementation(libs.plugin.detekt)
     implementation(libs.plugin.kotlin)
+    implementation(libs.plugin.mavenPublish)
 }

--- a/buildSrc/src/main/kotlin/ort-server-publication-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-publication-conventions.gradle.kts
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+plugins {
+    // Apply third-party plugins.
+    id("com.vanniktech.maven.publish")
+}
+
+mavenPublishing {
+    pom {
+        name = project.name
+        description = "Part of the ORT Server, the reference implementation of Eclipse Apoapsis."
+        url = "https://projects.eclipse.org/projects/technology.apoapsis"
+
+        developers {
+            developer {
+                name = "The ORT Server Project Authors"
+            }
+        }
+
+        licenses {
+            license {
+                name = "Apache-2.0"
+                url = "https://www.apache.org/licenses/LICENSE-2.0"
+            }
+        }
+    }
+
+    publishing {
+        repositories {
+            maven {
+                name = "githubPackages"
+
+                // The owner and repository need to be configured in the `GITHUB_REPOSITORY` environment variable,
+                // for example "octocat/Hello-Word". This variable is set by default in GitHub actions, see
+                // https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables.
+                url = uri("https://maven.pkg.github.com/${System.getenv("GITHUB_REPOSITORY")}")
+
+                // Username and password (a personal GitHub access token) should be specified as
+                // `githubPackagesUsername` and `githubPackagesPassword` Gradle properties or alternatively as
+                // `ORG_GRADLE_PROJECT_githubPackagesUsername` and `ORG_GRADLE_PROJECT_githubPackagesPassword`
+                // environment variables.
+                credentials(PasswordCredentials::class)
+            }
+        }
+    }
+}

--- a/clients/keycloak/build.gradle.kts
+++ b/clients/keycloak/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
 
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
     alias(libs.plugins.kotlinSerialization)

--- a/config/git/build.gradle.kts
+++ b/config/git/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 }
 
 group = "org.eclipse.apoapsis.ortserver.config"

--- a/config/github/build.gradle.kts
+++ b/config/github/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 }
 
 group = "org.eclipse.apoapsis.ortserver.config"

--- a/config/local/build.gradle.kts
+++ b/config/local/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 }
 
 group = "org.eclipse.apoapsis.ortserver.config"

--- a/config/secret-file/build.gradle.kts
+++ b/config/secret-file/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 }
 
 group = "org.eclipse.apoapsis.ortserver.config"

--- a/config/spi/build.gradle.kts
+++ b/config/spi/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
 
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 }
 
 group = "org.eclipse.apoapsis.ortserver.config"

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -28,6 +28,7 @@ plugins {
 
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
     alias(libs.plugins.jib)

--- a/dao/build.gradle.kts
+++ b/dao/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
 
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
     alias(libs.plugins.kotlinSerialization)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -71,13 +71,13 @@ dependencyAnalysis = { id = "com.autonomousapps.dependency-analysis", version.re
 gitSemver = { id = "com.github.jmongard.git-semver-plugin", version.ref = "gitSemverPlugin" }
 jib = { id = "com.google.cloud.tools.jib", version.ref = "jibPlugin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinPlugin" }
-mavenPublish = { id = "com.vanniktech.maven.publish", version.ref = "mavenPublishPlugin" }
 versions = { id = "com.github.ben-manes.versions", version.ref = "versionsPlugin" }
 
 [libraries]
 # These are Maven coordinates for Gradle plugins, which is necessary to use them in precompiled plugin scripts.
 plugin-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detektPlugin" }
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinPlugin" }
+plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublishPlugin" }
 
 exposedCore = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
 exposedDao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed" }

--- a/logaccess/loki/build.gradle.kts
+++ b/logaccess/loki/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
     alias(libs.plugins.kotlinSerialization)

--- a/logaccess/spi/build.gradle.kts
+++ b/logaccess/spi/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
 
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 }
 
 group = "org.eclipse.apoapsis.ortserver.logaccess"

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-multiplatform-conventions")
+    id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
     alias(libs.plugins.kotlinSerialization)

--- a/orchestrator/build.gradle.kts
+++ b/orchestrator/build.gradle.kts
@@ -25,6 +25,7 @@ val dockerImageTag: String by project
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
     alias(libs.plugins.jib)

--- a/secrets/file/build.gradle.kts
+++ b/secrets/file/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
     alias(libs.plugins.kotlinSerialization)

--- a/secrets/scaleway/build.gradle.kts
+++ b/secrets/scaleway/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
     alias(libs.plugins.kotlinSerialization)

--- a/secrets/spi/build.gradle.kts
+++ b/secrets/spi/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
 
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 }
 
 group = "org.eclipse.apoapsis.ortserver.secrets"

--- a/secrets/vault/build.gradle.kts
+++ b/secrets/vault/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
     alias(libs.plugins.kotlinSerialization)

--- a/services/authorization/build.gradle.kts
+++ b/services/authorization/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 }
 
 group = "org.eclipse.apoapsis.ortserver.services"

--- a/services/hierarchy/build.gradle.kts
+++ b/services/hierarchy/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 }
 
 group = "org.eclipse.apoapsis.ortserver.services"

--- a/services/infrastructure/build.gradle.kts
+++ b/services/infrastructure/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 }
 
 group = "org.eclipse.apoapsis.ortserver.services"

--- a/services/report-storage/build.gradle.kts
+++ b/services/report-storage/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 }
 
 group = "org.eclipse.apoapsis.ortserver.services"

--- a/services/secret/build.gradle.kts
+++ b/services/secret/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 }
 
 group = "org.eclipse.apoapsis.ortserver.services"

--- a/storage/database/build.gradle.kts
+++ b/storage/database/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 }
 
 group = "org.eclipse.apoapsis.ortserver.storage"

--- a/storage/s3/build.gradle.kts
+++ b/storage/s3/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
 
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 }
 
 group = "org.eclipse.apoapsis.ortserver.storage"

--- a/storage/spi/build.gradle.kts
+++ b/storage/spi/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
 
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 }
 
 group = "org.eclipse.apoapsis.ortserver.storage"

--- a/transport/activemqartemis/build.gradle.kts
+++ b/transport/activemqartemis/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
     alias(libs.plugins.kotlinSerialization)

--- a/transport/kubernetes-jobmonitor/build.gradle.kts
+++ b/transport/kubernetes-jobmonitor/build.gradle.kts
@@ -28,6 +28,7 @@ plugins {
 
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
     alias(libs.plugins.jib)

--- a/transport/kubernetes/build.gradle.kts
+++ b/transport/kubernetes/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
     alias(libs.plugins.kotlinSerialization)

--- a/transport/rabbitmq/build.gradle.kts
+++ b/transport/rabbitmq/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 }
 
 group = "org.eclipse.apoapsis.ortserver.transport"

--- a/transport/spi/build.gradle.kts
+++ b/transport/spi/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
 
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
     alias(libs.plugins.kotlinSerialization)

--- a/transport/sqs/build.gradle.kts
+++ b/transport/sqs/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
     alias(libs.plugins.kotlinSerialization)

--- a/utils/config/build.gradle.kts
+++ b/utils/config/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 }
 
 group = "org.eclipse.apoapsis.ortserver.utils"

--- a/utils/test/build.gradle.kts
+++ b/utils/test/build.gradle.kts
@@ -20,6 +20,7 @@
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-multiplatform-conventions")
+    id("ort-server-publication-conventions")
 }
 
 group = "org.eclipse.apoapsis.ortserver.utils"

--- a/workers/advisor/build.gradle.kts
+++ b/workers/advisor/build.gradle.kts
@@ -28,6 +28,7 @@ plugins {
 
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
     alias(libs.plugins.jib)

--- a/workers/analyzer/build.gradle.kts
+++ b/workers/analyzer/build.gradle.kts
@@ -30,6 +30,7 @@ plugins {
 
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
     alias(libs.plugins.jib)

--- a/workers/common/build.gradle.kts
+++ b/workers/common/build.gradle.kts
@@ -24,6 +24,7 @@ plugins {
 
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
     alias(libs.plugins.kotlinSerialization)

--- a/workers/config/build.gradle.kts
+++ b/workers/config/build.gradle.kts
@@ -30,6 +30,7 @@ plugins {
 
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
     alias(libs.plugins.jib)

--- a/workers/evaluator/build.gradle.kts
+++ b/workers/evaluator/build.gradle.kts
@@ -30,6 +30,7 @@ plugins {
 
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
     alias(libs.plugins.jib)

--- a/workers/notifier/build.gradle.kts
+++ b/workers/notifier/build.gradle.kts
@@ -30,6 +30,7 @@ plugins {
 
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
     alias(libs.plugins.jib)

--- a/workers/reporter/build.gradle.kts
+++ b/workers/reporter/build.gradle.kts
@@ -30,6 +30,7 @@ plugins {
 
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
     alias(libs.plugins.jib)

--- a/workers/scanner/build.gradle.kts
+++ b/workers/scanner/build.gradle.kts
@@ -30,6 +30,7 @@ plugins {
 
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
     alias(libs.plugins.jib)


### PR DESCRIPTION
This removes the last use of `allprojects` to decouple projects, also see [1].

[1]: https://docs.gradle.org/current/userguide/multi_project_configuration_and_execution.html#sec:decoupled_projects