### PR TITLE
ui: Timestamps with additional UTC information

### DIFF
--- a/ui/src/components/timestamp-with-utc.tsx
+++ b/ui/src/components/timestamp-with-utc.tsx
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { formatTimestamp } from '@/lib/utils.ts';
+
+type TimestampWithUTCProps = {
+  timestamp: string;
+  timeZone?: string | undefined;
+  locales?: Intl.LocalesArgument | undefined;
+  className?: string;
+};
+
+export const TimestampWithUTC = ({
+  timestamp,
+  timeZone,
+  locales,
+  className,
+}: TimestampWithUTCProps) => {
+  return (
+    <Tooltip>
+      <TooltipTrigger className={className}>
+        {formatTimestamp(timestamp, timeZone, locales)}
+      </TooltipTrigger>
+      <TooltipContent>{new Date(timestamp).toUTCString()}</TooltipContent>
+    </Tooltip>
+  );
+};

--- a/ui/src/routes/_layout/admin/runs/index.tsx
+++ b/ui/src/routes/_layout/admin/runs/index.tsx
@@ -39,6 +39,7 @@ import { FilterMultiSelect } from '@/components/data-table/filter-multi-select';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { OrtRunJobStatus } from '@/components/ort-run-job-status';
 import { RunDuration } from '@/components/run-duration';
