### PR TITLE
Deduplicate scan summaries

### DIFF
--- a/workers/scanner/src/main/kotlin/scanner/ScanSummaryCompare.kt
+++ b/workers/scanner/src/main/kotlin/scanner/ScanSummaryCompare.kt
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.scanner
+
+import org.eclipse.apoapsis.ortserver.model.runs.Issue
+import org.eclipse.apoapsis.ortserver.model.runs.scanner.CopyrightFinding
+import org.eclipse.apoapsis.ortserver.model.runs.scanner.LicenseFinding
+import org.eclipse.apoapsis.ortserver.model.runs.scanner.ScanSummary
+import org.eclipse.apoapsis.ortserver.model.runs.scanner.Snippet
+import org.eclipse.apoapsis.ortserver.model.runs.scanner.SnippetFinding
+import org.eclipse.apoapsis.ortserver.model.runs.scanner.TextLocation
+
+import org.ossreviewtoolkit.model.CopyrightFinding as OrtCopyrightFinding
+import org.ossreviewtoolkit.model.Issue as OrtIssue
+import org.ossreviewtoolkit.model.LicenseFinding as OrtLicenseFinding
+import org.ossreviewtoolkit.model.ScanSummary as OrtScanSummary
+import org.ossreviewtoolkit.model.Snippet as OrtSnippet
+import org.ossreviewtoolkit.model.SnippetFinding as OrtSnippetFinding
+import org.ossreviewtoolkit.model.TextLocation as OrtTextLocation
+
+/**
+ * Compare the given [ortSummary] with the given [serverSummary] and return a flag with the result.
+ */
+internal fun compareScanSummaries(ortSummary: OrtScanSummary, serverSummary: ScanSummary): Boolean {
+    @Suppress("ComplexCondition")
+    if (ortSummary.licenseFindings.size != serverSummary.licenseFindings.size ||
+        ortSummary.copyrightFindings.size != serverSummary.copyrightFindings.size ||
+        ortSummary.snippetFindings.size != serverSummary.snippetFindings.size ||
+        ortSummary.issues.size != serverSummary.issues.size
+    ) {
+        return false
+    }
+
+    return compareCollections(ortSummary.licenseFindings, serverSummary.licenseFindings, ::compareLicenseFinding) &&
+            compareCollections(
+                ortSummary.copyrightFindings,
+                serverSummary.copyrightFindings,
+                ::compareCopyrightFinding
+            ) &&
+            compareCollections(ortSummary.snippetFindings, serverSummary.snippetFindings, ::compareSnippetFinding) &&
+            compareCollections(ortSummary.issues, serverSummary.issues, ::compareIssues)
+}
+
+/**
+ * Compare the given collections [col1] and [col2] using the given [compare] function and return a flag with the result.
+ */
+private fun <S, T> compareCollections(col1: Collection<S>, col2: Collection<T>, compare: (S, T) -> Boolean): Boolean =
+    col1.zip(col2).all { (item1, item2) -> compare(item1, item2) }
+
+/**
+ * Compare the given [ortLicenseFinding] with the given [serverLicenseFinding] and return a flag with the result.
+ */
+private fun compareLicenseFinding(ortLicenseFinding: OrtLicenseFinding, serverLicenseFinding: LicenseFinding): Boolean =
+    ortLicenseFinding.license.toString() == serverLicenseFinding.spdxLicense &&
+            compareTextLocations(ortLicenseFinding.location, serverLicenseFinding.location)
+
+/**
+ * Compare the given [ortCopyrightFinding] with the given [serverCopyrightFinding] and return a flag with the result.
+ */
+private fun compareCopyrightFinding(
+    ortCopyrightFinding: OrtCopyrightFinding,
+    serverCopyrightFinding: CopyrightFinding
+): Boolean =
+    ortCopyrightFinding.statement == serverCopyrightFinding.statement &&
+            compareTextLocations(ortCopyrightFinding.location, serverCopyrightFinding.location)
+
+/**
+ * Compare the given [ortSnippetFinding] with the given [serverSnippetFinding] and return a flag with the result.
+ */
+private fun compareSnippetFinding(
+    ortSnippetFinding: OrtSnippetFinding,
+    serverSnippetFinding: SnippetFinding
+): Boolean {
+    if (ortSnippetFinding.snippets.size != serverSnippetFinding.snippets.size) return false
+
+    return compareTextLocations(ortSnippetFinding.sourceLocation, serverSnippetFinding.location) &&
+            compareCollections(ortSnippetFinding.snippets, serverSnippetFinding.snippets, ::compareSnippets)
+}
+
+/**
+ * Compare the given [ortSnippet] with the given [serverSnippet] and return a flag with the result.
+ */
+private fun compareSnippets(ortSnippet: OrtSnippet, serverSnippet: Snippet): Boolean =
+    ortSnippet.purl == serverSnippet.purl &&
+            ortSnippet.license.toString() == serverSnippet.spdxLicense &&
+            compareTextLocations(ortSnippet.location, serverSnippet.location)
+
+/**
+ * Compare the given [ortIssue] with the given [serverIssue] and return a flag with the result.
+ */
+private fun compareIssues(ortIssue: OrtIssue, serverIssue: Issue): Boolean =
+    ortIssue.source == serverIssue.source &&
+            ortIssue.message == serverIssue.message &&
+            ortIssue.severity.name == serverIssue.severity.name
+
+/**
+ * Compare the given [ortLocation] with the given [serverLocation] and return a flag with the result.
+ */
+private fun compareTextLocations(ortLocation: OrtTextLocation, serverLocation: TextLocation): Boolean =
+    ortLocation.startLine == serverLocation.startLine &&
+            ortLocation.endLine == serverLocation.endLine &&
+            ortLocation.path == serverLocation.path

