### PR TITLE
fix(ui): Go to first page in tables if filter or page size changes

### DIFF
--- a/ui/src/routes/_layout/admin/runs/index.tsx
+++ b/ui/src/routes/_layout/admin/runs/index.tsx
@@ -271,6 +271,7 @@ const RunsComponent = () => {
                 navigate({
                   search: {
                     ...search,
+                    page: 1,
                     status: statuses.length === 0 ? undefined : statuses,
                   },
                 });
@@ -279,7 +280,7 @@ const RunsComponent = () => {
           }
           resetFilters={() => {
             navigate({
-              search: { ...search, status: undefined },
+              search: { ...search, page: 1, status: undefined },
             });
           }}
           resetBtnVisible={status !== undefined}
@@ -296,7 +297,7 @@ const RunsComponent = () => {
           setPageSizeOptions={(size) => {
             return {
               to: Route.to,
-              search: { ...search, pageSize: size },
+              search: { ...search, page: 1, pageSize: size },
             };
           }}
         />

--- a/ui/src/routes/_layout/index.tsx
+++ b/ui/src/routes/_layout/index.tsx
@@ -128,7 +128,7 @@ export const IndexPage = () => {
           setPageSizeOptions={(size) => {
             return {
               to: Route.to,
-              search: { ...search, pageSize: size },
+              search: { ...search, page: 1, pageSize: size },
             };
           }}
         />

--- a/ui/src/routes/_layout/organizations/$orgId/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/index.tsx
@@ -312,7 +312,7 @@ const OrganizationComponent = () => {
           setPageSizeOptions={(size) => {
             return {
               to: Route.to,
-              search: { ...search, pageSize: size },
+              search: { ...search, page: 1, pageSize: size },
             };
           }}
         />

--- a/ui/src/routes/_layout/organizations/$orgId/infrastructure-services/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/infrastructure-services/index.tsx
@@ -316,7 +316,7 @@ const InfrastructureServices = () => {
           setPageSizeOptions={(size) => {
             return {
               to: Route.to,
-              search: { ...search, pageSize: size },
+              search: { ...search, page: 1, pageSize: size },
             };
           }}
         />

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/index.tsx
@@ -258,7 +258,7 @@ const ProductComponent = () => {
           setPageSizeOptions={(size) => {
             return {
               to: Route.to,
-              search: { ...search, pageSize: size },
+              search: { ...search, page: 1, pageSize: size },
             };
           }}
         />

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/vulnerabilities/index.tsx
@@ -277,7 +277,7 @@ const VulnerabilitiesComponent = () => {
             setPageSizeOptions={(size) => {
               return {
                 to: Route.to,
-                search: { ...search, pageSize: size },
+                search: { ...search, page: 1, pageSize: size },
               };
             }}
           />

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/index.tsx
@@ -346,7 +346,7 @@ const RepoComponent = () => {
           setPageSizeOptions={(size) => {
             return {
               to: Route.to,
-              search: { ...search, pageSize: size },
+              search: { ...search, page: 1, pageSize: size },
             };
           }}
         />

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/secrets/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/secrets/index.tsx
@@ -247,7 +247,7 @@ const RepositorySecrets = () => {
           setPageSizeOptions={(size) => {
             return {
               to: Route.to,
-              search: { ...search, pageSize: size },
+              search: { ...search, page: 1, pageSize: size },
             };
           }}
         />

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/secrets/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/secrets/index.tsx
@@ -244,7 +244,7 @@ const ProductSecrets = () => {
           setPageSizeOptions={(size) => {
             return {
               to: Route.to,
-              search: { ...search, pageSize: size },
+              search: { ...search, page: 1, pageSize: size },
             };
           }}
         />

--- a/ui/src/routes/_layout/organizations/$orgId/secrets/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/secrets/index.tsx
@@ -240,7 +240,7 @@ const OrganizationSecrets = () => {
           setPageSizeOptions={(size) => {
             return {
               to: Route.to,
-              search: { ...search, pageSize: size },
+              search: { ...search, page: 1, pageSize: size },
             };
           }}
         />


### PR DESCRIPTION
Set the page search parameter to one when changing the filter or the page size to prevent the event where the user could be on the nth page, and a change to the filter or page size might lead to a result where the nth page doesn't contain any items.