### PR TITLE
Allow to specify an alternative `ort.env.yml` file path 

### DIFF
--- a/.run/Run ORT Server.run.xml
+++ b/.run/Run ORT Server.run.xml
@@ -1,10 +1,10 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="Run ORT Server" type="JetRunConfigurationType">
     <envs>
-      <env name="DB_NAME" value="ort_server" />
       <env name="DB_HOST" value="localhost" />
-      <env name="DB_PORT" value="5433" />
+      <env name="DB_NAME" value="ort_server" />
       <env name="DB_PASSWORD" value="postgres" />
+      <env name="DB_PORT" value="5432" />
       <env name="DB_SCHEMA" value="ort_server" />
       <env name="DB_SSL_MODE" value="disable" />
       <env name="DB_URL" value="jdbc:postgresql://127.0.0.1:5433" />
@@ -13,13 +13,13 @@
       <env name="JWT_ISSUER" value="http://localhost:8081/realms/master" />
       <env name="JWT_REALM" value="master" />
       <env name="JWT_URI" value="http://localhost:8081/realms/master/protocol/openid-connect/certs" />
+      <env name="KEYCLOAK_ACCESS_TOKEN_URL" value="http://localhost:8081/realms/master/protocol/openid-connect/token" />
+      <env name="KEYCLOAK_API_URL" value="http://localhost:8081/admin/realms/master" />
       <env name="ORCHESTRATOR_SENDER_TRANSPORT_PASSWORD" value="admin" />
       <env name="ORCHESTRATOR_SENDER_TRANSPORT_QUEUE_NAME" value="orchestrator_queue" />
       <env name="ORCHESTRATOR_SENDER_TRANSPORT_SERVER_URI" value="amqp://rabbitmq:5672" />
       <env name="ORCHESTRATOR_SENDER_TRANSPORT_TYPE" value="rabbitMQ" />
       <env name="ORCHESTRATOR_SENDER_TRANSPORT_USERNAME" value="admin" />
-      <env name="KEYCLOAK_ACCESS_TOKEN_URL" value="http://localhost:8081/realms/master/protocol/openid-connect/token" />
-      <env name="KEYCLOAK_API_URL" value="http://localhost:8081/admin/realms/master" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="org.eclipse.apoapsis.ortserver.core.ApplicationKt" />
     <module name="ort-server.core.main" />

--- a/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
@@ -329,6 +329,7 @@ fun OrtRun.mapToApi(jobs: ApiJobs) =
         issues = issues.map { it.mapToApi() },
         jobConfigContext,
         resolvedJobConfigContext,
+        environmentConfigPath,
         traceId
     )
 
@@ -347,7 +348,8 @@ fun OrtRun.mapToApiSummary(jobs: ApiJobSummaries) =
         status = status.mapToApi(),
         labels = labels,
         jobConfigContext = jobConfigContext,
-        resolvedJobConfigContext = resolvedJobConfigContext
+        resolvedJobConfigContext = resolvedJobConfigContext,
+        environmentConfigPath = environmentConfigPath
     )
 
 fun OrtRunStatus.mapToApi() = ApiOrtRunStatus.valueOf(name)