--- a/workers/scanner/src/test/kotlin/ScanResultFixtures.kt
+++ b/workers/scanner/src/test/kotlin/ScanResultFixtures.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.scanner
+
+import kotlinx.datetime.Instant
+
+import org.eclipse.apoapsis.ortserver.model.RepositoryType
+import org.eclipse.apoapsis.ortserver.model.Severity
+import org.eclipse.apoapsis.ortserver.model.runs.Issue
+import org.eclipse.apoapsis.ortserver.model.runs.RemoteArtifact
+import org.eclipse.apoapsis.ortserver.model.runs.VcsInfo
+import org.eclipse.apoapsis.ortserver.model.runs.scanner.ArtifactProvenance
+import org.eclipse.apoapsis.ortserver.model.runs.scanner.CopyrightFinding
+import org.eclipse.apoapsis.ortserver.model.runs.scanner.KnownProvenance
+import org.eclipse.apoapsis.ortserver.model.runs.scanner.LicenseFinding
+import org.eclipse.apoapsis.ortserver.model.runs.scanner.RepositoryProvenance
+import org.eclipse.apoapsis.ortserver.model.runs.scanner.ScanResult
+import org.eclipse.apoapsis.ortserver.model.runs.scanner.ScanSummary
+import org.eclipse.apoapsis.ortserver.model.runs.scanner.ScannerDetail
+import org.eclipse.apoapsis.ortserver.model.runs.scanner.Snippet
+import org.eclipse.apoapsis.ortserver.model.runs.scanner.SnippetFinding
+import org.eclipse.apoapsis.ortserver.model.runs.scanner.TextLocation
+import org.eclipse.apoapsis.ortserver.workers.common.mapToOrt
+
+import org.ossreviewtoolkit.model.ScanResult as OrtScanResult
+import org.ossreviewtoolkit.scanner.ScannerMatcher
+
+import org.semver4j.Semver
+
+/**
+ * An object providing test data and functions to create [ScanResult] instances. It can be used by multiple test
+ * classes that need to deal with such data structures.
+ */
+internal object ScanResultFixtures {
+    const val SCANNER_VERSION = "1.0.0"
+    const val TIME_STAMP_SECONDS = 1678119934L
+
+    /** A matcher that matches all scanners with the default [SCANNER_VERSION]. */
+    val scannerMatcher = ScannerMatcher(
+        regScannerName = ".*",
+        minVersion = Semver(SCANNER_VERSION),
+        maxVersion = Semver(SCANNER_VERSION).nextMinor(),
+        configuration = null
+    )
+    fun createVcsInfo() = VcsInfo(
+        RepositoryType.GIT,
+        "https://github.com/apache/logging-log4j2.git",
+        "be881e503e14b267fb8a8f94b6d15eddba7ed8c4",
+        ""
+    )
+
+    fun createRepositoryProvenance(
+        vcsInfo: VcsInfo = createVcsInfo(),
+        resolvedRevision: String = vcsInfo.revision
+    ) = RepositoryProvenance(vcsInfo, resolvedRevision)
+
+    fun createRemoteArtifact() =
+        RemoteArtifact(
+            url = "https://repo1.maven.org/maven2/org/apache/logging/" +
+                    "log4j/log4j-api/2.14.1/log4j-api-2.14.1-sources.jar",
+            hashValue = "b2327c47ca413c1ec183575b19598e281fcd74d8",
+            hashAlgorithm = "SHA-1"
+        )
+
+    fun createArtifactProvenance() = ArtifactProvenance(createRemoteArtifact())
+
+    fun createIssue(source: String) =
+        Issue(Instant.fromEpochSeconds(TIME_STAMP_SECONDS), source, "message", Severity.ERROR)
+
+    fun createServerScanResult(
+        scannerName: String,
+        issue: Issue,
+        provenance: KnownProvenance,
+        scannerVersion: String = SCANNER_VERSION,
+        scannerConfig: String = "config",
+        additionalData: Map<String, String> = mapOf("additional1" to "data1", "additional2" to "data2")
+    ): ScanResult {
+        return ScanResult(
+            provenance = provenance,
+            scanner = ScannerDetail(scannerName, scannerVersion, scannerConfig),
+            summary = ScanSummary(
+                Instant.fromEpochSeconds(TIME_STAMP_SECONDS),
+                Instant.fromEpochSeconds(TIME_STAMP_SECONDS),
+                setOf(
+                    LicenseFinding(
+                        "LicenseRef-23",
+                        TextLocation("/example/path", 1, 50),
+                        Float.MIN_VALUE
+                    )
+                ),
+                setOf(
+                    CopyrightFinding(
+                        "Copyright Finding Statement",
+                        TextLocation("/example/path", 1, 50)
+                    )
+                ),
+                setOf(
+                    SnippetFinding(
+                        TextLocation("/example/path", 1, 50),
+                        setOf(
+                            Snippet(
+                                score = 1.0f,
+                                location = TextLocation("/example/path", 1, 50),
+                                provenance = createArtifactProvenance(),
+                                purl = "org.apache.logging.log4j:log4j-api:2.14.1",
+                                spdxLicense = "LicenseRef-23",
+                                additionalData = mapOf("data" to "value")
+                            ),
+                            Snippet(
+                                score = 2.0f,
+                                location = TextLocation("/example/path2", 10, 20),
+                                provenance = createRepositoryProvenance(),
+                                purl = "org.apache.logging.log4j:log4j-api:2.14.1",
+                                spdxLicense = "LicenseRef-23",
+                                additionalData = mapOf("data2" to "value2")
+                            )
+                        )
+                    )
+                ),
+                listOf(issue)
+            ),
+            additionalData
+        )
+    }
+
+    fun createScanResult(
+        scannerName: String,
+        issue: Issue,
+        provenance: KnownProvenance,
+        scannerVersion: String = SCANNER_VERSION,
+        scannerConfig: String = "config",
+        additionalData: Map<String, String> = mapOf("additional1" to "data1", "additional2" to "data2")
+    ): OrtScanResult =
+        createServerScanResult(scannerName, issue, provenance, scannerVersion, scannerConfig, additionalData).mapToOrt()
+}

