### PR TITLE
fix(api): Optimize performance by reducing ORT run data fetching

### DIFF
--- a/core/src/main/kotlin/api/RepositoriesRoute.kt
+++ b/core/src/main/kotlin/api/RepositoriesRoute.kt
@@ -33,11 +33,9 @@ import io.ktor.server.routing.Route
 import io.ktor.server.routing.route
 
 import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToApi
-import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToApiSummary
 import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToModel
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateSecret
-import org.eclipse.apoapsis.ortserver.api.v1.model.JobSummaries
 import org.eclipse.apoapsis.ortserver.api.v1.model.Jobs
 import org.eclipse.apoapsis.ortserver.api.v1.model.SortDirection
 import org.eclipse.apoapsis.ortserver.api.v1.model.SortProperty
@@ -115,14 +113,8 @@ fun Route.repositories() = route("repositories/{repositoryId}") {
             val repositoryId = call.requireIdParameter("repositoryId")
             val pagingOptions = call.pagingOptions(SortProperty("index", SortDirection.ASCENDING))
 
-            val jobsForOrtRuns = repositoryService.getOrtRuns(repositoryId, pagingOptions.mapToModel()).mapData {
-                    val jobSummaries = repositoryService.getJobs(repositoryId, it.index)?.mapToApiSummary()
-                        ?: JobSummaries()
-                    it.mapToApiSummary(jobSummaries)
-            }
-
-            val pagedResponse = jobsForOrtRuns.mapToApi { it }
-
+            val ortRunSummaries = repositoryService.getOrtRunSummaries(repositoryId, pagingOptions.mapToModel())
+            val pagedResponse = ortRunSummaries.mapToApi { it }
             call.respond(HttpStatusCode.OK, pagedResponse)
         }
 

--- a/dao/src/main/kotlin/repositories/DaoOrtRunRepository.kt
+++ b/dao/src/main/kotlin/repositories/DaoOrtRunRepository.kt
@@ -38,6 +38,7 @@ import org.eclipse.apoapsis.ortserver.model.JobConfigurations
 import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.OrtRunFilters
 import org.eclipse.apoapsis.ortserver.model.OrtRunStatus
+import org.eclipse.apoapsis.ortserver.model.OrtRunSummary
 import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
@@ -117,6 +118,17 @@ class DaoOrtRunRepository(private val db: Database) : OrtRunRepository {
     override fun listForRepository(repositoryId: Long, parameters: ListQueryParameters): ListQueryResult<OrtRun> =
         db.blockingQueryCatching {
             OrtRunDao.listQuery(parameters, OrtRunDao::mapToModel) { OrtRunsTable.repositoryId eq repositoryId }
+        }.getOrElse {
+            logger.error("Cannot list ORT runs for repository $repositoryId.", it)
+            ListQueryResult(emptyList(), parameters, 0L)
+        }
+
+    override fun listSummariesForRepository(
+        repositoryId: Long,
+        parameters: ListQueryParameters
+    ): ListQueryResult<OrtRunSummary> =
+        db.blockingQueryCatching {
+            OrtRunDao.listQuery(parameters, OrtRunDao::mapToSummaryModel) { OrtRunsTable.repositoryId eq repositoryId }
         }.getOrElse {
             logger.error("Cannot list ORT runs for repository $repositoryId.", it)
             ListQueryResult(emptyList(), parameters, 0L)

--- a/dao/src/main/kotlin/tables/AdvisorJobsTable.kt
+++ b/dao/src/main/kotlin/tables/AdvisorJobsTable.kt
@@ -26,6 +26,7 @@ import org.eclipse.apoapsis.ortserver.dao.utils.transformToDatabasePrecision
 import org.eclipse.apoapsis.ortserver.model.AdvisorJob
 import org.eclipse.apoapsis.ortserver.model.AdvisorJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.JobStatus
+import org.eclipse.apoapsis.ortserver.model.JobSummary
 
 import org.jetbrains.exposed.dao.LongEntity
 import org.jetbrains.exposed.dao.LongEntityClass
@@ -67,5 +68,13 @@ class AdvisorJobDao(id: EntityID<Long>) : LongEntity(id) {
         finishedAt = finishedAt,
         configuration = configuration,
         status = status,
+    )
+
+    fun mapToJobSummaryModel() = JobSummary(
+        id = id.value,
+        createdAt = createdAt,
+        startedAt = startedAt,
+        finishedAt = finishedAt,
+        status = status
     )
 }

--- a/dao/src/main/kotlin/tables/AnalyzerJobsTable.kt
+++ b/dao/src/main/kotlin/tables/AnalyzerJobsTable.kt
@@ -26,6 +26,7 @@ import org.eclipse.apoapsis.ortserver.dao.utils.transformToDatabasePrecision
 import org.eclipse.apoapsis.ortserver.model.AnalyzerJob
 import org.eclipse.apoapsis.ortserver.model.AnalyzerJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.JobStatus
+import org.eclipse.apoapsis.ortserver.model.JobSummary
 
 import org.jetbrains.exposed.dao.LongEntity
 import org.jetbrains.exposed.dao.LongEntityClass
@@ -66,6 +67,14 @@ class AnalyzerJobDao(id: EntityID<Long>) : LongEntity(id) {
         startedAt = startedAt,
         finishedAt = finishedAt,
         configuration = configuration,
+        status = status
+    )
+
+    fun mapToJobSummaryModel() = JobSummary(
+        id = id.value,
+        createdAt = createdAt,
+        startedAt = startedAt,
+        finishedAt = finishedAt,
         status = status
     )
 }