--- a/api/v1/model/src/commonMain/kotlin/OrtRun.kt
+++ b/api/v1/model/src/commonMain/kotlin/OrtRun.kt
@@ -117,6 +117,12 @@ data class OrtRun(
     val resolvedJobConfigContext: String? = null,
 
     /**
+     * The optional path to a environment configuration file. If this is not defined, the environment configuration is
+     * read from the default location `.ort.env.yml`.
+     */
+    val environmentConfigPath: String? = null,
+
+    /**
      * The trace ID that is assigned to this run. This is generated when the run is created. It can be used to
      * correlate the logs from different components that are taking part in processing of the run.
      */
@@ -152,7 +158,13 @@ data class CreateOrtRun(
     /**
      * The optional context for obtaining the configuration of this run.
      */
-    val jobConfigContext: String? = null
+    val jobConfigContext: String? = null,
+
+    /**
+     * The optional path to a environment configuration file. If this is not defined, the environment configuration is
+     * read from the default location `.ort.env.yml`.
+     */
+    val environmentConfigPath: String? = null,
 )
 
 @Serializable

--- a/api/v1/model/src/commonMain/kotlin/OrtRunSummary.kt
+++ b/api/v1/model/src/commonMain/kotlin/OrtRunSummary.kt
@@ -100,7 +100,13 @@ data class OrtRunSummary(
      * The resolved configuration context. When an ORT run is started, the configuration context is resolved once and
      * then stored, so that all workers access the same set of configuration properties.
      */
-    val resolvedJobConfigContext: String? = null
+    val resolvedJobConfigContext: String? = null,
+
+    /**
+     * The optional path to a environment configuration file. If this is not defined, the environment configuration is
+     * read from the default location `.ort.env.yml`.
+     */
+    val environmentConfigPath: String? = null
 )
 
 @Serializable

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val dockerBaseBuildArgs: String by project
 val dockerBaseImageTag: String by project
+val dockerImageTag: String by project
 
 plugins {
     alias(libs.plugins.dependencyAnalysis)
@@ -107,7 +108,7 @@ rootDir.walk().maxDepth(4).filter { it.isFile && it.extension == "Dockerfile" }.
                 "docker", "build",
                 "-f", dockerfile.path,
                 *buildArgs.toTypedArray(),
-                "-t", "ort-server-${name.lowercase()}:$dockerBaseImageTag",
+                "-t", "ort-server-${name.lowercase()}:$dockerImageTag",
                 "-q",
                 context
             )

--- a/core/src/main/kotlin/api/RepositoriesRoute.kt
+++ b/core/src/main/kotlin/api/RepositoriesRoute.kt
@@ -140,7 +140,8 @@ fun Route.repositories() = route("repositories/{repositoryId}") {
                     createOrtRun.path,
                     createOrtRun.jobConfigs.mapToModel(),
                     createOrtRun.jobConfigContext,
-                    createOrtRun.labels
+                    createOrtRun.labels,
+                    createOrtRun.environmentConfigPath
                 ).mapToApi(Jobs())
             )
         }

--- a/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
@@ -379,7 +379,8 @@ val getOrtRunsByRepositoryId: OpenApiRoute.() -> Unit = {
                                 status = OrtRunStatus.ACTIVE,
                                 labels = mapOf("label key" to "label value"),
                                 jobConfigContext = null,
-                                resolvedJobConfigContext = "32f955941e94d0a318e1c985903f42af924e9050"
+                                resolvedJobConfigContext = "32f955941e94d0a318e1c985903f42af924e9050",
+                                environmentConfigPath = null
                             )
                         ),
                         PagingData(
@@ -492,7 +493,8 @@ val getOrtRunByIndex: OpenApiRoute.() -> Unit = {
                         issues = emptyList(),
                         jobConfigContext = null,
                         resolvedJobConfigContext = "32f955941e94d0a318e1c985903f42af924e9050",
-                        traceId = "35b67725-a85b-4cc3-b2a4-60fd914634e7"
+                        traceId = "35b67725-a85b-4cc3-b2a4-60fd914634e7",
+                        environmentConfigPath = null
                     )
                 }
             }

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -88,7 +88,8 @@ val getOrtRunById: OpenApiRoute.() -> Unit = {
                         issues = emptyList(),
                         jobConfigContext = null,
                         resolvedJobConfigContext = "32f955941e94d0a318e1c985903f42af924e9050",
-                        traceId = "35b67724-a85a-4cc4-b2a4-60fd914634e7"
+                        traceId = "35b67724-a85a-4cc4-b2a4-60fd914634e7",
+                        environmentConfigPath = null
                     )
                 }
             }
