### PR TITLE
ui: Add package manager options to ORT Run creation form

### DIFF
--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
@@ -19,7 +19,6 @@
 
 import { UseFormReturn } from 'react-hook-form';
 
-import { MultiSelectField } from '@/components/form/multi-select-field';
 import {
   AccordionContent,
   AccordionItem,
@@ -35,8 +34,8 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
-import { packageManagers } from '@/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-types';
 import { CreateRunFormValues } from '../-create-run-utils';
+import { PackageManagerField } from './package-manager-field';
 
 type AnalyzerFieldsProps = {
   form: UseFormReturn<CreateRunFormValues>;
@@ -122,18 +121,7 @@ export const AnalyzerFields = ({ form }: AnalyzerFieldsProps) => {
               </FormItem>
             )}
           />
-          <MultiSelectField
-            form={form}
-            name='jobConfigs.analyzer.enabledPackageManagers'
-            label='Enabled package managers'
-            description={
-              <>
-                Select the package managers enabled for this ORT Run. Note that
-                the 'Unmanaged' package manager is always enabled.
-              </>
-            }
-            options={packageManagers}
-          />
+          <PackageManagerField form={form} />
         </AccordionContent>
       </AccordionItem>
     </div>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-components/package-manager-field.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-components/package-manager-field.tsx
@@ -1,0 +1,271 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { PlusIcon, TrashIcon } from 'lucide-react';
+import { useFieldArray, UseFormReturn } from 'react-hook-form';
+
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Separator } from '@/components/ui/separator';
+import { cn } from '@/lib/utils';
+import { packageManagers } from '@/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-types';
+import { CreateRunFormValues, PackageManagerId } from '../-create-run-utils';
+
+type PackageManagerFieldProps = {
+  form: UseFormReturn<CreateRunFormValues>;
+  className?: string;
+};
+
+export const PackageManagerField = ({
+  form,
+  className,
+}: PackageManagerFieldProps) => {
+  return (
+    <FormField
+      control={form.control}
+      name='jobConfigs.analyzer.packageManagers'
+      render={({ field }) => (
+        <FormItem
+          className={cn(
+            'mb-4 flex flex-col justify-between rounded-lg border p-4',
+            className
+          )}
+        >
+          <FormLabel>Enabled package managers</FormLabel>
+          <FormDescription className='pb-4'>
+            {
+              <>
+                Select the package managers enabled for this ORT Run. Note that
+                the 'Unmanaged' package manager is always enabled.
+              </>
+            }
+          </FormDescription>
+          <div className='flex items-center space-x-3'>
+            <Checkbox
+              id='check-all-items'
+              checked={
+                Object.values(field.value || {}).every((pm) => pm.enabled)
+                  ? true
+                  : Object.values(field.value || {}).some((pm) => pm.enabled)
+                    ? 'indeterminate'
+                    : false
+              }
+              onCheckedChange={(checked) => {
+                const enabledItems = checked
+                  ? Object.keys(field.value || {}).reduce(
+                      (acc, key) => {
+                        acc[key as keyof typeof field.value] = {
+                          ...field.value[key as keyof typeof field.value],
+                          enabled: true,
+                        };
+                        return acc;
+                      },
+                      {} as typeof field.value
+                    )
+                  : Object.keys(field.value || {}).reduce(
+                      (acc, key) => {
+                        acc[key as keyof typeof field.value] = {
+                          ...field.value[key as keyof typeof field.value],
+                          enabled: false,
+                        };
+                        return acc;
+                      },
+                      {} as typeof field.value
+                    );
+                form.setValue(
+                  'jobConfigs.analyzer.packageManagers',
+                  enabledItems
+                );
+              }}
+            />
+            <Label htmlFor='check-all-items' className='font-bold'>
+              Enable/disable all
+            </Label>
+          </div>
+          <Separator />
+          {packageManagers.map((pm, index) => {
+            const enabled = field.value?.[pm.id]?.enabled;
+
+            return (
+              <div key={pm.id} className='flex items-start space-x-3 space-y-0'>
+                <FormItem>
+                  <FormControl>
+                    <Checkbox
+                      checked={enabled}
+                      onCheckedChange={(checked) => {
+                        return checked
+                          ? field.onChange({
+                              ...field.value,
+                              [pm.id]: { ...field.value[pm.id], enabled: true },
+                            })
+                          : field.onChange({
+                              ...field.value,
+                              [pm.id]: {
+                                ...field.value[pm.id],
+                                enabled: false,
+                              },
+                            });
+                      }}
+                    />
+                  </FormControl>
+                </FormItem>
+                {enabled ? (
+                  <FieldWithOptions
+                    form={form}
+                    pmIndex={index}
+                    pmName={pm.id}
+                  />
+                ) : (
+                  <FormLabel className='font-normal'>{pm.label}</FormLabel>
+                )}
+              </div>
+            );
+          })}
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+};
+
+type FieldWithOptionsProps = {
+  form: UseFormReturn<CreateRunFormValues>;
+  pmIndex: number;
+  pmName: PackageManagerId;
+};
+
+const FieldWithOptions = ({ form, pmIndex, pmName }: FieldWithOptionsProps) => {
+  const {
+    fields: optionsFields,
+    append,
+    remove,
+  } = useFieldArray({
+    name: `jobConfigs.analyzer.packageManagers.${pmName}.options`,
+    control: form.control,
+  });
+
+  const pm = packageManagers[pmIndex];
+
+  // When using a rerun functionality, it is best to open up those
+  // accordions that have options set. This way the user can see the
+  // options that were set previously, and doesn't nee to search for
+  // them.
+  const defaultOpenAccordions = packageManagers
+    .filter((pm) => {
+      const options = form.getValues(
+        `jobConfigs.analyzer.packageManagers.${pm.id}.options`
+      );
+      return options && options.some((option) => option.key !== '');
+    })
+    .map((pm) => pm.id);
+
+  return (
+    <Accordion
+      type='multiple'
+      className='w-full'
+      defaultValue={defaultOpenAccordions}
+    >
+      <AccordionItem value={pm.id} className='border-none'>
+        <AccordionTrigger className='py-0'>
+          <Label className='font-normal hover:cursor-pointer'>{pm.label}</Label>
+        </AccordionTrigger>
+        <AccordionContent>
+          <Separator className='my-2' />
+          <h4 className='mt-2'>Options:</h4>
+          {optionsFields.map((field, index) => (
+            <div
+              key={field.id}
+              className='my-2 flex flex-row items-end space-x-2'
+            >
+              <div className='flex-auto'>
+                {index === 0 && <FormLabel>Key</FormLabel>}
+                <FormField
+                  control={form.control}
+                  name={`jobConfigs.analyzer.packageManagers.${pmName}.options.${index}.key`}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+              <div className='flex-auto'>
+                {index === 0 && <FormLabel>Value</FormLabel>}
+                <FormField
+                  control={form.control}
+                  name={`jobConfigs.analyzer.packageManagers.${pmName}.options.${index}.value`}
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+              <Button
+                type='button'
+                variant='outline'
+                size='sm'
+                onClick={() => {
+                  remove(index);
+                }}
+              >
+                <TrashIcon className='h-4 w-4' />
+              </Button>
+            </div>
+          ))}
+          <Button
+            size='sm'
+            className='mt-2'
+            variant='outline'
+            type='button'
+            onClick={() => {
+              append({ key: '', value: '' });
+            }}
+          >
+            Add option
+            <PlusIcon className='ml-1 h-4 w-4' />
+          </Button>
+          <Separator className='my-2' />
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+};

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/config/-components/analyzer-job-details.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/config/-components/analyzer-job-details.tsx
@@ -86,6 +86,34 @@ export const AnalyzerJobDetails = ({ run }: AnalyzerJobDetailsProps) => {
                     {jobConfigs.enabledPackageManagers.join(', ')}
                   </div>
                 )}
+                {jobConfigs?.packageManagerOptions && (
+                  <div className='space-y-2'>
+                    <Label className='font-semibold'>
+                      Package manager options:
+                    </Label>{' '}
+                    {Object.keys(jobConfigs.packageManagerOptions).map((pm) => (
+                      <div className='ml-2' key={pm}>
+                        <Label className='font-semibold'>{pm}:</Label>
+                        {jobConfigs.packageManagerOptions?.[pm].options && (
+                          <div className='ml-2'>
+                            <div className='ml-2'>
+                              {Object.entries(
+                                jobConfigs.packageManagerOptions[pm].options
+                              ).map(([key, value]) => (
+                                <div key={key}>
+                                  <Label className='font-semibold'>
+                                    {key}:
+                                  </Label>{' '}
+                                  {value}
+                                </div>
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    ))}
+                  </div>
+                )}
               </div>
             </div>
           )}


### PR DESCRIPTION
This PR adds the ability to also set options for package managers as part of the analyzer job configuration. When using the rerun functionality, the options are copied to the new run and in the analyzer configuration section of the form, all package managers for which options are set are opened by default.

Setting options for package managers:
![Screenshot from 2024-10-22 12-34-57](https://github.com/user-attachments/assets/9d44a8f5-f9fb-4ffb-8430-475bcae92755)

Options are also copied to the job configurations part of ORT run results:
![Screenshot from 2024-10-22 10-35-51](https://github.com/user-attachments/assets/97bf43c5-1668-45ea-9009-196e7452fa25)

Please see the commits for details.