### PR TITLE
feat(model): Add project descriptions

### DIFF
--- a/dao/src/main/kotlin/repositories/analyzerrun/DaoAnalyzerRunRepository.kt
+++ b/dao/src/main/kotlin/repositories/analyzerrun/DaoAnalyzerRunRepository.kt
@@ -168,6 +168,7 @@ private fun insertProject(
         this.vcsProcessed = vcsProcessed
 
         this.cpe = project.cpe
+        this.description = project.description
         this.homepageUrl = project.homepageUrl
         this.definitionFilePath = project.definitionFilePath
     }

--- a/dao/src/main/kotlin/repositories/analyzerrun/ProjectsTable.kt
+++ b/dao/src/main/kotlin/repositories/analyzerrun/ProjectsTable.kt
@@ -43,6 +43,7 @@ object ProjectsTable : LongIdTable("projects") {
 
     val cpe = text("cpe").nullable()
     val definitionFilePath = text("definition_file_path")
+    val description = text("description")
     val homepageUrl = text("homepage_url")
 }
 
@@ -70,6 +71,7 @@ class ProjectDao(id: EntityID<Long>) : LongEntity(id) {
 
     var cpe by ProjectsTable.cpe
     var definitionFilePath by ProjectsTable.definitionFilePath
+    var description by ProjectsTable.description
     var homepageUrl by ProjectsTable.homepageUrl
 
     var authors by AuthorDao via ProjectsAuthorsTable
@@ -89,6 +91,7 @@ class ProjectDao(id: EntityID<Long>) : LongEntity(id) {
         processedDeclaredLicense = processedDeclaredLicense.mapToModel(),
         vcs = vcs.mapToModel(),
         vcsProcessed = vcsProcessed.mapToModel(),
+        description = description,
         homepageUrl = homepageUrl,
         scopeNames = scopeNames.mapTo(mutableSetOf(), ProjectScopeDao::name)
     )

--- a/dao/src/main/resources/db/migration/V89__addProjectDescription.sql
+++ b/dao/src/main/resources/db/migration/V89__addProjectDescription.sql
@@ -1,0 +1,3 @@
+-- Add a description column to the projects table because project descriptions were added to ORT.
+
+ALTER TABLE projects ADD COLUMN description TEXT NOT NULL DEFAULT '';

--- a/dao/src/test/kotlin/migrations/V73__deduplicatePackagesAndProjectsTest.kt
+++ b/dao/src/test/kotlin/migrations/V73__deduplicatePackagesAndProjectsTest.kt
@@ -387,6 +387,7 @@ private val baseProject = Project(
     processedDeclaredLicense = baseProcessedDeclaredLicense,
     vcs = vcsInfo,
     vcsProcessed = vcsInfo,
+    description = "",
     homepageUrl = "https://example.com/project",
     scopeNames = setOf("compile", "test")
 )

--- a/dao/src/test/kotlin/repositories/analyzerrun/DaoAnalyzerRunRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/analyzerrun/DaoAnalyzerRunRepositoryTest.kt
@@ -178,6 +178,7 @@ private val project = Project(
         revision = "main",
         path = ""
     ),
+    description = "description",
     homepageUrl = "https://example.com",
     scopeNames = setOf("compile")
 )

--- a/dao/src/test/kotlin/repositories/scannerrun/DaoScannerRunRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/scannerrun/DaoScannerRunRepositoryTest.kt
@@ -405,6 +405,7 @@ private val project = Project(
         revision = "main",
         path = ""
     ),
+    description = "description",
     homepageUrl = "https://example.com",
     scopeNames = emptySet()
 )

--- a/model/src/commonMain/kotlin/runs/Project.kt
+++ b/model/src/commonMain/kotlin/runs/Project.kt
@@ -28,6 +28,7 @@ data class Project(
     val processedDeclaredLicense: ProcessedDeclaredLicense,
     val vcs: VcsInfo,
     val vcsProcessed: VcsInfo,
+    val description: String,
     val homepageUrl: String,
     val scopeNames: Set<String>
 )

--- a/workers/common/src/main/kotlin/common/OrtMappings.kt
+++ b/workers/common/src/main/kotlin/common/OrtMappings.kt
@@ -402,6 +402,7 @@ fun OrtProject.mapToModel() =
         processedDeclaredLicense = declaredLicensesProcessed.mapToModel(),
         vcs = vcs.mapToModel(),
         vcsProcessed = vcsProcessed.mapToModel(),
+        description = description,
         homepageUrl = homepageUrl,
         scopeNames = scopeNames.orEmpty()
     )

--- a/workers/common/src/main/kotlin/common/OrtServerMappings.kt
+++ b/workers/common/src/main/kotlin/common/OrtServerMappings.kt
@@ -480,6 +480,7 @@ fun Project.mapToOrt() =
         declaredLicensesProcessed = processedDeclaredLicense.mapToOrt(),
         vcs = vcs.mapToOrt(),
         vcsProcessed = vcsProcessed.mapToOrt(),
+        description = description,
         homepageUrl = homepageUrl,
         scopeNames = scopeNames.toSortedSet()
     )

--- a/workers/common/src/test/kotlin/OrtServerMappingsTest.kt
+++ b/workers/common/src/test/kotlin/OrtServerMappingsTest.kt
@@ -208,6 +208,7 @@ class OrtServerMappingsTest : WordSpec({
                     revision = OrtTestData.projectRevision,
                     path = ""
                 ),
+                description = "description",
                 homepageUrl = "https://example.org/project",
                 scopeNames = setOf("compile")
             )

--- a/workers/common/src/testFixtures/kotlin/OrtTestData.kt
+++ b/workers/common/src/testFixtures/kotlin/OrtTestData.kt
@@ -336,6 +336,7 @@ object OrtTestData {
             revision = projectRevision,
             path = ""
         ),
+        description = "description",
         homepageUrl = "https://example.org/project",
         scopeNames = setOf("compile")
     )


### PR DESCRIPTION
Add support for the new `description` property of projects which was introduced in ORT 42.0.0 [1].

[1]: https://github.com/oss-review-toolkit/ort/releases/tag/42.0.0