### PR TITLE
ci(renovate): Enable pinning of GitHub action digests

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
+    "helpers:pinGitHubActionDigests",
     ":semanticCommitScopeDisabled",
     ":semanticCommitTypeAll(deps)"
   ],


### PR DESCRIPTION
This improves the reproducibility of builds.