### PR TITLE
test(transport): Fix payload comparison in `checkMessage`

### DIFF
--- a/transport/spi/src/testFixtures/kotlin/Utils.kt
+++ b/transport/spi/src/testFixtures/kotlin/Utils.kt
@@ -90,6 +90,6 @@ fun <T> BlockingQueue<Message<T>>.checkMessage(traceId: String, runId: Long, pay
     poll(TEST_QUEUE_TIMEOUT, TimeUnit.SECONDS) shouldNotBeNull {
         header.traceId shouldBe traceId
         header.ortRunId shouldBe runId
-        payload shouldBe payload
+        this.payload shouldBe payload
     }
 }


### PR DESCRIPTION
Previously, the `payload` argument of the function was overwriting the `payload` property of the message class with the same name. This caused the test to compare the `payload` argument with itself.