### PR TITLE
fix(ui): Use a space when joining ecosystems with a comma

### DIFF
--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/-components/packages-statistics-card.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/-components/packages-statistics-card.tsx
@@ -103,7 +103,7 @@ export const PackagesStatisticsCard = ({
       description={
         ecoSystems.length
           ? ecoSystems.length > 1
-            ? `from ${ecoSystems.length} ecosystems (${ecoSystems.join(`,`)})`
+            ? `from ${ecoSystems.length} ecosystems (${ecoSystems.join(', ')})`
             : `from 1 ecosystem (${ecoSystems})`
           : status
             ? ''


### PR DESCRIPTION
While at it, also use single-quotes instead of backticks for the `join` argument string as no interpolation is needed.