### PR TITLE
ci(docker): Use tag suffix also for the base image cache

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -175,8 +175,8 @@ jobs:
         push: true
         tags: ${{ steps.meta-base.outputs.tags }}
         labels: ${{ steps.meta-base.outputs.labels }}
-        cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/ort-server-${{ matrix.docker.image }}:cache
-        cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/ort-server-${{ matrix.docker.image }}:cache,mode=max
+        cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/ort-server-${{ matrix.docker.image }}:cache${{ steps.compute-tag-suffix.outputs.suffix }}
+        cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/ort-server-${{ matrix.docker.image }}:cache${{ steps.compute-tag-suffix.outputs.suffix }},mode=max
 
     - name: Extract Docker Metadata for ${{ matrix.docker.jibImage }} Image
       if: ${{ matrix.docker.task != '' }}


### PR DESCRIPTION
If the `imageVariant` is configured in the build matrix, it is used as a suffix for the image tag. Also use the suffix for the cache image tag, otherwise the caches for different image variants overwrite each other.

This is a fixup for ab3657e.