### PR TITLE
fix(loki): Improve handling of responses with multiple streams

### DIFF
--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -166,6 +166,7 @@ logFileService {
   lokiUsername = ${?LOKI_USERNAME}
   lokiPassword = ${?LOKI_PASSWORD}
   lokiTenantId = ${?LOKI_TENANT_ID}
+  lokiTimeoutSec = ${?LOKI_TIMEOUT_SEC}
 }
 
 micrometer {

--- a/logaccess/loki/src/main/kotlin/LokiConfig.kt
+++ b/logaccess/loki/src/main/kotlin/LokiConfig.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.logaccess.loki
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.config.Path
 import org.eclipse.apoapsis.ortserver.utils.config.getIntOrDefault
+import org.eclipse.apoapsis.ortserver.utils.config.getIntOrNull
 import org.eclipse.apoapsis.ortserver.utils.config.getStringOrNull
 
 /**
@@ -62,7 +63,13 @@ data class LokiConfig(
      * will contain an additional header `X-Scope-OrgID` with this value.
      * See https://grafana.com/docs/loki/latest/operations/authentication/.
      */
-    val tenantId: String? = null
+    val tenantId: String? = null,
+
+    /**
+     * An optional timeout for requests sent to the Loki REST API in seconds. If this is unspecified, the default
+     * timeout from the Ktor HTTP client is used.
+     */
+    val timeoutSec: Int? = null
 ) {
     companion object {
         /** The configuration property that defines the root URL of the Loki server. */
@@ -82,6 +89,9 @@ data class LokiConfig(
 
         /** The configuration property that defines the tenant ID if in multi-tenant mode. */
         private const val TENANT_PROPERTY = "lokiTenantId"
+
+        /** The configuration property that defines a timeout for queries against the Loki REST API in seconds. */
+        private const val TIMEOUT_SEC_PROPERTY = "lokiTimeoutSec"
 
         /** The default limit to be passed to the query endpoint. */
         private const val DEFAULT_LIMIT = 1000
@@ -103,7 +113,8 @@ data class LokiConfig(
                 configManager.getIntOrDefault(LIMIT_PROPERTY, DEFAULT_LIMIT),
                 username,
                 password,
-                configManager.getStringOrNull(TENANT_PROPERTY)
+                configManager.getStringOrNull(TENANT_PROPERTY),
+                configManager.getIntOrNull(TIMEOUT_SEC_PROPERTY)
             )
         }
     }

--- a/logaccess/loki/src/main/kotlin/LokiLogFileProvider.kt
+++ b/logaccess/loki/src/main/kotlin/LokiLogFileProvider.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.logaccess.loki
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.okhttp.OkHttp
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.auth.providers.BasicAuthCredentials
 import io.ktor.client.plugins.auth.providers.basic
@@ -192,6 +193,12 @@ class LokiLogFileProvider(
                         }
                         sendWithoutRequest { true }
                     }
+                }
+            }
+
+            config.timeoutSec?.also { timeout ->
+                install(HttpTimeout) {
+                    requestTimeoutMillis = timeout * 1000L
                 }
             }
 

