### PR TITLE
build(Gradle): Enable parallel configuration cache access

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -17,11 +17,6 @@
  * License-Filename: LICENSE
  */
 
-import org.gradle.accessors.dm.LibrariesForLibs
-
-private val Project.libs: LibrariesForLibs
-    get() = extensions.getByType()
-
 plugins {
     // Use Kotlin DSL to write precompiled script plugins.
     `kotlin-dsl`

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,6 +17,7 @@
 
 org.gradle.caching = true
 org.gradle.configuration-cache = true
+org.gradle.configuration-cache.parallel = true
 org.gradle.jvmargs = -Xmx2g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
 org.gradle.kotlin.dsl.allWarningsAsErrors = true
 org.gradle.parallel = true


### PR DESCRIPTION
This should reduce time to configure builds, see [1].

[1]: https://docs.gradle.org/8.11/release-notes.html#configuration-cache-improvements