@@ -432,7 +433,8 @@ val getOrtRuns: OpenApiRoute.() -> Unit = {
                                 status = OrtRunStatus.FINISHED,
                                 labels = mapOf("label key" to "label value"),
                                 jobConfigContext = null,
-                                resolvedJobConfigContext = "32f955941e94d0a318e1c985903f42af924e9050"
+                                resolvedJobConfigContext = "32f955941e94d0a318e1c985903f42af924e9050",
+                                environmentConfigPath = null
                             )
                         ),
                         PagingData(

--- a/core/src/main/kotlin/services/OrchestratorService.kt
+++ b/core/src/main/kotlin/services/OrchestratorService.kt
@@ -55,7 +55,8 @@ class OrchestratorService(
         path: String?,
         jobConfig: JobConfigurations,
         jobConfigContext: String?,
-        labels: Map<String, String>?
+        labels: Map<String, String>?,
+        environmentConfigPath: String?
     ): OrtRun {
         val traceId = MDC.get("traceId")
 
@@ -68,7 +69,8 @@ class OrchestratorService(
                 jobConfig,
                 jobConfigContext,
                 labels.orEmpty(),
-                traceId = traceId
+                traceId = traceId,
+                environmentConfigPath = environmentConfigPath
             )
         }
 

--- a/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
@@ -342,7 +342,8 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                     JobConfigurations(),
                     null,
                     labelsMap,
-                    traceId = "trace1"
+                    traceId = "trace1",
+                    null
                 )
                 val run2 = ortRunRepository.create(
                     createdRepository.id,
@@ -351,7 +352,8 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                     JobConfigurations(),
                     "test",
                     labelsMap,
-                    traceId = "trace2"
+                    traceId = "trace2",
+                    null
                 )
 
                 val response = superuserClient.get("/api/v1/repositories/${createdRepository.id}/runs")
@@ -380,7 +382,8 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                     dbExtension.fixtures.jobConfigurations,
                     null,
                     labelsMap,
-                    traceId = "trace1"
+                    traceId = "trace1",
+                    null
                 )
 
                 val run2 = ortRunRepository.create(
@@ -390,7 +393,8 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                     dbExtension.fixtures.jobConfigurations,
                     "test",
                     labelsMap,
-                    traceId = "trace2"
+                    traceId = "trace2",
+                    null
                 )
 
                 val jobs1 = createJobSummaries(run1.id)
@@ -422,7 +426,8 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                     JobConfigurations(),
                     null,
                     labelsMap,
-                    traceId = "test-trace-id"
+                    traceId = "test-trace-id",
+                    null
                 )
                 val run2 = ortRunRepository.create(
                     createdRepository.id,
@@ -431,7 +436,8 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                     JobConfigurations(),
                     "testContext",
                     labelsMap,
-                    traceId = "trace"
+                    traceId = "trace",
+                    null
                 )
 
                 val query = "?sort=-revision,-createdAt&limit=1"
@@ -473,7 +479,8 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                     JobConfigurations(),
                     "jobConfigContext",
                     labelsMap,
-                    traceId = "some-trace-id"
+                    traceId = "some-trace-id",
+                    null
                 )
 
                 val response = superuserClient.get("/api/v1/repositories/${createdRepository.id}/runs/${run.index}")
@@ -494,7 +501,8 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                     JobConfigurations(),
                     "testContext",
                     labelsMap,
-                    traceId = "trace-id"
+                    traceId = "trace-id",
+                    null
                 )
 
                 val jobs = dbExtension.fixtures.createJobs(run.id).mapToApi()
@@ -516,7 +524,8 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                     JobConfigurations(),
                     null,
                     labelsMap,
-                    traceId = "test-trace-id"
+                    traceId = "test-trace-id",
+                    null
                 )
 
             requestShouldRequireRole(RepositoryPermission.READ_ORT_RUNS.roleName(createdRepository.id)) {

--- a/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
@@ -260,7 +260,8 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     JobConfigurations(),
                     "jobConfigContext",
                     labelsMap,
-                    traceId = "t1"
+                    traceId = "t1",
+                    null
                 )
 
                 val issue = ApiIssue(
@@ -291,7 +292,8 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     JobConfigurations(),
                     "testContext",
                     labelsMap,
-                    traceId = "trace"
+                    traceId = "trace",
+                    null
                 )
 
                 val jobs = dbExtension.fixtures.createJobs(run.id).mapToApi()
@@ -311,7 +313,8 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                 JobConfigurations(),
                 null,
                 labelsMap,
