### PR TITLE
ui: Support for listing and deleting users in admin section

### DIFF
--- a/ui/src/components/delete-dialog.tsx
+++ b/ui/src/components/delete-dialog.tsx
@@ -18,6 +18,7 @@
  */
 
 import { Loader2, OctagonAlert, TrashIcon } from 'lucide-react';
+import { useEffect, useState } from 'react';
 
 import {
   AlertDialog,
@@ -30,6 +31,7 @@ import {
   AlertDialogTrigger,
 } from '@/components/ui/alert-dialog';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import {
   Tooltip,
   TooltipContent,
@@ -47,6 +49,7 @@ interface DeleteDialogProps {
   onDelete: () => void;
   isPending: boolean;
   className?: string;
+  textConfirmation?: boolean;
 }
 
 export const DeleteDialog = ({
@@ -56,7 +59,18 @@ export const DeleteDialog = ({
   onDelete,
   isPending,
   className,
+  textConfirmation = false,
 }: DeleteDialogProps) => {
+  const [input, setInput] = useState('');
+  const isDeleteDisabled = textConfirmation && input !== item.name;
+
+  // Reset the input field whenever the dialog is opened/closed
+  useEffect(() => {
+    if (open) {
+      setInput('');
+    }
+  }, [open]);
+
   return (
     <AlertDialog open={open} onOpenChange={setOpen}>
       <Tooltip delayDuration={300}>
@@ -82,13 +96,35 @@ export const DeleteDialog = ({
             <AlertDialogTitle>Delete {item.descriptor}</AlertDialogTitle>
           </div>
         </AlertDialogHeader>
-        <AlertDialogDescription>
-          Are you sure you want to delete this {item.descriptor}:{' '}
-          <span className='font-bold'>{item.name}</span>?
-        </AlertDialogDescription>
+        {textConfirmation ? (
+          <AlertDialogDescription>
+            <div className='flex flex-col gap-2'>
+              <div>
+                Are you sure you want to delete this {item.descriptor}:{' '}
+                <span className='font-bold'>{item.name}</span>?
+              </div>
+              <div>
+                Deleting might have unwanted results and side effects, and the
+                deletion is irreversible. Please type{' '}
+                <span className='font-bold'>{item.name}</span> below to confirm
+                deletion.
+              </div>
+              <Input value={input} onChange={(e) => setInput(e.target.value)} />
+            </div>
+          </AlertDialogDescription>
+        ) : (
+          <AlertDialogDescription>
+            Are you sure you want to delete this {item.descriptor}:{' '}
+            <span className='font-bold'>{item.name}</span>?
+          </AlertDialogDescription>
+        )}
         <AlertDialogFooter>
           <AlertDialogCancel>Cancel</AlertDialogCancel>
-          <Button onClick={onDelete} className='bg-red-500'>
+          <Button
+            disabled={isDeleteDisabled}
+            onClick={onDelete}
+            className='bg-red-500'
+          >
             {isPending ? (
               <>
                 <span className='sr-only'>Deleting {item.descriptor}...</span>

--- a/ui/src/routes/_layout/admin/route.tsx
+++ b/ui/src/routes/_layout/admin/route.tsx
@@ -18,7 +18,7 @@
  */
 
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
-import { Eye, KeyRound, ListVideo, UserPlus } from 'lucide-react';
+import { Eye, KeyRound, ListVideo, User } from 'lucide-react';
 
 import { PageLayout } from '@/components/page-layout';
 
@@ -37,9 +37,9 @@ const Layout = () => {
       label: 'User Management',
       items: [
         {
-          title: 'Create User',
-          to: '/admin/users/create-user',
-          icon: () => <UserPlus className='h-4 w-4' />,
+          title: 'Users',
+          to: '/admin/users',
+          icon: () => <User className='h-4 w-4' />,
         },
         {
           title: 'Authorization',

--- a/ui/src/routes/_layout/admin/users/create-user.tsx
+++ b/ui/src/routes/_layout/admin/users/create-user.tsx
@@ -48,6 +48,9 @@ import { toast } from '@/lib/toast';
 
 const formSchema = z.object({
   username: z.string(),
+  firstName: z.string().optional(),
+  lastName: z.string().optional(),
+  email: z.string().email().optional(),
   password: z.string().optional(),
   temporary: z.boolean(),
 });
@@ -82,6 +85,9 @@ const CreateUser = () => {
     await mutateAsync({
       requestBody: {
         username: values.username,
+        firstName: values.firstName,
+        lastName: values.lastName,
+        email: values.email,
         password: values.password,
         temporary: values.temporary,
       },
@@ -104,6 +110,45 @@ const CreateUser = () => {
                   <FormLabel>Username</FormLabel>
                   <FormControl>
                     <Input {...field} autoFocus />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name='firstName'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>First name</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder='(optional)' />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name='lastName'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Last name</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder='(optional)' />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name='email'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Email address</FormLabel>
+                  <FormControl>
+                    <Input type='email' {...field} placeholder='(optional)' />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/ui/src/routes/_layout/admin/users/index.tsx
+++ b/ui/src/routes/_layout/admin/users/index.tsx
@@ -1,0 +1,205 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { useQueryClient } from '@tanstack/react-query';
+import { createFileRoute, Link } from '@tanstack/react-router';
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  getPaginationRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import { UserPlus } from 'lucide-react';
+import { useState } from 'react';
+
+import {
+  useAdminServiceDeleteUserByUsername,
+  useAdminServiceGetUsersKey,
+} from '@/api/queries';
+import { prefetchUseAdminServiceGetUsers } from '@/api/queries/prefetch';
+import { useAdminServiceGetUsersSuspense } from '@/api/queries/suspense';
+import { ApiError, User } from '@/api/requests';
+import { DataTable } from '@/components/data-table/data-table';
+import { DeleteDialog } from '@/components/delete-dialog';
+import { LoadingIndicator } from '@/components/loading-indicator';
+import { ToastError } from '@/components/toast-error';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { toast } from '@/lib/toast';
+import { paginationSchema } from '@/schemas';
+
+const defaultPageSize = 10;
+
+const columnHelper = createColumnHelper<User>();
+
+const columns = [
+  columnHelper.accessor('username', {
+    header: 'Username',
+    cell: ({ row }) => <>{row.original.username}</>,
+  }),
+  columnHelper.accessor('firstName', {
+    header: 'First name',
+    cell: ({ row }) => <>{row.original.firstName}</>,
+  }),
+  columnHelper.accessor('lastName', {
+    header: 'Last name',
+    cell: ({ row }) => <>{row.original.lastName}</>,
+  }),
+  columnHelper.accessor('email', {
+    header: 'Email address',
+    cell: ({ row }) => <>{row.original.email}</>,
+  }),
+  columnHelper.display({
+    id: 'actions',
+    header: () => <div className='text-right'>Actions</div>,
+    cell: function CellComponent({ row }) {
+      const queryClient = useQueryClient();
+      const [openDelDialog, setOpenDelDialog] = useState(false);
+
+      const { mutateAsync: delUser, isPending: isDelPending } =
+        useAdminServiceDeleteUserByUsername({
+          onSuccess() {
+            setOpenDelDialog(false);
+            toast.info('Delete User', {
+              description: `User "${row.original.username}" deleted successfully.`,
+            });
+            queryClient.invalidateQueries({
+              queryKey: [useAdminServiceGetUsersKey],
+            });
+          },
+          onError(error: ApiError) {
+            toast.error(error.message, {
+              description: <ToastError error={error} />,
+              duration: Infinity,
+              cancel: {
+                label: 'Dismiss',
+                onClick: () => {},
+              },
+            });
+          },
+        });
+
+      return (
+        <div className='flex justify-end'>
+          <DeleteDialog
+            open={openDelDialog}
+            setOpen={setOpenDelDialog}
+            item={{
+              descriptor: 'user',
+              name: row.original.username,
+            }}
+            onDelete={() => delUser({ username: row.original.username })}
+            isPending={isDelPending}
+            textConfirmation={true}
+          />
+        </div>
+      );
+    },
+  }),
+];
+
+const Users = () => {
+  const search = Route.useSearch();
+  const pageIndex = search.page ? search.page - 1 : 0;
+  const pageSize = search.pageSize ? search.pageSize : defaultPageSize;
+
+  const { data: users } = useAdminServiceGetUsersSuspense();
+
+  const table = useReactTable({
+    data: users || [],
+    columns,
+
+    state: {
+      pagination: {
+        pageIndex,
+        pageSize,
+      },
+    },
+    getCoreRowModel: getCoreRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+  });
+
+  return (
+    <Card className='h-fit'>
+      <CardHeader>
+        <CardTitle>Users</CardTitle>
+        <CardDescription>
+          These are all current users of the server. By clicking the delete
+          button in the action column you can delete users, and a written
+          confirmation is required to prevent accidental deletions.
+        </CardDescription>
+        <div className='py-2'>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button asChild size='sm' className='ml-auto gap-1'>
+                <Link to='/admin/users/create-user'>
+                  Add user
+                  <UserPlus className='h-4 w-4' />
+                </Link>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              Add a new user to the server. Note that the username has to be
+              unique.
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <CardContent>
+          <DataTable
+            table={table}
+            setCurrentPageOptions={(currentPage) => {
+              return {
+                to: Route.to,
+                search: { ...search, page: currentPage },
+              };
+            }}
+            setPageSizeOptions={(size) => {
+              return {
+                to: Route.to,
+                search: { ...search, page: 1, pageSize: size },
+              };
+            }}
+          />
+        </CardContent>
+      </CardContent>
+    </Card>
+  );
+};
+
+export const Route = createFileRoute('/_layout/admin/users/')({
+  validateSearch: paginationSchema,
+  loader: async ({ context }) => {
+    prefetchUseAdminServiceGetUsers(context.queryClient);
+  },
+  component: Users,
+  pendingComponent: LoadingIndicator,
+});


### PR DESCRIPTION
Please have a look at the individual commits for details.

![Screenshot from 2024-10-24 18-21-53](https://github.com/user-attachments/assets/91d61c24-3cd0-4397-bb4d-56f3fda164e1)

![Screenshot from 2024-10-24 18-21-29](https://github.com/user-attachments/assets/945b0502-7828-4fd4-b09f-cf2ee76d7333)

![Screenshot from 2024-10-24 18-22-24](https://github.com/user-attachments/assets/4fcaa9a9-4e3d-4f37-be6a-24d5b1483187)

![Screenshot from 2024-10-24 18-22-34](https://github.com/user-attachments/assets/f2b67512-e9ac-46e1-9f78-68deb8e6313f)

Open questions:
1. After adding a new user, should the UI navigate back to the "list users" view?
2. Or, should it stay on the same form, clear it and put focus to the `Username` field?
3. Also, the users list Card description might be a bit too verbose.
