### PR TITLE
chore(dao): Split the `parse` function of the `EnvironmentConfigLoader`

### DIFF
--- a/workers/common/src/main/kotlin/common/env/EnvironmentService.kt
+++ b/workers/common/src/main/kotlin/common/env/EnvironmentService.kt
@@ -101,7 +101,7 @@ class EnvironmentService(
         repositoryService: InfrastructureService?
     ): ResolvedEnvironmentConfig {
         val environmentConfigPath = context.ortRun.environmentConfigPath
-        val mergedConfig = configLoader.parse(repositoryFolder, environmentConfigPath).merge(config)
+        val mergedConfig = configLoader.resolveAndParse(repositoryFolder, environmentConfigPath).merge(config)
         val resolvedConfig = configLoader.resolve(mergedConfig, context.hierarchy)
 
         return setUpEnvironmentForConfig(context, resolvedConfig, repositoryService)

--- a/workers/common/src/main/kotlin/common/env/config/EnvironmentConfigLoader.kt
+++ b/workers/common/src/main/kotlin/common/env/config/EnvironmentConfigLoader.kt
@@ -111,8 +111,8 @@ class EnvironmentConfigLoader(
      * cause exceptions to be thrown. Semantic errors are handled according to the `strict` flag.
      */
     fun resolveAndParse(repositoryFolder: File, environmentConfigPath: String? = null): EnvironmentConfig =
-        resolveEnvironmentFile(repositoryFolder, environmentConfigPath)?.let { config ->
-            parse(config)
+        resolveEnvironmentConfigFile(repositoryFolder, environmentConfigPath)?.let { config ->
+            parseEnvironmentConfigFile(config)
         } ?: EnvironmentConfig()
 
     /**
@@ -120,7 +120,7 @@ class EnvironmentConfigLoader(
      * the given file path does not exist or is 'null', the default file path `.ort.env.yml` is used instead. Return the
      * resolved file.
      */
-    internal fun resolveEnvironmentFile(repositoryFolder: File, environmentConfigPath: String? = null): File? {
+    internal fun resolveEnvironmentConfigFile(repositoryFolder: File, environmentConfigPath: String? = null): File? {
         val customEnvironmentConfigFile = environmentConfigPath?.let {
             repositoryFolder.resolve(it).takeIf { file -> file.isFile }.alsoIfNull {
                 logger.warn("Custom environment configuration file '$environmentConfigPath' not found.")
@@ -139,12 +139,13 @@ class EnvironmentConfigLoader(
     }
 
     /**
-     * Parse the environment configuration file [configFile] and return the content as an [ResolvedEnvironmentConfig].
+     * Parse the environment configuration file [environmentConfigFile] and return the content as an
+     * [ResolvedEnvironmentConfig].
      */
-    internal fun parse(configFile: File): EnvironmentConfig {
-        logger.info("Parsing environment configuration file '{}'.", configFile)
+    internal fun parseEnvironmentConfigFile(environmentConfigFile: File): EnvironmentConfig {
+        logger.info("Parsing environment configuration file '{}'.", environmentConfigFile)
 
-        return configFile.inputStream().use { stream ->
+        return environmentConfigFile.inputStream().use { stream ->
             Yaml.default.decodeFromStream(EnvironmentConfig.serializer(), stream)
         }
     }

--- a/workers/common/src/test/kotlin/common/env/EnvironmentServiceTest.kt
+++ b/workers/common/src/test/kotlin/common/env/EnvironmentServiceTest.kt
@@ -575,7 +575,7 @@ private fun mockConfigLoader(config: ResolvedEnvironmentConfig): EnvironmentConf
     every { envConfig.merge(any()) } returns envConfig
 
     return mockk<EnvironmentConfigLoader> {
-        every { parse(repositoryFolder) } returns envConfig
+        every { resolveAndParse(repositoryFolder) } returns envConfig
         every { resolve(any(), repositoryHierarchy) } returns config
     }
 }
@@ -594,7 +594,7 @@ private fun mockConfigLoader(
     every { mockConfig.merge(envConfig) } returns envConfig
 
     return mockk {
-        every { parse(repositoryFolder) } returns mockConfig
+        every { resolveAndParse(repositoryFolder) } returns mockConfig
         every { resolve(envConfig, repositoryHierarchy) } returns resultConfig
     }
 }


### PR DESCRIPTION
This function was doing too many things. To simplify the tests, this commit breaks it up in two subfunctions.