### PR TITLE
fix(dao): One more fix for the migration to deduplicate issues

### DIFF
--- a/dao/src/main/resources/db/migration/V84__deduplicateIssues.sql
+++ b/dao/src/main/resources/db/migration/V84__deduplicateIssues.sql
@@ -136,7 +136,7 @@ INNER JOIN issues_with_hashes ih ON ssi.issue_hash = ih.hash;
 
 INSERT INTO identifiers_issues
 ("identifier_id", "issue_id")
-SELECT
+SELECT DISTINCT
   iih.identifier_id,
   ih.id
 FROM


### PR DESCRIPTION
The fix in 2490be36 was still not sufficient. Add a `DISTINCT` to prevent a duplicate key constraint violation.