### PR TITLE
Add affected path to issues

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
@@ -217,7 +217,7 @@ fun ApiEvaluatorJobConfiguration.mapToModel() =
         ruleSet
     )
 
-fun Issue.mapToApi() = ApiIssue(timestamp, source, message, severity.mapToApi())
+fun Issue.mapToApi() = ApiIssue(timestamp, source, message, severity.mapToApi(), affectedPath)
 
 fun Severity.mapToApi() = when (this) {
     Severity.ERROR -> ApiSeverity.ERROR

--- a/api/v1/model/src/commonMain/kotlin/Issue.kt
+++ b/api/v1/model/src/commonMain/kotlin/Issue.kt
@@ -37,5 +37,8 @@ data class Issue(
     val message: String,
 
     /** The [Severity] of the issue. */
-    val severity: Severity
+    val severity: Severity,
+
+    /** The optional file path this issue is related to. */
+    val affectedPath: String? = null
 )

--- a/dao/src/main/kotlin/tables/runs/shared/IssuesTable.kt
+++ b/dao/src/main/kotlin/tables/runs/shared/IssuesTable.kt
@@ -37,6 +37,7 @@ object IssuesTable : LongIdTable("issues") {
     val issueSource = text("source")
     val message = text("message")
     val severity = enumerationByName<Severity>("severity", 128)
+    val affectedPath = text("affected_path").nullable()
 }
 
 class IssueDao(id: EntityID<Long>) : LongEntity(id) {
@@ -47,6 +48,7 @@ class IssueDao(id: EntityID<Long>) : LongEntity(id) {
                 source = issue.source
                 message = issue.message
                 severity = issue.severity
+                affectedPath = issue.affectedPath
             }
     }
 
@@ -54,6 +56,13 @@ class IssueDao(id: EntityID<Long>) : LongEntity(id) {
     var source by IssuesTable.issueSource
     var message by IssuesTable.message
     var severity by IssuesTable.severity
+    var affectedPath by IssuesTable.affectedPath
 
-    fun mapToModel() = Issue(timestamp = timestamp, source = source, message = message, severity = severity)
+    fun mapToModel() = Issue(
+        timestamp = timestamp,
+        source = source,
+        message = message,
+        severity = severity,
+        affectedPath = affectedPath
+    )
 }

--- a/dao/src/main/resources/db/migration/V70__addAffectedPathToIssue.sql
+++ b/dao/src/main/resources/db/migration/V70__addAffectedPathToIssue.sql
@@ -1,0 +1,9 @@
+-- Add affected_path column to issues table.
+ALTER TABLE issues
+    ADD COLUMN affected_path text NULL;
+
+-- Set the affected path from the issue's message.
+UPDATE issues
+SET affected_path =
+        regexp_replace(message, 'ERROR: Timeout after ([0-9]+) seconds while scanning file ''(.+)''.', '\2', 'g')
+WHERE message ~ 'ERROR: Timeout after ([0-9]+) seconds while scanning file ''(.+)''.';

--- a/dao/src/test/kotlin/migrations/V70__addAffectedPathToIssueTest.kt
+++ b/dao/src/test/kotlin/migrations/V70__addAffectedPathToIssueTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.dao.migrations
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import kotlinx.datetime.Clock
+
+import org.eclipse.apoapsis.ortserver.dao.test.DatabaseMigrationTestExtension
+import org.eclipse.apoapsis.ortserver.model.Severity
+
+import org.jetbrains.exposed.dao.id.LongIdTable
+import org.jetbrains.exposed.sql.insertAndGetId
+import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
+import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.transactions.transaction
+
+@Suppress("ClassNaming")
+class V70__addAffectedPathToIssueTest : WordSpec({
+    val extension = extension(DatabaseMigrationTestExtension("69", "70"))
+
+    "migration V70" should {
+        "set the affectedPath column for existing issues" {
+            var issueIdWithTimeoutError: Long = 0
+            var issueIdWithoutTimeoutError: Long = 0
+
+            transaction {
+                issueIdWithTimeoutError = V69IssuesTable.create(
+                    "ERROR: Timeout after 12345 seconds while scanning file 'some/file/path'."
+                )
+                issueIdWithoutTimeoutError = V69IssuesTable.create("message")
+            }
+
+            extension.testAppliedMigration {
+                transaction {
+                    V70IssuesTable.selectAll().where { V70IssuesTable.id eq issueIdWithTimeoutError }.single().let {
+                        it[V70IssuesTable.affectedPath] shouldBe "some/file/path"
+                    }
+
+                    V70IssuesTable.selectAll().where { V70IssuesTable.id eq issueIdWithoutTimeoutError }.single().let {
+                        it[V70IssuesTable.affectedPath] shouldBe null
+                    }
+                }
+            }
+        }
+    }
+})
+
+private object V69IssuesTable : LongIdTable("issues") {
+    val timestamp = timestamp("timestamp")
+    val issueSource = text("source")
+    val message = text("message")
+    val severity = enumerationByName<Severity>("severity", 128)
+
+    fun create(message: String) = insertAndGetId {
+        it[timestamp] = Clock.System.now()
+        it[issueSource] = "source"
+        it[V69IssuesTable.message] = message
+        it[severity] = Severity.ERROR
+    }.value
+}
+
+private object V70IssuesTable : LongIdTable("issues") {
+    val timestamp = timestamp("timestamp")
+    val issueSource = text("source")
+    val message = text("message")
+    val severity = enumerationByName<Severity>("severity", 128)
+    val affectedPath = text("affected_path").nullable()
+}

--- a/model/src/commonMain/kotlin/runs/Issue.kt
+++ b/model/src/commonMain/kotlin/runs/Issue.kt
@@ -39,5 +39,8 @@ data class Issue(
     val message: String,
 
     /** The [Severity] of the issue. */
-    val severity: Severity
+    val severity: Severity,
+
+    /** The optional file path this issue is related to. */
+    val affectedPath: String? = null
 )

--- a/workers/common/src/main/kotlin/common/OrtMappings.kt
+++ b/workers/common/src/main/kotlin/common/OrtMappings.kt
@@ -310,7 +310,8 @@ fun OrtIssue.mapToModel() =
         timestamp = timestamp.toKotlinInstant(),
         source = source,
         message = message,
-        severity = severity.mapToModel()
+        severity = severity.mapToModel(),
+        affectedPath = affectedPath
     )
 
 fun OrtPackage.mapToModel() =

