### PR TITLE
build(gradle): Enable consistent `copy()` visibility

### DIFF
--- a/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-conventions.gradle.kts
@@ -52,6 +52,7 @@ tasks.named<KotlinCompile>("compileKotlin") {
 
     compilerOptions {
         allWarningsAsErrors = true
+        freeCompilerArgs = listOf("-Xconsistent-data-class-copy-visibility")
         jvmTarget = maxKotlinJvmTarget
         optIn = optInRequirements
     }


### PR DESCRIPTION
Apply upcoming Kotlin 2.1 behavior to align the `copy()` function's visibility to the visibility of the primary constructor for data classes. This avoids the new compiler warning with Kotlin 2.0.20 if properties of a private primary constructor are exposed via `copy()`, even though the `copy()` function is not called.