### PR TITLE
fix(core): Inject the `RuleViolationService`

### DIFF
--- a/core/src/main/kotlin/di/Module.kt
+++ b/core/src/main/kotlin/di/Module.kt
@@ -71,6 +71,7 @@ import org.eclipse.apoapsis.ortserver.services.PackageService
 import org.eclipse.apoapsis.ortserver.services.ProductService
 import org.eclipse.apoapsis.ortserver.services.ReportStorageService
 import org.eclipse.apoapsis.ortserver.services.RepositoryService
+import org.eclipse.apoapsis.ortserver.services.RuleViolationService
 import org.eclipse.apoapsis.ortserver.services.SecretService
 import org.eclipse.apoapsis.ortserver.services.UserService
 import org.eclipse.apoapsis.ortserver.services.VulnerabilityService
@@ -127,6 +128,7 @@ fun ortServerModule(config: ApplicationConfig) = module {
     single { SecretService(get(), get(), get(), get()) }
     single { VulnerabilityService(get()) }
     single { IssueService(get()) }
+    single { RuleViolationService(get()) }
     single { PackageService(get()) }
     single { UserService(get()) }
     singleOf(::ReportStorageService)


### PR DESCRIPTION
This is a fixup for 6701a1f. Fixes https://github.com/eclipse-apoapsis/ort-server/issues/1169.