### PR TITLE
chore: Use dedicated file matchers in tests

### DIFF
--- a/config/github/src/test/kotlin/GitHubConfigFileCacheTest.kt
+++ b/config/github/src/test/kotlin/GitHubConfigFileCacheTest.kt
@@ -22,7 +22,10 @@ package org.eclipse.apoapsis.ortserver.config.github
 import io.kotest.core.TestConfiguration
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.engine.spec.tempdir
+import io.kotest.matchers.file.aDirectory
+import io.kotest.matchers.file.exist
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
 
 import io.ktor.utils.io.ByteReadChannel
 
@@ -162,8 +165,8 @@ class GitHubConfigFileCacheTest : WordSpec({
             val cache = GitHubConfigFileCache(cacheDir, lockCheckInterval, 1, 3.days)
             cache.cleanup("current")
 
-            outdatedRevision.exists() shouldBe false
-            activeRevision.isDirectory shouldBe true
+            outdatedRevision shouldNot exist()
+            activeRevision shouldBe aDirectory()
         }
 
         "remove complete revision directories" {
@@ -185,7 +188,7 @@ class GitHubConfigFileCacheTest : WordSpec({
             val cache = GitHubConfigFileCache(cacheDir, lockCheckInterval, 1, 1.days)
             cache.cleanup("current")
 
-            revisionDir.exists() shouldBe false
+            revisionDir shouldNot exist()
         }
 
         "not remove the current revision" {
@@ -197,7 +200,7 @@ class GitHubConfigFileCacheTest : WordSpec({
             val cache = GitHubConfigFileCache(cacheDir, lockCheckInterval, 1, 1.days)
             cache.cleanup(revision)
 
-            currentRevision.exists() shouldBe true
+            currentRevision shouldBe aDirectory()
         }
 
         "remove outdated revisions with the configured ratio" {
@@ -210,11 +213,11 @@ class GitHubConfigFileCacheTest : WordSpec({
 
             repeat(ratio - 1) {
                 cache.cleanup("current")
-                revisionDir.exists() shouldBe true
+                revisionDir shouldBe aDirectory()
             }
 
             cache.cleanup("current")
-            revisionDir.exists() shouldBe false
+            revisionDir shouldNot exist()
         }
     }
 })

--- a/config/github/src/test/kotlin/GitHubConfigFileProviderTest.kt
+++ b/config/github/src/test/kotlin/GitHubConfigFileProviderTest.kt
@@ -41,8 +41,11 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.file.aDirectory
+import io.kotest.matchers.file.exist
 import io.kotest.matchers.longs.shouldBeGreaterThanOrEqual
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
 import io.kotest.matchers.string.shouldContain
 
 import io.ktor.http.HttpStatusCode
@@ -153,8 +156,8 @@ class GitHubConfigFileProviderTest : WordSpec({
             val provider = getProvider(cacheConfig)
             provider.resolveContext(Context(REVISION))
 
-            oldRevisionDir.exists() shouldBe false
-            currentRevisionDir.isDirectory shouldBe true
+            oldRevisionDir shouldNot exist()
+            currentRevisionDir shouldBe aDirectory()
         }
 
         "only clean up the cache when the default branch is processed" {
@@ -174,7 +177,7 @@ class GitHubConfigFileProviderTest : WordSpec({
             val provider = getProvider(cacheConfig)
             provider.resolveContext(Context(revision))
 
-            oldRevisionDir.exists() shouldBe true
+            oldRevisionDir shouldBe aDirectory()
         }
     }
 
@@ -206,7 +209,7 @@ class GitHubConfigFileProviderTest : WordSpec({
 
             server.allServeEvents shouldHaveSize 1
             val revisionCacheDir = cacheDir.resolve(REVISION)
-            revisionCacheDir.isDirectory shouldBe true
+            revisionCacheDir shouldBe aDirectory()
         }
 
         "throw an exception if the response has a wrong content type" {
@@ -325,7 +328,7 @@ class GitHubConfigFileProviderTest : WordSpec({
 
             server.allServeEvents shouldHaveSize 1
             val revisionCacheDir = cacheDir.resolve(REVISION)
-            revisionCacheDir.isDirectory shouldBe true
+            revisionCacheDir shouldBe aDirectory()
         }
     }
 

--- a/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
@@ -28,6 +28,7 @@ import io.kotest.engine.spec.tempdir
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.file.aFile
 import io.kotest.matchers.longs.shouldBeGreaterThan
 import io.kotest.matchers.longs.shouldBeLessThan
 import io.kotest.matchers.maps.shouldHaveSize
@@ -1352,7 +1353,7 @@ private fun logFileContent(source: LogSource): String =
  * Check whether the given [archiveFile] contains the correct logs for the given [sources].
  */
 private fun checkLogArchive(archiveFile: File, sources: Set<LogSource>) {
-    archiveFile.isFile shouldBe true
+    archiveFile shouldBe aFile()
     val currentDir = archiveFile.parentFile
 
     try {

--- a/storage/database/src/test/kotlin/LargeObjectsTest.kt
+++ b/storage/database/src/test/kotlin/LargeObjectsTest.kt
@@ -22,7 +22,9 @@ package org.eclipse.apoapsis.ortserver.storage.database
 import io.kotest.core.spec.Spec
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.engine.spec.tempdir
+import io.kotest.matchers.file.exist
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
 import io.kotest.matchers.types.shouldBeInstanceOf
 
 import io.mockk.every
@@ -80,7 +82,7 @@ class LargeObjectsTest : WordSpec({
             val stream = TempFileInputStream(file)
             stream.close()
 
-            file.exists() shouldBe false
+            file shouldNot exist()
         }
     }
 

--- a/storage/spi/src/test/kotlin/StorageEntryTest.kt
+++ b/storage/spi/src/test/kotlin/StorageEntryTest.kt
@@ -20,8 +20,11 @@
 package org.eclipse.apoapsis.ortserver.storage
 
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.paths.aFile
+import io.kotest.matchers.paths.exist
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
 
 import io.mockk.every
 import io.mockk.just
@@ -32,7 +35,6 @@ import io.mockk.verify
 import java.io.InputStream
 
 import kotlin.io.path.createTempFile
-import kotlin.io.path.exists
 
 class StorageEntryTest : StringSpec({
     "create" should {
@@ -41,11 +43,11 @@ class StorageEntryTest : StringSpec({
 
             val entry = StorageEntry.create(tempFile.toFile(), "some-content")
 
-            tempFile.exists() shouldBe true
+            tempFile shouldBe aFile()
 
             entry.close()
 
-            tempFile.exists() shouldBe false
+            tempFile shouldNot exist()
         }
 
         "create an object with an input stream" {

--- a/workers/common/src/test/kotlin/common/context/WorkerContextFactoryTest.kt
+++ b/workers/common/src/test/kotlin/common/context/WorkerContextFactoryTest.kt
@@ -27,11 +27,14 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.file.aDirectory
+import io.kotest.matchers.file.exist
 import io.kotest.matchers.maps.beEmpty as beEmptyMap
 import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.maps.shouldHaveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
 import io.kotest.matchers.shouldNotBe
 
 import io.mockk.every
@@ -109,7 +112,7 @@ class WorkerContextFactoryTest : WordSpec({
                 val dir1 = context.createTempDir()
                 val dir2 = context.createTempDir()
 
-                dir1.isDirectory shouldBe true
+                dir1 shouldBe aDirectory()
                 dir1 shouldNotBe dir2
             }
         }
@@ -127,7 +130,7 @@ class WorkerContextFactoryTest : WordSpec({
                 dir
             }
 
-            tempDir.exists() shouldBe false
+            tempDir shouldNot exist()
         }
     }
 

--- a/workers/reporter/src/test/kotlin/reporter/ReporterRunnerTest.kt
+++ b/workers/reporter/src/test/kotlin/reporter/ReporterRunnerTest.kt
@@ -27,6 +27,7 @@ import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.file.aDirectory
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
@@ -670,7 +671,7 @@ class ReporterRunnerTest : WordSpec({
                     null
                 } else {
                     dir.parentFile shouldBe configDirectory
-                    dir.isDirectory shouldBe true
+                    dir shouldBe aDirectory()
                     dir.name
                 }
                 downloadedAssets += ReporterAsset(path, relativeDir, thirdArg())
@@ -714,7 +715,7 @@ class ReporterRunnerTest : WordSpec({
             coEvery { context.downloadConfigurationDirectory(any(), any()) } answers {
                 val path = Path(firstArg<String>())
                 val dir = secondArg<File>()
-                dir.isDirectory shouldBe true
+                dir shouldBe aDirectory()
                 downloadedAssets[path] = dir
                 mapOf(path to File(path.path))
             }

--- a/workers/reporter/src/test/kotlin/reporter/SourceCodeBundleReporterTest.kt
+++ b/workers/reporter/src/test/kotlin/reporter/SourceCodeBundleReporterTest.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.workers.reporter
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.collections.shouldBeSingleton
+import io.kotest.matchers.file.exist
 import io.kotest.matchers.file.shouldContainFile
 import io.kotest.matchers.file.shouldContainNFiles
 import io.kotest.matchers.maps.containAnyKeys
@@ -30,6 +31,7 @@ import io.kotest.matchers.result.shouldBeSuccess
 import io.kotest.matchers.sequences.beEmpty
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
 import io.kotest.matchers.types.beInstanceOf
 
 import io.mockk.every
@@ -150,7 +152,7 @@ class SourceCodeBundleReporterTest : WordSpec({
                 it.shouldBeFailure<DownloadException>()
             }
 
-            bundleTmpOutputDir.exists() shouldBe false
+            bundleTmpOutputDir shouldNot exist()
             outputDir.walk().maxDepth(1).filter { it.isFile } should beEmpty()
         }
 


### PR DESCRIPTION
Be indeterminate when checking for a file to not exist, and specific when checking for existence.