### PR TITLE
ui: Move issues of an ORT Run to a separate page

### DIFF
--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/route.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/route.tsx
@@ -54,6 +54,10 @@ const Layout = () => {
       label: 'Technical',
       items: [
         {
+          title: 'Issues',
+          to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues',
+        },
+        {
           title: 'Reports',
           to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/reports',
         },

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/index.tsx
@@ -27,7 +27,13 @@ import { LoadingIndicator } from '@/components/loading-indicator';
 import { OrtRunJobStatus } from '@/components/ort-run-job-status';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { config } from '@/config';
 import { calculateDuration } from '@/helpers/get-run-duration';
@@ -194,51 +200,12 @@ const RunComponent = () => {
         </div>
         <Card className='flex flex-1 overflow-hidden'>
           <CardHeader>
-            <CardTitle>Issues</CardTitle>
-            <CardContent className='space-y-2 overflow-auto'>
-              <p>
-                Lorem ipsum dolor, sit amet consectetur adipisicing elit.
-                Possimus nobis necessitatibus amet deleniti quia quis
-                consequuntur cumque impedit accusantium dolorem, eos inventore
-                in sed magni dolorum nemo repellendus voluptates velit.
-              </p>
-              <p>
-                Lorem ipsum dolor, sit amet consectetur adipisicing elit.
-                Possimus nobis necessitatibus amet deleniti quia quis
-                consequuntur cumque impedit accusantium dolorem, eos inventore
-                in sed magni dolorum nemo repellendus voluptates velit.
-              </p>
-              <p>
-                Lorem ipsum dolor, sit amet consectetur adipisicing elit.
-                Possimus nobis necessitatibus amet deleniti quia quis
-                consequuntur cumque impedit accusantium dolorem, eos inventore
-                in sed magni dolorum nemo repellendus voluptates velit.
-              </p>
-              <p>
-                Lorem ipsum dolor, sit amet consectetur adipisicing elit.
-                Possimus nobis necessitatibus amet deleniti quia quis
-                consequuntur cumque impedit accusantium dolorem, eos inventore
-                in sed magni dolorum nemo repellendus voluptates velit.
-              </p>
-              <p>
-                Lorem ipsum dolor, sit amet consectetur adipisicing elit.
-                Possimus nobis necessitatibus amet deleniti quia quis
-                consequuntur cumque impedit accusantium dolorem, eos inventore
-                in sed magni dolorum nemo repellendus voluptates velit.
-              </p>
-              <p>
-                Lorem ipsum dolor, sit amet consectetur adipisicing elit.
-                Possimus nobis necessitatibus amet deleniti quia quis
-                consequuntur cumque impedit accusantium dolorem, eos inventore
-                in sed magni dolorum nemo repellendus voluptates velit.
-              </p>
-              <p>
-                Lorem ipsum dolor, sit amet consectetur adipisicing elit.
-                Possimus nobis necessitatibus amet deleniti quia quis
-                consequuntur cumque impedit accusantium dolorem, eos inventore
-                in sed magni dolorum nemo repellendus voluptates velit.
-              </p>
-            </CardContent>
+            <CardTitle>Summary</CardTitle>
+            <CardDescription>
+              When the corresponding API endpoints have been implemented, this
+              section will include a summary of the run, for example number of
+              issues by severity, and some statistical data from the run.
+            </CardDescription>
           </CardHeader>
         </Card>
       </div>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/issues/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/issues/index.tsx
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { useSuspenseQuery } from '@tanstack/react-query';
+import { createFileRoute } from '@tanstack/react-router';
+
+import { useRepositoriesServiceGetOrtRunByIndexKey } from '@/api/queries';
+import { RepositoriesService } from '@/api/requests';
+import { LoadingIndicator } from '@/components/loading-indicator';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+
+const IssuesComponent = () => {
+  const params = Route.useParams();
+  const locale = navigator.language;
+
+  const { data: ortRun } = useSuspenseQuery({
+    queryKey: [
+      useRepositoriesServiceGetOrtRunByIndexKey,
+      params.repoId,
+      params.runIndex,
+    ],
+    queryFn: async () =>
+      await RepositoriesService.getOrtRunByIndex({
+        repositoryId: Number.parseInt(params.repoId),
+        ortRunIndex: Number.parseInt(params.runIndex),
+      }),
+  });
+
+  return (
+    <Card className='mx-auto h-fit w-full max-w-4xl'>
+      <CardHeader>
+        <CardTitle>Technical issues related to the ORT Server</CardTitle>
+        <CardDescription>
+          These are issues related to the ORT Server, for example failing
+          configuration.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {ortRun.issues.length > 0 ? (
+          ortRun.issues.map((issue) => (
+            <Card key={issue.message}>
+              <CardHeader>
+                <CardTitle>
+                  <div className='text-sm'>
+                    <Label className='font-semibold'>Created at:</Label>{' '}
+                    {new Date(issue.timestamp).toLocaleString(locale)}
+                  </div>
+                </CardTitle>
+                <CardDescription>
+                  <div className='flex flex-col text-sm'>
+                    <div>
+                      <Label className='font-semibold'>Severity:</Label>{' '}
+                      {issue.severity}
+                    </div>
+                    <div>
+                      <Label className='font-semibold'>Source:</Label>{' '}
+                      {issue.source}
+                    </div>
+                  </div>
+                </CardDescription>
+                <CardContent className='text-sm'>{issue.message}</CardContent>
+              </CardHeader>
+            </Card>
+          ))
+        ) : (
+          <Label className='font-semibold'>No issues found.</Label>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/issues/'
+)({
+  loader: async ({ context, params }) => {
+    await context.queryClient.ensureQueryData({
+      queryKey: [
+        useRepositoriesServiceGetOrtRunByIndexKey,
+        params.repoId,
+        params.runIndex,
+      ],
+      queryFn: () =>
+        RepositoriesService.getOrtRunByIndex({
+          repositoryId: Number.parseInt(params.repoId),
+          ortRunIndex: Number.parseInt(params.runIndex),
+        }),
+    });
+  },
+  component: IssuesComponent,
+  pendingComponent: LoadingIndicator,
+});


### PR DESCRIPTION
Please see the commits for details.

NOTE: This PR is merely a factorization of the ORT run results pages and is by no means a complete implementation of the issues listing. Completing it needs at least #405 implemented, and depending on the issues endpoint and a possible run summary endpoint, the layout of the issues page will most probably need changes.