### PR TITLE
ci: Fix variable reference in Docker build

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -121,7 +121,7 @@ jobs:
           type=raw,value=${{ env.ORT_SERVER_VERSION }}
           type=ref,event=branch
           type=sha
-          type=raw,value=latest,enable=${{ is_default_branch }}
+          type=raw,value=latest,enable={{ is_default_branch }}
 
     - name: Build ${{ matrix.docker.image }} Image
       if: ${{ matrix.docker.dockerfile != '' }}
@@ -144,7 +144,7 @@ jobs:
           type=raw,value=${{ env.ORT_SERVER_VERSION }}
           type=ref,event=branch
           type=sha
-          type=raw,value=latest,enable=${{ is_default_branch}}
+          type=raw,value=latest,enable={{ is_default_branch }}
 
     - name: Build ${{ matrix.docker.jibImage }} Image
       if: ${{ matrix.docker.task != '' }}


### PR DESCRIPTION
The pattern `${{ is_default_branch }}` attempts to get a GitHub Actions
provided named value, but the default branch status is provided by the
Docker Metadata Action as a global expression to be used with Handlebars'
template format [1].

[1]: https://github.com/marketplace/actions/docker-metadata-action#global-expressions

Signed-off-by: Mikko Murto <mikko.murto@doubleopen.org>