### PR TITLE
Fix release artifact signing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
         # https://keyserver.ubuntu.com/pks/lookup?search=apoapsis-dev&fingerprint=on&op=index
         ORG_GRADLE_PROJECT_signingInMemoryKeyId: 437c0602
         ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GPG_PASSPHRASE }}
-      run: ./gradlew --no-configuration-cache publishAndReleaseToMavenCentral
+      run: ./gradlew --stacktrace --no-configuration-cache publishAndReleaseToMavenCentral
 
     - name: Generate Release Notes
       # Temporary implementation for the very first release. The release notes for this will be written by hand as they

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,9 @@ jobs:
         ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.ORG_OSSRH_PASSWORD }}
         ORG_GRADLE_PROJECT_RELEASE_SIGNING_ENABLED: true
         ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
-        ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.ORG_GPG_KEY_ID }}
+        # secrets.ORG_GPG_KEY_ID contains the wrong value, so hardcode the key id as found on:
+        # https://keyserver.ubuntu.com/pks/lookup?search=apoapsis-dev&fingerprint=on&op=index
+        ORG_GRADLE_PROJECT_signingInMemoryKeyId: 437c0602
         ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GPG_PASSPHRASE }}
       run: ./gradlew --no-configuration-cache publishAndReleaseToMavenCentral
 


### PR DESCRIPTION
The release workflow was using the wrong key id, see the commit messages for details.