### PR TITLE
Deduplicate issues

### DIFF
--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -85,6 +85,7 @@ database {
   sslCert = ${?DB_SSL_CERT}
   sslKey = ${?DB_SSL_KEY}
   sslRootCert = ${?DB_SSL_ROOT_CERT}
+  initSqlStatement = ${?DB_INIT_SQL_STATEMENT}
 }
 
 keycloak {

--- a/dao/src/main/kotlin/Database.kt
+++ b/dao/src/main/kotlin/Database.kt
@@ -91,6 +91,11 @@ fun createDataSource(config: DatabaseConfig): DataSource {
         config.sslCert?.let { addDataSourceProperty("sslcert", it) }
         config.sslKey?.let { addDataSourceProperty("sslkey", it) }
         config.sslRootCert?.let { addDataSourceProperty("sslrootcert", it) }
+
+        config.initSqlStatement?.let {
+            logger.info("Setting connection initialization statement to '{}'.", it)
+            connectionInitSql = it
+        }
     }
 
     dataSourceConfig.validate()

--- a/dao/src/main/kotlin/DatabaseConfig.kt
+++ b/dao/src/main/kotlin/DatabaseConfig.kt
@@ -107,6 +107,12 @@ data class DatabaseConfig(
      * [PostgreSQL documentation](https://www.postgresql.org/docs/current/libpq-ssl.html#LIBQ-SSL-CERTIFICATES).
      */
     val sslRootCert: String?,
+
+    /**
+     * An optional SQL statement that is executed when a new database connection is created. This can be used to
+     * set some defaults, for instance the schema search path.
+     */
+    val initSqlStatement: String?
 ) {
     companion object {
         /**
@@ -130,7 +136,8 @@ data class DatabaseConfig(
             sslMode = config.getString("database.sslMode"),
             sslCert = config.getStringOrNull("database.sslCert"),
             sslKey = config.getStringOrNull("database.sslKey"),
-            sslRootCert = config.getStringOrNull("database.sslRootCert")
+            sslRootCert = config.getStringOrNull("database.sslRootCert"),
+            initSqlStatement = config.getStringOrNull("database.initSqlStatement")
         )
     }
 }

--- a/dao/src/main/kotlin/tables/ScanSummariesIssuesTable.kt
+++ b/dao/src/main/kotlin/tables/ScanSummariesIssuesTable.kt
@@ -19,17 +19,45 @@
 
 package org.eclipse.apoapsis.ortserver.dao.tables
 
+import org.eclipse.apoapsis.ortserver.dao.tables.runs.shared.IssueDao
 import org.eclipse.apoapsis.ortserver.dao.tables.runs.shared.IssuesTable
+import org.eclipse.apoapsis.ortserver.model.runs.Issue
 
-import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.dao.LongEntity
+import org.jetbrains.exposed.dao.LongEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.LongIdTable
+import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
 
 /**
- * An intermediate table to store references from [ScanSummariesTable] and [IssuesTable].
+ * An intermediate table to store references from [ScanSummariesTable] and [IssuesTable] together with some
+ * additional properties.
  */
-object ScanSummariesIssuesTable : Table("scan_summaries_issues") {
+object ScanSummariesIssuesTable : LongIdTable("scan_summaries_issues") {
     val scanSummaryId = reference("scan_summary_id", ScanSummariesTable)
     val issueId = reference("issue_id", IssuesTable)
+    val timestamp = timestamp("timestamp")
+}
 
-    override val primaryKey: PrimaryKey
-        get() = PrimaryKey(scanSummaryId, issueId, name = "${tableName}_pkey")
+class ScanSummariesIssuesDao(id: EntityID<Long>) : LongEntity(id) {
+    companion object : LongEntityClass<ScanSummariesIssuesDao>(ScanSummariesIssuesTable) {
+        /**
+         * Create an entity based on the given [issue] and assign it to the given [scanSummaryId].
+         */
+        fun createByIssue(scanSummaryId: Long, issue: Issue): ScanSummariesIssuesDao = new {
+            this.scanSummary = ScanSummaryDao[scanSummaryId]
+            this.issue = IssueDao.createByIssue(issue)
+            this.timestamp = issue.timestamp
+        }
+    }
+
+    var scanSummary by ScanSummaryDao referencedOn ScanSummariesIssuesTable.scanSummaryId
+    var issue by IssueDao referencedOn ScanSummariesIssuesTable.issueId
+    var timestamp by ScanSummariesIssuesTable.timestamp
+
+    /**
+     * Map this DAO to an [Issue].
+     */
+    fun mapToModel(): Issue =
+        issue.mapToModel(at = timestamp, identifier = null, worker = null)
 }

--- a/dao/src/main/kotlin/tables/ScanSummariesTable.kt
+++ b/dao/src/main/kotlin/tables/ScanSummariesTable.kt
@@ -19,7 +19,6 @@
 
 package org.eclipse.apoapsis.ortserver.dao.tables
 
-import org.eclipse.apoapsis.ortserver.dao.tables.runs.shared.IssueDao
 import org.eclipse.apoapsis.ortserver.dao.utils.transformToDatabasePrecision
 import org.eclipse.apoapsis.ortserver.model.runs.scanner.ScanSummary
 
@@ -45,7 +44,7 @@ class ScanSummaryDao(id: EntityID<Long>) : LongEntity(id) {
     val licenseFindings by LicenseFindingDao referrersOn LicenseFindingsTable.scanSummaryId
     val copyrightFindings by CopyrightFindingDao referrersOn CopyrightFindingsTable.scanSummaryId
     val snippetFindings by SnippetFindingDao referrersOn SnippetFindingsTable.scanSummaryId
-    var issues by IssueDao via ScanSummariesIssuesTable
+    val issues by ScanSummariesIssuesDao referrersOn ScanSummariesIssuesTable.scanSummaryId
 
     fun mapToModel() = ScanSummary(
         startTime = startTime,
@@ -53,6 +52,6 @@ class ScanSummaryDao(id: EntityID<Long>) : LongEntity(id) {
         licenseFindings = licenseFindings.mapTo(mutableSetOf(), LicenseFindingDao::mapToModel),
         copyrightFindings = copyrightFindings.mapTo(mutableSetOf(), CopyrightFindingDao::mapToModel),
         snippetFindings = snippetFindings.mapTo(mutableSetOf(), SnippetFindingDao::mapToModel),
-        issues = issues.map(IssueDao::mapToModel)
+        issues = issues.map(ScanSummariesIssuesDao::mapToModel)
     )
 }

--- a/dao/src/main/kotlin/tables/runs/shared/IssuesTable.kt
+++ b/dao/src/main/kotlin/tables/runs/shared/IssuesTable.kt
@@ -29,6 +29,7 @@ import org.eclipse.apoapsis.ortserver.model.runs.Issue
 
 import org.jetbrains.exposed.dao.LongEntity
 import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.sql.and
 
 /**
  * A table to represent an ort issue.
@@ -42,8 +43,19 @@ object IssuesTable : SortableTable("issues") {
 
 class IssueDao(id: EntityID<Long>) : LongEntity(id) {
     companion object : SortableEntityClass<IssueDao>(IssuesTable) {
+        fun findByIssue(issue: Issue): IssueDao? = find {
+            IssuesTable.issueSource eq issue.source and
+                    (IssuesTable.message eq issue.message) and
+                    (IssuesTable.severity eq issue.severity) and
+                    (IssuesTable.affectedPath eq issue.affectedPath)
+        }.firstOrNull()
+
+        /**
+         * Return an [IssueDao] to represent the given [issue]. If the properties of the [issue] can be matched,
+         * an existing [IssueDao] is returned, otherwise a new one is created.
+         */
         fun createByIssue(issue: Issue): IssueDao =
-            new {
+            findByIssue(issue) ?: new {
                 source = issue.source
                 message = issue.message
                 severity = issue.severity

--- a/dao/src/main/kotlin/tables/runs/shared/IssuesTable.kt
+++ b/dao/src/main/kotlin/tables/runs/shared/IssuesTable.kt
@@ -21,6 +21,7 @@ package org.eclipse.apoapsis.ortserver.dao.tables.runs.shared
 
 import kotlinx.datetime.Instant
 
+import org.eclipse.apoapsis.ortserver.dao.utils.DigestFunction
 import org.eclipse.apoapsis.ortserver.dao.utils.SortableEntityClass
 import org.eclipse.apoapsis.ortserver.dao.utils.SortableTable
 import org.eclipse.apoapsis.ortserver.model.Severity
@@ -30,6 +31,7 @@ import org.eclipse.apoapsis.ortserver.model.runs.Issue
 import org.jetbrains.exposed.dao.LongEntity
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.stringLiteral
 
 /**
  * A table to represent an ort issue.
@@ -45,7 +47,7 @@ class IssueDao(id: EntityID<Long>) : LongEntity(id) {
     companion object : SortableEntityClass<IssueDao>(IssuesTable) {
         fun findByIssue(issue: Issue): IssueDao? = find {
             IssuesTable.issueSource eq issue.source and
-                    (IssuesTable.message eq issue.message) and
+                    (DigestFunction(IssuesTable.message) eq DigestFunction(stringLiteral(issue.message))) and
                     (IssuesTable.severity eq issue.severity) and
                     (IssuesTable.affectedPath eq issue.affectedPath)
         }.firstOrNull()

--- a/dao/src/main/kotlin/tables/runs/shared/IssuesTable.kt
+++ b/dao/src/main/kotlin/tables/runs/shared/IssuesTable.kt
@@ -23,20 +23,17 @@ import kotlinx.datetime.Instant
 
 import org.eclipse.apoapsis.ortserver.dao.utils.SortableEntityClass
 import org.eclipse.apoapsis.ortserver.dao.utils.SortableTable
-import org.eclipse.apoapsis.ortserver.dao.utils.transformToDatabasePrecision
 import org.eclipse.apoapsis.ortserver.model.Severity
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
 
 import org.jetbrains.exposed.dao.LongEntity
 import org.jetbrains.exposed.dao.id.EntityID
-import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
 
 /**
  * A table to represent an ort issue.
  */
 object IssuesTable : SortableTable("issues") {
-    val timestamp = timestamp("timestamp").sortable()
     val issueSource = text("source")
     val message = text("message")
     val severity = enumerationByName<Severity>("severity", 128)
@@ -47,7 +44,6 @@ class IssueDao(id: EntityID<Long>) : LongEntity(id) {
     companion object : SortableEntityClass<IssueDao>(IssuesTable) {
         fun createByIssue(issue: Issue): IssueDao =
             new {
-                timestamp = issue.timestamp
                 source = issue.source
                 message = issue.message
                 severity = issue.severity
@@ -55,13 +51,10 @@ class IssueDao(id: EntityID<Long>) : LongEntity(id) {
             }
     }
 
-    var timestamp by IssuesTable.timestamp.transformToDatabasePrecision()
     var source by IssuesTable.issueSource
     var message by IssuesTable.message
     var severity by IssuesTable.severity
     var affectedPath by IssuesTable.affectedPath
-
-    fun mapToModel() = mapToModel(timestamp, null, null)
 
     /**
      * Return a model representation of this [IssueDao] with the given additional properties.

--- a/dao/src/main/kotlin/utils/DigestFunction.kt
+++ b/dao/src/main/kotlin/utils/DigestFunction.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.dao.utils
+
+import org.jetbrains.exposed.sql.CustomFunction
+import org.jetbrains.exposed.sql.Expression
+import org.jetbrains.exposed.sql.QueryBuilder
+import org.jetbrains.exposed.sql.TextColumnType
+
+/**
+ * A custom function to calculate the SHA-256 digest of a string. This is used for looking up text values that can
+ * exceed the maximum length of an index.
+ */
+class DigestFunction(
+    private val expression: Expression<String>
+) : CustomFunction<String>("SHA256", TextColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
+        append("digest(")
+        expression.toQueryBuilder(this)
+        append(", 'sha256'::text)")
+    }
+}

--- a/dao/src/main/resources/db/migration/V83__scannerSummariesIssuesTimestamps.sql
+++ b/dao/src/main/resources/db/migration/V83__scannerSummariesIssuesTimestamps.sql
@@ -1,0 +1,29 @@
+-- This migration script extracts the timestamp from the issues table and moves it up to the scan_summaries_issues
+-- table. This is a preparation to deduplicate the entities in the issues table; the table will store only the
+-- most relevant properties for issues.
+
+-- Since the timestamp column is not nullable, create a new table that is populated and then renamed.
+CREATE TABLE scan_summaries_issues_with_timestamps
+(
+    id                bigserial                         PRIMARY KEY,
+    scan_summary_id   bigint REFERENCES scan_summaries  NOT NULL,
+    issue_id          bigint REFERENCES issues          NOT NULL,
+    timestamp         timestamp                         NOT NULL
+);
+
+INSERT INTO scan_summaries_issues_with_timestamps
+("scan_summary_id", "issue_id", "timestamp")
+SELECT
+  ssi.scan_summary_id,
+  ssi.issue_id,
+  i.timestamp
+FROM
+  scan_summaries_issues ssi
+  INNER JOIN issues i ON ssi.issue_id = i.id;
+
+DROP TABLE scan_summaries_issues;
+
+ALTER TABLE scan_summaries_issues_with_timestamps RENAME TO scan_summaries_issues;
+
+-- Remove the timestamp column from the issues table, since it is no longer used.
+ALTER TABLE issues DROP COLUMN timestamp;

--- a/dao/src/main/resources/db/migration/V84__deduplicateIssues.sql
+++ b/dao/src/main/resources/db/migration/V84__deduplicateIssues.sql
@@ -1,0 +1,133 @@
+-- This migration script performs a deduplication of the entities in the issues table. It works analogously to
+-- the deduplication script for packages and projects (V73__deduplicatePackagesAndProjects.sql) by assigning
+-- hash values to the issues based on their properties that are then used to match references to the remaining
+-- deduplicated issues.
+
+-- Create missing foreign key indexes to the issues table. This is necessary to speed up the deduplication process.
+CREATE INDEX ort_runs_issues_fkey on ort_runs_issues(issue_id);
+
+CREATE INDEX scan_summaries_issues_fkey on scan_summaries_issues(issue_id);
+
+-- Temporary function for assigning hash values to issues based on their properties.
+CREATE FUNCTION issue_hash(bigint) RETURNS text AS $$
+DECLARE
+  hash text;
+BEGIN
+    SELECT
+      encode(sha256(convert_to(concat(
+        i."source",
+        i.message,
+        i.severity,
+        i.affected_path
+      ), 'UTF8')),
+        'hex')
+    FROM issues i
+    WHERE i.id = $1
+    INTO hash;
+
+    RETURN hash;
+EXCEPTION WHEN others THEN
+    RETURN NULL;
+END;
+$$
+STRICT
+LANGUAGE plpgsql IMMUTABLE;
+
+-- A temporary view that assigns hash values to all issues.
+CREATE VIEW issues_with_hashes as
+SELECT
+  i.id,
+  issue_hash(i.id) hash
+FROM issues i;
+
+-- A temporary table to hold the IDs of the remaining deduplicated issues.
+CREATE TABLE issues_dedup
+(
+    id bigserial PRIMARY KEY
+);
+
+INSERT INTO issues_dedup
+SELECT
+  MIN(i.id)
+FROM issues_with_hashes i
+GROUP BY i.hash;
+
+-- Create link tables that use hashes to reference issues.
+
+CREATE TABLE ort_runs_issues_hashes
+(
+    id              bigserial                       PRIMARY KEY,
+    ort_run_id      bigint REFERENCES ort_runs      NOT NULL,
+    issue_hash      text                            NOT NULL,
+    identifier_id   bigint REFERENCES identifiers       NULL,
+    worker          text                                NULL,
+    timestamp       timestamp                       NOT NULL
+);
+
+INSERT INTO ort_runs_issues_hashes
+SELECT
+  ori.id, ori.ort_run_id, ih.hash, ori.identifier_id, ori.worker, ori."timestamp"
+FROM ort_runs_issues ori
+INNER JOIN issues_with_hashes ih on ori.issue_id = ih.id;
+
+CREATE TABLE scan_summaries_issues_hashes
+(
+    id                bigserial                         PRIMARY KEY,
+    scan_summary_id   bigint REFERENCES scan_summaries  NOT NULL,
+    issue_hash        text                              NOT NULL,
+    timestamp         timestamp                         NOT NULL
+);
+
+INSERT INTO scan_summaries_issues_hashes
+SELECT
+  ssi.id, ssi.scan_summary_id, ih.hash, ssi."timestamp"
+FROM scan_summaries_issues ssi
+INNER JOIN issues_with_hashes ih on ssi.issue_id = ih.id;
+
+-- Remove duplicates
+
+DELETE FROM ort_runs_issues;
+
+DELETE FROM scan_summaries_issues;
+
+DELETE FROM issues i
+WHERE NOT EXISTS (
+  SELECT FROM issues_dedup id
+  WHERE id.id = i.id
+);
+
+-- Recreate link tables.
+
+INSERT INTO ort_runs_issues
+SELECT
+  ori.id,
+  ori.ort_run_id,
+  ih.id,
+  ori.identifier_id,
+  ori.worker,
+  ori."timestamp"
+FROM
+  ort_runs_issues_hashes ori
+INNER JOIN issues_with_hashes ih ON ori.issue_hash = ih.hash;
+
+INSERT INTO scan_summaries_issues
+SELECT
+  ssi.id,
+  ssi.scan_summary_id,
+  ih.id,
+  ssi."timestamp"
+FROM
+  scan_summaries_issues_hashes ssi
+INNER JOIN issues_with_hashes ih ON ssi.issue_hash = ih.hash;
+
+-- Cleanup
+
+DROP TABLE issues_dedup;
+
+DROP TABLE ort_runs_issues_hashes;
+
+DROP TABLE scan_summaries_issues_hashes;
+
+DROP VIEW issues_with_hashes;
+
+DROP FUNCTION issue_hash;

--- a/dao/src/main/resources/db/migration/V85__issuesIndexOnValueColumns.sql
+++ b/dao/src/main/resources/db/migration/V85__issuesIndexOnValueColumns.sql
@@ -1,0 +1,15 @@
+-- This migration adds an index to the issues table on all its value columns to speed up the lookup for issues
+-- for deduplication. Unfortunately, a plain index does not work, since the "message" property is not restricted
+-- in size and can therefore exceed the maximum page size. To work around this, an expression index is used that
+-- is based on a hash value.
+
+-- Install the pgcrypto extension to be able to use the digest function.
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+-- Make sure that functions from extensions installed in the "public" schema are available.
+SET search_path = ${flyway:defaultSchema}, public;
+
+-- Create the expression index.
+CREATE UNIQUE INDEX "issues_all_value_columns"
+ON "issues"
+USING btree ("source", "severity", "affected_path", digest("message", 'sha256'::text));

--- a/dao/src/test/kotlin/DatabaseTest.kt
+++ b/dao/src/test/kotlin/DatabaseTest.kt
@@ -63,7 +63,8 @@ class DatabaseTest : WordSpec({
                 sslMode = "myTestSSLMode",
                 sslCert = "myTestSSLCert",
                 sslKey = "myTestSSLKey",
-                sslRootCert = "myTestSSLRootCert"
+                sslRootCert = "myTestSSLRootCert",
+                initSqlStatement = "SET search_path TO test,public;"
             )
 
             val secretsMap = mapOf(
@@ -90,6 +91,7 @@ class DatabaseTest : WordSpec({
                     "database.sslCert" to dbConfig.sslCert,
                     "database.sslKey" to dbConfig.sslKey,
                     "database.sslRootCert" to dbConfig.sslRootCert,
+                    "database.initSqlStatement" to dbConfig.initSqlStatement,
                     ConfigManager.CONFIG_MANAGER_SECTION to secretConfigMap
                 )
             )

--- a/dao/src/test/kotlin/tables/ScanSummariesIssuesTableTest.kt
+++ b/dao/src/test/kotlin/tables/ScanSummariesIssuesTableTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.dao.tables
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.shouldBe
+
+import kotlin.time.Duration.Companion.minutes
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+import org.eclipse.apoapsis.ortserver.dao.blockingQuery
+import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
+import org.eclipse.apoapsis.ortserver.dao.utils.toDatabasePrecision
+import org.eclipse.apoapsis.ortserver.model.Severity
+import org.eclipse.apoapsis.ortserver.model.runs.Identifier
+import org.eclipse.apoapsis.ortserver.model.runs.Issue
+
+class ScanSummariesIssuesTableTest : WordSpec() {
+    private val dbExtension = extension(DatabaseTestExtension())
+
+    init {
+        "createByIssue" should {
+            "create an entity for an issue" {
+                val summary = createScanSummary()
+                val issue = Issue(
+                    timestamp = Instant.parse("2024-10-18T05:56:06Z"),
+                    source = "test",
+                    message = "Some test issue",
+                    severity = Severity.WARNING,
+                    affectedPath = "test/path",
+                    identifier = Identifier("testType", "testNS", "testName", "testVersion"),
+                    worker = "testWorker"
+                )
+
+                dbExtension.db.blockingQuery {
+                    val newEntity = ScanSummariesIssuesDao.createByIssue(summary.id.value, issue)
+
+                    ScanSummariesIssuesDao.all().toList() shouldContainExactlyInAnyOrder listOf(newEntity)
+
+                    val expectedIssue = issue.copy(
+                        identifier = null,
+                        worker = null
+                    )
+                    newEntity.mapToModel() shouldBe expectedIssue
+                }
+            }
+        }
+    }
+
+    /**
+     * Create a [ScanSummaryDao] entity that can be used to assign issues to it.
+     */
+    private fun createScanSummary(): ScanSummaryDao =
+        dbExtension.db.blockingQuery {
+            ScanSummaryDao.new {
+                startTime = Clock.System.now().minus(2.minutes).toDatabasePrecision()
+                endTime = Clock.System.now().toDatabasePrecision()
+            }
+        }
+}

--- a/orchestrator/src/main/resources/application.conf
+++ b/orchestrator/src/main/resources/application.conf
@@ -51,6 +51,7 @@ database {
   sslCert = ${?DB_SSL_CERT}
   sslKey = ${?DB_SSL_KEY}
   sslRootCert = ${?DB_SSL_ROOT_CERT}
+  initSqlStatement = ${?DB_INIT_SQL_STATEMENT}
 }
 
 orchestrator {

--- a/transport/kubernetes-jobmonitor/src/main/resources/application.conf
+++ b/transport/kubernetes-jobmonitor/src/main/resources/application.conf
@@ -92,6 +92,7 @@ database {
   sslCert = ${?DB_SSL_CERT}
   sslKey = ${?DB_SSL_KEY}
   sslRootCert = ${?DB_SSL_ROOT_CERT}
+  initSqlStatement = ${?DB_INIT_SQL_STATEMENT}
 }
 
 orchestrator {

--- a/workers/advisor/src/main/resources/application.conf
+++ b/workers/advisor/src/main/resources/application.conf
@@ -69,6 +69,7 @@ database {
   sslCert = ${?DB_SSL_CERT}
   sslKey = ${?DB_SSL_KEY}
   sslRootCert = ${?DB_SSL_ROOT_CERT}
+  initSqlStatement = ${?DB_INIT_SQL_STATEMENT}
 }
 
 advisor {

--- a/workers/analyzer/src/main/resources/application.conf
+++ b/workers/analyzer/src/main/resources/application.conf
@@ -69,6 +69,7 @@ database {
   sslCert = ${?DB_SSL_CERT}
   sslKey = ${?DB_SSL_KEY}
   sslRootCert = ${?DB_SSL_ROOT_CERT}
+  initSqlStatement = ${?DB_INIT_SQL_STATEMENT}
 }
 
 analyzer {

--- a/workers/config/src/main/resources/application.conf
+++ b/workers/config/src/main/resources/application.conf
@@ -64,6 +64,7 @@ database {
   sslCert = ${?DB_SSL_CERT}
   sslKey = ${?DB_SSL_KEY}
   sslRootCert = ${?DB_SSL_ROOT_CERT}
+  initSqlStatement = ${?DB_INIT_SQL_STATEMENT}
 }
 
 config {

--- a/workers/evaluator/src/main/resources/application.conf
+++ b/workers/evaluator/src/main/resources/application.conf
@@ -69,6 +69,7 @@ database {
   sslCert = ${?DB_SSL_CERT}
   sslKey = ${?DB_SSL_KEY}
   sslRootCert = ${?DB_SSL_ROOT_CERT}
+  initSqlStatement = ${?DB_INIT_SQL_STATEMENT}
 }
 
 evaluator {

--- a/workers/notifier/src/main/resources/application.conf
+++ b/workers/notifier/src/main/resources/application.conf
@@ -64,6 +64,7 @@ database {
   sslCert = ${?DB_SSL_CERT}
   sslKey = ${?DB_SSL_KEY}
   sslRootCert = ${?DB_SSL_ROOT_CERT}
+  initSqlStatement = ${?DB_INIT_SQL_STATEMENT}
 }
 
 notifier {

--- a/workers/reporter/src/main/resources/application.conf
+++ b/workers/reporter/src/main/resources/application.conf
@@ -69,6 +69,7 @@ database {
   sslCert = ${?DB_SSL_CERT}
   sslKey = ${?DB_SSL_KEY}
   sslRootCert = ${?DB_SSL_ROOT_CERT}
+  initSqlStatement = ${?DB_INIT_SQL_STATEMENT}
 }
 
 reporter {

--- a/workers/scanner/src/main/resources/application.conf
+++ b/workers/scanner/src/main/resources/application.conf
@@ -69,6 +69,7 @@ database {
   sslCert = ${?DB_SSL_CERT}
   sslKey = ${?DB_SSL_KEY}
   sslRootCert = ${?DB_SSL_ROOT_CERT}
+  initSqlStatement = ${?DB_INIT_SQL_STATEMENT}
 }
 
 scanner {


### PR DESCRIPTION
This PR further refactors the database model for issues to deduplicate entities, so that issues with matching properties are reused. It also contains a migration script to remove existing duplicates. Refer to the single commits for further information.