### PR TITLE
refactor(hierarchy): Use DAO API to simplify `VulnerabilityService`

### DIFF
--- a/services/hierarchy/src/main/kotlin/VulnerabilityService.kt
+++ b/services/hierarchy/src/main/kotlin/VulnerabilityService.kt
@@ -27,13 +27,10 @@ import org.eclipse.apoapsis.ortserver.dao.tables.runs.advisor.AdvisorRunsIdentif
 import org.eclipse.apoapsis.ortserver.dao.tables.runs.advisor.AdvisorRunsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.runs.advisor.VulnerabilitiesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.runs.advisor.VulnerabilityDao
-import org.eclipse.apoapsis.ortserver.dao.tables.runs.advisor.VulnerabilityReferencesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.runs.shared.IdentifierDao
 import org.eclipse.apoapsis.ortserver.dao.tables.runs.shared.IdentifiersTable
 import org.eclipse.apoapsis.ortserver.dao.utils.listCustomQuery
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityWithIdentifier
-import org.eclipse.apoapsis.ortserver.model.runs.Identifier
-import org.eclipse.apoapsis.ortserver.model.runs.advisor.Vulnerability
-import org.eclipse.apoapsis.ortserver.model.runs.advisor.VulnerabilityReference
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
 
@@ -48,86 +45,21 @@ class VulnerabilityService(private val db: Database) {
         ortRunId: Long,
         parameters: ListQueryParameters = ListQueryParameters.DEFAULT
     ): ListQueryResult<VulnerabilityWithIdentifier> = db.dbQuery {
-        val vulnerabilityQueryResult =
-            VulnerabilityDao.listCustomQuery(parameters, ResultRow::toVulnerabilityWithIdentifierAndReference) {
-                val join = VulnerabilitiesTable innerJoin
-                        AdvisorResultsVulnerabilitiesTable innerJoin
-                        AdvisorResultsTable innerJoin
-                        AdvisorRunsIdentifiersTable innerJoin
-                        AdvisorRunsTable innerJoin
-                        AdvisorJobsTable innerJoin
-                        IdentifiersTable
-
-                join.select(
-                    VulnerabilitiesTable.id,
-                    VulnerabilitiesTable.externalId,
-                    VulnerabilitiesTable.summary,
-                    VulnerabilitiesTable.description,
-                    IdentifiersTable.type,
-                    IdentifiersTable.namespace,
-                    IdentifiersTable.name,
-                    IdentifiersTable.version
-                ).where { AdvisorJobsTable.ortRunId eq ortRunId }
-            }
-
-        // Get all references for the vulnerabilities.
-        val externalIds = vulnerabilityQueryResult.data.map { it.vulnerability.externalId }
-        val referencesByExternalId = getReferencesForVulnerabilities(externalIds)
-
-        // Add the references to the vulnerabilities.
-        val result = mutableListOf<VulnerabilityWithIdentifier>()
-        vulnerabilityQueryResult.data.forEach {
-            val references = referencesByExternalId[it.vulnerability.externalId].orEmpty()
-            val vulnerability = it.vulnerability.copy(references = references)
-            result.add(VulnerabilityWithIdentifier(vulnerability, it.identifier))
+        VulnerabilityDao.listCustomQuery(parameters, ResultRow::toVulnerabilityWithIdentifierAndReference) {
+            VulnerabilitiesTable
+                .innerJoin(AdvisorResultsVulnerabilitiesTable)
+                .innerJoin(AdvisorResultsTable)
+                .innerJoin(AdvisorRunsIdentifiersTable)
+                .innerJoin(AdvisorRunsTable)
+                .innerJoin(AdvisorJobsTable)
+                .innerJoin(IdentifiersTable)
+                .select(VulnerabilitiesTable.columns + IdentifiersTable.columns)
+                .where { AdvisorJobsTable.ortRunId eq ortRunId }
         }
-
-        ListQueryResult(result, parameters, vulnerabilityQueryResult.totalCount)
-    }
-
-    /**
-     * Get all references for the vulnerabilities with the given [externalIds]. Group them by the externalId.
-     */
-    private fun getReferencesForVulnerabilities(externalIds: List<String>): Map<String, List<VulnerabilityReference>> {
-        val result = mutableMapOf<String, List<VulnerabilityReference>>()
-
-        VulnerabilityReferencesTable.innerJoin(VulnerabilitiesTable)
-            .select(
-                VulnerabilityReferencesTable.vulnerabilityId,
-                VulnerabilityReferencesTable.url,
-                VulnerabilityReferencesTable.severity,
-                VulnerabilityReferencesTable.scoringSystem,
-                VulnerabilitiesTable.externalId
-            ).where { VulnerabilitiesTable.externalId inList externalIds }
-            .map {
-                it[VulnerabilitiesTable.externalId] to VulnerabilityReference(
-                    it[VulnerabilityReferencesTable.url],
-                    it[VulnerabilityReferencesTable.scoringSystem],
-                    it[VulnerabilityReferencesTable.severity]
-                )
-            }.forEach {
-                val vulnerabilities = result[it.first]?.toMutableList() ?: mutableListOf()
-                vulnerabilities.add(it.second)
-                result[it.first] = vulnerabilities
-            }
-
-        return result
     }
 }
 
-private fun ResultRow.toVulnerabilityWithIdentifierAndReference(): VulnerabilityWithIdentifier {
-    return VulnerabilityWithIdentifier(
-        vulnerability = Vulnerability(
-            this[VulnerabilitiesTable.externalId],
-            this[VulnerabilitiesTable.summary],
-            this[VulnerabilitiesTable.description],
-            emptyList() // References will be added in a separate step.
-        ),
-        identifier = Identifier(
-            this[IdentifiersTable.type],
-            this[IdentifiersTable.namespace],
-            this[IdentifiersTable.name],
-            this[IdentifiersTable.version],
-        )
-    )
-}
+private fun ResultRow.toVulnerabilityWithIdentifierAndReference() = VulnerabilityWithIdentifier(
+    vulnerability = VulnerabilityDao.wrapRow(this).mapToModel(),
+    identifier = IdentifierDao.wrapRow(this).mapToModel()
+)


### PR DESCRIPTION
Using the DAO API allows to apply several simplifications to the `VulnerabilityService`:

* The `wrapRow` function creates instances of the DAO class from a `ResultRow` avoiding the need for manual mapping.
* The `mapToModel` functions of the DAOs automatically load the related data avoiding the need for manually writing the queries.

While at it, also use the `columns` properties of the table classes to define the selected columns instead of listing them explicitly.

This also makes the code more robust with regards to refactorings, as changes to the columns of the involved tables will automatically be applied.