### PR TITLE
feat(core): Delete ORT runs before deleting the repository

### DIFF
--- a/core/src/main/kotlin/di/Module.kt
+++ b/core/src/main/kotlin/di/Module.kt
@@ -124,7 +124,7 @@ fun ortServerModule(config: ApplicationConfig) = module {
     }
     single { OrchestratorService(get(), get(), get()) }
     single { OrganizationService(get(), get(), get(), get()) }
-    single { ProductService(get(), get(), get(), get()) }
+    single { ProductService(get(), get(), get(), get(), get()) }
     single { RepositoryService(get(), get(), get(), get(), get(), get(), get(), get(), get(), get()) }
     single { SecretService(get(), get(), get(), get()) }
     single { VulnerabilityService(get()) }

--- a/core/src/main/kotlin/plugins/StatusPages.kt
+++ b/core/src/main/kotlin/plugins/StatusPages.kt
@@ -34,6 +34,7 @@ import org.eclipse.apoapsis.ortserver.core.utils.UrlPathFormatException
 import org.eclipse.apoapsis.ortserver.dao.QueryParametersException
 import org.eclipse.apoapsis.ortserver.dao.UniqueConstraintException
 import org.eclipse.apoapsis.ortserver.services.InvalidSecretReferenceException
+import org.eclipse.apoapsis.ortserver.services.OrganizationNotEmptyException
 import org.eclipse.apoapsis.ortserver.services.ReferencedEntityException
 import org.eclipse.apoapsis.ortserver.services.ReportNotFoundException
 import org.eclipse.apoapsis.ortserver.services.ResourceNotFoundException
@@ -67,6 +68,15 @@ fun Application.configureStatusPages() {
             call.respond(
                 HttpStatusCode.BadRequest,
                 ErrorResponse(message = "Secret reference could not be resolved.", e.message)
+            )
+        }
+        exception<OrganizationNotEmptyException> { call, e ->
+            call.respond(
+                HttpStatusCode.Conflict,
+                ErrorResponse(
+                    "Organization is not empty. Delete all products before deleting the organization.",
+                    e.message
+                )
             )
         }
         exception<ReferencedEntityException> { call, e ->

--- a/core/src/test/kotlin/api/DownloadsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/DownloadsRouteIntegrationTest.kt
@@ -71,6 +71,7 @@ class DownloadsRouteIntegrationTest : AbstractIntegrationTest({
             dbExtension.db,
             dbExtension.fixtures.productRepository,
             dbExtension.fixtures.repositoryRepository,
+            dbExtension.fixtures.ortRunRepository,
             authorizationService
         )
 

--- a/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
@@ -124,6 +124,7 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
             dbExtension.db,
             dbExtension.fixtures.productRepository,
             dbExtension.fixtures.repositoryRepository,
+            dbExtension.fixtures.ortRunRepository,
             authorizationService
         )
 

--- a/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
@@ -118,6 +118,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
             dbExtension.db,
             dbExtension.fixtures.productRepository,
             dbExtension.fixtures.repositoryRepository,
+            dbExtension.fixtures.ortRunRepository,
             authorizationService
         )
 

--- a/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
@@ -139,6 +139,7 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
             dbExtension.db,
             dbExtension.fixtures.productRepository,
             dbExtension.fixtures.repositoryRepository,
+            dbExtension.fixtures.ortRunRepository,
             authorizationService
         )
 

--- a/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
@@ -156,6 +156,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
             dbExtension.db,
             dbExtension.fixtures.productRepository,
             dbExtension.fixtures.repositoryRepository,
+            dbExtension.fixtures.ortRunRepository,
             authorizationService
         )
 