--- a/logaccess/loki/src/test/kotlin/LokiConfigTest.kt
+++ b/logaccess/loki/src/test/kotlin/LokiConfigTest.kt
@@ -34,16 +34,18 @@ class LokiConfigTest : StringSpec({
         val username = "lokiUser"
         val password = "lokiPass"
         val tenant = "testTenant"
+        val timeout = "17"
         val configMap = mapOf(
             "lokiServerUrl" to SERVER_URL,
             "lokiNamespace" to NAMESPACE,
             "lokiQueryLimit" to limit,
             "lokiUsername" to username,
             "lokiPassword" to password,
-            "lokiTenantId" to tenant
+            "lokiTenantId" to tenant,
+            "lokiTimeoutSec" to timeout
         )
         val configManager = createConfigManager(configMap)
-        val expectedConfig = LokiConfig(SERVER_URL, NAMESPACE, limit, username, password, tenant)
+        val expectedConfig = LokiConfig(SERVER_URL, NAMESPACE, limit, username, password, tenant, timeout.toInt())
 
         val lokiConfig = LokiConfig.create(configManager)
 

--- a/logaccess/loki/src/test/resources/loki-response-multi-streams.json.template
+++ b/logaccess/loki/src/test/resources/loki-response-multi-streams.json.template
@@ -1,0 +1,121 @@
+{
+  "status": "success",
+  "data": {
+    "resultType": "streams",
+    "result": [
+      {
+        "stream": {
+          "app": "analyzer-bf2f8d68-2c5f-4d0f-a3fe-xyz",
+          "container": "analyzer-bf2f8d68-2c5f-4d0f-a3fe-xyz",
+          "filename": "/var/log/pods/some_namespace_analyzer-bf2f8d68-2c5f-4d0f-a3fe-xyz/0.log",
+          "job": "some_namespace/analyzer-bf2f8d68-2c5f-4d0f-a3fe-xyz",
+          "namespace": "some_namespace",
+          "node_name": "someNode-12345-worker-1-0-5z246",
+          "pod": "analyzer-bf2f8d68-2c5f-4d0f-a3fe-xyz-jtm9s",
+          "run_id": "276",
+          "stream": "stdout",
+          "trace_id": "bf2f8d68-2c5f-4d0f-a3fe-xyz",
+          "detected_level": "INFO"
+        },
+        "values": [
+          <<log_values_info>>
+        ]
+      },
+      {
+        "stream": {
+          "app": "analyzer-bf2f8d68-2c5f-4d0f-a3fe-xyz",
+          "container": "analyzer-bf2f8d68-2c5f-4d0f-a3fe-xyz",
+          "filename": "/var/log/pods/some_namespace_analyzer-bf2f8d68-2c5f-4d0f-a3fe-xyz/0.log",
+          "job": "some_namespace/analyzer-bf2f8d68-2c5f-4d0f-a3fe-xyz",
+          "namespace": "some_namespace",
+          "node_name": "someNode-12345-worker-1-0-5z246",
+          "pod": "analyzer-bf2f8d68-2c5f-4d0f-a3fe-xyz-jtm9s",
+          "run_id": "276",
+          "stream": "stdout",
+          "trace_id": "bf2f8d68-2c5f-4d0f-a3fe-xyz",
+          "detected_level": "DEBUG"
+        },
+        "values": [
+          <<log_values_debug>>
+        ]
+      }
+    ],
+    "stats": {
+      "summary": {
+        "bytesProcessedPerSecond": 20815,
+        "linesProcessedPerSecond": 62,
+        "totalBytesProcessed": 67298,
+        "totalLinesProcessed": 202,
+        "execTime": 3.233054,
+        "queueTime": 0.043395,
+        "subqueries": 0,
+        "totalEntriesReturned": 200,
+        "splits": 0,
+        "shards": 16
+      },
+      "querier": {
+        "store": {
+          "totalChunksRef": 1,
+          "totalChunksDownloaded": 1,
+          "chunksDownloadTime": 3219614988,
+          "chunk": {
+            "headChunkBytes": 0,
+            "headChunkLines": 0,
+            "decompressedBytes": 67298,
+            "decompressedLines": 202,
+            "compressedBytes": 21721,
+            "totalDuplicates": 0
+          }
+        }
+      },
+      "ingester": {
+        "totalReached": 48,
+        "totalChunksMatched": 0,
+        "totalBatches": 0,
+        "totalLinesSent": 0,
+        "store": {
+          "totalChunksRef": 0,
+          "totalChunksDownloaded": 0,
+          "chunksDownloadTime": 0,
+          "chunk": {
+            "headChunkBytes": 0,
+            "headChunkLines": 0,
+            "decompressedBytes": 0,
+            "decompressedLines": 0,
+            "compressedBytes": 0,
+            "totalDuplicates": 0
+          }
+        }
+      },
+      "cache": {
+        "chunk": {
+          "entriesFound": 0,
+          "entriesRequested": 1,
+          "entriesStored": 1,
+          "bytesReceived": 0,
+          "bytesSent": 29171,
+          "requests": 1,
+          "downloadTime": 7306
+        },
+        "index": {
+          "entriesFound": 0,
+          "entriesRequested": 0,
+          "entriesStored": 0,
+          "bytesReceived": 0,
+          "bytesSent": 0,
+          "requests": 0,
+          "downloadTime": 0
+        },
+        "result": {
+          "entriesFound": 0,
+          "entriesRequested": 0,
+          "entriesStored": 0,
+          "bytesReceived": 0,
+          "bytesSent": 0,
+          "requests": 0,
+          "downloadTime": 0
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
If Loki is not correctly configured, it may return multiple log streams in query responses. This is problematic because there is no defined order between the entries in different streams. Therefore, the chunking algorithm does not work and may skip log entries.

Handle this by manually sorting log entries if multiple streams are detected. This will not fix all problems, the order of log statements over multiple chunks may still be mixed up; but the risk for dropping log entries is reduced.