### PR TITLE
test(transport): Increase the timeout when querying the blocking queue 

### DIFF
--- a/transport/spi/src/testFixtures/kotlin/Utils.kt
+++ b/transport/spi/src/testFixtures/kotlin/Utils.kt
@@ -28,6 +28,8 @@ import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 
+import kotlin.concurrent.thread
+
 import kotlinx.coroutines.runBlocking
 
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
@@ -71,12 +73,12 @@ fun startReceiver(configManager: ConfigManager): LinkedBlockingQueue<Message<Orc
         queue.offer(message)
     }
 
-    Thread {
+    thread {
         @Suppress("ForbiddenMethodCall")
         runBlocking {
             MessageReceiverFactory.createReceiver(OrchestratorEndpoint, configManager, ::handler)
         }
-    }.start()
+    }
 
     return queue
 }

--- a/transport/spi/src/testFixtures/kotlin/Utils.kt
+++ b/transport/spi/src/testFixtures/kotlin/Utils.kt
@@ -39,7 +39,7 @@ import org.eclipse.apoapsis.ortserver.transport.MessageReceiverFactory
 import org.eclipse.apoapsis.ortserver.transport.OrchestratorEndpoint
 
 const val TEST_QUEUE_NAME = "test_queue"
-const val TEST_QUEUE_TIMEOUT = 15L
+const val TEST_QUEUE_TIMEOUT = 30L
 
 /**
  * Create a [ConfigManager] with a test queue for [consumerName] using [transportType] and [transportName] that is


### PR DESCRIPTION
This is to try to limit the flakiness of the CI tests, e.g.:

```
org.eclipse.apoapsis.ortserver.transport.sqs.SqsMessageReceiverFactoryTest > Messages can have empty trace IDs FAILED
    java.lang.AssertionError: Expected value to not be null, but was null.
        at org.eclipse.apoapsis.ortserver.transport.testing.UtilsKt.checkMessage(Utils.kt:88)
        at org.eclipse.apoapsis.ortserver.transport.sqs.SqsMessageReceiverFactoryTest$1$5.invokeSuspend(SqsMessageReceiverFactoryTest.kt:110)

        Caused by:
        java.lang.AssertionError: Expected value to not be null, but was null.
            at org.eclipse.apoapsis.ortserver.transport.testing.UtilsKt.checkMessage(Utils.kt:88)
            ... 1 more
```