### PR TITLE
ci: Consistently use Ubuntu 24.04

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -6,54 +6,37 @@ runs:
   using: "composite"
 
   steps:
-    - name: Print Disk Space
-      shell: bash
-      run: df -h
-    - name: List Docker Images
-      if: ${{ false }} # Can be enabled if the 'Remove Unneeded Docker Images' step below needs to be updated.
-      shell: bash
-      run: docker images
-    - name: Remove Unneeded Docker Images
-      shell: bash
-      run: |
-        docker image rm \
-          node:16 \
-          node:16-alpine \
-          node:18 \
-          node:18-alpine \
-          node:20 \
-          node:20-alpine \
-          debian:10 \
-          debian:11 \
-          ubuntu:20.04 \
-          ubuntu:22.04
-    - name: Print Disk Space
-      shell: bash
-      run: df -h
-    - name: Get Size of Installed Tools
-      if: ${{ false }} # Can be enabled if the 'Remove Unneeded Tools' step below needs to be updated.
-      shell: bash
-      run: |
-        sudo du -hsc /usr/lib/*
-        sudo du -hsc /usr/local/*
-        sudo du -hsc /usr/local/lib/*
-        sudo du -hsc /usr/local/share/*
-        sudo du -hsc /usr/share/*
-    - name: Remove Unneeded Tools
-      shell: bash
-      run: |
-        sudo rm -rf /usr/local/lib/android
-        sudo rm -rf /usr/local/lib/node_modules
-        sudo rm -rf /usr/local/share/chromium
-        sudo rm -rf /usr/local/share/powershell
-        sudo rm -rf /usr/share/az_11.3.1
-        sudo rm -rf /usr/share/dotnet
-        sudo rm -rf /usr/share/kotlinc
-        sudo rm -rf /usr/share/mecab
-        sudo rm -rf /usr/share/miniconda
-        sudo rm -rf /usr/share/ri
-        sudo rm -rf /usr/share/sbt
-        sudo rm -rf /usr/share/swift
-    - name: Print Disk Space
-      shell: bash
-      run: df -h
+  - name: Print Disk Space
+    shell: bash
+    run: df -h
+  - name: Get Size of Installed Tools
+    if: ${{ false }} # Can be enabled if the 'Remove Unneeded Tools' step below needs to be updated.
+    shell: bash
+    run: |
+      sudo du -hsc /usr/lib/*
+      sudo du -hsc /usr/local/*
+      sudo du -hsc /usr/local/lib/*
+      sudo du -hsc /usr/local/share/*
+      sudo du -hsc /usr/share/*
+  - name: Remove Unneeded Tools
+    shell: bash
+    run: |
+      sudo rm -rf /usr/lib/dotnet
+      sudo rm -rf /usr/lib/firefox
+      sudo rm -rf /usr/local/aws-cli
+      sudo rm -rf /usr/local/aws-sam-cli
+      sudo rm -rf /usr/local/lib/android
+      sudo rm -rf /usr/local/lib/node_modules
+      sudo rm -rf /usr/local/share/chromium
+      sudo rm -rf /usr/local/share/powershell
+      sudo rm -rf /usr/local/share/vcpkg
+      sudo rm -rf /usr/share/az_12.1.0
+      sudo rm -rf /usr/share/kotlinc
+      sudo rm -rf /usr/share/mecab
+      sudo rm -rf /usr/share/miniconda
+      sudo rm -rf /usr/share/ri
+      sudo rm -rf /usr/share/swift
+      sudo rm -rf /usr/share/vim
+  - name: Print Disk Space
+    shell: bash
+    run: df -h

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -35,7 +35,7 @@ jobs:
       run: ./gradlew --stacktrace classes
 
   build-ui:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -77,7 +77,7 @@ jobs:
 
   test:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -112,7 +112,7 @@ jobs:
 
   integration-test:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   build:
     name: Build Docker Image
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       packages: write
     strategy:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   wrapper-validation:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4

--- a/.github/workflows/ort.yml
+++ b/.github/workflows/ort.yml
@@ -9,7 +9,7 @@ env:
 jobs:
   ort:
     name: Run ORT
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4

--- a/.github/workflows/publish-artifacts.yml
+++ b/.github/workflows/publish-artifacts.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   publish:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       packages: write
     steps:

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   renovate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout
       uses: actions/checkout@v4

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -24,7 +24,7 @@ jobs:
         configFile: .commitlintrc.yml
 
   detekt-issues:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     env:
       GRADLE_OPTS: -Dorg.gradle.daemon=false
     steps:
@@ -46,7 +46,7 @@ jobs:
       run: ./gradlew --stacktrace detektAll
 
   eslint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -70,7 +70,7 @@ jobs:
       run: pnpm -C ui lint 
 
   prettier:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
@@ -106,12 +106,12 @@ jobs:
       run: npx -y --package renovate -- renovate-config-validator .github/renovate-global.json
 
   reuse-tool:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4
 
     - name: Check REUSE Compliance
       run: |
-        pip install --user reuse==3.0.2
-        ~/.local/bin/reuse lint
+        pipx install reuse==3.0.2
+        reuse lint

--- a/.github/workflows/website-test.yml
+++ b/.github/workflows/website-test.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   website-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout Repository
       uses: actions/checkout@v4


### PR DESCRIPTION
Use `ubuntu-24.04` for all GitHub workflows. Previously, some workflows used `ubuntu-latest` while others used `ubuntu-22.04`. Using a specific version avoids unwanted upgrades which could break CI.

Upgrading the Docker build to `ubuntu-24.04` requires updating the `free-disk-space` action as the ubuntu-24.04 runners do not have pre-installed Docker images anymore. Also the list of tools to delete needs to be updated.