### PR TITLE
test(transport): Increase the queue timeout

### DIFF
--- a/transport/spi/src/testFixtures/kotlin/Utils.kt
+++ b/transport/spi/src/testFixtures/kotlin/Utils.kt
@@ -37,6 +37,7 @@ import org.eclipse.apoapsis.ortserver.transport.MessageReceiverFactory
 import org.eclipse.apoapsis.ortserver.transport.OrchestratorEndpoint
 
 const val TEST_QUEUE_NAME = "test_queue"
+const val TEST_QUEUE_TIMEOUT = 15L
 
 /**
  * Create a [ConfigManager] with a test queue for [consumerName] using [transportType] and [transportName] that is
@@ -83,7 +84,7 @@ fun startReceiver(configManager: ConfigManager): LinkedBlockingQueue<Message<Orc
  * Check that the next message in this queue has the given [traceId], [runId], and [payload].
  */
 fun <T> BlockingQueue<Message<T>>.checkMessage(traceId: String, runId: Long, payload: T) {
-    poll(5, TimeUnit.SECONDS) shouldNotBeNull {
+    poll(TEST_QUEUE_TIMEOUT, TimeUnit.SECONDS) shouldNotBeNull {
         header.traceId shouldBe traceId
         header.ortRunId shouldBe runId
         payload shouldBe payload


### PR DESCRIPTION
In CI, `SqsMessageReceiverFactoryTest` often fails with "Expected value to not be null, but was null" when polling the queue [1], which does return "null if the specified waiting time elapses before an element is available".

Triple the timeout to 15 seconds to try addressing that, and move the timeout to a constant while at it.

Hopefully fixes #720.

[1]: https://github.com/eclipse-apoapsis/ort-server/actions/runs/10488199036/job/29050829407?pr=861#step:5:3552