### PR TITLE
Stop building jdk specific Analyzer worker images

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -51,7 +51,6 @@ jobs:
           context: workers/analyzer/docker
           dockerfile: Analyzer.Dockerfile
           jibImage: analyzer-worker
-          imageVariant: jdk17
           task: :workers:analyzer:jibDockerBuild
           freeDiskSpace: true
         - image: config-worker-base-image

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -48,24 +48,6 @@ jobs:
         - jibImage: advisor-worker
           task: :workers:advisor:jibDockerBuild
         - image: analyzer-worker-base-image
-          buildArgs: TEMURIN_VERSION=21
-          context: workers/analyzer/docker
-          dockerfile: Analyzer.Dockerfile
-          jibImage: analyzer-worker
-          imageVariant: jdk21
-          task: :workers:analyzer:jibDockerBuild
-          freeDiskSpace: true
-        - image: analyzer-worker-base-image
-          buildArgs: |
-            TEMURIN_VERSION=11
-            ANDROID_CMD_VERSION=9862592
-          context: workers/analyzer/docker
-          dockerfile: Analyzer.Dockerfile
-          jibImage: analyzer-worker
-          imageVariant: jdk11
-          task: :workers:analyzer:jibDockerBuild
-          freeDiskSpace: true
-        - image: analyzer-worker-base-image
           context: workers/analyzer/docker
           dockerfile: Analyzer.Dockerfile
           jibImage: analyzer-worker


### PR DESCRIPTION
Since the ORT Analyzer plugins Gradle, GradleInspector and SBT now support JDK bootstrapping, there is no more need
for building image variants for various JDK versions of the Analyzer worker.

For details on the change, see the respective commits.