### PR TITLE
Add an endpoint for creating new users

### DIFF
--- a/api/v1/model/src/commonMain/kotlin/User.kt
+++ b/api/v1/model/src/commonMain/kotlin/User.kt
@@ -27,7 +27,16 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class User(
     val id: String,
-    val username: String
+    val username: String,
+)
+
+@Serializable
+data class CreateUser(
+    val username: String,
+    val password: String? = null,
+
+    /** Specifies whether the password is for one-time use only */
+    val temporary: Boolean = true
 )
 
 /**

--- a/clients/keycloak/src/main/kotlin/KeycloakClient.kt
+++ b/clients/keycloak/src/main/kotlin/KeycloakClient.kt
@@ -127,14 +127,22 @@ interface KeycloakClient {
     suspend fun getUser(username: UserName): User
 
     /**
-     * Create a new [user][User] in the Keycloak realm with the given [username], [firstName], [lastName] and [email].
+     * Create a new [user][User] in the Keycloak realm with the given [username], [firstName], [lastName], [email],
+     * [password] and [temporary].
      */
     suspend fun createUser(
         username: UserName,
         firstName: String? = null,
         lastName: String? = null,
-        email: String? = null
+        email: String? = null,
+        password: String? = null,
+        temporary: Boolean = false
     )
+
+    /**
+     * Check whether the [user][User] has credentials in the Keycloak realm.
+     */
+    suspend fun getUserHasCredentials(username: UserName): Boolean
 
     /**
      * Update the [user][User] with the given [id] within the Keycloak realm with the new [username], [firstName],

--- a/clients/keycloak/src/main/kotlin/UserCredentials.kt
+++ b/clients/keycloak/src/main/kotlin/UserCredentials.kt
@@ -17,18 +17,17 @@
  * License-Filename: LICENSE
  */
 
-package org.eclipse.apoapsis.ortserver.clients.keycloak.internal
+package org.eclipse.apoapsis.ortserver.clients.keycloak
 
 import kotlinx.serialization.Serializable
 
-import org.eclipse.apoapsis.ortserver.clients.keycloak.UserName
-
+/**
+ * Part of the request object for creating a new user with credentials in Keycloak.
+ */
 @Serializable
