### PR TITLE
feat(storage): Use suspend functions in the `StorageProvider`

### DIFF
--- a/core/src/test/kotlin/api/DownloadsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/DownloadsRouteIntegrationTest.kt
@@ -91,7 +91,7 @@ class DownloadsRouteIntegrationTest : AbstractIntegrationTest({
     /**
      * Create an [OrtRun], store a report for the created run, and return the created run.
      */
-    fun createReport(): OrtRun {
+    suspend fun createReport(): OrtRun {
         val run = dbExtension.fixtures.createOrtRun(repositoryId)
         val key = Key("${run.id}|$reportFile")
 

--- a/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
@@ -173,7 +173,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
     /**
      * Create an [OrtRun], store a report for the created run, and return the created run.
      */
-    fun createReport(): OrtRun {
+    suspend fun createReport(): OrtRun {
         val run = dbExtension.fixtures.createOrtRun(repositoryId)
         val key = Key("${run.id}|$reportFile")
 

--- a/services/report-storage/src/main/kotlin/ReportStorageService.kt
+++ b/services/report-storage/src/main/kotlin/ReportStorageService.kt
@@ -48,7 +48,7 @@ class ReportStorageService(
      * Return a [ReportDownloadData] object for the report with the given [fileName] for the specified [runId]. Throw a
      * [ReportNotFoundException] if the report cannot be resolved.
      */
-    fun fetchReport(runId: Long, fileName: String): ReportDownloadData {
+    suspend fun fetchReport(runId: Long, fileName: String): ReportDownloadData {
         val key = generateKey(runId, fileName)
         if (!reportStorage.containsKey(key)) throw ReportNotFoundException(runId, fileName)
 
@@ -64,7 +64,7 @@ class ReportStorageService(
      * Return a [ReportDownloadData] object for the report with the given [token] for the specified [runId]. Throw a
      * [ReportNotFoundException] if the report cannot be resolved or the token has expired.
      */
-    fun fetchReportByToken(runId: Long, token: String): ReportDownloadData {
+    suspend fun fetchReportByToken(runId: Long, token: String): ReportDownloadData {
         return reporterJobRepository.getReportByToken(runId, token)?.let { report ->
             logger.info("Resolved report '${report.filename}' for run $runId from token.")
 

--- a/services/report-storage/src/test/kotlin/ReportStorageServiceTest.kt
+++ b/services/report-storage/src/test/kotlin/ReportStorageServiceTest.kt
@@ -26,6 +26,7 @@ import io.kotest.matchers.string.shouldContain
 
 import io.ktor.http.ContentType
 
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 
@@ -50,8 +51,8 @@ class ReportStorageServiceTest : WordSpec({
             val key = Key("$runId|$fileName")
 
             val storage = mockk<Storage>()
-            every { storage.containsKey(key) } returns true
-            every { storage.read(key) } returns StorageEntry.create(
+            coEvery { storage.containsKey(key) } returns true
+            coEvery { storage.read(key) } returns StorageEntry.create(
                 ByteArrayInputStream(reportData),
                 contentType,
                 reportData.size.toLong()
@@ -72,7 +73,7 @@ class ReportStorageServiceTest : WordSpec({
             val fileName = "nonExistingReport.dat"
 
             val storage = mockk<Storage>()
-            every { storage.containsKey(any()) } returns false
+            coEvery { storage.containsKey(any()) } returns false
 
             val service = ReportStorageService(storage, mockk())
             val exception = shouldThrow<ReportNotFoundException> {
@@ -90,8 +91,8 @@ class ReportStorageServiceTest : WordSpec({
             val key = Key("$runId|$fileName")
 
             val storage = mockk<Storage>()
-            every { storage.containsKey(key) } returns true
-            every { storage.read(key) } returns StorageEntry.create(
+            coEvery { storage.containsKey(key) } returns true
+            coEvery { storage.read(key) } returns StorageEntry.create(
                 ByteArrayInputStream(reportData),
                 null,
                 reportData.size.toLong()
@@ -114,8 +115,8 @@ class ReportStorageServiceTest : WordSpec({
             val token = "test-report-token"
 
             val storage = mockk<Storage> {
-                every { containsKey(key) } returns true
-                every { read(key) } returns StorageEntry.create(
+                coEvery { containsKey(key) } returns true
+                coEvery { read(key) } returns StorageEntry.create(
                     ByteArrayInputStream(reportData),
                     contentType,
                     reportData.size.toLong()

--- a/storage/database/src/main/kotlin/DatabaseStorageProvider.kt
+++ b/storage/database/src/main/kotlin/DatabaseStorageProvider.kt
@@ -30,7 +30,7 @@ import org.eclipse.apoapsis.ortserver.storage.StorageProvider
 import org.jetbrains.exposed.sql.SizedIterable
 import org.jetbrains.exposed.sql.Transaction
 import org.jetbrains.exposed.sql.and
-import org.jetbrains.exposed.sql.transactions.transaction
+import org.jetbrains.exposed.sql.transactions.experimental.newSuspendedTransaction
 
 /**
  * Implementation of the [StorageProvider] interface that is backed by a database table using PostgreSQL's large
@@ -43,15 +43,15 @@ class DatabaseStorageProvider(
     /** The maximum size of a storage entry that can be loaded into memory. */
     private val inMemoryLimit: Int
 ) : StorageProvider {
-    override fun read(key: Key): StorageEntry = transaction {
+    override suspend fun read(key: Key): StorageEntry = newSuspendedTransaction {
         val entry = findByKey(key).single()
 
         val inputStream = readLargeObject(entry.data, entry.size, inMemoryLimit)
         StorageEntry.create(inputStream, entry.contentType, entry.size)
     }
 
-    override fun write(key: Key, data: InputStream, length: Long, contentType: String?) {
-        transaction {
+    override suspend fun write(key: Key, data: InputStream, length: Long, contentType: String?) {
+        newSuspendedTransaction {
             // In case of an override, delete the key first. This may not be the cleanest solution (it has the
             // side effect that the createdAt date is changed), but it is very easy to implement.
             deleteKey(key)
@@ -67,11 +67,11 @@ class DatabaseStorageProvider(
         }
     }
 
-    override fun contains(key: Key): Boolean = transaction {
+    override suspend fun contains(key: Key): Boolean = newSuspendedTransaction {
         !findByKey(key).empty()
     }
 
-    override fun delete(key: Key): Boolean = transaction {
+    override suspend fun delete(key: Key): Boolean = newSuspendedTransaction {
         deleteKey(key)
     }
 

--- a/storage/spi/build.gradle.kts
+++ b/storage/spi/build.gradle.kts
@@ -32,6 +32,8 @@ dependencies {
     api(projects.config.configSpi)
 
     implementation(projects.utils.config)
+    implementation(libs.kotlinxCoroutines)
+    implementation(libs.kotlinxCoroutinesSlf4j)
 
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestExtensionsTestContainer)

--- a/storage/spi/src/main/kotlin/Storage.kt
+++ b/storage/spi/src/main/kotlin/Storage.kt
@@ -23,6 +23,9 @@ import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.util.ServiceLoader
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.config.Path
 import org.eclipse.apoapsis.ortserver.utils.config.getStringOrNull
@@ -84,17 +87,16 @@ class Storage(
     /**
      * Return the [StorageEntry] associated with the given [key]. Throw a [StorageEntry] if this operation fails.
      */
-    fun read(key: Key): StorageEntry =
-        wrapException {
-            read(key)
-        }
+    suspend fun read(key: Key): StorageEntry = wrapException {
+        read(key)
+    }
 
     /**
      * Write the given [data] with the given [length] and optional [contentType] into this storage and associate it
      * with the given [key].  Throw a [StorageException] if this operation fails. Note that the caller is responsible
      * for closing the provided [InputStream].
      */
-    fun write(key: Key, data: InputStream, length: Long, contentType: String? = null) {
+    suspend fun write(key: Key, data: InputStream, length: Long, contentType: String? = null) {
         wrapException {
             write(key, data, length, contentType)
         }
@@ -104,7 +106,7 @@ class Storage(
      * Write the given [array][data] into this storage and associate it with the given [key]. Set the optional
      * [contentType]. Throw a [StorageException] if this operation fails.
      */
-    fun write(key: Key, data: ByteArray, contentType: String? = null) {
+    suspend fun write(key: Key, data: ByteArray, contentType: String? = null) {
         ByteArrayInputStream(data).use { stream ->
             write(key, stream, data.size.toLong(), contentType)
         }
@@ -114,7 +116,7 @@ class Storage(
      * Write the given [string][data] into this storage and associate it with the given [key]. Set the optional
      * [contentType]. Throw a [StorageException] if this operation fails.
      */
-    fun write(key: Key, data: String, contentType: String? = null) {
+    suspend fun write(key: Key, data: String, contentType: String? = null) {
         write(key, data.toByteArray(), contentType)
     }
 
@@ -122,21 +124,25 @@ class Storage(
      * Return a flag whether the given [key] is contained in this storage. Throw a [StorageException] if this
      * operation fails.
      */
-    fun containsKey(key: Key): Boolean = wrapException { contains(key) }
+    suspend fun containsKey(key: Key): Boolean = wrapException { contains(key) }
 
     /**
      * Delete the given [key] from this storage and return a flag whether it existed before. Throw a
      * [StorageException] if this operation fails.
      */
-    fun delete(key: Key): Boolean = wrapException { provider.delete(key) }
+    suspend fun delete(key: Key): Boolean = wrapException { provider.delete(key) }
 
     /**
      * Execute [block] on the wrapped [StorageProvider] and map occurring exceptions to [StorageException]s.
      */
-    private fun <T> wrapException(block: StorageProvider.() -> T): T =
+    private suspend fun <T> wrapException(block: suspend StorageProvider.() -> T): T =
         @Suppress("TooGenericExceptionCaught")
         try {
-            provider.block()
+            // To prevent the StorageException being suppressed by the coroutine exception handler, a new context is
+            // created here.
+            withContext(Dispatchers.IO) {
+                provider.block()
+            }
         } catch (e: Exception) {
             throw StorageException("Exception from StorageProvider.", e)
         }

--- a/storage/spi/src/main/kotlin/StorageProvider.kt
+++ b/storage/spi/src/main/kotlin/StorageProvider.kt
@@ -36,7 +36,7 @@ interface StorageProvider {
      * Return a [StorageEntry] that represents the data associated with the given [key]. Throw an exception if the
      * [key] does not exist.
      */
-    fun read(key: Key): StorageEntry
+    suspend fun read(key: Key): StorageEntry
 
     /**
      * Write the given [data] with the given [length] and optional [contentType] into this storage and associate it
@@ -47,16 +47,16 @@ interface StorageProvider {
      * expected by a *Content-Type* header. This function does not close the [InputStream][data]; this needs to be
      * done by the caller. Throw an exception if the write operation fails.
      */
-    fun write(key: Key, data: InputStream, length: Long, contentType: String? = null)
+    suspend fun write(key: Key, data: InputStream, length: Long, contentType: String? = null)
 
     /**
      * Return a flag whether an entry with the given [key] exists in this storage.
      */
-    fun contains(key: Key): Boolean
+    suspend fun contains(key: Key): Boolean
 
     /**
      * Delete the entry with the given [key] from this storage. Return *true* if such an entry existed and was deleted;
      * return *false* if the entry did not exist. Throw an exception if the delete operation fails.
      */
-    fun delete(key: Key): Boolean
+    suspend fun delete(key: Key): Boolean
 }

--- a/storage/spi/src/testFixtures/kotlin/StorageProviderFactoryForTesting.kt
+++ b/storage/spi/src/testFixtures/kotlin/StorageProviderFactoryForTesting.kt
@@ -89,7 +89,7 @@ class StorageProviderFactoryForTesting : StorageProviderFactory {
         val errorKey = if (config.hasPath(ERROR_KEY_PROPERTY)) config.getString(ERROR_KEY_PROPERTY) else "<undefined>"
 
         return object : StorageProvider {
-            override fun read(key: Key): StorageEntry =
+            override suspend fun read(key: Key): StorageEntry =
                 getEntry(key)?.let { entry ->
                     StorageEntry.create(
                         data = ByteArrayInputStream(entry.data),
@@ -98,7 +98,7 @@ class StorageProviderFactoryForTesting : StorageProviderFactory {
                     )
                 } ?: throw IOException("Could not resolve key '${key.key}'.")
 
-            override fun write(key: Key, data: InputStream, length: Long, contentType: String?) {
+            override suspend fun write(key: Key, data: InputStream, length: Long, contentType: String?) {
                 getEntry(key)
 
                 data.use {
@@ -106,9 +106,9 @@ class StorageProviderFactoryForTesting : StorageProviderFactory {
                 }
             }
 
-            override fun contains(key: Key): Boolean = getEntry(key) != null
+            override suspend fun contains(key: Key): Boolean = getEntry(key) != null
 
-            override fun delete(key: Key): Boolean {
+            override suspend fun delete(key: Key): Boolean {
                 val entry = getEntry(key)
 
                 storage -= key

--- a/workers/common/build.gradle.kts
+++ b/workers/common/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
     implementation(projects.model)
     implementation(projects.secrets.secretsSpi)
     implementation(projects.utils.config)
+    implementation(projects.utils.logging)
 
     implementation(libs.kaml)
     implementation(libs.kotlinxCoroutines)

--- a/workers/common/src/main/kotlin/common/OrtServerFileArchiveStorage.kt
+++ b/workers/common/src/main/kotlin/common/OrtServerFileArchiveStorage.kt
@@ -23,6 +23,7 @@ import java.io.InputStream
 
 import org.eclipse.apoapsis.ortserver.storage.Key
 import org.eclipse.apoapsis.ortserver.storage.Storage
+import org.eclipse.apoapsis.ortserver.utils.logging.runBlocking
 
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.KnownProvenance
@@ -58,15 +59,16 @@ class OrtServerFileArchiveStorage(
             }
     }
 
-    override fun getData(provenance: KnownProvenance): InputStream? {
+    override fun getData(provenance: KnownProvenance): InputStream? = runBlocking {
         val key = generateKey(provenance)
-        return if (storage.containsKey(key)) storage.read(key).data else null
+        if (storage.containsKey(key)) storage.read(key).data else null
     }
 
-    override fun hasData(provenance: KnownProvenance): Boolean =
+    override fun hasData(provenance: KnownProvenance): Boolean = runBlocking {
         storage.containsKey(generateKey(provenance))
+    }
 
-    override fun putData(provenance: KnownProvenance, data: InputStream, size: Long) {
+    override fun putData(provenance: KnownProvenance, data: InputStream, size: Long) = runBlocking {
         storage.write(generateKey(provenance), data, size, CONTENT_TYPE)
     }
 }

--- a/workers/reporter/src/main/kotlin/reporter/ReportStorage.kt
+++ b/workers/reporter/src/main/kotlin/reporter/ReportStorage.kt
@@ -60,7 +60,7 @@ class ReportStorage(
      * Store the given [files] in the associated [Storage] for the given [ORT run ID][runId]. The map with files has
      * the names to be used as keys and the corresponding report files as values.
      */
-    fun storeReportFiles(runId: Long, files: Map<String, File>) {
+    suspend fun storeReportFiles(runId: Long, files: Map<String, File>) {
         files.forEach { (name, file) ->
             val key = generateKey(runId, name)
             logger.info("Storing '{}' under key '{}'.", file.name, key.key)

--- a/workers/reporter/src/test/kotlin/reporter/ReporterRunnerTest.kt
+++ b/workers/reporter/src/test/kotlin/reporter/ReporterRunnerTest.kt
@@ -34,6 +34,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -128,7 +129,7 @@ class ReporterRunnerTest : WordSpec({
     "run" should {
         "return a result with report format and report names" {
             val storage = mockk<ReportStorage>()
-            every { storage.storeReportFiles(any(), any()) } just runs
+            coEvery { storage.storeReportFiles(any(), any()) } just runs
             val (contextFactory, _) = mockContext()
             val runner = ReporterRunner(storage, contextFactory, OptionsTransformerFactory(), configManager, mockk())
 
@@ -144,7 +145,7 @@ class ReporterRunnerTest : WordSpec({
             result.issues should beEmpty()
 
             val slotReports = slot<Map<String, File>>()
-            verify {
+            coVerify {
                 storage.storeReportFiles(RUN_ID, capture(slotReports))
             }
 

--- a/workers/scanner/src/main/kotlin/scanner/OrtServerFileListStorage.kt
+++ b/workers/scanner/src/main/kotlin/scanner/OrtServerFileListStorage.kt
@@ -23,6 +23,7 @@ import java.io.InputStream
 
 import org.eclipse.apoapsis.ortserver.storage.Key
 import org.eclipse.apoapsis.ortserver.storage.Storage
+import org.eclipse.apoapsis.ortserver.utils.logging.runBlocking
 
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.KnownProvenance
@@ -58,15 +59,16 @@ class OrtServerFileListStorage(
             }
     }
 
-    override fun getData(provenance: KnownProvenance): InputStream? {
+    override fun getData(provenance: KnownProvenance): InputStream? = runBlocking {
         val key = generateKey(provenance)
-        return if (storage.containsKey(key)) storage.read(key).data else null
+        if (storage.containsKey(key)) storage.read(key).data else null
     }
 
-    override fun hasData(provenance: KnownProvenance): Boolean =
+    override fun hasData(provenance: KnownProvenance): Boolean = runBlocking {
         storage.containsKey(generateKey(provenance))
+    }
 
-    override fun putData(provenance: KnownProvenance, data: InputStream, size: Long) {
+    override fun putData(provenance: KnownProvenance, data: InputStream, size: Long) = runBlocking {
         storage.write(generateKey(provenance), data, size, CONTENT_TYPE)
     }
 }


### PR DESCRIPTION
The `StorageProvider` interface from the storage abstraction defines some functions for reading and writing unstructured data. Some of the existing implementations implement those using HTTP requests, which are done using the suspendable functions of the HTTP client. This commit changes the API of the `StorageProvider` to make the functions suspendable. Please note that some of the Exposed transaction calls done by the `DatabaseStorageProvider.kt` have therefore to be adapted (see [1]).

[1]: https://jetbrains.github.io/Exposed/transactions.html#working-with-coroutines