### PR TITLE
ci(renovate): Configure custom manager for `libs.versions.toml`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,17 @@
     ":semanticCommitScopeDisabled",
     ":semanticCommitTypeAll(deps)"
   ],
+  "customManagers": [
+    {
+      "description": "Update Eclipse Temurin in libs.versions.toml",
+      "customType": "regex",
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "eclipse-temurin",
+      "fileMatch": ["^gradle\\/libs\\.versions\\.toml$"],
+      "matchStrings": ["eclipseTemurin = \"(?<currentValue>[^@]+)(?:@(?<currentDigest>sha256:[a-f0-9]+))\""],
+      "versioningTemplate": "docker"
+    }
+  ],
   "dependencyDashboard": false,
   "labels": ["dependencies"],
   "packageRules": [


### PR DESCRIPTION
Configure a custom manager for the Eclipse Temurin version defined in `libs.versions.toml` so that it gets updated automatically. This ensures that the version does not deviate from the version used in Dockerfiles.

Fixes #801.