### PR TITLE
fix(storage): Replace `withContext` by `supervisorScope`

### DIFF
--- a/storage/spi/src/main/kotlin/Storage.kt
+++ b/storage/spi/src/main/kotlin/Storage.kt
@@ -23,8 +23,7 @@ import java.io.ByteArrayInputStream
 import java.io.InputStream
 import java.util.ServiceLoader
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.supervisorScope
 
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.config.Path
@@ -138,9 +137,9 @@ class Storage(
     private suspend fun <T> wrapException(block: suspend StorageProvider.() -> T): T =
         @Suppress("TooGenericExceptionCaught")
         try {
-            // To prevent the StorageException being suppressed by the coroutine exception handler, a new context is
+            // To prevent the StorageException being suppressed by the coroutine exception handler, a new scope is
             // created here.
-            withContext(Dispatchers.IO) {
+            supervisorScope {
                 provider.block()
             }
         } catch (e: Exception) {


### PR DESCRIPTION
In order to obtain the correct exception thrown by a provider, the code was using the `withContext` function. This, however, caused problems with hanging jobs. Therefore, use `supervisorScope` instead.