--- a/workers/common/src/main/kotlin/common/OrtServerMappings.kt
+++ b/workers/common/src/main/kotlin/common/OrtServerMappings.kt
@@ -314,7 +314,7 @@ fun Excludes.mapToOrt() = OrtExcludes(paths.map(PathExclude::mapToOrt), scopes.m
 
 fun Identifier.mapToOrt() = OrtIdentifier(type, namespace, name, version)
 
-fun Issue.mapToOrt() = OrtIssue(timestamp.toJavaInstant(), source, message, severity.mapToOrt())
+fun Issue.mapToOrt() = OrtIssue(timestamp.toJavaInstant(), source, message, severity.mapToOrt(), affectedPath)
 
 fun IssueResolution.mapToOrt() = OrtIssueResolution(message, OrtIssueResolutionReason.valueOf(reason), comment)
 


### PR DESCRIPTION
feat: Add `affectedPath` to `Issue`

The ORT `Issue` has the `affectedPath` property since version 9.0.0 [1].

Also add a database migration that sets the affected path for existing
issues based on the message in the same way that ORT does [2].

[1]: https://github.com/oss-review-toolkit/ort/releases/tag/9.0.0
[2]: https://github.com/oss-review-toolkit/ort/blob/b3c98bbf24907d36ca003d78f532054d3c7b12a5/model/src/main/kotlin/ScanSummary.kt#L151-L163

Depends on #923 to be merged first.