### PR TITLE
test(github): Increase the delay between retries

### DIFF
--- a/config/github/src/test/kotlin/GitHubConfigFileCacheTest.kt
+++ b/config/github/src/test/kotlin/GitHubConfigFileCacheTest.kt
@@ -209,7 +209,7 @@ class GitHubConfigFileCacheTest : WordSpec({
 
             val cache = GitHubConfigFileCache(cacheDir, lockCheckInterval, 5, 1.days)
 
-            retry(10, 30.seconds) {
+            retry(10, 30.seconds, 2.seconds) {
                 cache.cleanup("current")
                 revisionDir.exists() shouldBe false
             }
@@ -219,7 +219,7 @@ class GitHubConfigFileCacheTest : WordSpec({
             val cacheDir = tempdir()
             val cache = GitHubConfigFileCache(cacheDir, lockCheckInterval, 10, 1.days)
 
-            retry(10, 30.seconds) {
+            retry(10, 30.seconds, 2.seconds) {
                 val now = Clock.System.now()
                 val revisionDir = cacheDir.createChildDirAt(revision(1), now - 2.days)
 


### PR DESCRIPTION
With the current delay of 1 second, the test code exhausts all its retries in 9 seconds, and it leads to some occasional flakiness in the CI.

This should solve the occasional CI error:

```
            org.eclipse.apoapsis.ortserver.config.github.GitHubConfigFileCacheTest > cleanup should > remove outdated revisions with the configured probability FAILED
    java.lang.AssertionError: Test failed after 9 seconds; attempted 10 times; underlying cause was expected:<false> but was:<true>
        at _COROUTINE._BOUNDARY._(CoroutineDebugging.kt:42)
        at kotlinx.coroutines.TimeoutKt.withTimeoutOrNull(Timeout.kt:101)
        at io.kotest.engine.test.interceptors.InvocationTimeoutInterceptor.intercept(InvocationTimeoutInterceptor.kt:42)
        at io.kotest.engine.test.TestInvocationInterceptor$runBeforeTestAfter$wrappedTest$1$1.invokeSuspend(TestInvocationInterceptor.kt:70)
        at io.kotest.engine.test.TestInvocationInterceptor$intercept$2$1.invokeSuspend(TestInvocationInterceptor.kt:36)
        at io.kotest.mpp.ReplayKt.replay(replay.kt:15)
        at io.kotest.engine.test.TestInvocationInterceptor$intercept$2.invokeSuspend(TestInvocationInterceptor.kt:32)
        at io.kotest.engine.test.TestInvocationInterceptor.intercept(TestInvocationInterceptor.kt:31)
        at io.kotest.engine.test.TestCaseExecutor$execute$3$1.invokeSuspend(TestCaseExecutor.kt:100)
        at io.kotest.engine.interceptors.MarkAbortedExceptionsAsSkippedTestInterceptor.intercept(MarkAbortedExceptionsAsSkippedTestInte
```