### PR TITLE
chore(core): Enable logs for the CORS plugin

### DIFF
--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -32,5 +32,6 @@
     <logger name="com.zaxxer.hikari" level="WARN"/>
     <logger name="org.flywaydb.core.internal.license.VersionPrinter" level="WARN"/>
     <logger name="io.ktor" level="INFO"/>
+    <logger name="io.ktor.server.plugins.cors.CORS" level="TRACE"/>
 
 </configuration>


### PR DESCRIPTION
Set the log level for the Ktor CORS plugin [1] to TRACE. This shows the reason if the CORS validation fails which helps with debugging CORS issues.