### PR TITLE
fix(docker): Ensure correct user for the cache directory

### DIFF
--- a/workers/analyzer/docker/Analyzer.Dockerfile
+++ b/workers/analyzer/docker/Analyzer.Dockerfile
@@ -116,6 +116,9 @@ RUN groupadd --gid $USER_GID $USERNAME \
     --home-dir $HOMEDIR \
     --create-home $USERNAME
 
+RUN mkdir -p $HOMEDIR/.cache \
+    && chown $USER:$USER $HOMEDIR/.cache
+
 RUN chgrp $USER /opt \
     && chmod g+wx /opt
 


### PR DESCRIPTION
This fixes the issue that the analyzer worker base image can not be built on macOS.

Error message before this fix:
```
RUN $GOBIN/go install github.com/bazelbuild/buildtools/buildozer@latest && chmod a+x $GOBIN/buildozer

go: downloading github.com/bazelbuild/buildtools v0.0.0-20240918101019-be1c24cc9a44
go: failed to initialize build cache at /home/ort/.cache/go-build: mkdir /home/ort/.cache/go-build: permission denied 
```