### PR TITLE
Get user roles from userinfo endpoint instead of ID token

### DIFF
--- a/scripts/docker/keycloak/master-realm.json
+++ b/scripts/docker/keycloak/master-realm.json
@@ -963,7 +963,8 @@
       "consentRequired" : false,
       "config" : {
         "user.attribute" : "foo",
-        "id.token.claim": "true",
+        "id.token.claim": "false",
+        "userinfo.token.claim" : "true",
         "access.token.claim" : "true",
         "claim.name" : "resource_access.${client_id}.roles",
         "jsonType.label" : "String",

--- a/ui/src/@types/oidc-client-ts.d.ts
+++ b/ui/src/@types/oidc-client-ts.d.ts
@@ -25,6 +25,12 @@
 import type { IdTokenClaims } from 'oidc-client-ts';
 
 declare module 'oidc-client-ts' {
+  /* Despite its name, the IdTokenClaims interface is also used as the
+   * type for the profile property in the auth.user object returned by
+   * the useAuth hook from react-oidc-context, which gets some of its
+   * data from the userinfo endpoint, so this declaration is needed
+   * even though the client roles are not included in the actual ID token.
+   */
   export interface IdTokenClaims {
     // Declare additional claim for resource_access to be able to access the roles of the user.
     resource_access: {

--- a/ui/src/config.ts
+++ b/ui/src/config.ts
@@ -46,6 +46,7 @@ const oidcConfig = {
   redirect_uri: UI_URL,
   client_id: CLIENT_ID,
   automaticSilentRenew: true,
+  loadUserInfo: true,
 } satisfies AuthProviderProps;
 
 const serverClientId = CLIENT_ID_SERVER;


### PR DESCRIPTION
Please see the individual commits for details.