--- a/dao/src/main/kotlin/repositories/ortrun/DaoOrtRunRepository.kt
+++ b/dao/src/main/kotlin/repositories/ortrun/DaoOrtRunRepository.kt
@@ -176,6 +176,10 @@ class DaoOrtRunRepository(private val db: Database) : OrtRunRepository {
     override fun delete(id: Long): Int = db.blockingQuery {
         OrtRunsTable.deleteWhere { OrtRunsTable.id eq id }
     }
+
+    override fun deleteByRepository(repositoryId: Long): Int = db.blockingQuery {
+        OrtRunsTable.deleteWhere { OrtRunsTable.repositoryId eq repositoryId }
+    }
 }
 
 /**

--- a/dao/src/main/kotlin/repositories/ortrun/DaoOrtRunRepository.kt
+++ b/dao/src/main/kotlin/repositories/ortrun/DaoOrtRunRepository.kt
@@ -25,6 +25,8 @@ import org.eclipse.apoapsis.ortserver.dao.blockingQuery
 import org.eclipse.apoapsis.ortserver.dao.blockingQueryCatching
 import org.eclipse.apoapsis.ortserver.dao.entityQuery
 import org.eclipse.apoapsis.ortserver.dao.mapAndDeduplicate
+import org.eclipse.apoapsis.ortserver.dao.repositories.product.ProductsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.repository.RepositoriesTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.repository.RepositoryDao
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.OrtRunIssueDao
 import org.eclipse.apoapsis.ortserver.dao.utils.applyFilter
@@ -46,7 +48,9 @@ import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.SizedCollection
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.delete
 import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.innerJoin
 import org.jetbrains.exposed.sql.max
 
 import org.slf4j.LoggerFactory
@@ -179,6 +183,15 @@ class DaoOrtRunRepository(private val db: Database) : OrtRunRepository {
 
     override fun deleteByRepository(repositoryId: Long): Int = db.blockingQuery {
         OrtRunsTable.deleteWhere { OrtRunsTable.repositoryId eq repositoryId }
+    }
+
+    override fun deleteByProduct(productId: Long): Int = db.blockingQuery {
+        OrtRunsTable
+            .innerJoin(RepositoriesTable, { repositoryId }, { RepositoriesTable.id })
+            .innerJoin(ProductsTable, { RepositoriesTable.productId }, { ProductsTable.id })
+            .delete(OrtRunsTable) {
+                ProductsTable.id eq productId
+            }
     }
 }
 

--- a/dao/src/main/kotlin/repositories/product/DaoProductRepository.kt
+++ b/dao/src/main/kotlin/repositories/product/DaoProductRepository.kt
@@ -28,6 +28,7 @@ import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.OptionalValue
 
 import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 
 class DaoProductRepository(private val db: Database) : ProductRepository {
     override fun create(name: String, description: String?, organizationId: Long) = db.blockingQuery {
@@ -42,6 +43,9 @@ class DaoProductRepository(private val db: Database) : ProductRepository {
 
     override fun list(parameters: ListQueryParameters) =
         db.blockingQuery { ProductDao.list(parameters).map { it.mapToModel() } }
+
+    override fun countForOrganization(organizationId: Long) =
+        ProductDao.count(ProductsTable.organizationId eq organizationId)
 
     override fun listForOrganization(organizationId: Long, parameters: ListQueryParameters) = db.blockingQuery {
         ProductDao.listQuery(parameters, ProductDao::mapToModel) { ProductsTable.organizationId eq organizationId }

--- a/dao/src/main/kotlin/repositories/repository/DaoRepositoryRepository.kt
+++ b/dao/src/main/kotlin/repositories/repository/DaoRepositoryRepository.kt
@@ -30,6 +30,8 @@ import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.OptionalValue
 
 import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.deleteWhere
 
 class DaoRepositoryRepository(private val db: Database) : RepositoryRepository {
     override fun create(type: RepositoryType, url: String, productId: Long) = db.blockingQuery {
@@ -67,4 +69,8 @@ class DaoRepositoryRepository(private val db: Database) : RepositoryRepository {
     }
 
     override fun delete(id: Long) = db.blockingQuery { RepositoryDao[id].delete() }
+
+    override fun deleteByProduct(productId: Long): Int = db.blockingQuery {
+        RepositoriesTable.deleteWhere { RepositoriesTable.productId eq productId }
+    }
 }

--- a/model/src/commonMain/kotlin/repositories/OrtRunRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/OrtRunRepository.kt
@@ -107,4 +107,9 @@ interface OrtRunRepository {
      * Delete an ORT run by [id].
      */
     fun delete(id: Long): Int
+
+    /**
+     * Delete the ORT runs of a repository, specified by the [repositoryId].
+     */
+    fun deleteByRepository(repositoryId: Long): Int
 }

--- a/model/src/commonMain/kotlin/repositories/OrtRunRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/OrtRunRepository.kt
@@ -32,6 +32,7 @@ import org.eclipse.apoapsis.ortserver.model.util.OptionalValue
 /**
  * A repository of [ORT runs][OrtRun].
  */
+@Suppress("TooManyFunctions")
 interface OrtRunRepository {
     /**
      * Create an ORT run.
@@ -112,4 +113,9 @@ interface OrtRunRepository {
      * Delete the ORT runs of a repository, specified by the [repositoryId].
      */
     fun deleteByRepository(repositoryId: Long): Int
+
+    /**
+     * Delete all ORT runs associated to this [productId].
+     */
+    fun deleteByProduct(productId: Long): Int
 }

