### PR TITLE
fix(orchestrator): Set the ORT run status to `FINISHED_WITH_ISSUES`

### DIFF
--- a/orchestrator/src/main/kotlin/Orchestrator.kt
+++ b/orchestrator/src/main/kotlin/Orchestrator.kt
@@ -375,10 +375,12 @@ class Orchestrator(
         if (createdJobs.isEmpty() && !context.hasRunningJobs()) {
             cleanupJobs(context.ortRun.id)
 
-            val ortRunStatus = if (context.isFailed()) {
-                OrtRunStatus.FAILED
-            } else {
-                OrtRunStatus.FINISHED
+            val ortRunStatus = when {
+                context.isFailed() -> OrtRunStatus.FAILED
+
+                context.isFinishedWithIssues() -> OrtRunStatus.FINISHED_WITH_ISSUES
+
+                else -> OrtRunStatus.FINISHED
             }
 
             log.info("Setting the final status of ORT run {} to '{}'.", context.ortRun.id, ortRunStatus.name)

--- a/orchestrator/src/main/kotlin/WorkerScheduleContext.kt
+++ b/orchestrator/src/main/kotlin/WorkerScheduleContext.kt
@@ -107,6 +107,12 @@ internal class WorkerScheduleContext(
      */
     fun isFailed(): Boolean =
         failed || jobs.values.any { it.status == JobStatus.FAILED }
+
+    /**
+    * Return a flag whether this [OrtRun] has finished with issues, i.e. it has at least one job with this state.
+    */
+    fun isFinishedWithIssues(): Boolean =
+        !isFailed() && jobs.values.any { it.status == JobStatus.FINISHED_WITH_ISSUES }
 }
 
 /**


### PR DESCRIPTION
If any of the workers finished with this status, and if no worker failed, the ORT run receives also this status.

This is a fixup for 3cc0a255010db9edb89e30d40229ace37c873679.