### PR TITLE
feat(core): Add REST API endpoint to delete ORT run

### DIFF
--- a/core/src/main/kotlin/api/RepositoriesRoute.kt
+++ b/core/src/main/kotlin/api/RepositoriesRoute.kt
@@ -42,6 +42,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.SortProperty
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateRepository
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateSecret
 import org.eclipse.apoapsis.ortserver.api.v1.model.Username
+import org.eclipse.apoapsis.ortserver.core.apiDocs.deleteOrtRunByIndex
 import org.eclipse.apoapsis.ortserver.core.apiDocs.deleteRepositoryById
 import org.eclipse.apoapsis.ortserver.core.apiDocs.deleteSecretByRepositoryIdAndName
 import org.eclipse.apoapsis.ortserver.core.apiDocs.deleteUserFromRepositoryGroup
@@ -62,6 +63,7 @@ import org.eclipse.apoapsis.ortserver.core.utils.requireIdParameter
 import org.eclipse.apoapsis.ortserver.core.utils.requireParameter
 import org.eclipse.apoapsis.ortserver.model.Secret
 import org.eclipse.apoapsis.ortserver.model.authorization.RepositoryPermission
+import org.eclipse.apoapsis.ortserver.services.OrtRunService
 import org.eclipse.apoapsis.ortserver.services.RepositoryService
 import org.eclipse.apoapsis.ortserver.services.SecretService
 
@@ -69,6 +71,7 @@ import org.koin.ktor.ext.inject
 
 fun Route.repositories() = route("repositories/{repositoryId}") {
     val orchestratorService by inject<OrchestratorService>()
+    val ortRunService by inject<OrtRunService>()
     val repositoryService by inject<RepositoryService>()
     val secretService by inject<SecretService>()
 
@@ -150,6 +153,16 @@ fun Route.repositories() = route("repositories/{repositoryId}") {
                         call.respond(HttpStatusCode.OK, it.mapToApi(jobs.mapToApi()))
                     }
                 } ?: call.respond(HttpStatusCode.NotFound)
+            }
+
+            delete(deleteOrtRunByIndex) { _ ->
+                requirePermission(RepositoryPermission.DELETE)
+
+                val repositoryId = call.requireIdParameter("repositoryId")
+                val ortRunIndex = call.requireIdParameter("ortRunIndex")
+
+                ortRunService.deleteOrtRun(repositoryId, ortRunIndex)
+                call.respond(HttpStatusCode.NoContent)
             }
         }
     }

--- a/core/src/main/kotlin/api/RunsRoute.kt
+++ b/core/src/main/kotlin/api/RunsRoute.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.apoapsis.ortserver.core.api
 
+import io.github.smiley4.ktorswaggerui.dsl.routing.delete
 import io.github.smiley4.ktorswaggerui.dsl.routing.get
 
 import io.ktor.http.ContentDisposition
@@ -46,6 +47,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatistics
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatus
 import org.eclipse.apoapsis.ortserver.api.v1.model.SortDirection
 import org.eclipse.apoapsis.ortserver.api.v1.model.SortProperty
+import org.eclipse.apoapsis.ortserver.core.apiDocs.deleteOrtRunById
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getIssuesByRunId
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getLogsByRunId
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getOrtRunById
@@ -128,6 +130,17 @@ fun Route.runs() = route("runs") {
                 repositoryService.getJobs(ortRun.repositoryId, ortRun.index)?.let { jobs ->
                     call.respond(HttpStatusCode.OK, ortRun.mapToApi(jobs.mapToApi()))
                 }
+            } ?: call.respond(HttpStatusCode.NotFound)
+        }
+
+        delete(deleteOrtRunById) { _ ->
+            val ortRunId = call.requireIdParameter("runId")
+
+            ortRunRepository.get(ortRunId)?.let { ortRun ->
+                requirePermission(RepositoryPermission.DELETE.roleName(ortRun.repositoryId))
+
+                ortRunService.deleteOrtRun(ortRunId)
+                call.respond(HttpStatusCode.NoContent)
             } ?: call.respond(HttpStatusCode.NotFound)
         }
 

--- a/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
@@ -502,6 +502,32 @@ val getOrtRunByIndex: OpenApiRoute.() -> Unit = {
     }
 }
 