-                traceId = "test-trace-id"
+                traceId = "test-trace-id",
+                null
             )
 
             requestShouldRequireRole(RepositoryPermission.READ_ORT_RUNS.roleName(repositoryId)) {
@@ -562,7 +565,8 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                 JobConfigurations(),
                 null,
                 labelsMap,
-                traceId = "test-trace-id"
+                traceId = "test-trace-id",
+                null
             )
 
             requestShouldRequireRole(RepositoryPermission.READ_ORT_RUNS.roleName(repositoryId)) {
@@ -962,7 +966,8 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                 JobConfigurations(),
                 null,
                 labelsMap,
-                traceId = "test-trace-id"
+                traceId = "test-trace-id",
+                null
             )
 
             requestShouldRequireRole(RepositoryPermission.READ_ORT_RUNS.roleName(repositoryId)) {
@@ -994,7 +999,8 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     JobConfigurations(),
                     "jobConfigContext",
                     labelsMap,
-                    traceId = "t1"
+                    traceId = "t1",
+                    null
                 )
 
                 val run2 = ortRunRepository.create(
@@ -1004,7 +1010,8 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     JobConfigurations(),
                     "jobConfigContext",
                     labelsMap,
-                    traceId = "t2"
+                    traceId = "t2",
+                    null
                 )
 
                 val response = superuserClient.get("/api/v1/runs")
@@ -1033,7 +1040,8 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     JobConfigurations(),
                     "jobConfigContext",
                     labelsMap,
-                    traceId = "t1"
+                    traceId = "t1",
+                    null
                 )
 
                 val run2 = ortRunRepository.create(
@@ -1043,7 +1051,8 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     JobConfigurations(),
                     "jobConfigContext",
                     labelsMap,
-                    traceId = "t2"
+                    traceId = "t2",
+                    null
                 )
 
                 val run3 = ortRunRepository.create(
@@ -1053,7 +1062,8 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     JobConfigurations(),
                     "jobConfigContext",
                     labelsMap,
-                    traceId = "t3"
+                    traceId = "t3",
+                    null
                 )
 
                 val updatedRun2 = ortRunRepository.update(run2.id, OrtRunStatus.FAILED.asPresent())
@@ -1094,7 +1104,8 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     JobConfigurations(),
                     "jobConfigContext",
                     labelsMap,
-                    traceId = "t1"
+                    traceId = "t1",
+                    null
                 )
 
                 val run2 = ortRunRepository.create(
@@ -1104,7 +1115,8 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     JobConfigurations(),
                     "jobConfigContext",
                     labelsMap,
-                    traceId = "t2"
+                    traceId = "t2",
+                    null
                 )
 
                 val run3 = ortRunRepository.create(
@@ -1114,7 +1126,8 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     JobConfigurations(),
                     "jobConfigContext",
                     labelsMap,
-                    traceId = "t3"
+                    traceId = "t3",
+                    null
                 )
 
                 ortRunRepository.update(run2.id, OrtRunStatus.FAILED.asPresent())

--- a/dao/src/main/kotlin/repositories/DaoOrtRunRepository.kt
+++ b/dao/src/main/kotlin/repositories/DaoOrtRunRepository.kt
@@ -64,7 +64,8 @@ class DaoOrtRunRepository(private val db: Database) : OrtRunRepository {
         jobConfigs: JobConfigurations,
         jobConfigContext: String?,
         labels: Map<String, String>,
-        traceId: String?
+        traceId: String?,
+        environmentConfigPath: String?
     ): OrtRun = db.blockingQuery {
         val maxIndex = OrtRunsTable.index.max()
         val lastIndex = OrtRunsTable
@@ -86,6 +87,7 @@ class DaoOrtRunRepository(private val db: Database) : OrtRunRepository {
             this.status = OrtRunStatus.CREATED
             this.labels = mapAndDeduplicate(labels.entries, ::getLabelDao)
             this.traceId = traceId
+            this.environmentConfigPath = environmentConfigPath
         }.mapToModel()
     }
 

