### PR TITLE
fix(storage): Don't use new context for storage

### DIFF
--- a/storage/spi/src/main/kotlin/Storage.kt
+++ b/storage/spi/src/main/kotlin/Storage.kt
@@ -23,9 +23,6 @@ import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.util.ServiceLoader
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
-
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.config.Path
 import org.eclipse.apoapsis.ortserver.utils.config.getStringOrNull
@@ -138,11 +135,7 @@ class Storage(
     private suspend fun <T> wrapException(block: suspend StorageProvider.() -> T): T =
         @Suppress("TooGenericExceptionCaught")
         try {
-            // To prevent the StorageException being suppressed by the coroutine exception handler, a new context is
-            // created here.
-            withContext(Dispatchers.IO) {
-                provider.block()
-            }
+            provider.block()
         } catch (e: Exception) {
             throw StorageException("Exception from StorageProvider.", e)
         }


### PR DESCRIPTION
Using a separate context makes the scanner hang indefinitely when
creating file lists. Remove the context to fix this.

Fixes #1295.