### PR TITLE
feat(ui): Always enable the `Unmanaged` package manager

### DIFF
--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
@@ -107,7 +107,10 @@ export const AnalyzerFields = ({ form }: AnalyzerFieldsProps) => {
             name='jobConfigs.analyzer.enabledPackageManagers'
             label='Enabled package managers'
             description={
-              <>Select the package managers enabled for this ORT Run.</>
+              <>
+                Select the package managers enabled for this ORT Run. Note that
+                the 'Unmanaged' package manager is always enabled.
+              </>
             }
             options={packageManagers}
           />

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/create-run.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/create-run.tsx
@@ -161,7 +161,10 @@ const CreateRunPage = () => {
         enabled: true,
         allowDynamicVersions: true,
         skipExcluded: true,
-        enabledPackageManagers: packageManagers.map((pm) => pm.id),
+        enabledPackageManagers: [
+          ...packageManagers.map((pm) => pm.id),
+          'Unmanaged',
+        ],
       },
       advisor: {
         enabled: true,


### PR DESCRIPTION
So far the `Unmanaged` package manager has always been disabled, causing unmanaged files (e.g. in a repository without definition files in the root, or no definition files at all) to be "swallowed" and disregarded when scanning. Address this by always enabling the `Unmanaged` package manager. While ORT allows to disable the `Unmanaged` package manager [1], there is a risk that users are unaware of the implications. As the use-cases for disabling the `Unmanaged` package manager are rather limited, simply do not allow to do that for now.

[1]: https://github.com/oss-review-toolkit/ort/commit/ba312efbeabdb32c225c13158703fb68414de106