### PR TITLE
feat(cli): Add initial ORT Server CLI implementation

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import com.google.cloud.tools.jib.gradle.JibTask
+
+val dockerImagePrefix: String by project
+val dockerImageTag: String by project
+
+plugins {
+    application
+
+    id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
+
+    // Apply third-party plugins.
+    alias(libs.plugins.jib)
+}
+
+group = "org.eclipse.apoapsis.ortserver.cli"
+
+tasks.withType<JibTask> {
+    notCompatibleWithConfigurationCache("https://github.com/GoogleContainerTools/jib/issues/3132")
+}
+
+application {
+    applicationName = "ort-server"
+    mainClass = "org.eclipse.apoapsis.ortserver.cli.OrtServerMainKt"
+}
+
+dependencies {
+    implementation(libs.clikt)
+}
+
+jib {
+    from.image = "eclipse-temurin:${libs.versions.eclipseTemurin.get()}"
+    to.image = "${dockerImagePrefix}ort-server-cli:$dockerImageTag"
+
+    container {
+        mainClass = "org.eclipse.apoapsis.ortserver.cli.OrtServerMainKt"
+        creationTime.set("USE_CURRENT_TIMESTAMP")
+    }
+}

--- a/cli/src/main/kotlin/OrtServerMain.kt
+++ b/cli/src/main/kotlin/OrtServerMain.kt
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.cli
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.main
+
+import kotlin.system.exitProcess
+
+const val COMMAND_NAME = "ort-server"
+
+fun main(args: Array<String>) {
+    OrtServerMain().main(args)
+    exitProcess(0)
+}
+
+class OrtServerMain : CliktCommand(COMMAND_NAME) {
+    override fun run() {
+        echo("Hello, ORT Server!")
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@ versionsPlugin = "0.51.0"
 
 # Gradle dependencies
 awsSdk = "1.3.62"
+clikt = "5.0.1"
 exposed = "0.55.0"
 flyway = "10.20.1"
 hikari = "6.0.0"
@@ -79,6 +80,7 @@ plugin-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", v
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinPlugin" }
 plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublishPlugin" }
 
+clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
 exposedCore = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
 exposedDao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed" }
 exposedJdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -25,6 +25,7 @@ rootProject.name = "ort-server"
 
 include(":api:v1:mapping")
 include(":api:v1:model")
+include(":cli")
 include(":clients:keycloak")
 include(":config:git")
 include(":config:github")


### PR DESCRIPTION
This commit introduces the new module `cli` for the ORT Server, intended to contain all upcoming implementations related to the CLI.