### PR TITLE
docs(ui): Align form descriptions

### DIFF
--- a/ui/src/routes/_layout/create-organization.tsx
+++ b/ui/src/routes/_layout/create-organization.tsx
@@ -36,7 +36,6 @@ import {
 import {
   Form,
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -103,9 +102,6 @@ const CreateOrganizationPage = () => {
                   <FormControl>
                     <Input {...field} autoFocus />
                   </FormControl>
-                  <FormDescription>
-                    The name of the organization.
-                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -119,9 +115,6 @@ const CreateOrganizationPage = () => {
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>
-                  <FormDescription>
-                    The description of the organization.
-                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/routes/_layout/create-organization.tsx
+++ b/ui/src/routes/_layout/create-organization.tsx
@@ -104,7 +104,7 @@ const CreateOrganizationPage = () => {
                     <Input {...field} autoFocus />
                   </FormControl>
                   <FormDescription>
-                    Enter the name of your organization
+                    The name of the organization.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -120,7 +120,7 @@ const CreateOrganizationPage = () => {
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>
                   <FormDescription>
-                    Description of the organization
+                    The description of the organization.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>

--- a/ui/src/routes/_layout/organizations/$orgId/create-product.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/create-product.tsx
@@ -37,7 +37,6 @@ import {
 import {
   Form,
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -108,7 +107,6 @@ const CreateProductPage = () => {
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>The name of the product.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -122,9 +120,6 @@ const CreateProductPage = () => {
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>
-                  <FormDescription>
-                    The description of the product.
-                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/routes/_layout/organizations/$orgId/create-product.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/create-product.tsx
@@ -108,9 +108,7 @@ const CreateProductPage = () => {
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>
-                    Enter the name of the product
-                  </FormDescription>
+                  <FormDescription>The name of the product.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -124,7 +122,9 @@ const CreateProductPage = () => {
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>
-                  <FormDescription>Description of the product</FormDescription>
+                  <FormDescription>
+                    The description of the product.
+                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/routes/_layout/organizations/$orgId/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/edit.tsx
@@ -40,7 +40,6 @@ import {
 import {
   Form,
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -122,9 +121,6 @@ const EditOrganizationPage = () => {
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>
-                    The name of the organization.
-                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -138,9 +134,6 @@ const EditOrganizationPage = () => {
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>
-                  <FormDescription>
-                    The description of the organization.
-                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/routes/_layout/organizations/$orgId/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/edit.tsx
@@ -123,7 +123,7 @@ const EditOrganizationPage = () => {
                     <Input {...field} />
                   </FormControl>
                   <FormDescription>
-                    Enter the name of your organization
+                    The name of the organization.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -139,7 +139,7 @@ const EditOrganizationPage = () => {
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>
                   <FormDescription>
-                    Description of the organization
+                    The description of the organization.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>

--- a/ui/src/routes/_layout/organizations/$orgId/infrastructure-services/$serviceName/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/infrastructure-services/$serviceName/edit.tsx
@@ -154,7 +154,7 @@ const EditInfrastructureServicePage = () => {
                     <Input {...field} />
                   </FormControl>
                   <FormDescription>
-                    The name of your infrastructure service (cannot be changed)
+                    The name of the infrastructure service (cannot be changed).
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -171,7 +171,7 @@ const EditInfrastructureServicePage = () => {
                     <Input {...field} type='url' />
                   </FormControl>
                   <FormDescription>
-                    Enter the URL of your infrastructure service
+                    The URL of the infrastructure service.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -187,7 +187,7 @@ const EditInfrastructureServicePage = () => {
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>
                   <FormDescription>
-                    Description of your infrastructure service
+                    The description of the infrastructure service.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -203,10 +203,10 @@ const EditInfrastructureServicePage = () => {
                     <Input {...field} />
                   </FormControl>
                   <FormDescription>
-                    Enter the name of the organization secret that contains the
-                    username of the credentials for your infrastructure service.
-                    Please note that you need to create the secret before you
-                    can use it here.
+                    The name of the organization secret that contains the
+                    username of the credentials for the infrastructure service.
+                    Please note that the secret first needs to be created in
+                    order to use it here.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -222,10 +222,10 @@ const EditInfrastructureServicePage = () => {
                     <Input {...field} />
                   </FormControl>
                   <FormDescription>
-                    Enter the name of the organization secret that contains the
-                    password of the credentials for your infrastructure service.
-                    Please note that you need to create the secret before you
-                    can use it here.
+                    The name of the organization secret that contains the
+                    password of the credentials for the infrastructure service.
+                    Please note that the secret first needs to be created in
+                    order to use it here.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>

--- a/ui/src/routes/_layout/organizations/$orgId/infrastructure-services/create.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/infrastructure-services/create.tsx
@@ -144,7 +144,7 @@ const CreateInfrastructureServicePage = () => {
                     <Input {...field} />
                   </FormControl>
                   <FormDescription>
-                    Enter the name of your infrastructure service
+                    The name of the infrastructure service.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -160,7 +160,7 @@ const CreateInfrastructureServicePage = () => {
                     <Input {...field} type='url' />
                   </FormControl>
                   <FormDescription>
-                    Enter the URL of your infrastructure service
+                    The URL of the infrastructure service.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -176,7 +176,7 @@ const CreateInfrastructureServicePage = () => {
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>
                   <FormDescription>
-                    Description of your infrastructure service
+                    The description of the infrastructure service.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -192,10 +192,10 @@ const CreateInfrastructureServicePage = () => {
                     <Input {...field} />
                   </FormControl>
                   <FormDescription>
-                    Enter the name of the organization secret that contains the
-                    username of the credentials for your infrastructure service.
-                    Please note that you need to create the secret before you
-                    can use it here.
+                    The name of the organization secret that contains the
+                    username of the credentials for the infrastructure service.
+                    Please note that the secret first needs to be created in
+                    order to use it here.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -211,10 +211,10 @@ const CreateInfrastructureServicePage = () => {
                     <Input {...field} />
                   </FormControl>
                   <FormDescription>
-                    Enter the name of the organization secret that contains the
-                    password of the credentials for your infrastructure service.
-                    Please note that you need to create the secret before you
-                    can use it here.
+                    The name of the organization secret that contains the
+                    password of the credentials for the infrastructure service.
+                    Please note that the secret first needs to be created in
+                    order to use it here.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/create-repository.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/create-repository.tsx
@@ -37,7 +37,6 @@ import {
 import {
   Form,
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -122,7 +121,6 @@ const CreateRepositoryPage = () => {
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>The URL of the repository.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -150,7 +148,6 @@ const CreateRepositoryPage = () => {
                       ))}
                     </SelectContent>
                   </Select>
-                  <FormDescription>The type of the repository.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/create-repository.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/create-repository.tsx
@@ -122,7 +122,7 @@ const CreateRepositoryPage = () => {
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>URL of the repository</FormDescription>
+                  <FormDescription>The URL of the repository.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -150,7 +150,7 @@ const CreateRepositoryPage = () => {
                       ))}
                     </SelectContent>
                   </Select>
-                  <FormDescription>Type of the repository</FormDescription>
+                  <FormDescription>The type of the repository.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/edit.tsx
@@ -40,7 +40,6 @@ import {
 import {
   Form,
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -121,7 +120,6 @@ const EditProductPage = () => {
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>The name of the product.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -135,9 +133,6 @@ const EditProductPage = () => {
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>
-                  <FormDescription>
-                    The description of the product.
-                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/edit.tsx
@@ -121,9 +121,7 @@ const EditProductPage = () => {
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>
-                    Enter the name of your product
-                  </FormDescription>
+                  <FormDescription>The name of the product.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -137,7 +135,9 @@ const EditProductPage = () => {
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>
-                  <FormDescription>Description of the product</FormDescription>
+                  <FormDescription>
+                    The description of the product.
+                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-components/advisor-fields.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-components/advisor-fields.tsx
@@ -68,7 +68,7 @@ export const AdvisorFields = ({ form }: AdvisorFieldsProps) => {
                   <FormLabel>Skip excluded</FormLabel>
                   <FormDescription>
                     A flag to control whether excluded scopes and paths should
-                    be skipped from the advisor.
+                    be skipped by the advisor.
                   </FormDescription>
                 </div>
                 <FormControl>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
@@ -90,7 +90,7 @@ export const AnalyzerFields = ({ form }: AnalyzerFieldsProps) => {
                   <FormLabel>Skip excluded</FormLabel>
                   <FormDescription>
                     A flag to control whether excluded scopes and paths should
-                    be skipped during the analysis.
+                    be skipped by the analyzer.
                   </FormDescription>
                 </div>
                 <FormControl>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-components/notifier-fields.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-components/notifier-fields.tsx
@@ -77,8 +77,8 @@ export const NotifierFields = ({ form }: NotifierFieldsProps) => {
                   <Input {...field} />
                 </FormControl>
                 <FormDescription>
-                  The notifier script to use. If this is null, the configured
-                  default notification will be used.
+                  The notifier script to use. If this is not specified, the
+                  configured default notification will be used.
                 </FormDescription>
                 <FormMessage />
               </FormItem>
@@ -95,8 +95,8 @@ export const NotifierFields = ({ form }: NotifierFieldsProps) => {
                 </FormControl>
                 <FormDescription>
                   The path to the resolutions file which is resolved from the
-                  configured configuration source. If this is null, the default
-                  path from ORT will be used.
+                  configured configuration source. If this is not specified, the
+                  default path from ORT will be used.
                 </FormDescription>
                 <FormMessage />
               </FormItem>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-components/scanner-fields.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-components/scanner-fields.tsx
@@ -67,8 +67,7 @@ export const ScannerFields = ({ form }: ScannerFieldsProps) => {
                   <FormDescription>
                     A flag to indicate whether packages that have a concluded
                     license and authors set (to derive copyrights from) should
-                    be skipped in the scan in favor of only using the declared
-                    information.
+                    be skipped by the scanner.
                   </FormDescription>
                 </div>
                 <FormControl>
@@ -88,7 +87,8 @@ export const ScannerFields = ({ form }: ScannerFieldsProps) => {
                 <div className='space-y-0.5'>
                   <FormLabel>Skip excluded</FormLabel>
                   <FormDescription>
-                    Do not scan excluded projects or packages.
+                    A flag to control whether excluded scopes and paths should
+                    by skipped by the scanner.
                   </FormDescription>
                 </div>
                 <FormControl>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/create-run.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/create-run.tsx
@@ -552,7 +552,7 @@ const CreateRunPage = () => {
                     <Input {...field} />
                   </FormControl>
                   <FormDescription>
-                    The repository revision used by this run
+                    The repository revision to use.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -565,13 +565,12 @@ const CreateRunPage = () => {
                 <FormItem className='pt-4'>
                   <FormLabel>Job configuration context</FormLabel>
                   <FormControl>
-                    <Input {...field} />
+                    <Input {...field} placeholder='(optional)' />
                   </FormControl>
                   <FormDescription>
-                    An optional context to be used when obtaining configuration
-                    for this run. The meaning of the context is up for
-                    interpretation by the implementation of the configuration
-                    provider.
+                    The context to use when obtaining configuration for this
+                    run. The meaning of the context is up for interpretation by
+                    the implementation of the configuration provider.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -584,11 +583,11 @@ const CreateRunPage = () => {
                 <FormItem className='pt-4'>
                   <FormLabel>Path</FormLabel>
                   <FormControl>
-                    <Input {...field} />
+                    <Input {...field} placeholder='(optional)' />
                   </FormControl>
                   <FormDescription>
-                    An optional subpath to limit the analysis to, for example,
-                    'dir/subdir'.
+                    The path to limit the analysis to, for example
+                    'path/to/source'.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/edit.tsx
@@ -42,7 +42,6 @@ import {
 import {
   Form,
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -141,7 +140,6 @@ const EditRepositoryPage = () => {
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>The URL of the repository.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -169,7 +167,6 @@ const EditRepositoryPage = () => {
                       ))}
                     </SelectContent>
                   </Select>
-                  <FormDescription>The type of the repository.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/edit.tsx
@@ -141,7 +141,7 @@ const EditRepositoryPage = () => {
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>URL of the repository</FormDescription>
+                  <FormDescription>The URL of the repository.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -169,7 +169,7 @@ const EditRepositoryPage = () => {
                       ))}
                     </SelectContent>
                   </Select>
-                  <FormDescription>Type of the repository</FormDescription>
+                  <FormDescription>The type of the repository.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/secrets/$secretName/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/secrets/$secretName/edit.tsx
@@ -155,7 +155,6 @@ const EditRepositorySecretPage = () => {
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>The value of the secret.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -169,9 +168,6 @@ const EditRepositorySecretPage = () => {
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>
-                  <FormDescription>
-                    The description of the secret.
-                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/secrets/$secretName/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/secrets/$secretName/edit.tsx
@@ -139,7 +139,7 @@ const EditRepositorySecretPage = () => {
                     <Input {...field} />
                   </FormControl>
                   <FormDescription>
-                    The name of the secret (cannot be changed)
+                    The name of the secret (cannot be changed).
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -155,9 +155,7 @@ const EditRepositorySecretPage = () => {
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>
-                    Enter a new value for the secret.
-                  </FormDescription>
+                  <FormDescription>The value of the secret.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -171,7 +169,9 @@ const EditRepositorySecretPage = () => {
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>
-                  <FormDescription>Description of the secret</FormDescription>
+                  <FormDescription>
+                    The description of the secret.
+                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/secrets/create-secret.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/secrets/create-secret.tsx
@@ -111,9 +111,7 @@ const CreateRepositorySecretPage = () => {
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>
-                    Enter the name of your secret
-                  </FormDescription>
+                  <FormDescription>The name of the secret.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -127,9 +125,7 @@ const CreateRepositorySecretPage = () => {
                   <FormControl>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>
-                    Enter the value of your secret
-                  </FormDescription>
+                  <FormDescription>The value of the secret.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -143,7 +139,9 @@ const CreateRepositorySecretPage = () => {
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>
-                  <FormDescription>Description of the secret</FormDescription>
+                  <FormDescription>
+                    The description of the secret.
+                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/secrets/create-secret.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/secrets/create-secret.tsx
@@ -36,7 +36,6 @@ import {
 import {
   Form,
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -111,7 +110,6 @@ const CreateRepositorySecretPage = () => {
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>The name of the secret.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -125,7 +123,6 @@ const CreateRepositorySecretPage = () => {
                   <FormControl>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>The value of the secret.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -139,9 +136,6 @@ const CreateRepositorySecretPage = () => {
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>
-                  <FormDescription>
-                    The description of the secret.
-                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/secrets/$secretName/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/secrets/$secretName/edit.tsx
@@ -151,7 +151,6 @@ const EditProductSecretPage = () => {
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>The value of the secret.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -165,9 +164,6 @@ const EditProductSecretPage = () => {
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>
-                  <FormDescription>
-                    The description of the secret.
-                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/secrets/$secretName/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/secrets/$secretName/edit.tsx
@@ -135,7 +135,7 @@ const EditProductSecretPage = () => {
                     <Input {...field} />
                   </FormControl>
                   <FormDescription>
-                    The name of the secret (cannot be changed)
+                    The name of the secret (cannot be changed).
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -151,9 +151,7 @@ const EditProductSecretPage = () => {
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>
-                    Enter a new value for the secret.
-                  </FormDescription>
+                  <FormDescription>The value of the secret.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -167,7 +165,9 @@ const EditProductSecretPage = () => {
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>
-                  <FormDescription>Description of the secret</FormDescription>
+                  <FormDescription>
+                    The description of the secret.
+                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/secrets/create-secret.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/secrets/create-secret.tsx
@@ -36,7 +36,6 @@ import {
 import {
   Form,
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -107,7 +106,6 @@ const CreateProductSecretPage = () => {
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>The name of the secret.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -121,7 +119,6 @@ const CreateProductSecretPage = () => {
                   <FormControl>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>The value of the secret.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -135,9 +132,6 @@ const CreateProductSecretPage = () => {
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>
-                  <FormDescription>
-                    The description of the secret.
-                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/secrets/create-secret.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/secrets/create-secret.tsx
@@ -107,9 +107,7 @@ const CreateProductSecretPage = () => {
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>
-                    Enter the name of your secret
-                  </FormDescription>
+                  <FormDescription>The name of the secret.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -123,9 +121,7 @@ const CreateProductSecretPage = () => {
                   <FormControl>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>
-                    Enter the value of your secret
-                  </FormDescription>
+                  <FormDescription>The value of the secret.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -139,7 +135,9 @@ const CreateProductSecretPage = () => {
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>
-                  <FormDescription>Description of the secret</FormDescription>
+                  <FormDescription>
+                    The description of the secret.
+                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/routes/_layout/organizations/$orgId/secrets/$secretName/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/secrets/$secretName/edit.tsx
@@ -152,7 +152,6 @@ const EditOrganizationSecretPage = () => {
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>The value of the secret.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -166,9 +165,6 @@ const EditOrganizationSecretPage = () => {
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>
-                  <FormDescription>
-                    The description of the secret.
-                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/routes/_layout/organizations/$orgId/secrets/$secretName/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/secrets/$secretName/edit.tsx
@@ -136,7 +136,7 @@ const EditOrganizationSecretPage = () => {
                     <Input {...field} />
                   </FormControl>
                   <FormDescription>
-                    The name of the secret (cannot be changed)
+                    The name of the secret (cannot be changed).
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -152,9 +152,7 @@ const EditOrganizationSecretPage = () => {
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>
-                    Enter a new value for the secret.
-                  </FormDescription>
+                  <FormDescription>The value of the secret.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -168,7 +166,9 @@ const EditOrganizationSecretPage = () => {
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>
-                  <FormDescription>Description of the secret</FormDescription>
+                  <FormDescription>
+                    The description of the secret.
+                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/routes/_layout/organizations/$orgId/secrets/create-secret.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/secrets/create-secret.tsx
@@ -36,7 +36,6 @@ import {
 import {
   Form,
   FormControl,
-  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -109,7 +108,6 @@ const CreateOrganizationSecretPage = () => {
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>The name of the secret.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -123,7 +121,6 @@ const CreateOrganizationSecretPage = () => {
                   <FormControl>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>The value of the secret.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -137,9 +134,6 @@ const CreateOrganizationSecretPage = () => {
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>
-                  <FormDescription>
-                    The description of the secret.
-                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/routes/_layout/organizations/$orgId/secrets/create-secret.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/secrets/create-secret.tsx
@@ -109,9 +109,7 @@ const CreateOrganizationSecretPage = () => {
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>
-                    Enter the name of your secret
-                  </FormDescription>
+                  <FormDescription>The name of the secret.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -125,9 +123,7 @@ const CreateOrganizationSecretPage = () => {
                   <FormControl>
                     <Input {...field} />
                   </FormControl>
-                  <FormDescription>
-                    Enter the value of your secret
-                  </FormDescription>
+                  <FormDescription>The value of the secret.</FormDescription>
                   <FormMessage />
                 </FormItem>
               )}
@@ -141,7 +137,9 @@ const CreateOrganizationSecretPage = () => {
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>
-                  <FormDescription>Description of the secret</FormDescription>
+                  <FormDescription>
+                    The description of the secret.
+                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}


### PR DESCRIPTION
Align the wording to have fewer different strings. Use punctuation even for single sentences.