### PR TITLE
Revert "feat(storage): Use suspend functions in the `StorageProvider`"

### DIFF
--- a/core/src/test/kotlin/api/DownloadsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/DownloadsRouteIntegrationTest.kt
@@ -91,7 +91,7 @@ class DownloadsRouteIntegrationTest : AbstractIntegrationTest({
     /**
      * Create an [OrtRun], store a report for the created run, and return the created run.
      */
-    suspend fun createReport(): OrtRun {
+    fun createReport(): OrtRun {
         val run = dbExtension.fixtures.createOrtRun(repositoryId)
         val key = Key("${run.id}|$reportFile")
 

--- a/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
@@ -176,7 +176,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
     /**
      * Create an [OrtRun], store a report for the created run, and return the created run.
      */
-    suspend fun createReport(): OrtRun {
+    fun createReport(): OrtRun {
         val run = dbExtension.fixtures.createOrtRun(repositoryId)
         val key = Key("${run.id}|$reportFile")
 

--- a/services/report-storage/src/main/kotlin/ReportStorageService.kt
+++ b/services/report-storage/src/main/kotlin/ReportStorageService.kt
@@ -48,7 +48,7 @@ class ReportStorageService(
      * Return a [ReportDownloadData] object for the report with the given [fileName] for the specified [runId]. Throw a
      * [ReportNotFoundException] if the report cannot be resolved.
      */
-    suspend fun fetchReport(runId: Long, fileName: String): ReportDownloadData {
+    fun fetchReport(runId: Long, fileName: String): ReportDownloadData {
         val key = generateKey(runId, fileName)
         if (!reportStorage.containsKey(key)) throw ReportNotFoundException(runId, fileName)
 
@@ -64,7 +64,7 @@ class ReportStorageService(
      * Return a [ReportDownloadData] object for the report with the given [token] for the specified [runId]. Throw a
      * [ReportNotFoundException] if the report cannot be resolved or the token has expired.
      */
-    suspend fun fetchReportByToken(runId: Long, token: String): ReportDownloadData {
+    fun fetchReportByToken(runId: Long, token: String): ReportDownloadData {
         return reporterJobRepository.getReportByToken(runId, token)?.let { report ->
             logger.info("Resolved report '${report.filename}' for run $runId from token.")
 

--- a/services/report-storage/src/test/kotlin/ReportStorageServiceTest.kt
+++ b/services/report-storage/src/test/kotlin/ReportStorageServiceTest.kt
@@ -26,7 +26,6 @@ import io.kotest.matchers.string.shouldContain
 
 import io.ktor.http.ContentType
 
-import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 
@@ -51,8 +50,8 @@ class ReportStorageServiceTest : WordSpec({
             val key = Key("$runId|$fileName")
 
             val storage = mockk<Storage>()
-            coEvery { storage.containsKey(key) } returns true
-            coEvery { storage.read(key) } returns StorageEntry.create(
+            every { storage.containsKey(key) } returns true
+            every { storage.read(key) } returns StorageEntry.create(
                 ByteArrayInputStream(reportData),
                 contentType,
                 reportData.size.toLong()
@@ -73,7 +72,7 @@ class ReportStorageServiceTest : WordSpec({
             val fileName = "nonExistingReport.dat"
 
             val storage = mockk<Storage>()
-            coEvery { storage.containsKey(any()) } returns false
+            every { storage.containsKey(any()) } returns false
 
             val service = ReportStorageService(storage, mockk())
             val exception = shouldThrow<ReportNotFoundException> {
@@ -91,8 +90,8 @@ class ReportStorageServiceTest : WordSpec({
             val key = Key("$runId|$fileName")
 
             val storage = mockk<Storage>()
-            coEvery { storage.containsKey(key) } returns true
-            coEvery { storage.read(key) } returns StorageEntry.create(
+            every { storage.containsKey(key) } returns true
+            every { storage.read(key) } returns StorageEntry.create(
                 ByteArrayInputStream(reportData),
                 null,
                 reportData.size.toLong()
@@ -115,8 +114,8 @@ class ReportStorageServiceTest : WordSpec({
             val token = "test-report-token"
 
             val storage = mockk<Storage> {
-                coEvery { containsKey(key) } returns true
-                coEvery { read(key) } returns StorageEntry.create(
+                every { containsKey(key) } returns true
+                every { read(key) } returns StorageEntry.create(
                     ByteArrayInputStream(reportData),
                     contentType,
                     reportData.size.toLong()

--- a/storage/s3/src/main/kotlin/S3StorageProvider.kt
+++ b/storage/s3/src/main/kotlin/S3StorageProvider.kt
@@ -36,6 +36,7 @@ import kotlin.io.path.outputStream
 import org.eclipse.apoapsis.ortserver.storage.Key
 import org.eclipse.apoapsis.ortserver.storage.StorageEntry
 import org.eclipse.apoapsis.ortserver.storage.StorageProvider
+import org.eclipse.apoapsis.ortserver.utils.logging.runBlocking
 
 /**
  * Implementation of the [StorageProvider] interface that is backed by AWS S3 storage.
@@ -50,31 +51,33 @@ class S3StorageProvider(
     /**
      * Retrieve the data associated with the given [key] from the S3 bucket.
      */
-    override suspend fun read(key: Key): StorageEntry = s3Client.getObject(
-        GetObjectRequest {
-            bucket = bucketName
-            this.key = key.key
-        }
-    ) { response ->
-        val data = checkNotNull(response.body) { "No data found for ${key.key}." }
-        val contentType = response.contentType
-        val tempFile = createTempFile()
+    override fun read(key: Key): StorageEntry = runBlocking {
+        s3Client.getObject(
+            GetObjectRequest {
+                bucket = bucketName
+                this.key = key.key
+            }
+        ) { response ->
+            val data = checkNotNull(response.body) { "No data found for ${key.key}." }
+            val contentType = response.contentType
+            val tempFile = createTempFile()
 
-        runCatching {
-            data.writeToFile(tempFile)
-            StorageEntry.create(tempFile.toFile(), contentType)
-        }.onFailure { tempFile.deleteExisting() }.getOrThrow()
+            runCatching {
+                data.writeToFile(tempFile)
+                StorageEntry.create(tempFile.toFile(), contentType)
+            }.onFailure { tempFile.deleteExisting() }.getOrThrow()
+        }
     }
 
     /**
      * Write the given [data] to the S3 bucket with the provided [key].
      */
-    override suspend fun write(key: Key, data: InputStream, length: Long, contentType: String?) {
+    override fun write(key: Key, data: InputStream, length: Long, contentType: String?): Unit = runBlocking {
         val tempFile = createTempFile()
 
         try {
             tempFile.outputStream().use { outputStream ->
-                data.copyTo(outputStream)
+                    data.copyTo(outputStream)
             }
 
             s3Client.putObject(
@@ -93,26 +96,30 @@ class S3StorageProvider(
     /**
      * Check if an object with the given [key] exists in the S3 bucket.
      */
-    override suspend fun contains(key: Key): Boolean = runCatching {
-        s3Client.getObject(
-            GetObjectRequest {
-                this.bucket = bucketName
-                this.key = key.key
-            }
-        ) {}
-    }.isSuccess
+    override fun contains(key: Key): Boolean = runBlocking {
+        runCatching {
+            s3Client.getObject(
+                GetObjectRequest {
+                    this.bucket = bucketName
+                    this.key = key.key
+                }
+            ) {}
+        }.isSuccess
+    }
 
     /**
      * Delete the object for the provided key in the S3 bucket.
      */
-    override suspend fun delete(key: Key): Boolean = if (contains(key)) {
-        runCatching {
-            s3Client.deleteObject {
-                this.bucket = bucketName
-                this.key = key.key
-            }
-        }.isSuccess
-    } else {
-        false
+    override fun delete(key: Key): Boolean = runBlocking {
+        if (contains(key)) {
+            runCatching {
+                s3Client.deleteObject {
+                    this.bucket = bucketName
+                    this.key = key.key
+                }
+            }.isSuccess
+        } else {
+            false
+        }
     }
 }

--- a/storage/spi/build.gradle.kts
+++ b/storage/spi/build.gradle.kts
@@ -32,8 +32,6 @@ dependencies {
     api(projects.config.configSpi)
 
     implementation(projects.utils.config)
-    implementation(libs.kotlinxCoroutines)
-    implementation(libs.kotlinxCoroutinesSlf4j)
 
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestExtensionsTestContainer)

--- a/storage/spi/src/main/kotlin/StorageProvider.kt
+++ b/storage/spi/src/main/kotlin/StorageProvider.kt
@@ -36,7 +36,7 @@ interface StorageProvider {
      * Return a [StorageEntry] that represents the data associated with the given [key]. Throw an exception if the
      * [key] does not exist.
      */
-    suspend fun read(key: Key): StorageEntry
+    fun read(key: Key): StorageEntry
 
     /**
      * Write the given [data] with the given [length] and optional [contentType] into this storage and associate it
@@ -47,16 +47,16 @@ interface StorageProvider {
      * expected by a *Content-Type* header. This function does not close the [InputStream][data]; this needs to be
      * done by the caller. Throw an exception if the write operation fails.
      */
-    suspend fun write(key: Key, data: InputStream, length: Long, contentType: String? = null)
+    fun write(key: Key, data: InputStream, length: Long, contentType: String? = null)
 
     /**
      * Return a flag whether an entry with the given [key] exists in this storage.
      */
-    suspend fun contains(key: Key): Boolean
+    fun contains(key: Key): Boolean
 
     /**
      * Delete the entry with the given [key] from this storage. Return *true* if such an entry existed and was deleted;
      * return *false* if the entry did not exist. Throw an exception if the delete operation fails.
      */
-    suspend fun delete(key: Key): Boolean
+    fun delete(key: Key): Boolean
 }

--- a/storage/spi/src/testFixtures/kotlin/StorageProviderFactoryForTesting.kt
+++ b/storage/spi/src/testFixtures/kotlin/StorageProviderFactoryForTesting.kt
@@ -89,7 +89,7 @@ class StorageProviderFactoryForTesting : StorageProviderFactory {
         val errorKey = if (config.hasPath(ERROR_KEY_PROPERTY)) config.getString(ERROR_KEY_PROPERTY) else "<undefined>"
 
         return object : StorageProvider {
-            override suspend fun read(key: Key): StorageEntry =
+            override fun read(key: Key): StorageEntry =
                 getEntry(key)?.let { entry ->
                     StorageEntry.create(
                         data = ByteArrayInputStream(entry.data),
@@ -98,7 +98,7 @@ class StorageProviderFactoryForTesting : StorageProviderFactory {
                     )
                 } ?: throw IOException("Could not resolve key '${key.key}'.")
 
-            override suspend fun write(key: Key, data: InputStream, length: Long, contentType: String?) {
+            override fun write(key: Key, data: InputStream, length: Long, contentType: String?) {
                 getEntry(key)
 
                 data.use {
@@ -106,9 +106,9 @@ class StorageProviderFactoryForTesting : StorageProviderFactory {
                 }
             }
 
-            override suspend fun contains(key: Key): Boolean = getEntry(key) != null
+            override fun contains(key: Key): Boolean = getEntry(key) != null
 
-            override suspend fun delete(key: Key): Boolean {
+            override fun delete(key: Key): Boolean {
                 val entry = getEntry(key)
 
                 storage -= key

--- a/workers/common/build.gradle.kts
+++ b/workers/common/build.gradle.kts
@@ -41,7 +41,6 @@ dependencies {
     implementation(projects.model)
     implementation(projects.secrets.secretsSpi)
     implementation(projects.utils.config)
-    implementation(projects.utils.logging)
 
     implementation(libs.kaml)
     implementation(libs.kotlinxCoroutines)

--- a/workers/common/src/main/kotlin/common/OrtServerFileArchiveStorage.kt
+++ b/workers/common/src/main/kotlin/common/OrtServerFileArchiveStorage.kt
@@ -23,7 +23,6 @@ import java.io.InputStream
 
 import org.eclipse.apoapsis.ortserver.storage.Key
 import org.eclipse.apoapsis.ortserver.storage.Storage
-import org.eclipse.apoapsis.ortserver.utils.logging.runBlocking
 
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.KnownProvenance
@@ -59,16 +58,15 @@ class OrtServerFileArchiveStorage(
             }
     }
 
-    override fun getData(provenance: KnownProvenance): InputStream? = runBlocking {
+    override fun getData(provenance: KnownProvenance): InputStream? {
         val key = generateKey(provenance)
-        if (storage.containsKey(key)) storage.read(key).data else null
+        return if (storage.containsKey(key)) storage.read(key).data else null
     }
 
-    override fun hasData(provenance: KnownProvenance): Boolean = runBlocking {
+    override fun hasData(provenance: KnownProvenance): Boolean =
         storage.containsKey(generateKey(provenance))
-    }
 
-    override fun putData(provenance: KnownProvenance, data: InputStream, size: Long) = runBlocking {
+    override fun putData(provenance: KnownProvenance, data: InputStream, size: Long) {
         storage.write(generateKey(provenance), data, size, CONTENT_TYPE)
     }
 }

--- a/workers/reporter/src/main/kotlin/reporter/ReportStorage.kt
+++ b/workers/reporter/src/main/kotlin/reporter/ReportStorage.kt
@@ -60,7 +60,7 @@ class ReportStorage(
      * Store the given [files] in the associated [Storage] for the given [ORT run ID][runId]. The map with files has
      * the names to be used as keys and the corresponding report files as values.
      */
-    suspend fun storeReportFiles(runId: Long, files: Map<String, File>) {
+    fun storeReportFiles(runId: Long, files: Map<String, File>) {
         files.forEach { (name, file) ->
             val key = generateKey(runId, name)
             logger.info("Storing '{}' under key '{}'.", file.name, key.key)

--- a/workers/reporter/src/test/kotlin/reporter/ReporterRunnerTest.kt
+++ b/workers/reporter/src/test/kotlin/reporter/ReporterRunnerTest.kt
@@ -34,7 +34,6 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
 
 import io.mockk.coEvery
-import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -129,7 +128,7 @@ class ReporterRunnerTest : WordSpec({
     "run" should {
         "return a result with report format and report names" {
             val storage = mockk<ReportStorage>()
-            coEvery { storage.storeReportFiles(any(), any()) } just runs
+            every { storage.storeReportFiles(any(), any()) } just runs
             val (contextFactory, _) = mockContext()
             val runner = ReporterRunner(storage, contextFactory, OptionsTransformerFactory(), configManager, mockk())
 
@@ -145,7 +144,7 @@ class ReporterRunnerTest : WordSpec({
             result.issues should beEmpty()
 
             val slotReports = slot<Map<String, File>>()
-            coVerify {
+            verify {
                 storage.storeReportFiles(RUN_ID, capture(slotReports))
             }
 

--- a/workers/scanner/src/main/kotlin/scanner/OrtServerFileListStorage.kt
+++ b/workers/scanner/src/main/kotlin/scanner/OrtServerFileListStorage.kt
@@ -23,7 +23,6 @@ import java.io.InputStream
 
 import org.eclipse.apoapsis.ortserver.storage.Key
 import org.eclipse.apoapsis.ortserver.storage.Storage
-import org.eclipse.apoapsis.ortserver.utils.logging.runBlocking
 
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.KnownProvenance
@@ -59,16 +58,15 @@ class OrtServerFileListStorage(
             }
     }
 
-    override fun getData(provenance: KnownProvenance): InputStream? = runBlocking {
+    override fun getData(provenance: KnownProvenance): InputStream? {
         val key = generateKey(provenance)
-        if (storage.containsKey(key)) storage.read(key).data else null
+        return if (storage.containsKey(key)) storage.read(key).data else null
     }
 
-    override fun hasData(provenance: KnownProvenance): Boolean = runBlocking {
+    override fun hasData(provenance: KnownProvenance): Boolean =
         storage.containsKey(generateKey(provenance))
-    }
 
-    override fun putData(provenance: KnownProvenance, data: InputStream, size: Long) = runBlocking {
+    override fun putData(provenance: KnownProvenance, data: InputStream, size: Long) {
         storage.write(generateKey(provenance), data, size, CONTENT_TYPE)
     }
 }


### PR DESCRIPTION
This reverts commit 851212d2458e28343b0b34e27b7d0182b0be9bc4 as scans get
stuck when creating file lists with the changes in the commit.

Fixes #1295.