### PR TITLE
refactor(config): Rename `DEFAULT_CONTEXT` to `EMPTY_CONTEXT`

### DIFF
--- a/config/github/src/main/kotlin/GitHubConfigFileProvider.kt
+++ b/config/github/src/main/kotlin/GitHubConfigFileProvider.kt
@@ -70,7 +70,7 @@ class GitHubConfigFileProvider(
      */
     private val baseUrl: String,
 
-    /** The default branch to be used if the default context is provided. */
+    /** The default branch to be used if no context is provided. */
     private val defaultBranch: String,
 
     /** The cache for storing already fetched configuration data. */
@@ -93,7 +93,7 @@ class GitHubConfigFileProvider(
         const val REPOSITORY_NAME = "gitHubRepositoryName"
 
         /**
-         * Configuration property that defines the default branch to be used if the user provides the default context.
+         * Configuration property that defines the default branch.
          */
         const val DEFAULT_BRANCH = "gitHubDefaultBranch"
 
@@ -224,7 +224,7 @@ class GitHubConfigFileProvider(
     }
 
     override fun resolveContext(context: Context): Context {
-        val branchName = if (context == ConfigManager.DEFAULT_CONTEXT) defaultBranch else context.name
+        val branchName = if (context == ConfigManager.EMPTY_CONTEXT) defaultBranch else context.name
         val response = sendHttpRequest("/branches/$branchName", JSON_CONTENT_TYPE_HEADER)
 
         if (!response.isPresent()) {

--- a/config/github/src/test/kotlin/GitHubConfigFileProviderTest.kt
+++ b/config/github/src/test/kotlin/GitHubConfigFileProviderTest.kt
@@ -95,12 +95,12 @@ class GitHubConfigFileProviderTest : WordSpec({
             resolvedContext.name shouldBe "0a4721665650ba7143871b22ef878e5b81c8f8b5"
         }
 
-        "resolve the default context successfully" {
+        "resolve the empty context successfully" {
             server.stubExistingRevision()
 
             val provider = getProvider()
 
-            val resolvedContext = provider.resolveContext(ConfigManager.DEFAULT_CONTEXT)
+            val resolvedContext = provider.resolveContext(ConfigManager.EMPTY_CONTEXT)
 
             resolvedContext.name shouldBe "0a4721665650ba7143871b22ef878e5b81c8f8b5"
         }

--- a/config/spi/src/main/kotlin/ConfigManager.kt
+++ b/config/spi/src/main/kotlin/ConfigManager.kt
@@ -80,11 +80,11 @@ class ConfigManager(
         const val SECRET_FROM_CONFIG_PROPERTY = "allowSecretsFromConfig"
 
         /**
-         * Constant for a default configuration context. This indicates that the user has not specified a specific
+         * Constant for an empty configuration context. This indicates that the user has not specified a specific
          * context. The concrete meaning is up to a [ConfigFileProvider] implementation; it should fall back to some
          * meaningful default.
          */
-        val DEFAULT_CONTEXT = Context("")
+        val EMPTY_CONTEXT = Context("")
 
         /** The service loader for file provider factories. */
         private val FILE_PROVIDER_LOADER = ServiceLoader.load(ConfigFileProviderFactory::class.java)
@@ -147,9 +147,9 @@ class ConfigManager(
         }
 
         /**
-         * Either return [context] if it is not *null* or the [DEFAULT_CONTEXT].
+         * Either return [context] if it is not *null* or the [EMPTY_CONTEXT].
          */
-        private fun safeContext(context: Context?): Context = context ?: DEFAULT_CONTEXT
+        private fun safeContext(context: Context?): Context = context ?: EMPTY_CONTEXT
 
         /**
          * Return the system's temporary directory.

--- a/config/spi/src/test/kotlin/ConfigManagerTest.kt
+++ b/config/spi/src/test/kotlin/ConfigManagerTest.kt
@@ -146,13 +146,13 @@ class ConfigManagerTest : WordSpec({
             resolvedContext.name shouldBe ConfigFileProviderFactoryForTesting.RESOLVED_PREFIX + context
         }
 
-        "use the default context" {
+        "use the empty context" {
             val manager = createConfigManager()
 
             val resolvedContext = manager.resolveContext(null)
 
             resolvedContext.name shouldBe ConfigFileProviderFactoryForTesting.RESOLVED_PREFIX +
-                    ConfigManager.DEFAULT_CONTEXT.name
+                    ConfigManager.EMPTY_CONTEXT.name
         }
 
         "handle exceptions from the provider" {

--- a/config/spi/src/testFixtures/kotlin/ConfigFileProviderFactoryForTesting.kt
+++ b/config/spi/src/testFixtures/kotlin/ConfigFileProviderFactoryForTesting.kt
@@ -69,7 +69,7 @@ class ConfigFileProviderFactoryForTesting : ConfigFileProviderFactory {
         checkConfigManagerSecretAccess(config, secretProvider)
 
         fun configRoot(context: Context): File =
-            if (context == ConfigManager.DEFAULT_CONTEXT) {
+            if (context == ConfigManager.EMPTY_CONTEXT) {
                 File("src/testFixtures/resources/config-files")
             } else {
                 File(context.name)


### PR DESCRIPTION
Be more specific that the constant provides an empty context, which better matches the semantics of applying a default if the empty context is provided. Previously, `DEFAULT_CONTEXT` sounded as if it already contained e.g. the default branch name.