### PR TITLE
ci(docker): Use Java 11 for the Docker build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -109,6 +109,12 @@ jobs:
       if: ${{ matrix.docker.freeDiskSpace }}
       uses: ./.github/actions/free-disk-space
 
+    - name: Setup Java 11
+      uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '11'
+
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v3
 


### PR DESCRIPTION
With the upgrade of the GitHub action runners to ubuntu-24.04 in 1234567, the default Java version has changed to Java 17 (compare [1] and [2]). This breaks the build of the analyzer worker build using JDK 11, because the server code is now built with an incompatible class file version.

Fix this by switching back to using JDK 11 in the Docker build workflow. This is only a temporary solution, as the next ORT release will only be available for Java 21 [3]. With this upgrade the JDK bootstrapping mechanism introduced in recent ORT releases has to be used, instead of building analyzer worker images with different JDKs.

[1]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#java
[2]: https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#java
[3]: https://github.com/oss-review-toolkit/ort/pull/9134