### PR TITLE
Deduplication migration

### DIFF
--- a/dao/src/main/kotlin/migrations/V72__deduplicatePackages.kt
+++ b/dao/src/main/kotlin/migrations/V72__deduplicatePackages.kt
@@ -1,0 +1,293 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+@file:Suppress("Filename")
+
+package db.migration
+
+import org.flywaydb.core.api.migration.BaseJavaMigration
+import org.flywaydb.core.api.migration.Context
+
+import org.jetbrains.exposed.dao.id.LongIdTable
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.update
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+
+@Suppress("ClassNaming")
+internal class V72__deduplicatePackages : BaseJavaMigration() {
+    private val logger: Logger = LoggerFactory.getLogger(this::class.java)
+
+    private var curIndex = -1L
+
+    override fun migrate(context: Context?) {
+        transaction {
+            while (nextPackageId() != null) {
+                val equalPackages = findEqualPackages(curIndex)
+
+                logger.info(
+                    "Found ${equalPackages.count()} equal packages for package with ID $curIndex: $equalPackages"
+                )
+
+                equalPackages.forEach {
+                    updateReferences(curIndex, it)
+                    deletePackage(it)
+                }
+
+                logger.info("Remaining packages: ${V72PackagesTable.selectAll().count()}")
+            }
+        }
+    }
+
+    /**
+     * Find the next package ID that is greater than the [curIndex].
+     */
+    private fun nextPackageId() =
+        V72PackagesTable.select(V72PackagesTable.id)
+            .where { V72PackagesTable.id greater curIndex }
+            .limit(1)
+            .singleOrNull()
+            ?.let {
+                curIndex = it[V72PackagesTable.id].value
+                curIndex
+            }
+
+    /**
+     * Find all packages that are equal to the package with the provided [pkgId]. Equal means that not only the values
+     * of the columns are equal, but also the references to other tables.
+     */
+    private fun findEqualPackages(pkgId: Long): List<Long> {
+        val pkg = V72PackagesTable.selectAll().where { V72PackagesTable.id eq pkgId }.single()
+
+        val authors = V72PackagesAuthorsTable.getForPackage(pkgId)
+        val declaredLicenses = V72PackagesDeclaredLicensesTable.getForPackage(pkgId)
+        val processedDeclaredLicenses = V72ProcessedDeclaredLicensesTable.getForPackage(pkgId)
+
+        return V72PackagesTable.selectAll().where {
+            V72PackagesTable.id neq pkgId and
+                    (V72PackagesTable.identifierId eq pkg[V72PackagesTable.identifierId]) and
+                    (V72PackagesTable.vcsId eq pkg[V72PackagesTable.vcsId]) and
+                    (V72PackagesTable.vcsProcessedId eq pkg[V72PackagesTable.vcsProcessedId]) and
+                    (V72PackagesTable.binaryArtifactId eq pkg[V72PackagesTable.binaryArtifactId]) and
+                    (V72PackagesTable.sourceArtifactId eq pkg[V72PackagesTable.sourceArtifactId]) and
+                    (V72PackagesTable.purl eq pkg[V72PackagesTable.purl]) and
+                    (V72PackagesTable.cpe eq pkg[V72PackagesTable.cpe]) and
+                    (V72PackagesTable.description eq pkg[V72PackagesTable.description]) and
+                    (V72PackagesTable.homepageUrl eq pkg[V72PackagesTable.homepageUrl]) and
+                    (V72PackagesTable.isMetadataOnly eq pkg[V72PackagesTable.isMetadataOnly]) and
+                    (V72PackagesTable.isModified eq pkg[V72PackagesTable.isModified])
+        }.map { it[V72PackagesTable.id].value }
+            .filter { V72PackagesAuthorsTable.getForPackage(it) == authors }
+            .filter { V72PackagesDeclaredLicensesTable.getForPackage(it) == declaredLicenses }
+            .filter { V72ProcessedDeclaredLicensesTable.getForPackage(it) == processedDeclaredLicenses }
+    }
+
+    /**
+     * Update all references to the [duplicatePkgId] to point to the [pkgId] instead.
+     */
+    private fun updateReferences(pkgId: Long, duplicatePkgId: Long) {
+        V72PackagesAnalyzerRunsTable.update({ V72PackagesAnalyzerRunsTable.packageId eq duplicatePkgId }) {
+            it[packageId] = pkgId
+        }
+    }
+
+    /**
+     * Delete the package with the provided [pkgId].
+     */
+    private fun deletePackage(pkgId: Long) {
+        V72PackagesAuthorsTable.deleteWhere { packageId eq pkgId }
+        V72PackagesDeclaredLicensesTable.deleteWhere { packageId eq pkgId }
+
+        V72ProcessedDeclaredLicensesTable.select(V72ProcessedDeclaredLicensesTable.id)
+            .where { V72ProcessedDeclaredLicensesTable.packageId eq pkgId }
+            .forEach { processedDeclaredLicense ->
+                val id = processedDeclaredLicense[V72ProcessedDeclaredLicensesTable.id].value
+
+                V72ProcessedDeclaredLicensesMappedDeclaredLicensesTable.deleteWhere {
+                    processedDeclaredLicenseId eq id
+                }
+
+                V72ProcessedDeclaredLicensesUnmappedDeclaredLicensesTable.deleteWhere {
+                    processedDeclaredLicenseId eq id
+                }
+            }
+
+        V72ProcessedDeclaredLicensesTable.deleteWhere { packageId eq pkgId }
+
+        V72PackagesTable.deleteWhere { id eq pkgId }
+    }
+}
+
+internal object V72PackagesTable : LongIdTable("packages") {
+    val identifierId = reference("identifier_id", V72IdentifiersTable)
+    val vcsId = reference("vcs_id", V72VcsInfoTable)
+    val vcsProcessedId = reference("vcs_processed_id", V72VcsInfoTable)
+    val binaryArtifactId = reference("binary_artifact_id", V72RemoteArtifactsTable)
+    val sourceArtifactId = reference("source_artifact_id", V72RemoteArtifactsTable)
+
+    val purl = text("purl")
+    val cpe = text("cpe").nullable()
+    val description = text("description")
+    val homepageUrl = text("homepage_url")
+    val isMetadataOnly = bool("is_metadata_only").default(false)
+    val isModified = bool("is_modified").default(false)
+}
+
+internal object V72IdentifiersTable : LongIdTable("identifiers") {
+    val type = text("type")
+    val namespace = text("namespace")
+    val name = text("name")
+    val version = text("version")
+}
+
+internal object V72VcsInfoTable : LongIdTable("vcs_info") {
+    val type = text("type")
+    val url = text("url")
+    val revision = text("revision")
+    val path = text("path")
+}
+
+internal object V72RemoteArtifactsTable : LongIdTable("remote_artifacts") {
+    val url = text("url")
+    val hashValue = text("hash_value")
+    val hashAlgorithm = text("hash_algorithm")
+}
+
+internal object V72PackagesAuthorsTable : Table("packages_authors") {
+    val authorId = reference("author_id", V72AuthorsTable)
+    val packageId = reference("package_id", V72PackagesTable)
+
+    override val primaryKey: PrimaryKey
+        get() = PrimaryKey(authorId, packageId, name = "${tableName}_pkey")
+
+    fun getForPackage(pkgId: Long): Set<Long> =
+        select(authorId)
+            .where { packageId eq pkgId }
+            .orderBy(packageId)
+            .mapTo(mutableSetOf()) { it[authorId].value }
+}
+
+internal object V72AuthorsTable : LongIdTable("authors") {
+    val name = text("name")
+}
+
+internal object V72PackagesDeclaredLicensesTable : Table("packages_declared_licenses") {
+    val packageId = reference("package_id", V72PackagesTable)
+    val declaredLicenseId = reference("declared_license_id", V72DeclaredLicensesTable)
+
+    override val primaryKey: PrimaryKey
+        get() = PrimaryKey(packageId, declaredLicenseId, name = "${tableName}_pkey")
+
+    fun getForPackage(pkgId: Long): Set<Long> =
+        select(declaredLicenseId)
+            .where { packageId eq pkgId }
+            .orderBy(packageId)
+            .mapTo(mutableSetOf()) { it[declaredLicenseId].value }
+}
+
+internal object V72DeclaredLicensesTable : LongIdTable("declared_licenses") {
+    val name = text("name")
+}
+
+internal object V72ProcessedDeclaredLicensesTable : LongIdTable("processed_declared_licenses") {
+    val packageId = reference("package_id", V72PackagesTable).nullable()
+//    val projectId = reference("project_id", ProjectsTable).nullable()
+
+    val spdxExpression = text("spdx_expression").nullable()
+
+    fun getForPackage(pkgId: Long): Set<V72ProcessedDeclaredLicense> =
+        selectAll()
+            .where { packageId eq pkgId }
+            .orderBy(packageId)
+            .mapTo(mutableSetOf()) { processedDeclaredLicense ->
+                val id = processedDeclaredLicense[id].value
+                val spdxExpression = processedDeclaredLicense[spdxExpression]
+
+                val mappedLicenses =
+                    V72ProcessedDeclaredLicensesMappedDeclaredLicensesTable.getForProcessedDeclaredLicense(id)
+
+                val unmappedLicenses =
+                    V72ProcessedDeclaredLicensesUnmappedDeclaredLicensesTable.getForProcessedDeclaredLicense(id)
+
+                V72ProcessedDeclaredLicense(spdxExpression, mappedLicenses, unmappedLicenses)
+            }
+}
+
+internal object V72ProcessedDeclaredLicensesMappedDeclaredLicensesTable :
+    Table("processed_declared_licenses_mapped_declared_licenses") {
+    val processedDeclaredLicenseId = reference("processed_declared_license_id", V72ProcessedDeclaredLicensesTable)
+    val mappedDeclaredLicenseId = reference("mapped_declared_license_id", V72MappedDeclaredLicensesTable)
+
+    override val primaryKey: PrimaryKey
+        get() = PrimaryKey(processedDeclaredLicenseId, mappedDeclaredLicenseId, name = "${tableName}_pkey")
+
+    fun getForProcessedDeclaredLicense(processedDeclaredLicense: Long) =
+        (this innerJoin V72MappedDeclaredLicensesTable)
+            .select(V72MappedDeclaredLicensesTable.declaredLicense, V72MappedDeclaredLicensesTable.mappedLicense)
+            .where { processedDeclaredLicenseId eq processedDeclaredLicense }
+            .associate {
+                it[V72MappedDeclaredLicensesTable.declaredLicense] to it[V72MappedDeclaredLicensesTable.mappedLicense]
+            }
+}
+
+internal object V72MappedDeclaredLicensesTable : LongIdTable("mapped_declared_licenses") {
+    val declaredLicense = text("declared_license")
+    val mappedLicense = text("mapped_license")
+}
+
+internal object V72ProcessedDeclaredLicensesUnmappedDeclaredLicensesTable :
+    Table("processed_declared_licenses_unmapped_declared_licenses") {
+    val processedDeclaredLicenseId = reference("processed_declared_license_id", V72ProcessedDeclaredLicensesTable)
+    val unmappedDeclaredLicenseId = reference("unmapped_declared_license_id", V72UnmappedDeclaredLicensesTable)
+
+    override val primaryKey: PrimaryKey
+        get() = PrimaryKey(processedDeclaredLicenseId, unmappedDeclaredLicenseId, name = "${tableName}_pkey")
+
+    fun getForProcessedDeclaredLicense(processedDeclaredLicense: Long) =
+        (this innerJoin V72UnmappedDeclaredLicensesTable)
+            .select(V72UnmappedDeclaredLicensesTable.unmappedLicense)
+            .where { processedDeclaredLicenseId eq processedDeclaredLicense }
+            .mapTo(mutableSetOf()) { it[V72UnmappedDeclaredLicensesTable.unmappedLicense] }
+}
+
+internal object V72UnmappedDeclaredLicensesTable : LongIdTable("unmapped_declared_licenses") {
+    val unmappedLicense = text("unmapped_license")
+}
+
+internal data class V72ProcessedDeclaredLicense(
+    val spdxExpression: String?,
+    val mappedLicenses: Map<String, String>,
+    val unmappedLicenses: Set<String>
+)
+
+internal object V72PackagesAnalyzerRunsTable : Table("packages_analyzer_runs") {
+    val packageId = reference("package_id", V72PackagesTable)
+    val analyzerRunId = reference("analyzer_run_id", V72AnalyzerRunsTable)
+
+    override val primaryKey: PrimaryKey
+        get() = PrimaryKey(packageId, analyzerRunId, name = "${tableName}_pkey")
+}
+
+internal object V72AnalyzerRunsTable : LongIdTable("analyzer_runs")

