### PR TITLE
feat(ui): Rework the list of reports

### DIFF
--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-types.ts
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-types.ts
@@ -90,23 +90,31 @@ export const packageManagers = [
 
 export const reportFormats = [
   {
-    id: 'AsciiDocTemplate',
-    label: 'AsciiDoc Template',
-  },
-  {
-    id: 'ortresult',
-    label: 'ORT Result',
-  },
-  {
-    id: 'PlainTextTemplate',
-    label: 'NOTICE file',
+    id: 'CycloneDx',
+    label: 'CycloneDX SBOM',
   },
   {
     id: 'SpdxDocument',
     label: 'SPDX Document',
   },
   {
+    id: 'PlainTextTemplate',
+    label: 'NOTICE file',
+  },
+  {
     id: 'WebApp',
-    label: 'Web App',
+    label: 'ORT Web App',
+  },
+  {
+    id: 'PdfTemplate',
+    label: 'ORT PDF Reports',
+  },
+  {
+    id: 'OrtResult',
+    label: 'ORT Result',
+  },
+  {
+    id: 'RunStatistics',
+    label: 'ORT Run Statistics',
   },
 ] as const;

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/create-run.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/create-run.tsx
@@ -182,7 +182,7 @@ const CreateRunPage = () => {
       },
       reporter: {
         enabled: true,
-        formats: ['ortresult', 'WebApp'],
+        formats: ['CycloneDx', 'SpdxDocument', 'WebApp'],
       },
       notifier: {
         enabled: false,


### PR DESCRIPTION
While reporters are still hard-coded, add some more commonly required types, remove rarely used ones, and move prominent types to the top.