### PR TITLE
ui: Show rule violations (main page)

### DIFF
--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/-components/rule-violations-statistics-card.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/-components/rule-violations-statistics-card.tsx
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { ListTree } from 'lucide-react';
+
+import { useRuleViolationsServiceGetRuleViolationsByRunId } from '@/api/queries';
+import { JobStatus } from '@/api/requests';
+import { LoadingIndicator } from '@/components/loading-indicator';
+import { StatisticsCard } from '@/components/statistics-card';
+import { ToastError } from '@/components/toast-error';
+import { getStatusFontColor } from '@/helpers/get-status-class';
+import { toast } from '@/lib/toast';
+
+type RuleViolationsStatisticsCardProps = {
+  status: JobStatus | undefined;
+  runId: number;
+};
+
+export const RuleViolationsStatisticsCard = ({
+  status,
+  runId,
+}: RuleViolationsStatisticsCardProps) => {
+  const {
+    data: ruleViolations,
+    isPending: ruleViolationsIsPending,
+    isError: ruleViolationsIsError,
+    error: ruleViolationsError,
+  } = useRuleViolationsServiceGetRuleViolationsByRunId({
+    runId: runId,
+    limit: 100000,
+  });
+
+  if (ruleViolationsIsPending) {
+    return (
+      <StatisticsCard
+        title='Rule Violations'
+        icon={() => (
+          <ListTree className={`h-4 w-4 ${getStatusFontColor(status)}`} />
+        )}
+        value={<LoadingIndicator />}
+        className='h-full hover:bg-muted/50'
+      />
+    );
+  }
+
+  if (ruleViolationsIsError) {
+    toast.error('Unable to load data', {
+      description: <ToastError error={ruleViolationsError} />,
+      duration: Infinity,
+      cancel: {
+        label: 'Dismiss',
+        onClick: () => {},
+      },
+    });
+    return;
+  }
+
+  const ruleViolationsTotal = ruleViolations.pagination.totalCount;
+
+  return (
+    <StatisticsCard
+      title='Rule Violations'
+      icon={() => (
+        <ListTree className={`h-4 w-4 ${getStatusFontColor(status)}`} />
+      )}
+      value={status ? ruleViolationsTotal : 'N/A'}
+      className='h-full hover:bg-muted/50'
+    />
+  );
+};

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { Bug, Repeat, Scale, ShieldQuestion } from 'lucide-react';
+import { Bug, Repeat, ShieldQuestion } from 'lucide-react';
 
 import { useVulnerabilitiesServiceGetVulnerabilitiesByRunId } from '@/api/queries';
 import { prefetchUseRepositoriesServiceGetOrtRunByIndex } from '@/api/queries/prefetch';
@@ -45,6 +45,7 @@ import {
 } from '@/helpers/get-status-class';
 import { toast } from '@/lib/toast';
 import { PackagesStatisticsCard } from './-components/packages-statistics-card';
+import { RuleViolationsStatisticsCard } from './-components/rule-violations-statistics-card';
 
 const RunComponent = () => {
   const params = Route.useParams();
@@ -70,9 +71,10 @@ const RunComponent = () => {
     }
   );
 
-  // Note that this is very inefficient as it fetches all vulnerabilities for the run,
-  // while for this purpose we only need the total count, so this is a temporary solution.
-  // The query will be replaced with the ORT Run statistics query once it is implemented.
+  // Note that this is very inefficient as it fetches all data from the endpoints,
+  // while for this purpose we only need the total counts, so this is a temporary solution.
+  // The queries will be replaced with the ORT Run statistics query once it is implemented.
+
   const {
     data: vulnerabilities,
     isPending: vulnIsPending,
@@ -293,15 +295,9 @@ const RunComponent = () => {
               runIndex: params.runIndex,
             }}
           >
-            <StatisticsCard
-              title='Rule Violations'
-              icon={() => (
-                <Scale
-                  className={`h-4 w-4 ${getStatusFontColor(ortRun.jobs.evaluator?.status)}`}
-                />
-              )}
-              value={ortRun.jobs.evaluator ? '-' : 'N/A'}
-              className='h-full hover:bg-muted/50'
+            <RuleViolationsStatisticsCard
+              runId={ortRun.id}
+              status={ortRun.jobs.evaluator?.status}
             />
           </Link>
         </div>

--- a/ui/src/schemas/index.ts
+++ b/ui/src/schemas/index.ts
@@ -25,5 +25,10 @@ export const paginationSchema = z.object({
   pageSize: z.number().optional(),
 });
 
+// Grouping schema that is used for search parameter validation
+export const tableGroupingSchema = z.object({
+  groups: z.array(z.string()).optional(),
+});
+
 // Enum schema for the groupId parameter of the Groups endpoints
 export const groupsSchema = z.enum(['admins', 'writers', 'readers']);


### PR DESCRIPTION
This is the first PR in a series of upcoming PRs, which implements the main view of rule violations.:

Statistics card in the ORT run results main page, showing the number of rule violations:
![Screenshot from 2024-10-10 12-19-25](https://github.com/user-attachments/assets/c22d2053-cfdb-437e-845a-3f252d13d96d)

Rule violations main page, which is a grouped table, by default grouping is set for the severity:
![Screenshot from 2024-10-10 12-20-55](https://github.com/user-attachments/assets/a60dd6e6-a9cc-45de-8904-098d334bb22a)

Details modal (see pending issues):
![Screenshot from 2024-10-10 14-05-48](https://github.com/user-attachments/assets/df62a7f5-13a5-4169-b21c-0caaa0419533)


Pending issues:
- as rule violation endpoint doesn't return unique IDs for rule violations, details routes cannot yet be created in the front-end. Therefore, as a first implementation, the details are shown in modals
- dynamic sorting needs to possibly be added to the rule violations table in an upcoming PR
- once the details are moved to their own separate sub-pages, we need a markup renderer for how-to-fix texts