--- a/dao/src/main/kotlin/tables/EvaluatorJobsTable.kt
+++ b/dao/src/main/kotlin/tables/EvaluatorJobsTable.kt
@@ -24,6 +24,7 @@ import org.eclipse.apoapsis.ortserver.dao.utils.transformToDatabasePrecision
 import org.eclipse.apoapsis.ortserver.model.EvaluatorJob
 import org.eclipse.apoapsis.ortserver.model.EvaluatorJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.JobStatus
+import org.eclipse.apoapsis.ortserver.model.JobSummary
 
 import org.jetbrains.exposed.dao.LongEntity
 import org.jetbrains.exposed.dao.LongEntityClass
@@ -65,5 +66,13 @@ class EvaluatorJobDao(id: EntityID<Long>) : LongEntity(id) {
         finishedAt = finishedAt,
         configuration = configuration,
         status = status,
+    )
+
+    fun mapToJobSummaryModel() = JobSummary(
+        id = id.value,
+        createdAt = createdAt,
+        startedAt = startedAt,
+        finishedAt = finishedAt,
+        status = status
     )
 }

--- a/dao/src/main/kotlin/tables/ReporterJobsTable.kt
+++ b/dao/src/main/kotlin/tables/ReporterJobsTable.kt
@@ -24,6 +24,7 @@ import org.eclipse.apoapsis.ortserver.dao.tables.runs.reporter.ReporterRunsTable
 import org.eclipse.apoapsis.ortserver.dao.utils.jsonb
 import org.eclipse.apoapsis.ortserver.dao.utils.transformToDatabasePrecision
 import org.eclipse.apoapsis.ortserver.model.JobStatus
+import org.eclipse.apoapsis.ortserver.model.JobSummary
 import org.eclipse.apoapsis.ortserver.model.ReporterJob
 import org.eclipse.apoapsis.ortserver.model.ReporterJobConfiguration
 
@@ -67,5 +68,13 @@ class ReporterJobDao(id: EntityID<Long>) : LongEntity(id) {
         configuration = configuration,
         status = status,
         filenames = reporterRun?.reports?.map { it.filename }?.sorted().orEmpty()
+    )
+
+    fun mapToJobSummaryModel() = JobSummary(
+        id = id.value,
+        createdAt = createdAt,
+        startedAt = startedAt,
+        finishedAt = finishedAt,
+        status = status
     )
 }

--- a/dao/src/main/kotlin/tables/ScannerJobsTable.kt
+++ b/dao/src/main/kotlin/tables/ScannerJobsTable.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.dao.tables
 import org.eclipse.apoapsis.ortserver.dao.utils.jsonb
 import org.eclipse.apoapsis.ortserver.dao.utils.transformToDatabasePrecision
 import org.eclipse.apoapsis.ortserver.model.JobStatus
+import org.eclipse.apoapsis.ortserver.model.JobSummary
 import org.eclipse.apoapsis.ortserver.model.ScannerJob
 import org.eclipse.apoapsis.ortserver.model.ScannerJobConfiguration
 
@@ -65,5 +66,13 @@ class ScannerJobDao(id: EntityID<Long>) : LongEntity(id) {
         finishedAt = finishedAt,
         configuration = configuration,
         status = status,
+    )
+
+    fun mapToJobSummaryModel() = JobSummary(
+        id = id.value,
+        createdAt = createdAt,
+        startedAt = startedAt,
+        finishedAt = finishedAt,
+        status = status
     )
 }