-internal data class UserRequest(
-    val username: UserName?,
-    val firstName: String?,
-    val lastName: String?,
-    val email: String?,
-    val enabled: Boolean = true,
-    val credentials: List<Credential> = emptyList()
+data class UserCredentials(
+    val id: String,
+    val type: String,
+    val createdDate: Long,
+    val credentialData: String
 )

--- a/clients/keycloak/src/main/kotlin/internal/Credential.kt
+++ b/clients/keycloak/src/main/kotlin/internal/Credential.kt
@@ -21,14 +21,9 @@ package org.eclipse.apoapsis.ortserver.clients.keycloak.internal
 
 import kotlinx.serialization.Serializable
 
-import org.eclipse.apoapsis.ortserver.clients.keycloak.UserName
-
 @Serializable
-internal data class UserRequest(
-    val username: UserName?,
-    val firstName: String?,
-    val lastName: String?,
-    val email: String?,
-    val enabled: Boolean = true,
-    val credentials: List<Credential> = emptyList()
+internal data class Credential(
+    val type: String = "password",
+    val value: String,
+    val temporary: Boolean = false
 )

--- a/clients/keycloak/src/test/kotlin/AbstractKeycloakClientTest.kt
+++ b/clients/keycloak/src/test/kotlin/AbstractKeycloakClientTest.kt
@@ -401,11 +401,22 @@ abstract class AbstractKeycloakClientTest : WordSpec() {
         }
 
         "createUser" should {
-            "successfully add a new realm user" {
+            "successfully add a new realm user without credentials" {
                 client.createUser(UserName("test_user"))
                 val user = client.getUser(UserName("test_user"))
 
                 user.username shouldBe UserName("test_user")
+                client.getUserHasCredentials(UserName("test_user")) shouldBe false
+
+                client.deleteUser(user.id)
+            }
+
+            "successfully add a new realm user with credentials" {
+                client.createUser(username = UserName("test_user"), password = "test123", temporary = true)
+                val user = client.getUser(UserName("test_user"))
+
+                user.username shouldBe UserName("test_user")
+                client.getUserHasCredentials(UserName("test_user")) shouldBe true
 
                 client.deleteUser(user.id)
             }

--- a/core/src/main/kotlin/api/AdminRoute.kt
+++ b/core/src/main/kotlin/api/AdminRoute.kt
@@ -20,9 +20,11 @@
 package org.eclipse.apoapsis.ortserver.core.api
 
 import io.github.smiley4.ktorswaggerui.dsl.routing.get
+import io.github.smiley4.ktorswaggerui.dsl.routing.post
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.call
+import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.route
@@ -31,9 +33,12 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
+import org.eclipse.apoapsis.ortserver.api.v1.model.CreateUser
+import org.eclipse.apoapsis.ortserver.core.apiDocs.postUsers
 import org.eclipse.apoapsis.ortserver.core.apiDocs.runPermissionsSync
 import org.eclipse.apoapsis.ortserver.core.authorization.requireSuperuser
 import org.eclipse.apoapsis.ortserver.services.AuthorizationService
+import org.eclipse.apoapsis.ortserver.services.UserService
 
 import org.koin.ktor.ext.inject
 
@@ -51,6 +56,21 @@ fun Route.admin() = route("admin") {
 
                 call.respond(HttpStatusCode.Accepted)
             }
+        }
+    }
+    /**
+     * For CRUD operations for users.
+     */
+    route("users") {
+        val userService by inject<UserService>()
+
+        post(postUsers) {
+            requireSuperuser()
+
+            val createUser = call.receive<CreateUser>()
+            userService.createUser(createUser.username, createUser.password, createUser.temporary)
+
+            call.respond(HttpStatusCode.Created)
         }
     }
 }

--- a/core/src/main/kotlin/apiDocs/AdminDocs.kt
+++ b/core/src/main/kotlin/apiDocs/AdminDocs.kt
@@ -23,6 +23,8 @@ import io.github.smiley4.ktorswaggerui.dsl.routes.OpenApiRoute
 
 import io.ktor.http.HttpStatusCode
 
+import org.eclipse.apoapsis.ortserver.api.v1.model.CreateUser
+
 val runPermissionsSync: OpenApiRoute.() -> Unit = {
     operationId = "runPermissionsSync"
     summary = ""
@@ -38,6 +40,33 @@ val runPermissionsSync: OpenApiRoute.() -> Unit = {
 
         HttpStatusCode.Unauthorized to {
             description = "Unauth."
+        }
+    }
+}
+
+val postUsers: OpenApiRoute.() -> Unit = {
+    operationId = "postUsers"
+    summary = "Create a user, possibly with a password. This is enabled for server administrators only."
+    tags = listOf("Admin")
+
+    request {
+        jsonBody<CreateUser> {
+            example("Create User") {
+                value = CreateUser(username = "newUser", password = "password", temporary = true)
+                description = "temporary=true means the password is for one-time use only and needs to be changed " +
+                        "on first login. If password is not set, temporary is ignored."
+            }
+        }
+    }
+
+    response {
+        HttpStatusCode.Created to {
+            description = "Successfully created the user."
+        }
+
+        // Note: Keycloak doesn't distinguish technical from logical errors; it just returns 500 for both.
+        HttpStatusCode.InternalServerError to {
+            description = "A user with the same username already exists."
         }
     }
 }

--- a/core/src/main/kotlin/di/Module.kt
+++ b/core/src/main/kotlin/di/Module.kt
@@ -72,6 +72,7 @@ import org.eclipse.apoapsis.ortserver.services.ProductService
 import org.eclipse.apoapsis.ortserver.services.ReportStorageService
 import org.eclipse.apoapsis.ortserver.services.RepositoryService
 import org.eclipse.apoapsis.ortserver.services.SecretService
+import org.eclipse.apoapsis.ortserver.services.UserService
 import org.eclipse.apoapsis.ortserver.services.VulnerabilityService
 import org.eclipse.apoapsis.ortserver.storage.Storage
 
@@ -127,6 +128,7 @@ fun ortServerModule(config: ApplicationConfig) = module {
     single { VulnerabilityService(get()) }
     single { IssueService(get()) }
     single { PackageService(get()) }
+    single { UserService(get()) }
     singleOf(::ReportStorageService)
     singleOf(::InfrastructureServiceService)
 }

--- a/core/src/test/kotlin/api/UsersRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/UsersRouteIntegrationTest.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2022 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.core.api
+
+import io.kotest.assertions.ktor.client.shouldHaveStatus
+
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.http.HttpStatusCode
+
+import org.eclipse.apoapsis.ortserver.api.v1.model.CreateUser
+import org.eclipse.apoapsis.ortserver.utils.test.Integration
+
+class UsersRouteIntegrationTest : AbstractIntegrationTest({
+    tags(Integration)
+
+    val testUsername = "test123"
+    val testPassword = "password123"
+    val testTemporary = true
+
+    "POST /admin/users" should {
+        "create a new user" {
+            integrationTestApplication {
+                val user = CreateUser(testUsername, testPassword, testTemporary)
+
+                val response = superuserClient.post("/api/v1/admin/users") {
+                    setBody(user)
+                }
+
+                response shouldHaveStatus HttpStatusCode.Created
+            }
+        }
+        "respond with an internal error if the user already exists" {
+            integrationTestApplication {
+                val user = CreateUser(testUsername, testPassword, testTemporary)
+
+                superuserClient.post("/api/v1/admin/users") {
+                    setBody(user)
+                }
+                val response = superuserClient.post("/api/v1/admin/users") {
+                    setBody(user)
+                }
+
+                response shouldHaveStatus HttpStatusCode.InternalServerError
+            }
+        }
+    }
+})

--- a/model/src/commonMain/kotlin/User.kt
+++ b/model/src/commonMain/kotlin/User.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2022 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.model
+
+/**
+ * A data class representing a user.
+ */
+data class User(
+    /** The username of the user. */
+    val username: String,
+
+    /** The password of the user. */
+    val password: String?,
+
+    /** Whether the password is temporary. */
+    val temporary: Boolean,
+
+    /** The first name of the user. */
+    val firstName: String? = null,
+
+    /** The last name of the user. */
+    val lastName: String? = null,
+
+    /** The mail address of the user. */
+    val email: String? = null,
+
+    /** Specifies, whether the user can log in or not. */
+    val enabled: Boolean = true
+)

--- a/scripts/requests/users.http
+++ b/scripts/requests/users.http
@@ -1,0 +1,10 @@
+### Create a User
+POST {{host}}/admin/users
+Authorization: Bearer {{$auth.token("keycloak")}}
+Content-Type: application/json
+
+{
+  "username": "username",
+  "password": "password",
+  "temporary": "false",
+}

--- a/services/authorization/src/main/kotlin/UserService.kt
+++ b/services/authorization/src/main/kotlin/UserService.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2022 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.services
+
+import org.eclipse.apoapsis.ortserver.clients.keycloak.KeycloakClient
+import org.eclipse.apoapsis.ortserver.clients.keycloak.UserName
+import org.eclipse.apoapsis.ortserver.model.User
+
+/**
+ * A service providing functions for working with [users][User].
+ */
+class UserService(
+    private val keycloakClient: KeycloakClient
+) {
+    /**
+     * Create a user. If "password" is null, then "temporary" is ignored.
+     */
+    suspend fun createUser(username: String, password: String?, temporary: Boolean) = run {
+        keycloakClient.createUser(username = UserName(username), password = password, temporary = temporary)
+    }
+}


### PR DESCRIPTION
Please see the commits for details.
A subsequent PR will implement a minimal admin UI for creating new users.

Resolves #1088.