+import { TimestampWithUTC } from '@/components/timestamp-with-utc';
 import { ToastError } from '@/components/toast-error';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -57,7 +58,6 @@ import {
 import { config } from '@/config';
 import { getStatusBackgroundColor } from '@/helpers/get-status-class';
 import { toast } from '@/lib/toast';
-import { formatTimestamp } from '@/lib/utils';
 import { ortRunStatus, paginationSchema, statusSchema } from '@/schemas';
 
 const defaultPageSize = 10;
@@ -124,14 +124,14 @@ const columns = [
   }),
   columnHelper.accessor('createdAt', {
     header: 'Created At',
-    cell: ({ row }) => <>{formatTimestamp(row.original.createdAt)}</>,
+    cell: ({ row }) => <TimestampWithUTC timestamp={row.original.createdAt} />,
     size: 95,
   }),
   columnHelper.accessor('finishedAt', {
     header: 'Finished At',
     cell: ({ row }) =>
       row.original.finishedAt ? (
-        <>{formatTimestamp(row.original.finishedAt)}</>
+        <TimestampWithUTC timestamp={row.original.finishedAt} />
       ) : (
         <span className='italic'>Not finished yet</span>
       ),

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/-components/last-run-date.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/-components/last-run-date.tsx
@@ -20,8 +20,8 @@
 import { Loader2 } from 'lucide-react';
 
 import { useRepositoriesServiceGetOrtRunsByRepositoryId } from '@/api/queries';
+import { TimestampWithUTC } from '@/components/timestamp-with-utc';
 import { config } from '@/config';
-import { formatTimestamp } from '@/lib/utils.ts';
 
 export const LastRunDate = ({ repoId }: { repoId: number }) => {
   const {
@@ -64,9 +64,9 @@ export const LastRunDate = ({ repoId }: { repoId: number }) => {
   return (
     <>
       {run.finishedAt ? (
-        <div>{formatTimestamp(run.finishedAt)}</div>
+        <TimestampWithUTC timestamp={run.finishedAt} />
       ) : (
-        <div className='italic'>{formatTimestamp(run.createdAt)}</div>
+        <TimestampWithUTC className='italic' timestamp={run.createdAt} />
       )}
     </>
   );

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/index.tsx
@@ -24,6 +24,7 @@ import { prefetchUseRepositoriesServiceGetOrtRunByIndex } from '@/api/queries/pr
 import { useRepositoriesServiceGetOrtRunByIndexSuspense } from '@/api/queries/suspense';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { OrtRunJobStatus } from '@/components/ort-run-job-status';
+import { TimestampWithUTC } from '@/components/timestamp-with-utc';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -37,7 +38,6 @@ import { Label } from '@/components/ui/label';
 import { config } from '@/config';
 import { calculateDuration } from '@/helpers/get-run-duration';
 import { getStatusBackgroundColor } from '@/helpers/get-status-class';
-import { formatTimestamp } from '@/lib/utils.ts';
 import { IssuesStatisticsCard } from './-components/issues-statistics-card';
 import { PackagesStatisticsCard } from './-components/packages-statistics-card';
 import { RuleViolationsStatisticsCard } from './-components/rule-violations-statistics-card';
@@ -117,13 +117,13 @@ const RunComponent = () => {
               </div>
               <div className='text-sm'>
                 <Label className='font-semibold'>Created at:</Label>{' '}
-                {formatTimestamp(ortRun.createdAt)}
+                <TimestampWithUTC timestamp={ortRun.createdAt} />
               </div>
               {ortRun.finishedAt && (
                 <div>
                   <div className='text-sm'>
                     <Label className='font-semibold'>Finished at:</Label>{' '}
-                    {formatTimestamp(ortRun.finishedAt)}
+                    <TimestampWithUTC timestamp={ortRun.finishedAt} />
                   </div>
                   <div className='text-sm'>
                     <Label className='font-semibold'>Duration:</Label>{' '}

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/issues/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/_layout/runs/$runIndex/issues/index.tsx
@@ -38,6 +38,7 @@ import { DataTable } from '@/components/data-table/data-table';
 import { DataTableToolbar } from '@/components/data-table/data-table-toolbar';
 import { FilterMultiSelect } from '@/components/data-table/filter-multi-select';
 import { LoadingIndicator } from '@/components/loading-indicator';
+import { TimestampWithUTC } from '@/components/timestamp-with-utc';
 import { ToastError } from '@/components/toast-error';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -50,7 +51,6 @@ import {
 } from '@/components/ui/card';
 import { getIssueSeverityBackgroundColor } from '@/helpers/get-status-class';
 import { toast } from '@/lib/toast';
-import { formatTimestamp } from '@/lib/utils.ts';
 import {
   issueSeverity,
   issueSeveritySchema,
@@ -135,7 +135,7 @@ const renderSubComponent = ({ row }: { row: Row<Issue> }) => {
     <div className='flex flex-col gap-4'>
       <div className='flex gap-1 text-sm'>
         <div className='font-semibold'>Created at</div>
-        <div>{formatTimestamp(issue.timestamp)}</div>
+        <TimestampWithUTC timestamp={issue.timestamp} />
         <div>by</div>
         <div className='font-semibold'>{issue.worker}</div>
       </div>

--- a/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/index.tsx
+++ b/ui/src/routes/_layout/organizations/$orgId/products/$productId/repositories/$repoId/index.tsx
@@ -40,6 +40,7 @@ import { DeleteDialog } from '@/components/delete-dialog';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { OrtRunJobStatus } from '@/components/ort-run-job-status';
 import { RunDuration } from '@/components/run-duration';
+import { TimestampWithUTC } from '@/components/timestamp-with-utc';
 import { ToastError } from '@/components/toast-error';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -58,7 +59,6 @@ import {
 import { config } from '@/config';
 import { getStatusBackgroundColor } from '@/helpers/get-status-class';
 import { toast } from '@/lib/toast';
-import { formatTimestamp } from '@/lib/utils.ts';
 import { paginationSchema } from '@/schemas';
 
 const defaultPageSize = 10;
@@ -89,7 +89,7 @@ const columns: ColumnDef<GetOrtRunsByRepositoryIdResponse['data'][number]>[] = [
   {
     accessorKey: 'createdAt',
     header: () => <div>Created At</div>,
-    cell: ({ row }) => <div>{formatTimestamp(row.original.createdAt)}</div>,
+    cell: ({ row }) => <TimestampWithUTC timestamp={row.original.createdAt} />,
   },
   {
     accessorKey: 'runStatus',


### PR DESCRIPTION
Please have a look at the individual commits for details.

![Screenshot from 2024-11-06 14-38-42](https://github.com/user-attachments/assets/cf561e0a-e43c-4cb4-9c1a-6545e16e493c)

![Screenshot from 2024-11-06 14-38-24](https://github.com/user-attachments/assets/225d6bda-646b-4932-ac7f-05f5416c48c3)

![Screenshot from 2024-11-06 14-38-42](https://github.com/user-attachments/assets/5034d516-d527-4db1-9488-cf5b523eb0a6)
