### PR TITLE
fix(scanner): Add missing configuration properties for S3 storage

### DIFF
--- a/workers/scanner/src/main/resources/application.conf
+++ b/workers/scanner/src/main/resources/application.conf
@@ -90,4 +90,9 @@ fileListStorage {
   namespace = ${?FILE_LIST_STORAGE_NAMESPACE}
   inMemoryLimit = 1048576
   inMemoryLimit = ${?FILE_LIST_STORAGE_IN_MEMORY_LIMIT}
+  s3AccessKey = ${?FILE_LIST_STORAGE_ACCESS_KEY}
+  s3SecretKey = ${?FILE_LIST_STORAGE_SECRET_KEY}
+  s3Region = ${?FILE_LIST_STORAGE_REGION}
+  s3BucketName = ${?FILE_LIST_STORAGE_BUCKET_NAME}
+  s3EndpointUrl = ${?FILE_LIST_STORAGE_ENDPOINT_URL}
 }


### PR DESCRIPTION
Add the missing configuration properties to use S3 as file list storage.