### PR TITLE
feat: Include the log level into the archive download

### DIFF
--- a/core/src/main/kotlin/api/RunsRoute.kt
+++ b/core/src/main/kotlin/api/RunsRoute.kt
@@ -80,20 +80,18 @@ fun Route.runs() = route("runs/{runId}") {
             call.forRun(ortRunRepository) { ortRun ->
                 requirePermission(RepositoryPermission.READ_ORT_RUNS.roleName(ortRun.repositoryId))
 
-                val logArchive = logFileService.createLogFilesArchive(
-                    ortRun.id,
-                    call.extractSteps(),
-                    call.extractLevel(),
-                    ortRun.createdAt,
-                    ortRun.finishedAt ?: Clock.System.now()
-                )
+                val sources = call.extractSteps()
+                val level = call.extractLevel()
+                val startTime = ortRun.createdAt
+                val endTime = ortRun.finishedAt ?: Clock.System.now()
+                val logArchive = logFileService.createLogFilesArchive(ortRun.id, sources, level, startTime, endTime)
 
                 try {
                     call.response.header(
                         HttpHeaders.ContentDisposition,
                         ContentDisposition.Attachment.withParameter(
                             ContentDisposition.Parameters.FileName,
-                            "${ortRun.id}_logs.zip"
+                            "run-${ortRun.id}-$level-logs.zip"
                         ).toString()
                     )
 

--- a/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
@@ -283,7 +283,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
 
                 val response = superuserClient.get("/api/v1/runs/${run.id}/logs")
 
-                val expectedContentDispositionHeader = "attachment; filename=${run.id}_logs.zip"
+                val expectedContentDispositionHeader = "attachment; filename=run-${run.id}-INFO-logs.zip"
                 response.headers["Content-Disposition"] shouldBe expectedContentDispositionHeader
                 response.headers["Content-Type"] shouldBe "application/zip"
             }

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/logs/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/logs/index.tsx
@@ -79,7 +79,7 @@ const ReportComponent = () => {
         ?.find((entry) => entry.includes('filename='))
         ?.replace('filename=', '')
         ?.trim();
-      a.download = filename ?? `${runId}_logs.zip`;
+      a.download = filename ?? `run-${runId}-${level}-logs.zip`;
       a.click();
       window.URL.revokeObjectURL(url);
     } catch (error) {


### PR DESCRIPTION
This helps to avoid archives being overwritten when different levels are downloaded for the same run.