### PR TITLE
ci: Add a workflow to run ORT

### DIFF
--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -1,0 +1,21 @@
+name: ORT
+
+on:
+  workflow_dispatch:
+
+env:
+  ORT_IMAGE: ghcr.io/oss-review-toolkit/ort-minimal
+
+jobs:
+  ort:
+    name: Run ORT
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@v4
+
+    - name: Pull ORT Docker Image
+      run: docker pull ${{ env.ORT_IMAGE }}
+
+    - name: Check ORT Requirements
+      run: docker run --rm ${{ env.ORT_IMAGE }} requirements


### PR DESCRIPTION
Add a workflow to run ORT on the ORT Server. This will later be included in the release workflow to generate an SBOM and probably also in PR checks.

To be able to manually trigger a workflow, it must first be merged to the main branch. Therefore, only include the basics in this commit to download the image and run the requirements command. This makes it easier to prepare another PR which adds the execution of the ORT tools and the required configuration.