### PR TITLE
UI: Show job statuses in repository list in the product page

### DIFF
--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/-components/last-job-status.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/-components/last-job-status.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { Loader2 } from 'lucide-react';
+
+import { useRepositoriesServiceGetOrtRunsByRepositoryId } from '@/api/queries';
+import { OrtRunJobStatus } from '@/components/ort-run-job-status';
+
+export const LastJobStatus = ({ repoId }: { repoId: number }) => {
+  const {
+    data: runs,
+    isPending: runsIsPending,
+    isError: runsIsError,
+  } = useRepositoriesServiceGetOrtRunsByRepositoryId({
+    repositoryId: repoId,
+    limit: 1,
+    sort: '-index',
+  });
+
+  if (runsIsPending) {
+    return (
+      <>
+        <span className='sr-only'>Loading...</span>
+        <Loader2 size={16} className='mx-3 animate-spin' />
+      </>
+    );
+  }
+
+  if (runsIsError) {
+    return <span>Error loading run.</span>;
+  }
+
+  if (runs.data.length === 0) return null;
+
+  const run = runs.data[0];
+
+  return (
+    <OrtRunJobStatus
+      jobs={run.jobs}
+      pollInterval={30000}
+      orgId={run.organizationId.toString()}
+      productId={run.productId.toString()}
+      repoId={run.repositoryId.toString()}
+      runIndex={run.index.toString()}
+    />
+  );
+};

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/-components/last-run-status.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/-components/last-run-status.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { Loader2 } from 'lucide-react';
+
+import { useRepositoriesServiceGetOrtRunsByRepositoryId } from '@/api/queries';
+import { Badge } from '@/components/ui/badge';
+import { getStatusBackgroundColor } from '@/helpers/get-status-class';
+
+export const LastRunStatus = ({ repoId }: { repoId: number }) => {
+  const {
+    data: runs,
+    isPending: runsIsPending,
+    isError: runsIsError,
+  } = useRepositoriesServiceGetOrtRunsByRepositoryId({
+    repositoryId: repoId,
+    limit: 1,
+    sort: '-index',
+  });
+
+  if (runsIsPending) {
+    return (
+      <>
+        <span className='sr-only'>Loading...</span>
+        <Loader2 size={16} className='mx-3 animate-spin' />
+      </>
+    );
+  }
+
+  if (runsIsError) {
+    return <span>Error loading run.</span>;
+  }
+
+  if (runs.data.length === 0) return null;
+
+  const run = runs.data[0];
+
+  return (
+    <Badge
+      className={`border ${getStatusBackgroundColor(run.status)} hover:bg-${getStatusBackgroundColor(run.status)}`}
+    >
+      {run.status}
+    </Badge>
+  );
+};

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/index.tsx
@@ -55,6 +55,8 @@ import {
 } from '@/components/ui/tooltip';
 import { toast } from '@/lib/toast';
 import { paginationSchema } from '@/schemas';
+import { LastJobStatus } from './-components/last-job-status';
+import { LastRunStatus } from './-components/last-run-status';
 
 const defaultPageSize = 10;
 
@@ -80,6 +82,16 @@ const columns: ColumnDef<Repository>[] = [
         </div>
       </>
     ),
+  },
+  {
+    accessorKey: 'runStatus',
+    header: () => <div>Last Run Status</div>,
+    cell: ({ row }) => <LastRunStatus repoId={row.original.id} />,
+  },
+  {
+    accessorKey: 'jobStatus',
+    header: () => <div>Last Job Status</div>,
+    cell: ({ row }) => <LastJobStatus repoId={row.original.id} />,
   },
 ];
 


### PR DESCRIPTION
Show the status badge and the job status circles in the product details page to see a quick overview of runs in repositories.

![Screenshot from 2024-10-08 12-52-33](https://github.com/user-attachments/assets/6ae44ed2-d9e1-4a49-93a3-9830f0818e38)
