### PR TITLE
fix(logaccess): Prevent a potential endless loop

### DIFF
--- a/logaccess/loki/src/main/kotlin/LokiLogFileProvider.kt
+++ b/logaccess/loki/src/main/kotlin/LokiLogFileProvider.kt
@@ -104,7 +104,18 @@ class LokiLogFileProvider(
                 }
 
                 if (statements.size >= config.limit && deDuplicatedStatements.isNotEmpty()) {
-                    downloadChunk(statements.last().timestamp, deDuplicatedStatements)
+                    val lastTimestamp = statements.last().timestamp
+
+                    if (lastTimestamp != from) {
+                        downloadChunk(lastTimestamp, deDuplicatedStatements)
+                    } else {
+                        logger.error(
+                            "Possible loss of log data for run '{}' and source '{}' " +
+                            "due to number of identical timestamps exceeds chunk size limit.",
+                            ortRunId,
+                            source
+                        )
+                    }
                 }
             }
 


### PR DESCRIPTION
Given Loki is used as log aggregation system, when multiple log statements are generated in quick succession (burst), these log statements potentially all carry the same timestamp. When the Loki HTTP API is used to fetch the log statements for a given time interval using chunks defined by a start timestamp, this leads to an endless loop in the ORT server if the chunk size is smaller than the number of log statements with identical timestamps. This bugfix prevents this endless loop by making sure that each chunk is fetched at most a single time.