--- a/model/src/commonMain/kotlin/OrtRunSummary.kt
+++ b/model/src/commonMain/kotlin/OrtRunSummary.kt
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.model
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+
+/**
+ * The summary of an ORT run.
+ */
+@Serializable
+data class OrtRunSummary(
+    /**
+     * The unique identifier.
+     */
+    val id: Long,
+
+    /**
+     * The index of this ORT run for the affected repository. Together with the [repositoryId], this property uniquely
+     * identifies an ORT run.
+     */
+    val index: Long,
+
+    /**
+     * The id of the [Organization] this run belongs to.
+     */
+    val organizationId: Long,
+
+    /**
+     * The id of the [Product] this run belongs to.
+     */
+    val productId: Long,
+
+    /**
+     * The id of the repository for this run.
+     */
+    val repositoryId: Long,
+
+    /**
+     * The repository revision used by this run.
+     */
+    val revision: String,
+
+    /**
+     * The optional VCS sub-path of the project repository, which should be downloaded instead of the whole repository.
+     * If this is not specified, the entire repository will be downloaded.
+     */
+    val path: String? = null,
+
+    /**
+     * The time this run was created.
+     */
+    val createdAt: Instant,
+
+    /**
+     * The time when this run was finished or *null* if it is not yet finished.
+     */
+    val finishedAt: Instant? = null,
+
+    /**
+     * The jobs for this run.
+     */
+    val jobs: JobSummaries,
+
+    /**
+     * The status of this run.
+     */
+    val status: OrtRunStatus,
+
+    /**
+     * The labels of this run.
+     */
+    val labels: Options,
+
+    /**
+     * An optional context to be used when obtaining configuration for this ORT run. This context is passed to the
+     * configuration manager and can be used to select a specific subset or a version of configuration properties. If
+     * this value is missing, the default configuration context should be used.
+     */
+    val jobConfigContext: String? = null,
+
+    /**
+     * The resolved configuration context. When an ORT run is started, the configuration context is resolved once and
+     * then stored, so that all workers access the same set of configuration properties.
+     */
+    val resolvedJobConfigContext: String? = null,
+
+    /**
+     * The optional path to an environment configuration file. If this is not defined, the environment configuration is
+     * read from the default location `.ort.env.yml`.
+     */
+    val environmentConfigPath: String? = null
+)
+
+/**
+ * The summaries of all jobs in an ORT run.
+ */
+@Serializable
+data class JobSummaries(
+    val analyzer: JobSummary? = null,
+    val advisor: JobSummary? = null,
+    val scanner: JobSummary? = null,
+    val evaluator: JobSummary? = null,
+    val reporter: JobSummary? = null
+)
+
+/**
+ * The summary of a job.
+ */
+@Serializable
+data class JobSummary(
+    /**
+     * The unique identifier of the job.
+     */
+    val id: Long,
+
+    /**
+     * The time the job was created.
+     */
+    val createdAt: Instant,
+
+    /**
+     * The time the job was started.
+     */
+    val startedAt: Instant? = null,
+
+    /**
+     * The time the job finished.
+     */
+    val finishedAt: Instant? = null,
+
+    /**
+     * The job status.
+     */
+    val status: JobStatus
+)

--- a/model/src/commonMain/kotlin/repositories/OrtRunRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/OrtRunRepository.kt
@@ -23,6 +23,7 @@ import org.eclipse.apoapsis.ortserver.model.JobConfigurations
 import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.OrtRunFilters
 import org.eclipse.apoapsis.ortserver.model.OrtRunStatus
+import org.eclipse.apoapsis.ortserver.model.OrtRunSummary
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
@@ -71,6 +72,15 @@ interface OrtRunRepository {
         repositoryId: Long,
         parameters: ListQueryParameters = ListQueryParameters.DEFAULT
     ): ListQueryResult<OrtRun>
+
+    /**
+     * List all ORT runs for a [repository][repositoryId] according to the given [parameters],
+     * but only return a summary of each run.
+     */
+    fun listSummariesForRepository(
+        repositoryId: Long,
+        parameters: ListQueryParameters = ListQueryParameters.DEFAULT
+    ): ListQueryResult<OrtRunSummary>
 
     /**
      * Update an ORT run by [id] with the [present][OptionalValue.Present] values. If [issues] or [labels] are

--- a/services/hierarchy/src/main/kotlin/RepositoryService.kt
+++ b/services/hierarchy/src/main/kotlin/RepositoryService.kt
@@ -23,6 +23,7 @@ import org.eclipse.apoapsis.ortserver.dao.dbQuery
 import org.eclipse.apoapsis.ortserver.dao.dbQueryCatching
 import org.eclipse.apoapsis.ortserver.model.Jobs
 import org.eclipse.apoapsis.ortserver.model.OrtRun
+import org.eclipse.apoapsis.ortserver.model.OrtRunSummary
 import org.eclipse.apoapsis.ortserver.model.Repository
 import org.eclipse.apoapsis.ortserver.model.RepositoryType
 import org.eclipse.apoapsis.ortserver.model.authorization.RepositoryRole
@@ -95,13 +96,14 @@ class RepositoryService(
     }
 
     /**
-     * Get the runs executed on the given [repository][repositoryId] according to the given [parameters].
+     * Get the summaries of the runs executed on the given [repository][repositoryId] according
+     * to the given [parameters].
      */
-    suspend fun getOrtRuns(
+    suspend fun getOrtRunSummaries(
         repositoryId: Long,
         parameters: ListQueryParameters = ListQueryParameters.DEFAULT
-    ): ListQueryResult<OrtRun> = db.dbQuery {
-        ortRunRepository.listForRepository(repositoryId, parameters)
+    ): ListQueryResult<OrtRunSummary> = db.dbQuery {
+        ortRunRepository.listSummariesForRepository(repositoryId, parameters)
     }
 
     /**


### PR DESCRIPTION
Limit the fetched data for repository runs to only what is needed for the REST API response,
enhancing performance by avoiding excess loading of unused related entities.

Utilize lazy-loading in the Kotlin Exposed framework by no longer prematurely mapping of unused columns to object attributes.

Number of generated SQL statements in the BE is reduced at least by 50%.