### PR TITLE
Deduplicate scan results

### DIFF
--- a/dao/src/main/kotlin/tables/ScanResultsTable.kt
+++ b/dao/src/main/kotlin/tables/ScanResultsTable.kt
@@ -37,6 +37,8 @@ import org.jetbrains.exposed.dao.LongEntity
 import org.jetbrains.exposed.dao.LongEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.LongIdTable
+import org.jetbrains.exposed.sql.ISqlExpressionBuilder
+import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.and
 
 /**
@@ -58,19 +60,21 @@ object ScanResultsTable : LongIdTable("scan_results") {
 
 class ScanResultDao(id: EntityID<Long>) : LongEntity(id) {
     companion object : LongEntityClass<ScanResultDao>(ScanResultsTable) {
-        fun findByRemoteArtifact(artifact: RemoteArtifact) =
-            find {
-                ScanResultsTable.artifactUrl eq artifact.url and
-                        (ScanResultsTable.artifactHash eq artifact.hashValue) and
-                        (ScanResultsTable.artifactHashAlgorithm eq artifact.hashAlgorithm)
-            }
+        /**
+         * Return an expression that encapsulates the condition that the scan result matches the given [artifact].
+         */
+        fun ISqlExpressionBuilder.matchesRemoteArtifact(artifact: RemoteArtifact): Op<Boolean> =
+            (ScanResultsTable.artifactUrl eq artifact.url) and
+                    (ScanResultsTable.artifactHash eq artifact.hashValue) and
+                    (ScanResultsTable.artifactHashAlgorithm eq artifact.hashAlgorithm)
 
-        fun findByVcsInfo(vcs: VcsInfo) =
-            find {
-                ScanResultsTable.vcsType eq vcs.type.name and
-                        (ScanResultsTable.vcsUrl eq vcs.url) and
-                        (ScanResultsTable.vcsRevision eq vcs.revision)
-            }
+        /**
+         * Return an expression that encapsulates the condition that the scan result matches the given [vcs].
+         */
+        fun ISqlExpressionBuilder.matchesVcsInfo(vcs: VcsInfo): Op<Boolean> =
+            (ScanResultsTable.vcsType eq vcs.type.name) and
+                    (ScanResultsTable.vcsUrl eq vcs.url) and
+                    (ScanResultsTable.vcsRevision eq vcs.revision)
     }
 
     var artifactUrl by ScanResultsTable.artifactUrl

--- a/dao/src/main/kotlin/utils/utils/JsonHashFunction.kt
+++ b/dao/src/main/kotlin/utils/utils/JsonHashFunction.kt
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.dao.utils.utils
+
+import org.jetbrains.exposed.sql.CustomFunction
+import org.jetbrains.exposed.sql.Expression
+import org.jetbrains.exposed.sql.QueryBuilder
+import org.jetbrains.exposed.sql.TextColumnType
+
+/**
+ * A custom function to calculate a hash value on a JSONB column. This is used for querying JSON data in a functional
+ * index.
+ */
+class JsonHashFunction(
+    private val expression: Expression<*>
+) : CustomFunction<String>("jsonb_hash_extended", TextColumnType()) {
+    override fun toQueryBuilder(queryBuilder: QueryBuilder) = queryBuilder {
+        append("jsonb_hash_extended(")
+        expression.toQueryBuilder(this)
+        append(", 0)")
+    }
+}