--- a/workers/scanner/src/test/kotlin/ScanSummaryCompareTest.kt
+++ b/workers/scanner/src/test/kotlin/ScanSummaryCompareTest.kt
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2023 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.scanner
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.inspectors.forAll
+import io.kotest.matchers.shouldBe
+
+import org.eclipse.apoapsis.ortserver.model.runs.scanner.CopyrightFinding
+import org.eclipse.apoapsis.ortserver.model.runs.scanner.LicenseFinding
+import org.eclipse.apoapsis.ortserver.model.runs.scanner.Snippet
+import org.eclipse.apoapsis.ortserver.model.runs.scanner.SnippetFinding
+import org.eclipse.apoapsis.ortserver.model.runs.scanner.TextLocation
+import org.eclipse.apoapsis.ortserver.workers.common.mapToOrt
+import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.createArtifactProvenance
+import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.createIssue
+import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.createRepositoryProvenance
+import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.createServerScanResult
+
+/**
+ * Test class for testing the hash values generated for scan summaries. Since this functionality does not require
+ * database access, it is tested by a separate class to speed up test execution.
+ */
+class ScanSummaryCompareTest : WordSpec({
+    "compareScanSummaries" should {
+        "return false for scan summaries with different license findings" {
+            val provenance = createRepositoryProvenance()
+            val summary1 = createServerScanResult("ScanCode", createIssue("source1"), provenance).summary.mapToOrt()
+            val summary2 = createServerScanResult("ScanCode", createIssue("source2"), provenance).summary
+                .copy(
+                    licenseFindings = setOf(
+                        LicenseFinding(
+                            "LicenseRef-24",
+                            TextLocation("/example/path", 1, 50),
+                            Float.MIN_VALUE
+                        )
+                    )
+                )
+
+            compareScanSummaries(summary1, summary2) shouldBe false
+        }
+
+        "return false for scan summaries with different copyright findings" {
+            val provenance = createRepositoryProvenance()
+            val summary1 = createServerScanResult("ScanCode", createIssue("source1"), provenance).summary.mapToOrt()
+            val summary2 = createServerScanResult("ScanCode", createIssue("source2"), provenance).summary
+                .copy(
+                    copyrightFindings = setOf(
+                        CopyrightFinding("(C)", TextLocation("/example/path", 1, 50))
+                    )
+                )
+
+            compareScanSummaries(summary1, summary2) shouldBe false
+        }
+
+        "return false for scan summaries with different snippet findings" {
+            val provenance = createRepositoryProvenance()
+            val summary1 = createServerScanResult("ScanCode", createIssue("source1"), provenance).summary.mapToOrt()
+            val summary2 = createServerScanResult("ScanCode", createIssue("source2"), provenance).summary
+                .copy(
+                    snippetFindings = setOf(
+                        SnippetFinding(
+                            TextLocation("/example/path", 1, 50),
+                            setOf(
+                                Snippet(
+                                    score = 1.0f,
+                                    location = TextLocation("/example/path", 1, 50),
+                                    provenance = createArtifactProvenance(),
+                                    purl = "org.apache.logging.log4j:log4j-api:2.14.1",
+                                    spdxLicense = "LicenseRef-23",
+                                    additionalData = mapOf("data" to "value")
+                                )
+                            )
+                        )
+                    )
+                )
+
+            compareScanSummaries(summary1, summary2) shouldBe false
+        }
+
+        "return false for scan summaries with different issues" {
+            val provenance = createArtifactProvenance()
+            val summary1 = createServerScanResult("ScanCode", createIssue("source1"), provenance).summary.mapToOrt()
+            val summary2 = createServerScanResult("ScanCode", createIssue("source2"), provenance).summary
+
+            compareScanSummaries(summary1, summary2) shouldBe false
+        }
+
+        "return true for equivalent scan summaries from ORT and ORT Server" {
+            val serverSummaries = listOf(
+                createServerScanResult("ScanCode", createIssue("source1"), createArtifactProvenance()).summary,
+                createServerScanResult("ScanCode", createIssue("source2"), createArtifactProvenance()).summary,
+                createServerScanResult("ScanCode", createIssue("source3"), createArtifactProvenance()).summary
+                    .copy(
+                        licenseFindings = setOf(
+                            LicenseFinding(
+                                "LicenseRef-24",
+                                TextLocation("/example/path", 1, 50),
+                                Float.MIN_VALUE
+                            )
+                        )
+                    ),
+                createServerScanResult("ScanCode", createIssue("source4"), createArtifactProvenance()).summary
+                    .copy(
+                        copyrightFindings = setOf(
+                            CopyrightFinding("(C)", TextLocation("/example/path", 1, 50))
+                        )
+                    ),
+                createServerScanResult("ScanCode", createIssue("source5"), createRepositoryProvenance()).summary
+                    .copy(
+                        snippetFindings = setOf(
+                            SnippetFinding(
+                                TextLocation("/example/path", 1, 50),
+                                setOf(
+                                    Snippet(
+                                        score = 1.0f,
+                                        location = TextLocation("/example/path", 1, 50),
+                                        provenance = createArtifactProvenance(),
+                                        purl = "org.apache.logging.log4j:log4j-api:2.14.1",
+                                        spdxLicense = "LicenseRef-23",
+                                        additionalData = mapOf("data" to "value")
+                                    )
+                                )
+                            )
+                        )
+                    )
+            )
+
+            serverSummaries.forAll { summary ->
+                val ortSummary = summary.mapToOrt()
+                compareScanSummaries(ortSummary, summary) shouldBe true
+            }
+        }
+    }
+})


### PR DESCRIPTION
This PR prevents the creation of duplicate entities for scan summaries in cases where a single scan operation yields multiple results.