### PR TITLE
feat(ui): Include the global run ID into the log archive download

### DIFF
--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/index.tsx
@@ -75,7 +75,7 @@ const RunComponent = () => {
       const url = window.URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = 'logs.zip';
+      a.download = `logs-global-run-${runId}.zip`;
       a.click();
       window.URL.revokeObjectURL(url);
     } catch (error) {


### PR DESCRIPTION
This avoids conflicts when downloading multiple archives.