--- a/dao/src/main/kotlin/tables/OrtRunsTable.kt
+++ b/dao/src/main/kotlin/tables/OrtRunsTable.kt
@@ -56,6 +56,7 @@ object OrtRunsTable : SortableTable("ort_runs") {
     val finishedAt = timestamp("finished_at").nullable()
     val path = text("path").nullable()
     val traceId = text("trace_id").nullable()
+    val environmentConfigPath = text("environment_config_path").nullable()
 }
 
 class OrtRunDao(id: EntityID<Long>) : LongEntity(id) {
@@ -78,6 +79,7 @@ class OrtRunDao(id: EntityID<Long>) : LongEntity(id) {
     var labels by LabelDao via OrtRunsLabelsTable
     var vcsId by OrtRunsTable.vcsId
     var vcsProcessedId by OrtRunsTable.vcsProcessedId
+    var environmentConfigPath by OrtRunsTable.environmentConfigPath
 
     val advisorJob by AdvisorJobDao optionalBackReferencedOn AdvisorJobsTable.ortRunId
     val analyzerJob by AnalyzerJobDao optionalBackReferencedOn AnalyzerJobsTable.ortRunId
@@ -109,6 +111,7 @@ class OrtRunDao(id: EntityID<Long>) : LongEntity(id) {
         issues = issues.map { it.mapToModel() },
         jobConfigContext = jobConfigContext,
         resolvedJobConfigContext = resolvedJobConfigContext,
-        traceId = traceId
+        traceId = traceId,
+        environmentConfigPath = environmentConfigPath
     )
 }

--- a/dao/src/main/resources/db/migration/V81__addEnvironmentConfigPath.sql
+++ b/dao/src/main/resources/db/migration/V81__addEnvironmentConfigPath.sql
@@ -1,0 +1,23 @@
+/*
+ *
+ *  * Copyright (C) 2024  The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *  *
+ *  * Licensed under the Apache License, Version 2.0 (the "License");
+ *  * you may not use this file except in compliance with the License.
+ *  * You may obtain a copy of the License at
+ *  *
+ *  *     https://www.apache.org/licenses/LICENSE-2.0
+ *  *
+ *  * Unless required by applicable law or agreed to in writing, software
+ *  * distributed under the License is distributed on an "AS IS" BASIS,
+ *  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  * See the License for the specific language governing permissions and
+ *  * limitations under the License.
+ *  *
+ *  * SPDX-License-Identifier: Apache-2.0
+ *  * License-Filename: LICENSE
+ *
+ */
+
+ALTER TABLE ort_runs
+    ADD COLUMN environment_config_path text NULL;

--- a/dao/src/test/kotlin/repositories/DaoOrtRunRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/DaoOrtRunRepositoryTest.kt
@@ -84,6 +84,7 @@ class DaoOrtRunRepositoryTest : StringSpec({
         val path = "somePath"
         val jobConfigContext = "someConfigContext"
         val traceId = "trace-1234"
+        val environmentConfigPath = "path/to/env.yml"
 
         val createdOrtRun = ortRunRepository.create(
             repositoryId,
@@ -92,7 +93,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations,
             jobConfigContext,
             labelsMap,
-            traceId = traceId
+            traceId = traceId,
+            environmentConfigPath
         )
 
         val dbEntry = ortRunRepository.get(createdOrtRun.id)
@@ -119,7 +121,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             nestedRepositoryIds = emptyMap(),
             repositoryConfigId = null,
             issues = emptyList(),
-            traceId = traceId
+            traceId = traceId,
+            environmentConfigPath = environmentConfigPath
         )
     }
 
@@ -133,7 +136,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations,
             null,
             labelsMap,
-            traceId = null
+            traceId = null,
+            null
         ).index shouldBe 1
         ortRunRepository.create(
             otherRepository.id,
@@ -142,7 +146,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations,
             null,
             labelsMap,
-            traceId = null
+            traceId = null,
+            null
         ).index shouldBe 1
         ortRunRepository.create(
             otherRepository.id,
@@ -151,7 +156,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations,
             null,
             labelsMap,
-            traceId = "some-trace-id"
+            traceId = "some-trace-id",
+            null
         ).index shouldBe 2
         ortRunRepository.create(
             repositoryId,
@@ -160,7 +166,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations,
             null,
             labelsMap,
-            traceId = null
+            traceId = null,
+            null
         ).index shouldBe 2
     }
 
@@ -172,7 +179,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations,
             null,
             labelsMap,
