### PR TITLE
Revert "ci(release): Disable generation of release notes"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,12 +47,7 @@ jobs:
       run: ./gradlew --stacktrace --no-configuration-cache publishAndReleaseToMavenCentral
 
     - name: Generate Release Notes
-      # Temporarily disable the generation of release notes until the first non-release candidate tag was created.
-      # This is required because otherwise the release notes contain the full commit history and would therefore exceed
-      # the size limit for GitHub releases.
-      # See also: https://github.com/jmongard/Git.SemVersioning.Gradle/issues/61
-      run: echo "# $ORT_SERVER_VERSION" > RELEASE_NOTES.md
-      #run: ./gradlew -q printChangeLog > RELEASE_NOTES.md
+      run: ./gradlew -q printChangeLog > RELEASE_NOTES.md
 
     - name: Create GitHub Release
       env:


### PR DESCRIPTION
This reverts commit ec42e5a as the issue has been fixed upstream in the version taken into use in e8dd7cc.