--- a/dao/src/main/resources/db/migration/V87__deduplicateScanResults.sql
+++ b/dao/src/main/resources/db/migration/V87__deduplicateScanResults.sql
@@ -1,0 +1,128 @@
+-- This migration script deduplicates the scan_results table. Duplicates were possible in the past since all FossID
+-- results have been stored without checking whether there is already a result with identical properties. Also, due to
+-- a race condition when multiple ORT runs process the same packages concurrently, duplicates for other scanners could
+-- have been created. After the deduplication, it is possible to again reintroduce unique constraints on the
+-- scan_results table, which had been removed in migration 47.
+
+-- Temporary function for assigning hash values to scan results based on their properties.
+CREATE FUNCTION scan_result_hash(bigint) RETURNS text AS $$
+DECLARE
+  hash text;
+BEGIN
+    SELECT
+      encode(sha256(convert_to(concat(
+        sr.artifact_url,
+        sr.artifact_hash,
+        sr.artifact_hash_algorithm,
+        sr.vcs_type,
+        sr.vcs_url,
+        sr.vcs_revision,
+        sr.scanner_name,
+        sr.scanner_version,
+        sr.scanner_configuration,
+        jsonb_hash_extended( sr.additional_data, 0)
+      ), 'UTF8')),
+        'hex')
+    FROM scan_results sr
+    WHERE sr.id = $1
+    INTO hash;
+
+    RETURN hash;
+EXCEPTION WHEN others THEN
+    RETURN NULL;
+END;
+$$
+STRICT
+LANGUAGE plpgsql IMMUTABLE;
+
+-- A temporary view that assigns hash values to all scan_results.
+CREATE VIEW scan_results_with_hashes as
+SELECT
+  sr.id,
+  scan_result_hash(sr.id) hash
+FROM scan_results sr;
+
+-- A temporary table to hold the IDs of the remaining deduplicated scan_results.
+CREATE TABLE scan_results_dedup
+(
+    id bigserial PRIMARY KEY
+);
+
+INSERT INTO scan_results_dedup
+SELECT
+  MIN(sr.id)
+FROM scan_results_with_hashes sr
+GROUP BY sr.hash;
+
+-- Create link tables that use hashes to reference issues.
+
+CREATE TABLE scanner_runs_scan_results_hashes
+(
+    scanner_run_id   bigint NOT NULL,
+    scan_result_hash text   NOT NULL
+);
+
+INSERT INTO scanner_runs_scan_results_hashes
+SELECT
+  sr.scanner_run_id,
+  srh.hash
+FROM scanner_runs_scan_results sr
+INNER JOIN scan_results_with_hashes srh on sr.scan_result_id = srh.id;
+
+-- Delete duplicates.
+
+DELETE FROM scanner_runs_scan_results;
+
+-- Create a temporary foreign key index. This is needed, otherwise, the following DELETE statement would take
+-- very long.
+CREATE INDEX scanner_runs_scan_results_fkey
+    ON scanner_runs_scan_results (scan_result_id);
+
+DELETE FROM scan_results
+WHERE id NOT IN (
+  SELECT sd.id
+  FROM scan_results_dedup sd
+);
+
+DROP INDEX scanner_runs_scan_results_fkey;
+
+-- Recreate link tables.
+
+INSERT INTO scanner_runs_scan_results
+SELECT DISTINCT
+  srs.scanner_run_id,
+  srh.id
+FROM scanner_runs_scan_results_hashes srs
+INNER JOIN scan_results_with_hashes srh on srs.scan_result_hash = srh.hash;
+
+-- Cleanup.
+
+DROP VIEW scan_results_with_hashes;
+
+DROP TABLE scan_results_dedup;
+
+DROP TABLE scanner_runs_scan_results_hashes;
+
+DROP FUNCTION scan_result_hash;
+
+-- Reintroduce unique indexes.
+
+CREATE UNIQUE INDEX on scan_results(
+    artifact_url,
+    artifact_hash,
+    artifact_hash_algorithm,
+    scanner_name,
+    scanner_version,
+    scanner_configuration,
+    jsonb_hash_extended(additional_data, 0)
+);
+
+CREATE UNIQUE INDEX on scan_results(
+    vcs_type,
+    vcs_url,
+    vcs_revision,
+    scanner_name,
+    scanner_version,
+    scanner_configuration,
+    jsonb_hash_extended(additional_data, 0)
+);

--- a/workers/scanner/build.gradle.kts
+++ b/workers/scanner/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     implementation(projects.utils.logging)
     implementation(projects.workers.common)
 
+    implementation(libs.kotlinxSerializationJson)
     implementation(libs.ortScanner)
     implementation(libs.typesafeConfig)
 


### PR DESCRIPTION
This PR prevents that duplicate scan results are stored if multiple scanner workers are run in parallel. It contains a migration that cleans up existing duplicates and introduces unique constraints. Note that the migration will take a while on larger databases (50 minutes in our setup).