### PR TITLE
fix(ui): Do not render 0 values as falsy values

### DIFF
--- a/ui/src/components/statistics-card.tsx
+++ b/ui/src/components/statistics-card.tsx
@@ -46,7 +46,9 @@ export const StatisticsCard = ({
       </CardHeader>
       <CardContent className='text-sm'>
         <div className='flex flex-col'>
-          <div className='text-2xl font-bold'>{value ? value : 'Failed'}</div>
+          <div className='text-2xl font-bold'>
+            {value !== undefined ? value : 'Failed'}
+          </div>
           <div className='text-xs'>{description}</div>
         </div>
       </CardContent>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/-components/packages-statistics-card.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/-components/packages-statistics-card.tsx
@@ -99,13 +99,15 @@ export const PackagesStatisticsCard = ({
       icon={() => (
         <ListTree className={`h-4 w-4 ${getStatusFontColor(status)}`} />
       )}
-      value={status ? packagesTotal : 'Unavailable'}
+      value={status ? packagesTotal : 'Skipped'}
       description={
         ecoSystems.length
           ? ecoSystems.length > 1
             ? `from ${ecoSystems.length} ecosystems (${ecoSystems.join(`,`)})`
             : `from 1 ecosystem (${ecoSystems})`
-          : ''
+          : status
+            ? ''
+            : 'Enable the job for results'
       }
       className='h-full hover:bg-muted/50'
     />

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/-components/rule-violations-statistics-card.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/-components/rule-violations-statistics-card.tsx
@@ -79,7 +79,8 @@ export const RuleViolationsStatisticsCard = ({
       icon={() => (
         <ListTree className={`h-4 w-4 ${getStatusFontColor(status)}`} />
       )}
-      value={status ? ruleViolationsTotal : 'Unavailable'}
+      value={status ? ruleViolationsTotal : 'Skipped'}
+      description={status ? '' : 'Enable the job for results'}
       className='h-full hover:bg-muted/50'
     />
   );

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/index.tsx
@@ -282,7 +282,10 @@ const RunComponent = () => {
                   className={`h-4 w-4 ${getStatusFontColor(ortRun.jobs.advisor?.status)}`}
                 />
               )}
-              value={ortRun.jobs.advisor ? vulnTotal : 'Unavailable'}
+              value={ortRun.jobs.advisor ? vulnTotal : 'Skipped'}
+              description={
+                ortRun.jobs.advisor ? '' : 'Enable the job for results'
+              }
               className='h-full hover:bg-muted/50'
             />
           </Link>


### PR DESCRIPTION
This avoids e.g. 0 vulnerabilities being shown as "Failed" in the run overview.