### PR TITLE
feat(ui): Prefer the backend-provided log archive name

### DIFF
--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/index.tsx
@@ -75,7 +75,13 @@ const RunComponent = () => {
       const url = window.URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
-      a.download = `logs-global-run-${runId}.zip`;
+      const filename = response.headers
+        .get('content-disposition')
+        ?.split(';')
+        ?.find((entry) => entry.includes('filename='))
+        ?.replace('filename=', '')
+        ?.trim();
+      a.download = filename ?? `${runId}_logs.zip`;
       a.click();
       window.URL.revokeObjectURL(url);
     } catch (error) {


### PR DESCRIPTION
Otherwise align with [1] as a fallback.

[1]: https://github.com/eclipse-apoapsis/ort-server/blob/03f5738d78aacb1ef4814b3d3eb657cf641cbee8/core/src/main/kotlin/api/RunsRoute.kt#L98