### PR TITLE
fix(kubernetes-jobmonitor): Add missing config options for sender

### DIFF
--- a/transport/kubernetes-jobmonitor/src/main/resources/application.conf
+++ b/transport/kubernetes-jobmonitor/src/main/resources/application.conf
@@ -93,3 +93,18 @@ database {
   sslKey = ${?DB_SSL_KEY}
   sslRootCert = ${?DB_SSL_ROOT_CERT}
 }
+
+orchestrator {
+  sender {
+    type = "activeMQ"
+    type = ${?ORCHESTRATOR_SENDER_TRANSPORT_TYPE}
+    serverUri = "amqp://localhost:61616"
+    serverUri = ${?ORCHESTRATOR_SENDER_TRANSPORT_SERVER_URI}
+    queueName = "orchestrator_queue"
+    queueName = ${?ORCHESTRATOR_SENDER_TRANSPORT_QUEUE_NAME}
+    username = "username"
+    username = ${?ORCHESTRATOR_SENDER_TRANSPORT_USERNAME}
+    password = "password"
+    password = ${?ORCHESTRATOR_SENDER_TRANSPORT_PASSWORD}
+  }
+}


### PR DESCRIPTION
Add the missing configuration options for sending messages to the orchestrator to `application.conf`. Note the configuration also works without it, but the options should there for reference and consistency.

Fixes #874.