### PR TITLE
feat(core): Delete reports in storage on deletion of ORT run

### DIFF
--- a/core/src/main/kotlin/api/RepositoriesRoute.kt
+++ b/core/src/main/kotlin/api/RepositoriesRoute.kt
@@ -156,13 +156,15 @@ fun Route.repositories() = route("repositories/{repositoryId}") {
             }
 
             delete(deleteOrtRunByIndex) { _ ->
-                requirePermission(RepositoryPermission.DELETE)
-
                 val repositoryId = call.requireIdParameter("repositoryId")
                 val ortRunIndex = call.requireIdParameter("ortRunIndex")
 
-                ortRunService.deleteOrtRun(repositoryId, ortRunIndex)
-                call.respond(HttpStatusCode.NoContent)
+                requirePermission(RepositoryPermission.DELETE)
+
+                repositoryService.getOrtRunId(repositoryId, ortRunIndex)?.let { ortRunId ->
+                    ortRunService.deleteOrtRun(ortRunId)
+                    call.respond(HttpStatusCode.NoContent)
+                } ?: call.respond(HttpStatusCode.NotFound)
             }
         }
     }

--- a/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
@@ -505,6 +505,7 @@ val getOrtRunByIndex: OpenApiRoute.() -> Unit = {
 val deleteOrtRunByIndex: OpenApiRoute.() -> Unit = {
     operationId = "deleteOrtRunByIndex"
     summary = "Delete an ORT run of a repository."
+    description = "This operation deletes an ORT run and all generated data, including the generated reports."
     tags = listOf("Repositories")
 
     request {

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -101,6 +101,7 @@ val getOrtRunById: OpenApiRoute.() -> Unit = {
 val deleteOrtRunById: OpenApiRoute.() -> Unit = {
     operationId = "deleteOrtRunById"
     summary = "Delete an ORT run."
+    description = "This operation deletes an ORT run and all generated data, including the generated reports."
     tags = listOf("Runs")
 
     request {

--- a/core/src/main/kotlin/di/Module.kt
+++ b/core/src/main/kotlin/di/Module.kt
@@ -132,7 +132,7 @@ fun ortServerModule(config: ApplicationConfig) = module {
     single { RuleViolationService(get()) }
     single { PackageService(get()) }
     single { UserService(get()) }
-    single { OrtRunService(get(), get()) }
+    single { OrtRunService(get(), get(), get(), get()) }
     singleOf(::ReportStorageService)
     singleOf(::InfrastructureServiceService)
 }

--- a/dao/src/main/kotlin/repositories/ortrun/DaoOrtRunRepository.kt
+++ b/dao/src/main/kotlin/repositories/ortrun/DaoOrtRunRepository.kt
@@ -95,6 +95,11 @@ class DaoOrtRunRepository(private val db: Database) : OrtRunRepository {
             .firstOrNull()?.mapToModel()
     }
 
+    override fun getIdByIndex(repositoryId: Long, ortRunIndex: Long): Long? = db.blockingQuery {
+        OrtRunDao.find { OrtRunsTable.repositoryId eq repositoryId and (OrtRunsTable.index eq ortRunIndex) }
+            .firstOrNull()?.id?.value
+    }
+
     override fun list(parameters: ListQueryParameters, filters: OrtRunFilters?): ListQueryResult<OrtRun> =
         db.blockingQuery {
             OrtRunDao.listQuery(parameters, OrtRunDao::mapToModel) {
@@ -170,12 +175,6 @@ class DaoOrtRunRepository(private val db: Database) : OrtRunRepository {
 
     override fun delete(id: Long): Int = db.blockingQuery {
         OrtRunsTable.deleteWhere { OrtRunsTable.id eq id }
-    }
-
-    override fun deleteByRepositoryIdAndOrtRunIndex(repositoryId: Long, ortRunIndex: Long): Int = db.blockingQuery {
-        OrtRunsTable.deleteWhere {
-            (OrtRunsTable.repositoryId eq repositoryId) and (index eq ortRunIndex)
-        }
     }
 }
 

--- a/model/src/commonMain/kotlin/repositories/OrtRunRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/OrtRunRepository.kt
@@ -58,6 +58,13 @@ interface OrtRunRepository {
     fun getByIndex(repositoryId: Long, ortRunIndex: Long): OrtRun?
 
     /**
+     * Get the id of an ORT run by its [index][ortRunIndex] within a [repository][repositoryId].
+     * This function is more efficient than [getByIndex], as it only retrieves the ID of the ORT run or
+     * returns null if the ORT run is not found.
+     */
+    fun getIdByIndex(repositoryId: Long, ortRunIndex: Long): Long?
+
+    /**
      * List all ORT runs according to the given [parameters] and [filters].
      */
     fun list(
@@ -100,9 +107,4 @@ interface OrtRunRepository {
      * Delete an ORT run by [id].
      */
     fun delete(id: Long): Int
-
-    /**
-     * Delete an ORT run by [repositoryId] and [ortRunIndex].
-     */
-    fun deleteByRepositoryIdAndOrtRunIndex(repositoryId: Long, ortRunIndex: Long): Int
 }

--- a/services/hierarchy/build.gradle.kts
+++ b/services/hierarchy/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     api(libs.exposedCore)
 
     implementation(projects.dao)
+    implementation(projects.services.reportStorageService)
 
     runtimeOnly(libs.logback)
 

--- a/services/hierarchy/src/main/kotlin/RepositoryService.kt
+++ b/services/hierarchy/src/main/kotlin/RepositoryService.kt
@@ -96,6 +96,15 @@ class RepositoryService(
     }
 
     /**
+     * Get the id of an ORT run by its [index][ortRunIndex] within a [repository][repositoryId].
+     * This function is more efficient than [getOrtRun], as it only retrieves the ID of the ORT run or
+     * returns null if the ORT run is not found.
+     */
+    suspend fun getOrtRunId(repositoryId: Long, ortRunIndex: Long): Long? = db.dbQuery {
+        ortRunRepository.getIdByIndex(repositoryId, ortRunIndex)
+    }
+
+    /**
      * Get the summaries of the runs executed on the given [repository][repositoryId] according
      * to the given [parameters].
      */

--- a/services/report-storage/src/main/kotlin/ReportStorageService.kt
+++ b/services/report-storage/src/main/kotlin/ReportStorageService.kt
@@ -71,6 +71,15 @@ class ReportStorageService(
             fetchReport(runId, report.filename)
         } ?: throw ReportNotFoundException(runId, "<from token>")
     }
+
+    /**
+     * Delete a report with the given [fileName] for the specified [runId].
+     * Throw a [ReportNotFoundException] if the report does not exist.
+     */
+    suspend fun deleteReport(runId: Long, fileName: String) {
+        val key = generateKey(runId, fileName)
+        if (!reportStorage.delete(key)) throw ReportNotFoundException(runId, fileName)
+    }
 }
 
 /**


### PR DESCRIPTION
On deletion of an ORT run via the REST API, also delete the associated reports from storage that were created during this ORT run.