### PR TITLE
ui: Issues page

### DIFF
--- a/ui/src/helpers/get-status-class.ts
+++ b/ui/src/helpers/get-status-class.ts
@@ -17,27 +17,18 @@
  * License-Filename: LICENSE
  */
 
-// Status types
+import { JobStatus, OrtRunStatus, Severity } from '@/api/requests';
 
-// Statuses reported either by ORT Runs or the individual jobs within them
-type Status =
-  | 'CREATED'
-  | 'SCHEDULED'
-  | 'RUNNING'
-  | 'ACTIVE'
-  | 'FAILED'
-  | 'FINISHED'
-  | 'FINISHED_WITH_ISSUES'
-  | undefined;
+// Combine statuses reported either by ORT Runs or the individual jobs within them.
+export type Status = JobStatus | OrtRunStatus | undefined;
 
+// There is no vulnerability rating in the OpenApi spec, so define it here.
 export type VulnerabilityRating =
   | 'CRITICAL'
   | 'HIGH'
   | 'MEDIUM'
   | 'LOW'
   | 'NONE';
-
-type RuleViolationSeverity = 'ERROR' | 'WARNING' | 'HINT';
 
 // TailwindCSS classes matching to statuses
 //
@@ -89,10 +80,18 @@ const VULNERABILITY_RATING_BG_COLOR: {
 } as const;
 
 const RULE_VIOLATION_SEVERITY_BG_COLOR: {
-  [K in RuleViolationSeverity]: string;
+  [K in Severity]: string;
 } = {
   ERROR: 'bg-red-600',
-  WARNING: 'bg-orange-600',
+  WARNING: 'bg-amber-500',
+  HINT: 'bg-neutral-300',
+} as const;
+
+const ISSUE_SEVERITY_BG_COLOR: {
+  [K in Severity]: string;
+} = {
+  ERROR: 'bg-red-600',
+  WARNING: 'bg-amber-500',
   HINT: 'bg-neutral-300',
 } as const;
 
