### PR TITLE
ui: Add results sub-pages for all ORT Run results

### DIFF
--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/route.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/route.tsx
@@ -18,7 +18,14 @@
  */
 
 import { createFileRoute, Outlet } from '@tanstack/react-router';
-import { Eye, FileText, ListTree, Scale, ShieldQuestion } from 'lucide-react';
+import {
+  Boxes,
+  Eye,
+  FileText,
+  ListTree,
+  Scale,
+  ShieldQuestion,
+} from 'lucide-react';
 
 import { PageLayout } from '@/components/page-layout';
 
@@ -33,19 +40,28 @@ const Layout = () => {
           icon: () => <Eye className='h-4 w-4' />,
         },
         {
+          title: 'Packages',
+          to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages',
+          icon: () => <Boxes className='h-4 w-4' />,
+        },
+        {
           title: 'Dependencies',
+          to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/dependencies',
           icon: () => <ListTree className='h-4 w-4' />,
         },
         {
           title: 'Vulnerabilities',
+          to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities',
           icon: () => <ShieldQuestion className='h-4 w-4' />,
         },
         {
           title: 'License Findings',
+          to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings',
           icon: () => <FileText className='h-4 w-4' />,
         },
         {
           title: 'Rule Violations',
+          to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations',
           icon: () => <Scale className='h-4 w-4' />,
         },
       ],

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/dependencies/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/dependencies/index.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { createFileRoute } from '@tanstack/react-router';
+
+import { LoadingIndicator } from '@/components/loading-indicator';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+
+const DependenciesComponent = () => {
+  return (
+    <Card className='h-fit'>
+      <CardHeader>
+        <CardTitle>Dependencies</CardTitle>
+        <CardDescription>Dependency graphs of the project.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Label className='font-semibold'>Not implemented yet.</Label>
+      </CardContent>
+    </Card>
+  );
+};
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/dependencies/'
+)({
+  component: DependenciesComponent,
+  pendingComponent: LoadingIndicator,
+});

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/license-findings/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/license-findings/index.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { createFileRoute } from '@tanstack/react-router';
+
+import { LoadingIndicator } from '@/components/loading-indicator';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+
+const LicenseFindingsComponent = () => {
+  return (
+    <Card className='h-fit'>
+      <CardHeader>
+        <CardTitle>License findings</CardTitle>
+        <CardDescription>
+          License and copyright findings of the project.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Label className='font-semibold'>Not implemented yet.</Label>
+      </CardContent>
+    </Card>
+  );
+};
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/license-findings/'
+)({
+  component: LicenseFindingsComponent,
+  pendingComponent: LoadingIndicator,
+});

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/packages/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/packages/index.tsx
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { createFileRoute } from '@tanstack/react-router';
+
+import { LoadingIndicator } from '@/components/loading-indicator';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+
+const PackagesComponent = () => {
+  return (
+    <Card className='h-fit'>
+      <CardHeader>
+        <CardTitle>Packages</CardTitle>
+        <CardDescription>
+          Table of deduplicated packages found as dependencies of the project.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Label className='font-semibold'>Not implemented yet.</Label>
+      </CardContent>
+    </Card>
+  );
+};
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/packages/'
+)({
+  component: PackagesComponent,
+  pendingComponent: LoadingIndicator,
+});

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/rule-violations/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/rule-violations/index.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { createFileRoute } from '@tanstack/react-router';
+
+import { LoadingIndicator } from '@/components/loading-indicator';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+
+const RuleViolationsComponent = () => {
+  return (
+    <Card className='h-fit'>
+      <CardHeader>
+        <CardTitle>Rule violations</CardTitle>
+        <CardDescription>Rule violations of the project.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Label className='font-semibold'>Not implemented yet.</Label>
+      </CardContent>
+    </Card>
+  );
+};
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/rule-violations/'
+)({
+  component: RuleViolationsComponent,
+  pendingComponent: LoadingIndicator,
+});

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/vulnerabilities/index.tsx
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { createFileRoute } from '@tanstack/react-router';
+
+import { LoadingIndicator } from '@/components/loading-indicator';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+
+const VulnerabilitiesComponent = () => {
+  return (
+    <Card className='h-fit'>
+      <CardHeader>
+        <CardTitle>Vulnerabilities</CardTitle>
+        <CardDescription>Vulnerabilities of the project.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Label className='font-semibold'>Not implemented yet.</Label>
+      </CardContent>
+    </Card>
+  );
+};
+
+export const Route = createFileRoute(
+  '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/vulnerabilities/'
+)({
+  component: VulnerabilitiesComponent,
+  pendingComponent: LoadingIndicator,
+});


### PR DESCRIPTION
![Capture](https://github.com/user-attachments/assets/8e3af398-c855-425b-840c-e795cd616144)

Please see the commit for details.