### PR TITLE
chore(ui): List the path after the revision

### DIFF
--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-components/evaluator-fields.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/-components/evaluator-fields.tsx
@@ -74,9 +74,7 @@ export const EvaluatorFields = ({ form }: EvaluatorFieldsProps) => {
                 </FormControl>
                 <FormDescription>
                   The path to the rules file to get from the configuration
-                  provider. Note: In case this field is left empty, the default
-                  path of the config file provider has to include a rules file,
-                  otherwise the Evaluator job will fail.
+                  provider.
                 </FormDescription>
                 <FormMessage />
               </FormItem>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/create-run.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/create-run.tsx
@@ -146,6 +146,23 @@ const CreateRunPage = () => {
             />
             <FormField
               control={form.control}
+              name='path'
+              render={({ field }) => (
+                <FormItem className='pt-4'>
+                  <FormLabel>Path</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder='(optional)' />
+                  </FormControl>
+                  <FormDescription>
+                    The path to limit the analysis to, for example
+                    'path/to/source'.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
               name='jobConfigContext'
               render={({ field }) => (
                 <FormItem className='pt-4'>
@@ -157,23 +174,6 @@ const CreateRunPage = () => {
                     The context to use when obtaining configuration for this
                     run. The meaning of the context is up for interpretation by
                     the implementation of the configuration provider.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name='path'
-              render={({ field }) => (
-                <FormItem className='pt-4'>
-                  <FormLabel>Path</FormLabel>
-                  <FormControl>
-                    <Input {...field} placeholder='(optional)' />
-                  </FormControl>
-                  <FormDescription>
-                    The path to limit the analysis to, for example
-                    'path/to/source'.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>


### PR DESCRIPTION
The path is more related to the revision (as both related to the repository) than the job configuration, so swap the order of fields to account for that.