### PR TITLE
ui: Edit sidebar and main content alignment

### DIFF
--- a/ui/src/components/page-layout.tsx
+++ b/ui/src/components/page-layout.tsx
@@ -27,7 +27,7 @@ interface PageLayoutProps {
 
 export const PageLayout = ({ sections, children }: PageLayoutProps) => {
   return (
-    <Page className='flex flex-col gap-4 md:flex-row'>
+    <Page className='flex flex-col justify-center gap-4 md:flex-row'>
       {sections && (
         <Pane className='w-full md:w-52'>
           <Sidebar sections={sections} />

--- a/ui/src/components/page-layout.tsx
+++ b/ui/src/components/page-layout.tsx
@@ -33,7 +33,7 @@ export const PageLayout = ({ sections, children }: PageLayoutProps) => {
           <Sidebar sections={sections} />
         </Pane>
       )}
-      <Content>{children}</Content>
+      <Content className='w-full md:max-w-4xl'>{children}</Content>
     </Page>
   );
 };

--- a/ui/src/components/page-layout.tsx
+++ b/ui/src/components/page-layout.tsx
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { Sidebar, SidebarNavProps } from '@/components/sidebar';
+import { Content, Page, Pane } from '@/components/ui/layout';
+
+interface PageLayoutProps {
+  sections: SidebarNavProps['sections'] | undefined;
+  children: React.ReactNode;
+}
+
+export const PageLayout = ({ sections, children }: PageLayoutProps) => {
+  return (
+    <Page className='flex flex-col gap-4 md:flex-row'>
+      {sections && (
+        <Pane className='w-full md:w-52'>
+          <Sidebar sections={sections} />
+        </Pane>
+      )}
+      <Content>{children}</Content>
+    </Page>
+  );
+};

--- a/ui/src/components/sidebar.tsx
+++ b/ui/src/components/sidebar.tsx
@@ -24,7 +24,7 @@ import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
 
-interface SidebarNavProps {
+export interface SidebarNavProps {
   sections: {
     label?: string;
     items: {
@@ -48,10 +48,7 @@ interface SidebarNavProps {
 
 export const Sidebar = ({ sections, className, ...props }: SidebarNavProps) => {
   return (
-    <nav
-      className={cn('mb-4 w-full md:mb-0 md:mr-2 md:w-52', className)}
-      {...props}
-    >
+    <nav className={cn('w-full', className)} {...props}>
       <div className='flex flex-col items-start'>
         {sections.map((section) => {
           if (section.visible === false) {

--- a/ui/src/components/ui/layout.tsx
+++ b/ui/src/components/ui/layout.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import React from 'react';
+
+import { cn } from '@/lib/utils';
+
+const Content = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn(className)} {...props} />
+));
+Content.displayName = 'Content';
+
+const Pane = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn(className)} {...props} />
+));
+Pane.displayName = 'Pane';
+
+const Page = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('w-full', className)} {...props} />
+));
+Page.displayName = 'Page';
+
+export { Content, Pane, Page };

--- a/ui/src/routes/_layout/organizations/$orgId/create-product.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/create-product.tsx
@@ -91,7 +91,7 @@ const CreateProductPage = () => {
   }
 
   return (
-    <Card className='mx-auto w-full max-w-4xl'>
+    <Card className='w-full max-w-4xl'>
       <CardHeader>
         <CardTitle>Create Product</CardTitle>
       </CardHeader>

--- a/ui/src/routes/_layout/organizations/$orgId/create-product.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/create-product.tsx
@@ -91,7 +91,7 @@ const CreateProductPage = () => {
   }
 
   return (
-    <Card className='w-full max-w-4xl'>
+    <Card>
       <CardHeader>
         <CardTitle>Create Product</CardTitle>
       </CardHeader>

--- a/ui/src/routes/_layout/organizations/$orgId/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/edit.tsx
@@ -107,7 +107,7 @@ const EditOrganizationPage = () => {
   }
 
   return (
-    <Card className='w-full max-w-4xl'>
+    <Card>
       <CardHeader>Edit Organization</CardHeader>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>

--- a/ui/src/routes/_layout/organizations/$orgId/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/edit.tsx
@@ -107,7 +107,7 @@ const EditOrganizationPage = () => {
   }
 
   return (
-    <Card className='mx-auto w-full max-w-4xl'>
+    <Card className='w-full max-w-4xl'>
       <CardHeader>Edit Organization</CardHeader>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>

--- a/ui/src/routes/_layout/organizations/$orgId/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/index.tsx
@@ -161,7 +161,7 @@ const OrganizationComponent = () => {
 
   return (
     <TooltipProvider>
-      <Card className='mx-auto w-full max-w-4xl'>
+      <Card className='w-full max-w-4xl'>
         <CardHeader>
           <CardTitle className='flex flex-row justify-between'>
             <div className='flex items-stretch'>

--- a/ui/src/routes/_layout/organizations/$orgId/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/index.tsx
@@ -161,7 +161,7 @@ const OrganizationComponent = () => {
 
   return (
     <TooltipProvider>
-      <Card className='w-full max-w-4xl'>
+      <Card>
         <CardHeader>
           <CardTitle className='flex flex-row justify-between'>
             <div className='flex items-stretch'>

--- a/ui/src/routes/_layout/organizations/$orgId/infrastructure-services/$serviceName/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/infrastructure-services/$serviceName/edit.tsx
@@ -139,7 +139,7 @@ const EditInfrastructureServicePage = () => {
   };
 
   return (
-    <Card className='w-full max-w-4xl'>
+    <Card>
       <CardHeader>Edit Infrastructure Service</CardHeader>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)}>

--- a/ui/src/routes/_layout/organizations/$orgId/infrastructure-services/$serviceName/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/infrastructure-services/$serviceName/edit.tsx
@@ -139,7 +139,7 @@ const EditInfrastructureServicePage = () => {
   };
 
   return (
-    <Card className='mx-auto w-full max-w-4xl'>
+    <Card className='w-full max-w-4xl'>
       <CardHeader>Edit Infrastructure Service</CardHeader>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)}>

--- a/ui/src/routes/_layout/organizations/$orgId/infrastructure-services/create.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/infrastructure-services/create.tsx
@@ -119,7 +119,7 @@ const CreateInfrastructureServicePage = () => {
    */
 
   return (
-    <Card className='w-full max-w-4xl'>
+    <Card>
       <CardHeader>
         <CardTitle>Create Infrastructure Service</CardTitle>
         <CardDescription>

--- a/ui/src/routes/_layout/organizations/$orgId/infrastructure-services/create.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/infrastructure-services/create.tsx
@@ -119,7 +119,7 @@ const CreateInfrastructureServicePage = () => {
    */
 
   return (
-    <Card className='mx-auto w-full max-w-4xl'>
+    <Card className='w-full max-w-4xl'>
       <CardHeader>
         <CardTitle>Create Infrastructure Service</CardTitle>
         <CardDescription>

--- a/ui/src/routes/_layout/organizations/$orgId/infrastructure-services/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/infrastructure-services/index.tsx
@@ -274,7 +274,7 @@ const InfrastructureServices = () => {
 
   return (
     <TooltipProvider>
-      <Card className='w-full max-w-7xl'>
+      <Card>
         <CardHeader>
           <CardTitle>Infrastructure Services</CardTitle>
           <CardDescription>

--- a/ui/src/routes/_layout/organizations/$orgId/infrastructure-services/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/infrastructure-services/index.tsx
@@ -274,7 +274,7 @@ const InfrastructureServices = () => {
 
   return (
     <TooltipProvider>
-      <Card className='mx-auto w-full max-w-7xl'>
+      <Card className='w-full max-w-7xl'>
         <CardHeader>
           <CardTitle>Infrastructure Services</CardTitle>
           <CardDescription>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/create-repository.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/create-repository.tsx
@@ -105,7 +105,7 @@ const CreateRepositoryPage = () => {
   }
 
   return (
-    <Card className='mx-auto w-full max-w-4xl'>
+    <Card className='w-full max-w-4xl'>
       <CardHeader>
         <CardTitle>Add repository</CardTitle>
       </CardHeader>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/create-repository.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/create-repository.tsx
@@ -105,7 +105,7 @@ const CreateRepositoryPage = () => {
   }
 
   return (
-    <Card className='w-full max-w-4xl'>
+    <Card>
       <CardHeader>
         <CardTitle>Add repository</CardTitle>
       </CardHeader>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/edit.tsx
@@ -106,7 +106,7 @@ const EditProductPage = () => {
   }
 
   return (
-    <Card className='w-full max-w-4xl'>
+    <Card>
       <CardHeader>Edit Product</CardHeader>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/edit.tsx
@@ -106,7 +106,7 @@ const EditProductPage = () => {
   }
 
   return (
-    <Card className='mx-auto w-full max-w-4xl'>
+    <Card className='w-full max-w-4xl'>
       <CardHeader>Edit Product</CardHeader>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/index.tsx
@@ -163,7 +163,7 @@ const ProductComponent = () => {
 
   return (
     <TooltipProvider>
-      <Card className='w-full max-w-4xl'>
+      <Card>
         <CardHeader>
           <CardTitle className='flex flex-row justify-between'>
             <div className='flex items-stretch'>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/index.tsx
@@ -163,7 +163,7 @@ const ProductComponent = () => {
 
   return (
     <TooltipProvider>
-      <Card className='mx-auto w-full max-w-4xl'>
+      <Card className='w-full max-w-4xl'>
         <CardHeader>
           <CardTitle className='flex flex-row justify-between'>
             <div className='flex items-stretch'>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/route.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/route.tsx
@@ -20,7 +20,7 @@
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 import { Eye, FileText, ListTree, Scale, ShieldQuestion } from 'lucide-react';
 
-import { Sidebar } from '@/components/sidebar';
+import { PageLayout } from '@/components/page-layout';
 
 const Layout = () => {
   const sections = [
@@ -74,10 +74,9 @@ const Layout = () => {
   ];
 
   return (
-    <div className='flex h-full w-full gap-2'>
-      <Sidebar sections={sections} />
+    <PageLayout sections={sections}>
       <Outlet />
-    </div>
+    </PageLayout>
   );
 };
 export const Route = createFileRoute(

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/issues/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/issues/index.tsx
@@ -50,7 +50,7 @@ const IssuesComponent = () => {
   });
 
   return (
-    <Card className='mx-auto h-fit w-full max-w-4xl'>
+    <Card className='h-fit w-full max-w-4xl'>
       <CardHeader>
         <CardTitle>Technical issues related to the ORT Server</CardTitle>
         <CardDescription>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/issues/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/issues/index.tsx
@@ -50,7 +50,7 @@ const IssuesComponent = () => {
   });
 
   return (
-    <Card className='h-fit w-full max-w-4xl'>
+    <Card className='h-fit'>
       <CardHeader>
         <CardTitle>Technical issues related to the ORT Server</CardTitle>
         <CardDescription>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/logs/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/logs/index.tsx
@@ -101,7 +101,7 @@ const ReportComponent = () => {
   };
 
   return (
-    <Card className='w-full max-w-4xl'>
+    <Card>
       <CardHeader>
         <CardTitle>Logs from global run ID {ortRun.id}</CardTitle>
         <CardDescription>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/logs/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/logs/index.tsx
@@ -101,7 +101,7 @@ const ReportComponent = () => {
   };
 
   return (
-    <Card className='mx-auto w-full max-w-4xl'>
+    <Card className='w-full max-w-4xl'>
       <CardHeader>
         <CardTitle>Logs from global run ID {ortRun.id}</CardTitle>
         <CardDescription>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/reports/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/reports/index.tsx
@@ -89,7 +89,7 @@ const ReportComponent = () => {
   }
 
   return (
-    <Card className='mx-auto w-full max-w-4xl'>
+    <Card className='w-full max-w-4xl'>
       <CardHeader>
         <CardTitle>Reports from run {ortRun.index}</CardTitle>
         <CardDescription>Click the file to download.</CardDescription>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/reports/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/reports/index.tsx
@@ -89,7 +89,7 @@ const ReportComponent = () => {
   }
 
   return (
-    <Card className='w-full max-w-4xl'>
+    <Card>
       <CardHeader>
         <CardTitle>Reports from run {ortRun.index}</CardTitle>
         <CardDescription>Click the file to download.</CardDescription>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/create-run.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/create-run.tsx
@@ -535,7 +535,7 @@ const CreateRunPage = () => {
   }
 
   return (
-    <Card className='mx-auto w-full max-w-4xl'>
+    <Card className='w-full max-w-4xl'>
       <CardHeader>
         <CardTitle>Create an ORT run</CardTitle>
       </CardHeader>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/create-run.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/create-run.tsx
@@ -535,7 +535,7 @@ const CreateRunPage = () => {
   }
 
   return (
-    <Card className='w-full max-w-4xl'>
+    <Card>
       <CardHeader>
         <CardTitle>Create an ORT run</CardTitle>
       </CardHeader>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/edit.tsx
@@ -124,7 +124,7 @@ const EditRepositoryPage = () => {
   }
 
   return (
-    <Card className='mx-auto w-full max-w-4xl'>
+    <Card className='w-full max-w-4xl'>
       <CardHeader>
         <CardTitle>Edit repository</CardTitle>
       </CardHeader>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/edit.tsx
@@ -124,7 +124,7 @@ const EditRepositoryPage = () => {
   }
 
   return (
-    <Card className='w-full max-w-4xl'>
+    <Card>
       <CardHeader>
         <CardTitle>Edit repository</CardTitle>
       </CardHeader>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/index.tsx
@@ -267,7 +267,7 @@ const RepoComponent = () => {
 
   return (
     <TooltipProvider>
-      <Card className='mx-auto w-full max-w-4xl'>
+      <Card className='w-full max-w-4xl'>
         <CardHeader>
           <CardTitle className='flex flex-row justify-between'>
             <div className='flex items-stretch'>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/index.tsx
@@ -267,7 +267,7 @@ const RepoComponent = () => {
 
   return (
     <TooltipProvider>
-      <Card className='w-full max-w-4xl'>
+      <Card>
         <CardHeader>
           <CardTitle className='flex flex-row justify-between'>
             <div className='flex items-stretch'>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/route.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/route.tsx
@@ -19,11 +19,10 @@
 
 import { createFileRoute, Outlet, useParams } from '@tanstack/react-router';
 import { BookLock, Eye } from 'lucide-react';
-import { Suspense } from 'react';
 
 import { useRepositoriesServiceGetRepositoryByIdKey } from '@/api/queries';
 import { RepositoriesService } from '@/api/requests';
-import { Sidebar } from '@/components/sidebar';
+import { PageLayout } from '@/components/page-layout';
 import { useUser } from '@/hooks/use-user';
 
 const Layout = () => {
@@ -49,10 +48,13 @@ const Layout = () => {
 
   return (
     <>
-      {!runIndex && <Sidebar sections={[{ items: navItems }]} />}
-      <Suspense fallback={<div>Loading...</div>}>
+      {!runIndex ? (
+        <PageLayout sections={[{ items: navItems }]}>
+          <Outlet />
+        </PageLayout>
+      ) : (
         <Outlet />
-      </Suspense>
+      )}
     </>
   );
 };

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/secrets/$secretName/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/secrets/$secretName/edit.tsx
@@ -124,7 +124,7 @@ const EditRepositorySecretPage = () => {
   };
 
   return (
-    <Card className='mx-auto w-full max-w-4xl'>
+    <Card className='w-full max-w-4xl'>
       <CardHeader>Edit Repository Secret</CardHeader>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/secrets/$secretName/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/secrets/$secretName/edit.tsx
@@ -124,7 +124,7 @@ const EditRepositorySecretPage = () => {
   };
 
   return (
-    <Card className='w-full max-w-4xl'>
+    <Card>
       <CardHeader>Edit Repository Secret</CardHeader>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/secrets/create-secret.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/secrets/create-secret.tsx
@@ -96,7 +96,7 @@ const CreateRepositorySecretPage = () => {
   }
 
   return (
-    <Card className='w-full max-w-4xl'>
+    <Card>
       <CardHeader>Create Repository Secret</CardHeader>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/secrets/create-secret.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/secrets/create-secret.tsx
@@ -96,7 +96,7 @@ const CreateRepositorySecretPage = () => {
   }
 
   return (
-    <Card className='mx-auto w-full max-w-4xl'>
+    <Card className='w-full max-w-4xl'>
       <CardHeader>Create Repository Secret</CardHeader>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/secrets/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/secrets/index.tsx
@@ -208,7 +208,7 @@ const RepositorySecrets = () => {
 
   return (
     <TooltipProvider>
-      <Card className='w-full max-w-4xl'>
+      <Card>
         <CardHeader>
           <CardTitle>Secrets</CardTitle>
           <CardDescription>Manage secrets for {repo.url}.</CardDescription>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/secrets/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/secrets/index.tsx
@@ -208,7 +208,7 @@ const RepositorySecrets = () => {
 
   return (
     <TooltipProvider>
-      <Card className='mx-auto w-full max-w-4xl'>
+      <Card className='w-full max-w-4xl'>
         <CardHeader>
           <CardTitle>Secrets</CardTitle>
           <CardDescription>Manage secrets for {repo.url}.</CardDescription>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/route.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/route.tsx
@@ -19,11 +19,10 @@
 
 import { createFileRoute, Outlet, useParams } from '@tanstack/react-router';
 import { BookLock, Eye } from 'lucide-react';
-import { Suspense } from 'react';
 
 import { useProductsServiceGetProductByIdKey } from '@/api/queries';
 import { ProductsService } from '@/api/requests';
-import { Sidebar } from '@/components/sidebar';
+import { PageLayout } from '@/components/page-layout';
 import { useUser } from '@/hooks/use-user';
 
 const Layout = () => {
@@ -49,10 +48,13 @@ const Layout = () => {
 
   return (
     <>
-      {!runIndex && !repoId && <Sidebar sections={[{ items: navItems }]} />}
-      <Suspense fallback={<div>Loading...</div>}>
+      {!runIndex && !repoId ? (
+        <PageLayout sections={[{ items: navItems }]}>
+          <Outlet />
+        </PageLayout>
+      ) : (
         <Outlet />
-      </Suspense>
+      )}
     </>
   );
 };

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/secrets/$secretName/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/secrets/$secretName/edit.tsx
@@ -120,7 +120,7 @@ const EditProductSecretPage = () => {
   };
 
   return (
-    <Card className='mx-auto w-full max-w-4xl'>
+    <Card className='w-full max-w-4xl'>
       <CardHeader>Edit Product Secret</CardHeader>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/secrets/$secretName/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/secrets/$secretName/edit.tsx
@@ -120,7 +120,7 @@ const EditProductSecretPage = () => {
   };
 
   return (
-    <Card className='w-full max-w-4xl'>
+    <Card>
       <CardHeader>Edit Product Secret</CardHeader>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/secrets/create-secret.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/secrets/create-secret.tsx
@@ -92,7 +92,7 @@ const CreateProductSecretPage = () => {
   }
 
   return (
-    <Card className='mx-auto w-full max-w-4xl'>
+    <Card className='w-full max-w-4xl'>
       <CardHeader>Create Product Secret</CardHeader>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/secrets/create-secret.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/secrets/create-secret.tsx
@@ -92,7 +92,7 @@ const CreateProductSecretPage = () => {
   }
 
   return (
-    <Card className='w-full max-w-4xl'>
+    <Card>
       <CardHeader>Create Product Secret</CardHeader>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/secrets/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/secrets/index.tsx
@@ -207,7 +207,7 @@ const ProductSecrets = () => {
 
   return (
     <TooltipProvider>
-      <Card className='w-full max-w-4xl'>
+      <Card>
         <CardHeader>
           <CardTitle>Secrets</CardTitle>
           <CardDescription>Manage secrets for {product.name}.</CardDescription>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/secrets/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/secrets/index.tsx
@@ -207,7 +207,7 @@ const ProductSecrets = () => {
 
   return (
     <TooltipProvider>
-      <Card className='mx-auto w-full max-w-4xl'>
+      <Card className='w-full max-w-4xl'>
         <CardHeader>
           <CardTitle>Secrets</CardTitle>
           <CardDescription>Manage secrets for {product.name}.</CardDescription>

--- a/ui/src/routes/_layout/organizations/$orgId/route.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/route.tsx
@@ -19,11 +19,10 @@
 
 import { createFileRoute, Outlet, useParams } from '@tanstack/react-router';
 import { BookLock, Eye, ServerCog } from 'lucide-react';
-import { Suspense } from 'react';
 
 import { useOrganizationsServiceGetOrganizationByIdKey } from '@/api/queries';
 import { OrganizationsService } from '@/api/requests';
-import { Sidebar } from '@/components/sidebar';
+import { PageLayout } from '@/components/page-layout';
 import { useUser } from '@/hooks/use-user';
 
 const Layout = () => {
@@ -54,14 +53,15 @@ const Layout = () => {
   ];
 
   return (
-    <div className='flex flex-col md:flex-row'>
-      {!productId && !repoId && !runIndex && (
-        <Sidebar sections={[{ items: navItems }]} />
-      )}
-      <Suspense fallback={<div>Loading...</div>}>
+    <>
+      {!productId && !repoId && !runIndex ? (
+        <PageLayout sections={[{ items: navItems }]}>
+          <Outlet />
+        </PageLayout>
+      ) : (
         <Outlet />
-      </Suspense>
-    </div>
+      )}
+    </>
   );
 };
 

--- a/ui/src/routes/_layout/organizations/$orgId/secrets/$secretName/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/secrets/$secretName/edit.tsx
@@ -121,7 +121,7 @@ const EditOrganizationSecretPage = () => {
   };
 
   return (
-    <Card className='mx-auto w-full max-w-4xl'>
+    <Card className='w-full max-w-4xl'>
       <CardHeader>Edit Organization Secret</CardHeader>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>

--- a/ui/src/routes/_layout/organizations/$orgId/secrets/$secretName/edit.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/secrets/$secretName/edit.tsx
@@ -121,7 +121,7 @@ const EditOrganizationSecretPage = () => {
   };
 
   return (
-    <Card className='w-full max-w-4xl'>
+    <Card>
       <CardHeader>Edit Organization Secret</CardHeader>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>

--- a/ui/src/routes/_layout/organizations/$orgId/secrets/create-secret.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/secrets/create-secret.tsx
@@ -94,7 +94,7 @@ const CreateOrganizationSecretPage = () => {
   }
 
   return (
-    <Card className='mx-auto w-full max-w-4xl'>
+    <Card className='w-full max-w-4xl'>
       <CardHeader>Create Organization Secret</CardHeader>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>

--- a/ui/src/routes/_layout/organizations/$orgId/secrets/create-secret.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/secrets/create-secret.tsx
@@ -94,7 +94,7 @@ const CreateOrganizationSecretPage = () => {
   }
 
   return (
-    <Card className='w-full max-w-4xl'>
+    <Card>
       <CardHeader>Create Organization Secret</CardHeader>
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>

--- a/ui/src/routes/_layout/organizations/$orgId/secrets/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/secrets/index.tsx
@@ -203,7 +203,7 @@ const OrganizationSecrets = () => {
 
   return (
     <TooltipProvider>
-      <Card className='mx-auto w-full max-w-4xl'>
+      <Card className='w-full max-w-4xl'>
         <CardHeader>
           <CardTitle>Secrets</CardTitle>
           <CardDescription>

--- a/ui/src/routes/_layout/organizations/$orgId/secrets/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/secrets/index.tsx
@@ -203,7 +203,7 @@ const OrganizationSecrets = () => {
 
   return (
     <TooltipProvider>
-      <Card className='w-full max-w-4xl'>
+      <Card>
         <CardHeader>
           <CardTitle>Secrets</CardTitle>
           <CardDescription>

--- a/ui/src/routes/_layout/route.tsx
+++ b/ui/src/routes/_layout/route.tsx
@@ -25,7 +25,7 @@ const Layout = () => {
   return (
     <div className='flex min-h-screen w-full flex-col'>
       <Header />
-      <main className='flex h-full flex-col gap-4 p-4 md:w-full md:gap-8 md:p-8'>
+      <main className='flex h-full flex-col gap-4 p-4 md:w-full md:items-center md:gap-8 md:p-8'>
         <Outlet />
       </main>
     </div>


### PR DESCRIPTION
Please see individual commits and pictures and explanation below for details.

![Näyttökuva (112)](https://github.com/user-attachments/assets/b5daddb4-2ada-4188-a746-f91627f9f580)

To get the sidebar to always be in the same place on the page and not jump around, the main contents have to have the same width everywhere (unless there can be more or less empty space on the right side than on the left side of the sidebar+main-content combined div, i.e. the combined div won't be centered). The contents everywhere else would look quite stupid with a wider width, so the table in the Infrastructure Services page now has a horizontal scroll bar. This page could possibly have an exception to the rule, but the issue is, that if the width is declared on the individual pages themselves, the sidebar will flash on the left side before rendering in the correct spot, as it is declared on the route.tsx files, and I guess will do a first render before the other contents are ready to be rendered. When the surrounding div with the fixed width is declared in the route.tsx files, this flashing effect goes away. If we want to have the Infrastructure Services page wider, perhaps the surrounding div class name could be evaluated based on the current route, but then of course the sidebar would jump when visiting this page.

![Näyttökuva (113)](https://github.com/user-attachments/assets/2f350ebb-e764-4c24-8f94-a3fcd02f97d0)

![Näyttökuva (114)](https://github.com/user-attachments/assets/2e35f5e7-c5d9-4343-952a-101dc8f99550)