-            traceId = "some-trace-id"
+            traceId = "some-trace-id",
+            null
         )
 
         ortRunRepository.getByIndex(repositoryId, ortRun.index) shouldBe ortRun
@@ -190,7 +198,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations,
             null,
             labelsMap,
-            traceId = "some-trace-id"
+            traceId = "some-trace-id",
+            null
         )
 
         ortRunRepository.get(ortRun.id) shouldBe ortRun
@@ -204,7 +213,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations,
             null,
             labelsMap,
-            traceId = "the-first-trace-id"
+            traceId = "the-first-trace-id",
+            null
         )
 
         val ortRun2 = ortRunRepository.create(
@@ -214,7 +224,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations,
             null,
             labelsMap,
-            traceId = "the-second-trace-id"
+            traceId = "the-second-trace-id",
+            null
         )
 
         ortRunRepository.list() shouldBe ListQueryResult(listOf(ortRun1, ortRun2), ListQueryParameters.DEFAULT, 2)
@@ -228,7 +239,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations,
             null,
             labelsMap,
-            traceId = "t"
+            traceId = "t",
+            null
         )
 
         val ortRun2 = ortRunRepository.create(
@@ -238,7 +250,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations,
             null,
             labelsMap,
-            traceId = "trace-id"
+            traceId = "trace-id",
+            null
         )
 
         val parameters = ListQueryParameters(
@@ -257,7 +270,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations,
             null,
             labelsMap,
-            traceId = "t"
+            traceId = "t",
+            null
         )
 
         val ortRun2 = ortRunRepository.create(
@@ -267,7 +281,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations,
             null,
             labelsMap,
-            traceId = "trace-id"
+            traceId = "trace-id",
+            null
         )
 
         val failedRun = ortRunRepository.update(ortRun2.id, status = OrtRunStatus.FAILED.asPresent())
@@ -293,7 +308,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations,
             null,
             labelsMap,
-            traceId = "t"
+            traceId = "t",
+            null
         )
 
         val ortRun2 = ortRunRepository.create(
@@ -303,7 +319,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations,
             null,
             labelsMap,
-            traceId = "trace-id"
+            traceId = "trace-id",
+            null
         )
 
         ortRunRepository.update(ortRun2.id, status = OrtRunStatus.FAILED.asPresent())
@@ -329,7 +346,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations,
             null,
             labelsMap,
-            traceId = "the-first-trace-id"
+            traceId = "the-first-trace-id",
+            null
         )
         val ortRun2 = ortRunRepository.create(
             repositoryId,
@@ -338,7 +356,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations,
             null,
             labelsMap,
-            traceId = "the-second-trace-id"
+            traceId = "the-second-trace-id",
+            null
         )
 
         ortRunRepository.listForRepository(repositoryId) shouldBe
@@ -346,7 +365,16 @@ class DaoOrtRunRepositoryTest : StringSpec({
     }
 
     "listForRepositories should apply query parameters" {
-        ortRunRepository.create(repositoryId, "revision1", null, jobConfigurations, null, labelsMap, traceId = "t")
+        ortRunRepository.create(
+            repositoryId,
+            "revision1",
+            null,
+            jobConfigurations,
+            null,
+            labelsMap,
+            traceId = "t",
+            null
+        )
         val ortRun2 = ortRunRepository.create(
             repositoryId,
             "revision2",
@@ -354,7 +382,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations,
             null,
             labelsMap,
-            traceId = "trace-id"
+            traceId = "trace-id",
+            null
         )
 
         val parameters = ListQueryParameters(
@@ -405,7 +434,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations,
             null,
             labelsMap,
-            "theTraceId"
+            "theTraceId",
+            null
         )
 
         val resolvedContext = "theResolvedConfigContext"
@@ -468,7 +498,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations,
             null,
             labelsMap,
-            "theTraceId"
+            "theTraceId",
+            null
         )
 
         ortRunRepository.update(
@@ -494,7 +525,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations,
             null,
             emptyMap(),
-            "theTraceId"
+            "theTraceId",
+            null
         )
 
         val updateResult = ortRunRepository.update(ortRun.id, status = OrtRunStatus.FINISHED.asPresent())
@@ -511,7 +543,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations,
             null,
             emptyMap(),
-            "traceIT"
+            "traceIT",
+            null
         )
 
         val updateResult = ortRunRepository.update(ortRun.id, status = OrtRunStatus.FAILED.asPresent())
