### PR TITLE
fix(dao): Fix an issue in the deduplication migration

### DIFF
--- a/dao/src/main/resources/db/migration/V73__deduplicatePackagesAndProjects.sql
+++ b/dao/src/main/resources/db/migration/V73__deduplicatePackagesAndProjects.sql
@@ -333,7 +333,7 @@ WHERE
 CREATE VIEW projects_with_hashes AS
 SELECT
   p.id,
-  encode(sha256(concat(
+  encode(sha256(convert_to(concat(
     p.identifier_id,
     p.vcs_id,
     p.vcs_processed_id,
@@ -344,7 +344,7 @@ SELECT
     pa.authors,
     ps.scopes,
     ppl.processed_license_hash
-  )::bytea),
+  ), 'UTF8')),
     'hex') AS hash
 FROM
   projects p


### PR DESCRIPTION
This is a fix for 3bef62c. If a property of a project contains a special character like a backslash, the migration could fail. This can be prevented by using the `convert_to()` function in the same way this was already done for packages.