+val deleteOrtRunByIndex: OpenApiRoute.() -> Unit = {
+    operationId = "deleteOrtRunByIndex"
+    summary = "Delete an ORT run of a repository."
+    tags = listOf("Repositories")
+
+    request {
+        pathParameter<Long>("repositoryId") {
+            description = "The repository's ID."
+        }
+
+        pathParameter<Long>("ortRunIndex") {
+            description = "The index of an ORT run."
+        }
+    }
+
+    response {
+        HttpStatusCode.NoContent to {
+            description = "Successfully deleted the ORT run."
+        }
+
+        HttpStatusCode.NotFound to {
+            description = "The ORT run does not exist."
+        }
+    }
+}
+
 val getSecretsByRepositoryId: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretsByRepositoryId"
     summary = "Get all secrets of a repository."

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -98,6 +98,28 @@ val getOrtRunById: OpenApiRoute.() -> Unit = {
     }
 }
 
+val deleteOrtRunById: OpenApiRoute.() -> Unit = {
+    operationId = "deleteOrtRunById"
+    summary = "Delete an ORT run."
+    tags = listOf("Runs")
+
+    request {
+        pathParameter<Long>("runId") {
+            description = "The run's ID."
+        }
+    }
+
+    response {
+        HttpStatusCode.NoContent to {
+            description = "Successfully deleted the ORT run."
+        }
+
+        HttpStatusCode.NotFound to {
+            description = "The ORT run does not exist."
+        }
+    }
+}
+
 val getReportByRunIdAndFileName: OpenApiRoute.() -> Unit = {
     operationId = "GetReportByRunIdAndFileName"
     summary = "Download a report of an ORT run."

--- a/dao/src/main/kotlin/repositories/DaoOrtRunRepository.kt
+++ b/dao/src/main/kotlin/repositories/DaoOrtRunRepository.kt
@@ -47,7 +47,9 @@ import org.eclipse.apoapsis.ortserver.model.util.OptionalValue
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.SizedCollection
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.max
 
 import org.slf4j.LoggerFactory
@@ -169,8 +171,14 @@ class DaoOrtRunRepository(private val db: Database) : OrtRunRepository {
         OrtRunDao[id].mapToModel()
     }
 
-    override fun delete(id: Long) = db.blockingQuery {
-        OrtRunDao[id].delete()
+    override fun delete(id: Long): Int = db.blockingQuery {
+        OrtRunsTable.deleteWhere { OrtRunsTable.id eq id }
+    }
+
+    override fun deleteByRepositoryIdAndOrtRunIndex(repositoryId: Long, ortRunIndex: Long): Int = db.blockingQuery {
+        OrtRunsTable.deleteWhere {
+            (OrtRunsTable.repositoryId eq repositoryId) and (index eq ortRunIndex)
+        }
     }
 }
 

--- a/model/src/commonMain/kotlin/repositories/OrtRunRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/OrtRunRepository.kt
@@ -99,5 +99,10 @@ interface OrtRunRepository {
     /**
      * Delete an ORT run by [id].
      */
-    fun delete(id: Long)
+    fun delete(id: Long): Int
+
+    /**
+     * Delete an ORT run by [repositoryId] and [ortRunIndex].
+     */
+    fun deleteByRepositoryIdAndOrtRunIndex(repositoryId: Long, ortRunIndex: Long): Int
 }

--- a/services/hierarchy/src/main/kotlin/OrtRunService.kt
+++ b/services/hierarchy/src/main/kotlin/OrtRunService.kt
@@ -41,4 +41,18 @@ class OrtRunService(
     ): ListQueryResult<OrtRun> = db.dbQuery {
         ortRunRepository.list(parameters, filters)
     }
+
+    suspend fun deleteOrtRun(ortRunId: Long): Unit = db.dbQuery {
+        if (ortRunRepository.delete(ortRunId) == 0) {
+            throw ResourceNotFoundException("ORT run with id '$ortRunId' not found.")
+        }
+    }
+
+    suspend fun deleteOrtRun(repositoryId: Long, ortRunIndex: Long) = db.dbQuery {
+        if (ortRunRepository.deleteByRepositoryIdAndOrtRunIndex(repositoryId, ortRunIndex) == 0) {
+            throw ResourceNotFoundException(
+                "ORT run with repositoryId '$repositoryId' and ortRunIndex '$ortRunIndex' not found."
+            )
+        }
+    }
 }


### PR DESCRIPTION
Add REST API endpoint to delete ORT run by either the `ortRunId` or the combination of `repositoryId` and `ortRunIndex`. 

The database foreign key constraints option _CASCADE DELETE_ between the nodes of the directed graph where the ORT run is the root node are already established, so by deleting the ORT run, also all dependent other subordinate nodes are deleted.