@@ -528,7 +561,8 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations,
             null,
             labelsMap,
-            traceId = "delete-without-trace"
+            traceId = "delete-without-trace",
+            null
         )
 
         ortRunRepository.delete(ortRun.id)

--- a/dao/src/test/kotlin/utils/ListQueryTest.kt
+++ b/dao/src/test/kotlin/utils/ListQueryTest.kt
@@ -147,7 +147,8 @@ class ListQueryTest : StringSpec() {
                     JobConfigurations(),
                     null,
                     mapOf("label1" to "label1"),
-                    traceId = "trace-$idx"
+                    traceId = "trace-$idx",
+                    null
                 )
             }
 

--- a/dao/src/testFixtures/kotlin/Fixtures.kt
+++ b/dao/src/testFixtures/kotlin/Fixtures.kt
@@ -145,7 +145,8 @@ class Fixtures(private val db: Database) {
         jobConfigurations,
         null,
         mapOf("label key" to "label value"),
-        traceId = "trace-this-run"
+        traceId = "trace-this-run0",
+        environmentConfigPath = "path/to/env.yml"
     )
 
     fun createAnalyzerJob(

--- a/model/src/commonMain/kotlin/OrtRun.kt
+++ b/model/src/commonMain/kotlin/OrtRun.kt
@@ -136,6 +136,12 @@ data class OrtRun(
     val resolvedJobConfigContext: String?,
 
     /**
+     * The optional path to a environment configuration file. If this is not defined, the environment configuration is
+     * read from the default location `.ort.env.yml`.
+     */
+    val environmentConfigPath: String? = null,
+
+    /**
      * The trace ID that is assigned to this run. This is generated when the run is created. It can be used to
      * correlate the logs from different components that are taking part in processing of the run.
      */

--- a/model/src/commonMain/kotlin/repositories/OrtRunRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/OrtRunRepository.kt
@@ -42,7 +42,8 @@ interface OrtRunRepository {
         jobConfigs: JobConfigurations,
         jobConfigContext: String? = null,
         labels: Map<String, String>,
-        traceId: String?
+        traceId: String?,
+        environmentConfigPath: String?,
     ): OrtRun
 
     /**

--- a/orchestrator/src/test/kotlin/OrchestratorEndpointTest.kt
+++ b/orchestrator/src/test/kotlin/OrchestratorEndpointTest.kt
@@ -115,6 +115,7 @@ class OrchestratorEndpointTest : KoinTest, StringSpec() {
                     emptyList(),
                     null,
                     null,
+                    environmentConfigPath = null,
                     "trace-id"
                 )
             )

--- a/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
@@ -352,7 +352,8 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
                     emptyList(),
                     null,
                     null,
-                    "trace-id"
+                    null,
+                    "trace-id",
                 )
             }
 

--- a/workers/common/src/main/kotlin/common/env/EnvironmentService.kt
+++ b/workers/common/src/main/kotlin/common/env/EnvironmentService.kt
@@ -100,7 +100,8 @@ class EnvironmentService(
         config: EnvironmentConfig?,
         repositoryService: InfrastructureService?
     ): ResolvedEnvironmentConfig {
-        val mergedConfig = configLoader.parse(repositoryFolder).merge(config)
+        val environmentConfigPath = context.ortRun.environmentConfigPath
+        val mergedConfig = configLoader.parse(repositoryFolder, environmentConfigPath).merge(config)
         val resolvedConfig = configLoader.resolve(mergedConfig, context.hierarchy)
 
         return setUpEnvironmentForConfig(context, resolvedConfig, repositoryService)

--- a/workers/common/src/main/kotlin/common/env/config/EnvironmentConfigLoader.kt
+++ b/workers/common/src/main/kotlin/common/env/config/EnvironmentConfigLoader.kt
@@ -38,6 +38,8 @@ import org.eclipse.apoapsis.ortserver.workers.common.env.definition.RepositoryEn
 import org.eclipse.apoapsis.ortserver.workers.common.env.definition.SecretVariableDefinition
 import org.eclipse.apoapsis.ortserver.workers.common.env.definition.SimpleVariableDefinition
 
+import org.ossreviewtoolkit.utils.common.alsoIfNull
+
 import org.slf4j.LoggerFactory
 
 /**
@@ -96,25 +98,41 @@ class EnvironmentConfigLoader(
     private val definitionFactory: EnvironmentDefinitionFactory
 ) {
     companion object {
-        /** The path to the environment configuration file relative to the root folder of the repository. */
-        const val CONFIG_FILE_PATH = ".ort.env.yml"
+        /** The default path to the environment configuration file relative to the root folder of the repository. */
+        const val DEFAULT_CONFIG_FILE_PATH = ".ort.env.yml"
 
         private val logger = LoggerFactory.getLogger(EnvironmentConfigLoader::class.java)
     }
 
     /**
-     * Read the environment configuration file from the repository defined by the given [Hierarchy] checked out at
-     * the given [repositoryFolder] and return an [ResolvedEnvironmentConfig] with its content. Syntactic errors in the
-     * file cause exceptions to be thrown. Semantic errors are handled according to the `strict` flag.
+     * Read the environment configuration file [environmentConfigPath] from the repository defined by the given
+     * [Hierarchy] checked out at the given [repositoryFolder] and return an [ResolvedEnvironmentConfig] with its
+     * content. If not file path is provided, the default path `.ort.env.yml` is used. Syntactic errors in the file
+     * cause exceptions to be thrown. Semantic errors are handled according to the `strict` flag.
      */
-    fun parse(repositoryFolder: File): EnvironmentConfig =
-        repositoryFolder.resolve(CONFIG_FILE_PATH).takeIf { it.isFile }?.let { configFile ->
+    fun parse(repositoryFolder: File, environmentConfigPath: String? = null): EnvironmentConfig {
+        val customEnvironmentConfigFile = environmentConfigPath?.let {
+            repositoryFolder.resolve(it).takeIf { file -> file.isFile }
+        }.alsoIfNull {
+            logger.warn("Custom environment configuration file '$environmentConfigPath' not found.")
+        }
+
+        val defaultEnvironmentConfigFile = if (customEnvironmentConfigFile == null) {
+            repositoryFolder.resolve(DEFAULT_CONFIG_FILE_PATH).takeIf { it.isFile }.alsoIfNull {
+                logger.info("Default environment configuration file '$DEFAULT_CONFIG_FILE_PATH' not found.")
+            }
+        } else {
+            null
+        }
+
+        return (customEnvironmentConfigFile ?: defaultEnvironmentConfigFile)?.let { configFile ->
             logger.info("Parsing environment configuration file '{}'.", configFile)
 
             configFile.inputStream().use { stream ->
                 Yaml.default.decodeFromStream(EnvironmentConfig.serializer(), stream)
             }
         } ?: EnvironmentConfig()
+    }
 
     /**
      * Resolve the given [config] for the repository defined by the given [hierarchy]. This function is used when the

--- a/workers/common/src/test/kotlin/OrtServerMappingsTest.kt
+++ b/workers/common/src/test/kotlin/OrtServerMappingsTest.kt
@@ -145,6 +145,7 @@ class OrtServerMappingsTest : WordSpec({
                 listOf(runIssue),
                 "default",
                 "c80ef3bcd2bec428da923a188dd0870b1153995c",
+                null,
                 "trace-4321"
             )
 

--- a/workers/common/src/test/kotlin/common/env/config/EnvironmentConfigLoaderTest.kt
+++ b/workers/common/src/test/kotlin/common/env/config/EnvironmentConfigLoaderTest.kt
@@ -399,7 +399,7 @@ class EnvironmentConfigLoaderTest : StringSpec() {
         val tempDir = tempdir()
 
         javaClass.getResourceAsStream("/$name")?.use { stream ->
-            val target = tempDir.resolve(EnvironmentConfigLoader.CONFIG_FILE_PATH)
+            val target = tempDir.resolve(EnvironmentConfigLoader.DEFAULT_CONFIG_FILE_PATH)
             target.outputStream().use { out ->
                 stream.copyTo(out)
             }


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.