--- a/dao/src/test/kotlin/migrations/V72__deduplicatePackagesTest.kt
+++ b/dao/src/test/kotlin/migrations/V72__deduplicatePackagesTest.kt
@@ -1,0 +1,490 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package db.migration
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.should
+
+import org.eclipse.apoapsis.ortserver.dao.disableForeignKeyConstraints
+import org.eclipse.apoapsis.ortserver.dao.test.DatabaseMigrationTestExtension
+
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.insertAndGetId
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+
+@Suppress("ClassNaming")
+class V72__deduplicatePackagesTest : WordSpec({
+    val extension = extension(DatabaseMigrationTestExtension("71", "72"))
+
+    var identifier1 = 0L
+    var identifier2 = 0L
+
+    var vcs1 = 0L
+    var vcs2 = 0L
+
+    var vcsProcessed1 = 0L
+    var vcsProcessed2 = 0L
+
+    var binaryArtifact1 = 0L
+    var binaryArtifact2 = 0L
+
+    var sourceArtifact1 = 0L
+    var sourceArtifact2 = 0L
+
+    beforeEach {
+        transaction {
+            identifier1 = V72IdentifiersTable.insertAndGetId {
+                it[type] = "type1"
+                it[namespace] = "namespace1"
+                it[name] = "name1"
+                it[version] = "version1"
+            }.value
+
+            identifier2 = V72IdentifiersTable.insertAndGetId {
+                it[type] = "type2"
+                it[namespace] = "namespace2"
+                it[name] = "name2"
+                it[version] = "version2"
+            }.value
+
+            vcs1 = V72VcsInfoTable.insertAndGetId {
+                it[type] = "type1"
+                it[url] = "url1"
+                it[revision] = "revision1"
+                it[path] = "path1"
+            }.value
+
+            vcs2 = V72VcsInfoTable.insertAndGetId {
+                it[type] = "type2"
+                it[url] = "url2"
+                it[revision] = "revision2"
+                it[path] = "path2"
+            }.value
+
+            vcsProcessed1 = V72VcsInfoTable.insertAndGetId {
+                it[type] = "processed_type1"
+                it[url] = "processed_url1"
+                it[revision] = "processed_revision1"
+                it[path] = "processed_path1"
+            }.value
+
+            vcsProcessed2 = V72VcsInfoTable.insertAndGetId {
+                it[type] = "processed_type2"
+                it[url] = "processed_url2"
+                it[revision] = "processed_revision2"
+                it[path] = "processed_path2"
+            }.value
+
+            binaryArtifact1 = V72RemoteArtifactsTable.insertAndGetId {
+                it[url] = "binary_url1"
+                it[hashValue] = "binary_hashValue1"
+                it[hashAlgorithm] = "binary_hashAlgorithm1"
+            }.value
+
+            binaryArtifact2 = V72RemoteArtifactsTable.insertAndGetId {
+                it[url] = "binary_url2"
+                it[hashValue] = "binary_hashValue2"
+                it[hashAlgorithm] = "binary_hashAlgorithm2"
+            }.value
+
+            sourceArtifact1 = V72RemoteArtifactsTable.insertAndGetId {
+                it[url] = "source_url1"
+                it[hashValue] = "source_hashValue1"
+                it[hashAlgorithm] = "source_hashAlgorithm1"
+            }.value
+
+            sourceArtifact2 = V72RemoteArtifactsTable.insertAndGetId {
+                it[url] = "source_url2"
+                it[hashValue] = "source_hashValue2"
+                it[hashAlgorithm] = "source_hashAlgorithm2"
+            }.value
+        }
+    }
+
+    "the migration" should {
+        "keep different packages" {
+            var pkg1 = 0L
+            var pkg2 = 0L
+            var pkg3 = 0L
+            var pkg4 = 0L
+            var pkg5 = 0L
+            var pkg6 = 0L
+
+            transaction {
+                pkg1 = createPackage(identifier1, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+                pkg2 = createPackage(identifier2, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+                pkg3 = createPackage(identifier1, vcs2, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+                pkg4 = createPackage(identifier1, vcs1, vcsProcessed2, binaryArtifact1, sourceArtifact1)
+                pkg5 = createPackage(identifier1, vcs1, vcsProcessed1, binaryArtifact2, sourceArtifact1)
+                pkg6 = createPackage(identifier1, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact2)
+            }
+
+            extension.testAppliedMigration {
+                transaction {
+                    V72PackagesTable.selectAll().map { it[V72PackagesTable.id].value } should
+                            containExactly(pkg1, pkg2, pkg3, pkg4, pkg5, pkg6)
+                }
+            }
+        }
+
+        "keep packages with different authors" {
+            var pkg1 = 0L
+            var pkg2 = 0L
+            var pkg3 = 0L
+
+            var author1: Long
+            var author2: Long
+
+            transaction {
+                pkg1 = createPackage(identifier1, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+                pkg2 = createPackage(identifier1, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+                pkg3 = createPackage(identifier1, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+
+                author1 = createAuthor("author1")
+                author2 = createAuthor("author2")
+
+                addAuthors(pkg1, author1)
+                addAuthors(pkg2, author2)
+                addAuthors(pkg3, author1, author2)
+            }
+
+            extension.testAppliedMigration {
+                transaction {
+                    V72PackagesTable.selectAll().map { it[V72PackagesTable.id].value } should
+                            containExactly(pkg1, pkg2, pkg3)
+                }
+            }
+        }
+
+        "keep packages with different declared licenses" {
+            var pkg1 = 0L
+            var pkg2 = 0L
+            var pkg3 = 0L
+
+            var license1: Long
+            var license2: Long
+
+            transaction {
+                pkg1 = createPackage(identifier1, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+                pkg2 = createPackage(identifier1, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+                pkg3 = createPackage(identifier1, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+
+                license1 = createDeclaredLicense("license1")
+                license2 = createDeclaredLicense("license2")
+
+                addDeclaredLicenses(pkg1, license1)
+                addDeclaredLicenses(pkg2, license2)
+                addDeclaredLicenses(pkg3, license1, license2)
+            }
+
+            extension.testAppliedMigration {
+                transaction {
+                    V72PackagesTable.selectAll().map { it[V72PackagesTable.id].value } should
+                            containExactly(pkg1, pkg2, pkg3)
+                }
+            }
+        }
+
+        "keep packages with different processed declared licenses" {
+            var pkg1 = 0L
+            var pkg2 = 0L
+            var pkg3 = 0L
+            var pkg4 = 0L
+            var pkg5 = 0L
+            var pkg6 = 0L
+            var pkg7 = 0L
+
+            val license1 = "license1"
+            val license2 = "license2"
+
+            var mappedLicense1: Long
+            var mappedLicense2: Long
+
+            var unmappedLicense1: Long
+            var unmappedLicense2: Long
+
+            transaction {
+                pkg1 = createPackage(identifier1, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+                pkg2 = createPackage(identifier1, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+                pkg3 = createPackage(identifier1, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+                pkg4 = createPackage(identifier1, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+                pkg5 = createPackage(identifier1, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+                pkg6 = createPackage(identifier1, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+                pkg7 = createPackage(identifier1, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+
+                mappedLicense1 = createMappedDeclaredLicense("license1", "mapped1")
+                mappedLicense2 = createMappedDeclaredLicense("license2", "mapped2")
+
+                unmappedLicense1 = createUnmappedDeclaredLicense("unmapped1")
+                unmappedLicense2 = createUnmappedDeclaredLicense("unmapped2")
+
+                createProcessedDeclaredLicense(pkg1, license1, listOf(mappedLicense1), listOf(unmappedLicense1))
+                createProcessedDeclaredLicense(pkg2, null, listOf(mappedLicense1), listOf(unmappedLicense1))
+                createProcessedDeclaredLicense(pkg3, license2, listOf(mappedLicense1), listOf(unmappedLicense1))
+                createProcessedDeclaredLicense(pkg4, license1, emptyList(), listOf(unmappedLicense1))
+                createProcessedDeclaredLicense(pkg5, license1, listOf(mappedLicense2), listOf(unmappedLicense1))
+                createProcessedDeclaredLicense(pkg6, license1, listOf(mappedLicense1), emptyList())
+                createProcessedDeclaredLicense(pkg7, license1, listOf(mappedLicense1), listOf(unmappedLicense2))
+            }
+
+            extension.testAppliedMigration {
+                transaction {
+                    V72PackagesTable.selectAll().map { it[V72PackagesTable.id].value } should
+                            containExactly(pkg1, pkg2, pkg3, pkg4, pkg5, pkg6, pkg7)
+                }
+            }
+        }
+
+        "remove duplicate packages" {
+            var pkg1 = 0L
+            var pkg2 = 0L
+            var pkg3 = 0L
+
+            var author1: Long
+            var author2: Long
+
+            var license1: Long
+            var license2: Long
+
+            val spdxExpression = "license1 AND license2"
+
+            var mappedLicense1: Long
+            var mappedLicense2: Long
+
+            var unmappedLicense1: Long
+            var unmappedLicense2: Long
+
+            transaction {
+                pkg1 = createPackage(identifier1, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+                pkg2 = createPackage(identifier1, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+                pkg3 = createPackage(identifier1, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+
+                author1 = createAuthor("author1")
+                author2 = createAuthor("author2")
+
+                addAuthors(pkg1, author1, author2)
+                addAuthors(pkg2, author1, author2)
+                addAuthors(pkg3, author2, author1)
+
+                license1 = createDeclaredLicense("license1")
+                license2 = createDeclaredLicense("license2")
+
+                addDeclaredLicenses(pkg1, license1, license2)
+                addDeclaredLicenses(pkg2, license1, license2)
+                addDeclaredLicenses(pkg3, license2, license1)
+
+                mappedLicense1 = createMappedDeclaredLicense("license1", "mapped1")
+                mappedLicense2 = createMappedDeclaredLicense("license2", "mapped2")
+
+                unmappedLicense1 = createUnmappedDeclaredLicense("unmapped1")
+                unmappedLicense2 = createUnmappedDeclaredLicense("unmapped2")
+
+                createProcessedDeclaredLicense(
+                    pkg1,
+                    spdxExpression,
+                    listOf(mappedLicense1, mappedLicense2),
+                    listOf(unmappedLicense1, unmappedLicense2)
+                )
+
+                createProcessedDeclaredLicense(
+                    pkg2,
+                    spdxExpression,
+                    listOf(mappedLicense1, mappedLicense2),
+                    listOf(unmappedLicense1, unmappedLicense2)
+                )
+
+                createProcessedDeclaredLicense(
+                    pkg3,
+                    spdxExpression,
+                    listOf(mappedLicense2, mappedLicense1),
+                    listOf(unmappedLicense2, unmappedLicense1)
+                )
+            }
+
+            extension.testAppliedMigration {
+                transaction {
+                    V72PackagesTable.selectAll().map { it[V72PackagesTable.id].value } should
+                            containExactly(pkg1)
+
+                    V72ProcessedDeclaredLicensesTable.selectAll()
+                        .where { V72ProcessedDeclaredLicensesTable.packageId inList listOf(pkg2, pkg3) }
+                        .toList() should beEmpty()
+                }
+            }
+        }
+
+        "update the association from analyzer runs to packages" {
+            val analzyerRun1 = 1L
+            val analzyerRun2 = 2L
+            val analzyerRun3 = 3L
+
+            var pkg1 = 0L
+            var pkg2 = 0L
+            var pkg3 = 0L
+            var pkg4 = 0L
+            var pkg5 = 0L
+            var pkg6 = 0L
+
+            transaction {
+                pkg1 = createPackage(identifier1, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+                pkg2 = createPackage(identifier2, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+                pkg3 = createPackage(identifier1, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+                pkg4 = createPackage(identifier2, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+                pkg5 = createPackage(identifier1, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+                pkg6 = createPackage(identifier2, vcs1, vcsProcessed1, binaryArtifact1, sourceArtifact1)
+
+                disableForeignKeyConstraints {
+                    V72PackagesAnalyzerRunsTable.insert {
+                        it[packageId] = pkg1
+                        it[analyzerRunId] = analzyerRun1
+                    }
+
+                    V72PackagesAnalyzerRunsTable.insert {
+                        it[packageId] = pkg2
+                        it[analyzerRunId] = analzyerRun1
+                    }
+
+                    V72PackagesAnalyzerRunsTable.insert {
+                        it[packageId] = pkg3
+                        it[analyzerRunId] = analzyerRun2
+                    }
+
+                    V72PackagesAnalyzerRunsTable.insert {
+                        it[packageId] = pkg4
+                        it[analyzerRunId] = analzyerRun2
+                    }
+
+                    V72PackagesAnalyzerRunsTable.insert {
+                        it[packageId] = pkg5
+                        it[analyzerRunId] = analzyerRun3
+                    }
+
+                    V72PackagesAnalyzerRunsTable.insert {
+                        it[packageId] = pkg6
+                        it[analyzerRunId] = analzyerRun3
+                    }
+                }
+            }
+
+            extension.testAppliedMigration {
+                transaction {
+                    V72PackagesAnalyzerRunsTable.selectAll()
+                        .where { V72PackagesAnalyzerRunsTable.analyzerRunId eq analzyerRun1 }
+                        .map { it[V72PackagesAnalyzerRunsTable.packageId].value } should
+                            containExactly(pkg1, pkg2)
+
+                    V72PackagesAnalyzerRunsTable.selectAll()
+                        .where { V72PackagesAnalyzerRunsTable.analyzerRunId eq analzyerRun2 }
+                        .map { it[V72PackagesAnalyzerRunsTable.packageId].value } should
+                            containExactly(pkg1, pkg2)
+
+                    V72PackagesAnalyzerRunsTable.selectAll()
+                        .where { V72PackagesAnalyzerRunsTable.analyzerRunId eq analzyerRun3 }
+                        .map { it[V72PackagesAnalyzerRunsTable.packageId].value } should
+                            containExactly(pkg1, pkg2)
+                }
+            }
+        }
+    }
+})
+
+private fun createPackage(
+    identifier: Long,
+    vcs: Long,
+    vcsProcessed: Long,
+    binaryArtifact: Long,
+    sourceArtifact: Long
+) =
+    V72PackagesTable.insertAndGetId {
+        it[identifierId] = identifier
+        it[vcsId] = vcs
+        it[vcsProcessedId] = vcsProcessed
+        it[binaryArtifactId] = binaryArtifact
+        it[sourceArtifactId] = sourceArtifact
+        it[purl] = "pkg"
+        it[cpe] = "cpe"
+        it[description] = "description"
+        it[homepageUrl] = "homepageUrl"
+        it[isMetadataOnly] = false
+        it[isModified] = false
+    }.value
+
+private fun createAuthor(name: String) = V72AuthorsTable.insertAndGetId { it[this.name] = name }.value
+
+private fun addAuthors(pkg: Long, vararg authors: Long) =
+    authors.forEach { author ->
+        V72PackagesAuthorsTable.insert {
+            it[packageId] = pkg
+            it[authorId] = author
+        }
+    }
+
+private fun createDeclaredLicense(license: String) =
+    V72DeclaredLicensesTable.insertAndGetId {
+        it[name] = license
+    }.value
+
+private fun addDeclaredLicenses(pkg: Long, vararg licenses: Long) =
+    licenses.forEach { license ->
+        V72PackagesDeclaredLicensesTable.insert {
+            it[packageId] = pkg
+            it[declaredLicenseId] = license
+        }
+    }
+
+private fun createMappedDeclaredLicense(declaredLicense: String, mappedLicense: String) =
+    V72MappedDeclaredLicensesTable.insertAndGetId {
+        it[this.declaredLicense] = declaredLicense
+        it[this.mappedLicense] = mappedLicense
+    }.value
+
+private fun createUnmappedDeclaredLicense(license: String) =
+    V72UnmappedDeclaredLicensesTable.insertAndGetId {
+        it[this.unmappedLicense] = license
+    }.value
+
+private fun createProcessedDeclaredLicense(
+    pkg: Long,
+    license: String?,
+    mappedLicenses: List<Long>,
+    unmappedLicenses: List<Long>
+) {
+    val processedLicenseId = V72ProcessedDeclaredLicensesTable.insertAndGetId {
+        it[packageId] = pkg
+        it[spdxExpression] = license
+    }.value
+
+    mappedLicenses.forEach { mappedLicenseId ->
+        V72ProcessedDeclaredLicensesMappedDeclaredLicensesTable.insert {
+            it[processedDeclaredLicenseId] = processedLicenseId
+            it[mappedDeclaredLicenseId] = mappedLicenseId
+        }
+    }
+
+    unmappedLicenses.forEach { unmappedLicenseId ->
+        V72ProcessedDeclaredLicensesUnmappedDeclaredLicensesTable.insert {
+            it[processedDeclaredLicenseId] = processedLicenseId
+            it[unmappedDeclaredLicenseId] = unmappedLicenseId
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a migration script to remove the duplicated packages and projects from the DB.

This is still WIP, but I want to share my current state before my vacations. The migration test does not yet test projects. It is currently failing for packages, since after the migration, there are more packages left than expected. I think, there is some copy & paste error in the script.

From the script, you can get the basic idea. Feel free to ignore if you come up with a better solution.