--- a/model/src/commonMain/kotlin/repositories/ProductRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/ProductRepository.kt
@@ -52,6 +52,11 @@ interface ProductRepository {
     ): ListQueryResult<Product>
 
     /**
+     * Count the products associated to an [organization][organizationId].
+     */
+    fun countForOrganization(organizationId: Long): Long
+
+    /**
      * Update a product by [id] with the [present][OptionalValue.Present] values.
      */
     fun update(

--- a/model/src/commonMain/kotlin/repositories/RepositoryRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/RepositoryRepository.kt
@@ -72,4 +72,9 @@ interface RepositoryRepository {
      * Delete a repository by [id].
      */
     fun delete(id: Long)
+
+    /**
+     * Delete all [Repositories][Repository] associated to this [productId].
+     */
+    fun deleteByProduct(productId: Long): Int
 }

--- a/services/hierarchy/src/main/kotlin/OrganizationService.kt
+++ b/services/hierarchy/src/main/kotlin/OrganizationService.kt
@@ -76,6 +76,12 @@ class OrganizationService(
      * Delete an organization by [organizationId].
      */
     suspend fun deleteOrganization(organizationId: Long): Unit = db.dbQueryCatching {
+        if (productRepository.countForOrganization(organizationId) != 0L) {
+            throw OrganizationNotEmptyException(
+                "Cannot delete organization '$organizationId', as it still contains products."
+            )
+        }
+
         organizationRepository.delete(organizationId)
     }.onSuccess {
         runCatching {
@@ -179,3 +185,5 @@ class OrganizationService(
         authorizationService.removeUserFromGroup(username, groupName)
     }
 }
+
+class OrganizationNotEmptyException(message: String) : Exception(message)

--- a/services/hierarchy/src/main/kotlin/ProductService.kt
+++ b/services/hierarchy/src/main/kotlin/ProductService.kt
@@ -21,10 +21,12 @@ package org.eclipse.apoapsis.ortserver.services
 
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
 import org.eclipse.apoapsis.ortserver.dao.dbQueryCatching
+import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.Product
 import org.eclipse.apoapsis.ortserver.model.Repository
 import org.eclipse.apoapsis.ortserver.model.RepositoryType
 import org.eclipse.apoapsis.ortserver.model.authorization.ProductRole
+import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.ProductRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.RepositoryRepository
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
@@ -45,6 +47,7 @@ class ProductService(
     private val db: Database,
     private val productRepository: ProductRepository,
     private val repositoryRepository: RepositoryRepository,
+    private val ortRunRepository: OrtRunRepository,
     private val authorizationService: AuthorizationService
 ) {
     /**
@@ -62,9 +65,12 @@ class ProductService(
     }.getOrThrow()
 
     /**
-     * Delete a product by [productId].
+     * Delete a [product][productId] with its [repositories][Repository] and [OrtRun]s.
      */
     suspend fun deleteProduct(productId: Long): Unit = db.dbQueryCatching {
+        ortRunRepository.deleteByProduct(productId)
+        repositoryRepository.deleteByProduct(productId)
+
         productRepository.delete(productId)
     }.onSuccess {
         runCatching {

--- a/services/hierarchy/src/main/kotlin/RepositoryService.kt
+++ b/services/hierarchy/src/main/kotlin/RepositoryService.kt
@@ -63,9 +63,11 @@ class RepositoryService(
     private val authorizationService: AuthorizationService
 ) {
     /**
-     * Delete a repository by [repositoryId].
+     * Delete the [Repository] by its [repositoryId] and all [OrtRun]s that are associated with it.
      */
     suspend fun deleteRepository(repositoryId: Long): Unit = db.dbQueryCatching {
+        ortRunRepository.deleteByRepository(repositoryId)
+
         repositoryRepository.delete(repositoryId)
     }.onSuccess {
         runCatching {

--- a/services/hierarchy/src/test/kotlin/RepositoryServiceTest.kt
+++ b/services/hierarchy/src/test/kotlin/RepositoryServiceTest.kt
@@ -79,6 +79,21 @@ class RepositoryServiceTest : WordSpec({
                 authorizationService.deleteRepositoryRoles(fixtures.repository.id)
             }
         }
+
+        "delete all ORT runs of the repository" {
+            val service = createService()
+
+            val repository = fixtures.createRepository()
+
+            fixtures.createOrtRun(repository.id)
+            fixtures.createOrtRun(repository.id)
+
+            fixtures.ortRunRepository.listForRepository(repository.id).totalCount shouldBe 2
+
+            service.deleteRepository(repository.id)
+
+            fixtures.ortRunRepository.listForRepository(repository.id).totalCount shouldBe 0
+        }
     }
 
     "getJobs" should {


### PR DESCRIPTION
Enable the user to delete a repository by recursively deleting the ORT runs which are linked to this specific repository.

Resolves #100.