### PR TITLE
refactor(reporter): Do not download all license texts at once

### DIFF
--- a/model/src/commonMain/kotlin/JobConfigurations.kt
+++ b/model/src/commonMain/kotlin/JobConfigurations.kt
@@ -334,8 +334,8 @@ data class ReporterJobConfiguration(
     val resolutionsFile: String? = null,
 
     /**
-     * An optional path to a configuration directory containing custom license texts. If defined, all files from this
-     * directory are downloaded and made available via a `DefaultLicenseTextProvider` instance.
+     * An optional path to a configuration directory containing custom license texts. If defined, files from this
+     * directory are accessed by a `DefaultLicenseTextProvider` instance.
      */
     val customLicenseTextDir: String? = null,
 

--- a/workers/reporter/src/main/kotlin/reporter/LoggingLicenseTextProvider.kt
+++ b/workers/reporter/src/main/kotlin/reporter/LoggingLicenseTextProvider.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package reporter
+
+import java.io.File
+
+import kotlin.time.measureTimedValue
+
+import org.ossreviewtoolkit.reporter.DefaultLicenseTextProvider
+import org.ossreviewtoolkit.reporter.LicenseTextProvider
+
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger(LoggingLicenseTextProvider::class.java)
+
+/**
+ * A [LicenseTextProvider] that delegates to a [DefaultLicenseTextProvider] and logs the time it takes to query the
+ * license text file.
+ */
+class LoggingLicenseTextProvider(private val licenseTextDirectory: File) : LicenseTextProvider {
+    private val delegate: DefaultLicenseTextProvider = DefaultLicenseTextProvider(listOf(licenseTextDirectory))
+
+    override fun getLicenseTextReader(licenseId: String): (() -> String)? {
+        logger.debug("Get custom license text for '$licenseId' from '${licenseTextDirectory.absolutePath}'.")
+
+        val measurement = measureTimedValue {
+            delegate.getLicenseTextReader(licenseId)
+        }
+
+        logger.debug("Custom license text for '$licenseId' accessed in ${measurement.duration}.")
+
+        return measurement.value
+    }
+}

--- a/workers/reporter/src/test/kotlin/reporter/ReporterRunnerTest.kt
+++ b/workers/reporter/src/test/kotlin/reporter/ReporterRunnerTest.kt
@@ -733,11 +733,10 @@ class ReporterRunnerTest : WordSpec({
 
             val customLicenseText = "This is a custom license."
             val licenseId = "LicenseRef-Test-License"
-            val customLicenseTextFile = configDirectory.resolve(licenseId).also { it.writeText(customLicenseText) }
-            val customLicenseTextsPath = "custom-license-texts"
+            configDirectory.resolve(licenseId).also { it.writeText(customLicenseText) }
             val jobConfig = ReporterJobConfiguration(
                 formats = listOf(format),
-                customLicenseTextDir = customLicenseTextsPath
+                customLicenseTextDir = configDirectory.absolutePath
             )
 
             val resolvedContext = Context("theResolvedContext")
@@ -745,9 +744,6 @@ class ReporterRunnerTest : WordSpec({
             val (contextFactory, context) = mockContext()
             every { context.ortRun.resolvedJobConfigContext } returns resolvedContext.name
             every { context.configManager } returns configManager
-            coEvery { context.downloadConfigurationDirectory(Path(customLicenseTextsPath), any()) } returns mapOf(
-                Path(customLicenseTextsPath) to customLicenseTextFile
-            )
 
             val runner = ReporterRunner(
                 mockk(relaxed = true),


### PR DESCRIPTION
The runner currently downloads all the license texts to a temporary directory and builds a `LicenseTextProvider` for it. This is unoptimal because not all of these texts may be needed and they can be hosted on a network share (NFS).
This commit adapts the logic to only access the requested license text files.