@@ -136,7 +135,12 @@ export function getVulnerabilityRatingBackgroundColor(
 
 // Get the color class for coloring the background of rule violation severities
 export function getRuleViolationSeverityBackgroundColor(
-  rating: RuleViolationSeverity
+  severity: Severity
 ): string {
-  return RULE_VIOLATION_SEVERITY_BG_COLOR[rating];
+  return RULE_VIOLATION_SEVERITY_BG_COLOR[severity];
+}
+
+// Get the color class for coloring the background of issue severities
+export function getIssueSeverityBackgroundColor(severity: Severity): string {
+  return ISSUE_SEVERITY_BG_COLOR[severity];
 }

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/-components/issues-statistics-card.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/-components/issues-statistics-card.tsx
@@ -36,17 +36,12 @@ export const IssuesStatisticsCard = ({
   status,
   runId,
 }: IssuesStatisticsCardProps) => {
-  const {
-    data: issues,
-    isPending: issuesIsPending,
-    isError: issuesIsError,
-    error: issuesError,
-  } = useIssuesServiceGetIssuesByRunId({
+  const { data, isPending, isError, error } = useIssuesServiceGetIssuesByRunId({
     runId: runId,
     limit: 1,
   });
 
-  if (issuesIsPending) {
+  if (isPending) {
     return (
       <StatisticsCard
         title='Issues'
@@ -57,9 +52,9 @@ export const IssuesStatisticsCard = ({
     );
   }
 
-  if (issuesIsError) {
+  if (isError) {
     toast.error('Unable to load data', {
-      description: <ToastError error={issuesError} />,
+      description: <ToastError error={error} />,
       duration: Infinity,
       cancel: {
         label: 'Dismiss',
@@ -69,7 +64,7 @@ export const IssuesStatisticsCard = ({
     return;
   }
 
-  const issuesTotal = issues.pagination.totalCount;
+  const issuesTotal = data.pagination.totalCount;
 
   return (
     <StatisticsCard

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/-components/issues-statistics-card.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/-components/issues-statistics-card.tsx
@@ -17,9 +17,9 @@
  * License-Filename: LICENSE
  */
 
-import { Scale } from 'lucide-react';
+import { Bug } from 'lucide-react';
 
-import { useRuleViolationsServiceGetRuleViolationsByRunId } from '@/api/queries';
+import { useIssuesServiceGetIssuesByRunId } from '@/api/queries';
 import { JobStatus } from '@/api/requests';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { StatisticsCard } from '@/components/statistics-card';
@@ -27,41 +27,39 @@ import { ToastError } from '@/components/toast-error';
 import { getStatusFontColor } from '@/helpers/get-status-class';
 import { toast } from '@/lib/toast';
 
-type RuleViolationsStatisticsCardProps = {
+type IssuesStatisticsCardProps = {
   status: JobStatus | undefined;
   runId: number;
 };
 
-export const RuleViolationsStatisticsCard = ({
+export const IssuesStatisticsCard = ({
   status,
   runId,
-}: RuleViolationsStatisticsCardProps) => {
+}: IssuesStatisticsCardProps) => {
   const {
-    data: ruleViolations,
-    isPending: ruleViolationsIsPending,
-    isError: ruleViolationsIsError,
-    error: ruleViolationsError,
-  } = useRuleViolationsServiceGetRuleViolationsByRunId({
+    data: issues,
+    isPending: issuesIsPending,
+    isError: issuesIsError,
+    error: issuesError,
+  } = useIssuesServiceGetIssuesByRunId({
     runId: runId,
     limit: 1,
   });
 
-  if (ruleViolationsIsPending) {
+  if (issuesIsPending) {
     return (
       <StatisticsCard
-        title='Rule Violations'
-        icon={() => (
-          <Scale className={`h-4 w-4 ${getStatusFontColor(status)}`} />
-        )}
+        title='Issues'
+        icon={() => <Bug className={`h-4 w-4 ${getStatusFontColor(status)}`} />}
         value={<LoadingIndicator />}
         className='h-full hover:bg-muted/50'
       />
     );
   }
 
-  if (ruleViolationsIsError) {
+  if (issuesIsError) {
     toast.error('Unable to load data', {
-      description: <ToastError error={ruleViolationsError} />,
+      description: <ToastError error={issuesError} />,
       duration: Infinity,
       cancel: {
         label: 'Dismiss',
@@ -71,13 +69,13 @@ export const RuleViolationsStatisticsCard = ({
     return;
   }
 
-  const ruleViolationsTotal = ruleViolations.pagination.totalCount;
+  const issuesTotal = issues.pagination.totalCount;
 
   return (
     <StatisticsCard
-      title='Rule Violations'
-      icon={() => <Scale className={`h-4 w-4 ${getStatusFontColor(status)}`} />}
-      value={status ? ruleViolationsTotal : 'Skipped'}
+      title='Issues'
+      icon={() => <Bug className={`h-4 w-4 ${getStatusFontColor(status)}`} />}
+      value={status ? issuesTotal : 'Skipped'}
       description={status ? '' : 'Enable the job for results'}
       className='h-full hover:bg-muted/50'
     />

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/-components/packages-statistics-card.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/-components/packages-statistics-card.tsx
@@ -37,21 +37,17 @@ export const PackagesStatisticsCard = ({
   status,
   runId,
 }: PackagesStatisticsCardProps) => {
-  const {
-    data: packages,
-    isPending: packagesIsPending,
-    isError: packagesIsError,
-    error: packagesError,
-  } = usePackagesServiceGetPackagesByRunId({
-    runId: runId,
-    // Use a large page size for packages request to try to use all packages
-    // for finding de-duplicated package types.
-    // Another option would be to do two packages queries: first to find the
-    // total number of packages, second to fetch using the total as the page
-    // size.
-    // This can be simplified once the ORT Run statistics query is implemented.
-    limit: 100000,
-  });
+  const { data, isPending, isError, error } =
+    usePackagesServiceGetPackagesByRunId({
+      runId: runId,
+      // Use a large page size for packages request to try to use all packages
+      // for finding de-duplicated package types.
+      // Another option would be to do two packages queries: first to find the
+      // total number of packages, second to fetch using the total as the page
+      // size.
+      // This can be simplified once the ORT Run statistics query is implemented.
+      limit: 100000,
+    });
 
   // Find de-duplicated package types in packages data and sort alphabetically.
   // Packages data can be quite large, so use memoization to avoid unnecessary
@@ -60,13 +56,13 @@ export const PackagesStatisticsCard = ({
     () =>
       [
         ...new Set(
-          packages?.data.map((item) => item.identifier?.type).filter(Boolean)
+          data?.data.map((item) => item.identifier?.type).filter(Boolean)
         ),
       ].sort(),
-    [packages?.data]
+    [data?.data]
   );
 
-  if (packagesIsPending) {
+  if (isPending) {
     return (
       <StatisticsCard
         title='Packages'
@@ -79,9 +75,9 @@ export const PackagesStatisticsCard = ({
     );
   }
 
-  if (packagesIsError) {
+  if (isError) {
     toast.error('Unable to load data', {
-      description: <ToastError error={packagesError} />,
+      description: <ToastError error={error} />,
       duration: Infinity,
       cancel: {
         label: 'Dismiss',
@@ -91,7 +87,7 @@ export const PackagesStatisticsCard = ({
     return;
   }
 
-  const packagesTotal = packages.pagination.totalCount;
+  const packagesTotal = data.pagination.totalCount;
 
   return (
     <StatisticsCard

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/-components/rule-violations-statistics-card.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/-components/rule-violations-statistics-card.tsx
@@ -36,17 +36,13 @@ export const RuleViolationsStatisticsCard = ({
   status,
   runId,
 }: RuleViolationsStatisticsCardProps) => {
-  const {
-    data: ruleViolations,
-    isPending: ruleViolationsIsPending,
-    isError: ruleViolationsIsError,
-    error: ruleViolationsError,
-  } = useRuleViolationsServiceGetRuleViolationsByRunId({
-    runId: runId,
-    limit: 1,
-  });
+  const { data, isPending, isError, error } =
+    useRuleViolationsServiceGetRuleViolationsByRunId({
+      runId: runId,
+      limit: 1,
+    });
 
-  if (ruleViolationsIsPending) {
+  if (isPending) {
     return (
       <StatisticsCard
         title='Rule Violations'
@@ -59,9 +55,9 @@ export const RuleViolationsStatisticsCard = ({
     );
   }
 
-  if (ruleViolationsIsError) {
+  if (isError) {
     toast.error('Unable to load data', {
-      description: <ToastError error={ruleViolationsError} />,
+      description: <ToastError error={error} />,
       duration: Infinity,
       cancel: {
         label: 'Dismiss',
@@ -71,7 +67,7 @@ export const RuleViolationsStatisticsCard = ({
     return;
   }
 
-  const ruleViolationsTotal = ruleViolations.pagination.totalCount;
+  const ruleViolationsTotal = data.pagination.totalCount;
 
   return (
     <StatisticsCard

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/-components/vulnerabilities-statistics-card.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/-components/vulnerabilities-statistics-card.tsx
@@ -36,17 +36,13 @@ export const VulnerabilitiesStatisticsCard = ({
   status,
   runId,
 }: VulnerabilitiesStatisticsCardProps) => {
-  const {
-    data: vulnerabilities,
-    isPending: vulnerabilitiesIsPending,
-    isError: vulnerabilitiesIsError,
-    error: VulnerabilitiesError,
-  } = useVulnerabilitiesServiceGetVulnerabilitiesByRunId({
-    runId: runId,
-    limit: 1,
-  });
+  const { data, isPending, isError, error } =
+    useVulnerabilitiesServiceGetVulnerabilitiesByRunId({
+      runId: runId,
+      limit: 1,
+    });
 
-  if (vulnerabilitiesIsPending) {
+  if (isPending) {
     return (
       <StatisticsCard
         title='Vulnerabilities'
@@ -59,9 +55,9 @@ export const VulnerabilitiesStatisticsCard = ({
     );
   }
 
-  if (vulnerabilitiesIsError) {
+  if (isError) {
     toast.error('Unable to load data', {
-      description: <ToastError error={VulnerabilitiesError} />,
+      description: <ToastError error={error} />,
       duration: Infinity,
       cancel: {
         label: 'Dismiss',
@@ -71,7 +67,7 @@ export const VulnerabilitiesStatisticsCard = ({
     return;
   }
 
-  const vulnerabilitiesTotal = vulnerabilities.pagination.totalCount;
+  const vulnerabilitiesTotal = data.pagination.totalCount;
 
   return (
     <StatisticsCard

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/-components/vulnerabilities-statistics-card.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/-components/vulnerabilities-statistics-card.tsx
@@ -17,9 +17,9 @@
  * License-Filename: LICENSE
  */
 
-import { Scale } from 'lucide-react';
+import { ShieldQuestion } from 'lucide-react';
 
-import { useRuleViolationsServiceGetRuleViolationsByRunId } from '@/api/queries';
+import { useVulnerabilitiesServiceGetVulnerabilitiesByRunId } from '@/api/queries';
 import { JobStatus } from '@/api/requests';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { StatisticsCard } from '@/components/statistics-card';
@@ -27,31 +27,31 @@ import { ToastError } from '@/components/toast-error';
 import { getStatusFontColor } from '@/helpers/get-status-class';
 import { toast } from '@/lib/toast';
 
-type RuleViolationsStatisticsCardProps = {
+type VulnerabilitiesStatisticsCardProps = {
   status: JobStatus | undefined;
   runId: number;
 };
 
-export const RuleViolationsStatisticsCard = ({
+export const VulnerabilitiesStatisticsCard = ({
   status,
   runId,
-}: RuleViolationsStatisticsCardProps) => {
+}: VulnerabilitiesStatisticsCardProps) => {
   const {
-    data: ruleViolations,
-    isPending: ruleViolationsIsPending,
-    isError: ruleViolationsIsError,
-    error: ruleViolationsError,
-  } = useRuleViolationsServiceGetRuleViolationsByRunId({
+    data: vulnerabilities,
+    isPending: vulnerabilitiesIsPending,
+    isError: vulnerabilitiesIsError,
+    error: VulnerabilitiesError,
+  } = useVulnerabilitiesServiceGetVulnerabilitiesByRunId({
     runId: runId,
     limit: 1,
   });
 
-  if (ruleViolationsIsPending) {
+  if (vulnerabilitiesIsPending) {
     return (
       <StatisticsCard
-        title='Rule Violations'
+        title='Vulnerabilities'
         icon={() => (
-          <Scale className={`h-4 w-4 ${getStatusFontColor(status)}`} />
+          <ShieldQuestion className={`h-4 w-4 ${getStatusFontColor(status)}`} />
         )}
         value={<LoadingIndicator />}
         className='h-full hover:bg-muted/50'
@@ -59,9 +59,9 @@ export const RuleViolationsStatisticsCard = ({
     );
   }
 
-  if (ruleViolationsIsError) {
+  if (vulnerabilitiesIsError) {
     toast.error('Unable to load data', {
-      description: <ToastError error={ruleViolationsError} />,
+      description: <ToastError error={VulnerabilitiesError} />,
       duration: Infinity,
       cancel: {
         label: 'Dismiss',
@@ -71,13 +71,15 @@ export const RuleViolationsStatisticsCard = ({
     return;
   }
 
-  const ruleViolationsTotal = ruleViolations.pagination.totalCount;
+  const vulnerabilitiesTotal = vulnerabilities.pagination.totalCount;
 
   return (
     <StatisticsCard
-      title='Rule Violations'
-      icon={() => <Scale className={`h-4 w-4 ${getStatusFontColor(status)}`} />}
-      value={status ? ruleViolationsTotal : 'Skipped'}
+      title='Vulnerabilities'
+      icon={() => (
+        <ShieldQuestion className={`h-4 w-4 ${getStatusFontColor(status)}`} />
+      )}
+      value={status ? vulnerabilitiesTotal : 'Skipped'}
       description={status ? '' : 'Enable the job for results'}
       className='h-full hover:bg-muted/50'
     />

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/issues/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/issues/index.tsx
@@ -18,10 +18,29 @@
  */
 
 import { createFileRoute } from '@tanstack/react-router';
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  getExpandedRowModel,
+  getFilteredRowModel,
+  getPaginationRowModel,
+  Row,
+  useReactTable,
+} from '@tanstack/react-table';
+import { Minus, Plus } from 'lucide-react';
+import { useMemo } from 'react';
 
+import { useIssuesServiceGetIssuesByRunId } from '@/api/queries';
 import { prefetchUseRepositoriesServiceGetOrtRunByIndex } from '@/api/queries/prefetch';
 import { useRepositoriesServiceGetOrtRunByIndexSuspense } from '@/api/queries/suspense';
+import { Issue } from '@/api/requests';
+import { DataTable } from '@/components/data-table/data-table';
+import { DataTableToolbar } from '@/components/data-table/data-table-toolbar';
+import { FilterMultiSelect } from '@/components/data-table/filter-multi-select';
 import { LoadingIndicator } from '@/components/loading-indicator';
+import { ToastError } from '@/components/toast-error';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import {
   Card,
   CardContent,
@@ -29,56 +48,233 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { Label } from '@/components/ui/label';
+import { getIssueSeverityBackgroundColor } from '@/helpers/get-status-class';
+import { toast } from '@/lib/toast';
 import { formatTimestamp } from '@/lib/utils.ts';
+import {
+  issueSeverity,
+  issueSeveritySchema,
+  paginationSchema,
+} from '@/schemas';
+
+const defaultPageSize = 10;
+
+const columnHelper = createColumnHelper<Issue>();
+
+const columns = [
+  columnHelper.accessor('severity', {
+    header: 'Severity',
+    cell: ({ row }) => (
+      <Badge
+        className={`border ${getIssueSeverityBackgroundColor(row.original.severity)} hover:bg-${getIssueSeverityBackgroundColor(row.original.severity)}`}
+      >
+        {row.original.severity}
+      </Badge>
+    ),
+    filterFn: (row, _columnId, filterValue): boolean => {
+      return filterValue.includes(row.original.severity);
+    },
+  }),
+  columnHelper.display({
+    id: 'package',
+    header: 'Package ID',
+    cell: function CellComponent({ row }) {
+      if (!row.original.identifier) {
+        return null;
+      }
+      const { type, namespace, name, version } = row.original.identifier;
+      return (
+        <div className='font-semibold'>
+          {type ? type.concat(':') : ''}
+          {namespace ? namespace.concat('/') : ''}
+          {name ? name : ''}
+          {version ? '@'.concat(version) : ''}
+        </div>
+      );
+    },
+  }),
+  columnHelper.accessor('affectedPath', {
+    header: 'Affected Path',
+    cell: ({ row }) => row.original.affectedPath,
+  }),
+
+  columnHelper.accessor('source', {
+    header: 'Source',
+    cell: ({ row }) => row.original.source,
+  }),
+  columnHelper.display({
+    id: 'moreInfo',
+    size: 50,
+    cell: function CellComponent({ row }) {
+      return row.getCanExpand() ? (
+        <Button
+          variant='outline'
+          size='sm'
+          {...{
+            onClick: row.getToggleExpandedHandler(),
+            style: { cursor: 'pointer' },
+          }}
+        >
+          {row.getIsExpanded() ? (
+            <Minus className='h-4 w-4' />
+          ) : (
+            <Plus className='h-4 w-4' />
+          )}
+        </Button>
+      ) : (
+        'No info'
+      );
+    },
+  }),
+];
+
+const renderSubComponent = ({ row }: { row: Row<Issue> }) => {
+  const issue = row.original;
+
+  return (
+    <div className='flex flex-col gap-4'>
+      <div className='flex gap-1 text-sm'>
+        <div className='font-semibold'>Created at</div>
+        <div>{formatTimestamp(issue.timestamp)}</div>
+        <div>by</div>
+        <div className='font-semibold'>{issue.worker}</div>
+      </div>
+      <div className='whitespace-pre-line italic text-muted-foreground'>
+        {issue.message || 'No details.'}
+      </div>
+    </div>
+  );
+};
 
 const IssuesComponent = () => {
   const params = Route.useParams();
+  const search = Route.useSearch();
+  const navigate = Route.useNavigate();
+
+  // All of these need to be memoized to prevent unnecessary re-renders
+  // and (at least for Firefox) the browser freezing up.
+
+  const pageIndex = useMemo(
+    () => (search.page ? search.page - 1 : 0),
+    [search.page]
+  );
+
+  const pageSize = useMemo(
+    () => (search.pageSize ? search.pageSize : defaultPageSize),
+    [search.pageSize]
+  );
+
+  const severity = useMemo(
+    () => (search.severity ? search.severity : undefined),
+    [search.severity]
+  );
+
+  const columnFilters = useMemo(
+    () => (severity ? [{ id: 'severity', value: severity }] : []),
+    [severity]
+  );
 
   const { data: ortRun } = useRepositoriesServiceGetOrtRunByIndexSuspense({
     repositoryId: Number.parseInt(params.repoId),
     ortRunIndex: Number.parseInt(params.runIndex),
   });
 
+  const {
+    data: issues,
+    isPending,
+    isError,
+    error,
+  } = useIssuesServiceGetIssuesByRunId({
+    runId: ortRun.id,
+    limit: 100000,
+  });
+
+  const table = useReactTable({
+    data: issues?.data || [],
+    columns,
+    state: {
+      pagination: {
+        pageIndex,
+        pageSize,
+      },
+      columnFilters,
+    },
+    getCoreRowModel: getCoreRowModel(),
+    getExpandedRowModel: getExpandedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
+    getPaginationRowModel: getPaginationRowModel(),
+    getRowCanExpand: () => true,
+  });
+
+  if (isPending) {
+    return <LoadingIndicator />;
+  }
+
+  if (isError) {
+    toast.error('Unable to load data', {
+      description: <ToastError error={error} />,
+      duration: Infinity,
+      cancel: {
+        label: 'Dismiss',
+        onClick: () => {},
+      },
+    });
+    return;
+  }
+
   return (
     <Card className='h-fit'>
       <CardHeader>
-        <CardTitle>Technical issues related to the ORT Server</CardTitle>
+        <CardTitle>Issues (ORT run global ID: {ortRun.id})</CardTitle>
         <CardDescription>
-          These are issues related to the ORT Server, for example failing
-          configuration.
+          These are the technical issues that were found during the analysis.
         </CardDescription>
       </CardHeader>
       <CardContent>
-        {ortRun.issues.length > 0 ? (
-          ortRun.issues.map((issue) => (
-            <Card key={issue.message}>
-              <CardHeader>
-                <CardTitle>
-                  <div className='text-sm'>
-                    <Label className='font-semibold'>Created at:</Label>{' '}
-                    {formatTimestamp(issue.timestamp)}
-                  </div>
-                </CardTitle>
-                <CardDescription>
-                  <div className='flex flex-col text-sm'>
-                    <div>
-                      <Label className='font-semibold'>Severity:</Label>{' '}
-                      {issue.severity}
-                    </div>
-                    <div>
-                      <Label className='font-semibold'>Source:</Label>{' '}
-                      {issue.source}
-                    </div>
-                  </div>
-                </CardDescription>
-                <CardContent className='text-sm'>{issue.message}</CardContent>
-              </CardHeader>
-            </Card>
-          ))
-        ) : (
-          <Label className='font-semibold'>No issues found.</Label>
-        )}
+        <DataTableToolbar
+          filters={
+            <FilterMultiSelect
+              title='Issue Severity'
+              options={issueSeverity.options.map((severity) => ({
+                label: severity,
+                value: severity,
+              }))}
+              selected={severity || []}
+              setSelected={(severities) => {
+                navigate({
+                  search: {
+                    ...search,
+                    page: 1,
+                    severity: severities.length === 0 ? undefined : severities,
+                  },
+                });
+              }}
+            />
+          }
+          resetFilters={() => {
+            navigate({
+              search: { ...search, page: 1, severity: undefined },
+            });
+          }}
+          resetBtnVisible={severity !== undefined}
+          className='mb-2'
+        />
+        <DataTable
+          table={table}
+          renderSubComponent={renderSubComponent}
+          setCurrentPageOptions={(currentPage) => {
+            return {
+              to: Route.to,
+              search: { ...search, page: currentPage },
+            };
+          }}
+          setPageSizeOptions={(size) => {
+            return {
+              to: Route.to,
+              search: { ...search, page: 1, pageSize: size },
+            };
+          }}
+        />
       </CardContent>
     </Card>
   );
@@ -87,6 +283,7 @@ const IssuesComponent = () => {
 export const Route = createFileRoute(
   '/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/issues/'
 )({
+  validateSearch: paginationSchema.merge(issueSeveritySchema),
   loader: async ({ context, params }) => {
     await prefetchUseRepositoriesServiceGetOrtRunByIndex(context.queryClient, {
       repositoryId: Number.parseInt(params.repoId),

--- a/ui/src/schemas/index.ts
+++ b/ui/src/schemas/index.ts
@@ -19,7 +19,7 @@
 
 import z from 'zod';
 
-import { OrtRunStatus } from '@/api/requests';
+import { OrtRunStatus, Severity } from '@/api/requests';
 
 // Pagination schema that is used for search parameter validation
 export const paginationSchema = z.object({
@@ -42,4 +42,16 @@ export const ortRunStatus: z.ZodEnum<[OrtRunStatus, ...OrtRunStatus[]]> =
 // Status schema that is used for search parameter validation
 export const statusSchema = z.object({
   status: z.array(ortRunStatus).optional(),
+});
+
+// Enum schema for the possible values of the issue severities
+export const issueSeverity: z.ZodEnum<[Severity, ...Severity[]]> = z.enum([
+  'HINT',
+  'WARNING',
+  'ERROR',
+]);
+
+// Issue severity schema that is used for search parameter validation
+export const issueSeveritySchema = z.object({
+  severity: z.array(issueSeverity).optional(),
 });


### PR DESCRIPTION
Please see the commits for details.

An open question: I believe the issues are sorted by timestamp by default. It could make the issues table cleaner if the back-end sorting would be hard-coded in the UI into severity instead. Another possibility would be to do also sorting on client side, but this hasn't yet been implemented in this PR.