### PR TITLE
ui(routes): Use some more fitting icons

### DIFF
--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/route.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/route.tsx
@@ -18,13 +18,7 @@
  */
 
 import { createFileRoute, Outlet } from '@tanstack/react-router';
-import {
-  ArrowRightLeft,
-  Cigarette,
-  Eye,
-  FileText,
-  FolderTree,
-} from 'lucide-react';
+import { Eye, FileText, ListTree, Scale, ShieldQuestion } from 'lucide-react';
 
 import { Sidebar } from '@/components/sidebar';
 
@@ -40,11 +34,11 @@ const Layout = () => {
         },
         {
           title: 'Dependencies',
-          icon: () => <FolderTree className='h-4 w-4' />,
+          icon: () => <ListTree className='h-4 w-4' />,
         },
         {
           title: 'Vulnerabilities',
-          icon: () => <Cigarette className='h-4 w-4' />,
+          icon: () => <ShieldQuestion className='h-4 w-4' />,
         },
         {
           title: 'License Findings',
@@ -52,7 +46,7 @@ const Layout = () => {
         },
         {
           title: 'Rule Violations',
-          icon: () => <ArrowRightLeft className='h-4 w-4' />,
+          icon: () => <Scale className='h-4 w-4' />,
         },
       ],
     },


### PR DESCRIPTION
Use [1] for dependencies to avoid a folder-look, use [2] for vulnerabilities to avoid a connection to smoking, and [3] for rule violations to match a bit ORT's evaluator logo [4].

[1]: https://lucide.dev/icons/list-tree
[2]: https://lucide.dev/icons/shield-question
[3]: https://lucide.dev/icons/scale
[4]: https://github.com/oss-review-toolkit/ort/blob/main/logos/evaluator.png