### PR TITLE
ui: Multisorting for all sortable tables

### DIFF
--- a/ui/src/components/data-table/data-table.tsx
+++ b/ui/src/components/data-table/data-table.tsx
@@ -66,9 +66,10 @@ interface DataTableProps<TData> extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * A function to provide `LinkOptions` for a link to set current sorting in the URL.
    */
-  setSortingOptions?: (
-    sorting: { id: string; desc: boolean } | undefined
-  ) => LinkOptions;
+  setSortingOptions?: (sorting: {
+    id: string;
+    desc: boolean | undefined; // For column removal to work when multisorting, this needed to be changed
+  }) => LinkOptions;
   enableGrouping?: boolean;
 }
 
@@ -165,19 +166,16 @@ export function DataTable<TData>({
                             <Tooltip>
                               <TooltipTrigger asChild>
                                 <Link
-                                  {...setSortingOptions(
-                                    header.column.getIsSorted() === 'desc'
-                                      ? undefined
-                                      : {
-                                          id: header.column.id,
-                                          // For sortable columns, the order of sorting is asc -> desc -> [no sorting].
-                                          desc:
-                                            header.column.getIsSorted() ===
-                                            'asc'
-                                              ? true
-                                              : false,
-                                        }
-                                  )}
+                                  {...setSortingOptions({
+                                    id: header.column.id,
+                                    // For sortable columns, the order of sorting is asc -> desc -> [no sorting].
+                                    desc:
+                                      header.column.getIsSorted() === 'desc'
+                                        ? undefined
+                                        : header.column.getIsSorted() === 'asc'
+                                          ? true
+                                          : false,
+                                  })}
                                 >
                                   <Button
                                     variant='ghost'
@@ -209,13 +207,11 @@ export function DataTable<TData>({
                               </TooltipTrigger>
                               <TooltipContent>
                                 {header.column.getCanSort()
-                                  ? header.column.getNextSortingOrder() ===
-                                    'asc'
-                                    ? 'Sort ascending'
-                                    : header.column.getNextSortingOrder() ===
-                                        'desc'
-                                      ? 'Sort descending'
-                                      : 'Clear sorting'
+                                  ? header.column.getIsSorted() === 'asc'
+                                    ? 'Sort descending'
+                                    : header.column.getIsSorted() === 'desc'
+                                      ? 'Clear sorting'
+                                      : 'Sort ascending'
                                   : undefined}
                               </TooltipContent>
                             </Tooltip>

--- a/ui/src/helpers/handle-multisort.ts
+++ b/ui/src/helpers/handle-multisort.ts
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { SortingState } from '@tanstack/react-table';
+
+/**
+ * Handle multi-sorting of table columns.
+ *
+ * @param columns Current sorting state of the table.
+ * @param column The column to sort by.
+ * @returns Updated sorting state of the table:
+ * (1) if the column is not in the sorting array, it is added with ascending order;
+ * (2) if the column is already in the sorting array and is sorted in ascending order, it is updated to descending order;
+ * (3) if the column is already in the sorting array and is sorted in descending order, it is removed from the sorting array.
+ */
+export const updateColumnSorting = (
+  columns: SortingState | undefined,
+  column: {
+    id: string;
+    desc: boolean | undefined; // For column removal to work, the type must be extended from ColumnSort
+  }
+): SortingState | undefined => {
+  // When no sorting is applied, do early return with the column
+  if (!columns) {
+    return [{ ...column, desc: column.desc ?? false }];
+  }
+
+  // Find if the column already exists in the sorting array
+  const index = columns.findIndex((c) => c.id === column.id);
+
+  // Initialize a new sorting array
+  let updatedSort: SortingState = [];
+
+  if (index >= 0) {
+    // If column already exists, safely get the current sorting order
+    const currentSortOrder = columns[index];
+
+    if (currentSortOrder && !currentSortOrder.desc) {
+      // Cycle from asc to desc
+      updatedSort = [...columns];
+      updatedSort[index] = { id: column.id, desc: true };
+    } else {
+      // Remove the column when cycling to none
+      updatedSort = columns.filter((_, ind) => ind !== index);
+    }
+  } else {
+    // If column is not in the sort array, add it with asc order
+    updatedSort = [...columns, { id: column.id, desc: false }];
+  }
+
+  // Update the search object with the new sort order
+  return updatedSort.length > 0 ? updatedSort : undefined;
+};
+
+//
+// Unit tests for the updateColumnSorting() function
+//
+
+if (import.meta.vitest) {
+  const { it, expect } = import.meta.vitest;
+
+  it('adds a new column to an empty sorting state', () => {
+    const columns = undefined;
+    const column = { id: 'column1', desc: false };
+
+    expect(updateColumnSorting(columns, column)).toEqual([
+      { id: 'column1', desc: false },
+    ]);
+  });
+
+  it('adds a new column to an existing sorting state', () => {
+    const columns = [{ id: 'column1', desc: false }];
+    const column = { id: 'column2', desc: false };
+
+    expect(updateColumnSorting(columns, column)).toEqual([
+      { id: 'column1', desc: false },
+      { id: 'column2', desc: false },
+    ]);
+  });
+
+  it('updates the sorting state of an existing column from desc -> asc', () => {
+    const columns = [{ id: 'column1', desc: false }];
+    const column = { id: 'column1', desc: false };
+
+    expect(updateColumnSorting(columns, column)).toEqual([
+      { id: 'column1', desc: true },
+    ]);
+  });
+
+  it('when an existing column is asc -> removes the column from the sorting state', () => {
+    const columns = [{ id: 'column1', desc: true }];
+    const column = { id: 'column1', desc: true };
+
+    expect(updateColumnSorting(columns, column)).toEqual(undefined);
+  });
+
+  it('more complicated sorting state update', () => {
+    const columns = [
+      { id: 'column1', desc: false },
+      { id: 'column2', desc: true },
+      { id: 'column3', desc: false },
+    ];
+    const column = { id: 'column2', desc: true };
+
+    expect(updateColumnSorting(columns, column)).toEqual([
+      { id: 'column1', desc: false },
+      { id: 'column3', desc: false },
+    ]);
+  });
+}

--- a/ui/src/routes/organizations/$orgId/products/$productId/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/index.tsx
@@ -283,7 +283,10 @@ const ProductComponent = () => {
             productId: params.productId,
           }}
           search={{
-            sortBy: { id: 'rating', desc: true },
+            sortBy: [
+              { id: 'rating', desc: true },
+              { id: 'count', desc: true },
+            ],
           }}
         >
           <Suspense

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/index.tsx
@@ -207,7 +207,7 @@ const RunComponent = () => {
               repoId: params.repoId,
               runIndex: params.runIndex,
             }}
-            search={{ sortBy: { id: 'severity', desc: true } }}
+            search={{ sortBy: [{ id: 'severity', desc: true }] }}
           >
             <IssuesStatisticsCard
               runId={ortRun.id}
@@ -236,7 +236,7 @@ const RunComponent = () => {
               repoId: params.repoId,
               runIndex: params.runIndex,
             }}
-            search={{ sortBy: { id: 'rating', desc: true } }}
+            search={{ sortBy: [{ id: 'rating', desc: true }] }}
           >
             <VulnerabilitiesStatisticsCard
               runId={ortRun.id}
@@ -251,7 +251,7 @@ const RunComponent = () => {
               repoId: params.repoId,
               runIndex: params.runIndex,
             }}
-            search={{ sortBy: { id: 'severity', desc: true } }}
+            search={{ sortBy: [{ id: 'severity', desc: true }] }}
           >
             <RuleViolationsStatisticsCard
               runId={ortRun.id}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues/index.tsx
@@ -51,6 +51,7 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { getIssueSeverityBackgroundColor } from '@/helpers/get-status-class';
+import { updateColumnSorting } from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-to-string';
 import { compareSeverity } from '@/helpers/sorting-functions';
 import { toast } from '@/lib/toast';
@@ -180,7 +181,7 @@ const IssuesComponent = () => {
   );
 
   const sortBy = useMemo(
-    () => (search.sortBy ? [search.sortBy] : undefined),
+    () => (search.sortBy ? search.sortBy : undefined),
     [search.sortBy]
   );
 
@@ -291,7 +292,7 @@ const IssuesComponent = () => {
               to: Route.to,
               search: {
                 ...search,
-                sortBy: sortBy,
+                sortBy: updateColumnSorting(search.sortBy, sortBy),
               },
             };
           }}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/route.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/route.tsx
@@ -80,7 +80,7 @@ const Layout = () => {
           to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities',
           params,
           search: {
-            sortBy: { id: 'rating', desc: true },
+            sortBy: [{ id: 'rating', desc: true }],
           },
           icon: () => <ShieldQuestion className='h-4 w-4' />,
         },
@@ -95,7 +95,7 @@ const Layout = () => {
           to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations',
           params,
           search: {
-            sortBy: { id: 'severity', desc: true },
+            sortBy: [{ id: 'severity', desc: true }],
           },
           icon: () => <Scale className='h-4 w-4' />,
         },
@@ -109,7 +109,7 @@ const Layout = () => {
           to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues',
           params,
           search: {
-            sortBy: { id: 'severity', desc: true },
+            sortBy: [{ id: 'severity', desc: true }],
           },
           icon: () => <Bug className='h-4 w-4' />,
         },

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
@@ -52,6 +52,7 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { getRuleViolationSeverityBackgroundColor } from '@/helpers/get-status-class';
+import { updateColumnSorting } from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-to-string';
 import { compareSeverity } from '@/helpers/sorting-functions';
 import {
@@ -176,7 +177,7 @@ const RuleViolationsComponent = () => {
     [severity]
   );
   const sortBy = useMemo(
-    () => (search.sortBy ? [search.sortBy] : undefined),
+    () => (search.sortBy ? search.sortBy : undefined),
     [search.sortBy]
   );
 
@@ -272,7 +273,7 @@ const RuleViolationsComponent = () => {
               to: Route.to,
               search: {
                 ...search,
-                sortBy: sortBy,
+                sortBy: updateColumnSorting(search.sortBy, sortBy),
               },
             };
           }}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
@@ -57,6 +57,7 @@ import {
 } from '@/components/ui/table';
 import { calcOverallVulnerability } from '@/helpers/calc-overall-vulnerability';
 import { getVulnerabilityRatingBackgroundColor } from '@/helpers/get-status-class';
+import { updateColumnSorting } from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-to-string';
 import { compareVulnerabilityRating } from '@/helpers/sorting-functions';
 import { toast } from '@/lib/toast';
@@ -233,7 +234,7 @@ const VulnerabilitiesComponent = () => {
   );
 
   const sortBy = useMemo(
-    () => (search.sortBy ? [search.sortBy] : undefined),
+    () => (search.sortBy ? search.sortBy : undefined),
     [search.sortBy]
   );
 
@@ -323,7 +324,7 @@ const VulnerabilitiesComponent = () => {
               to: Route.to,
               search: {
                 ...search,
-                sortBy: sortBy,
+                sortBy: updateColumnSorting(search.sortBy, sortBy),
               },
             };
           }}

--- a/ui/src/routes/organizations/$orgId/products/$productId/route.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/route.tsx
@@ -40,7 +40,10 @@ const Layout = () => {
       title: 'Vulnerabilities',
       to: '/organizations/$orgId/products/$productId/vulnerabilities',
       search: {
-        sortBy: { id: 'rating', desc: true },
+        sortBy: [
+          { id: 'rating', desc: true },
+          { id: 'count', desc: true },
+        ],
       },
       icon: () => <ShieldQuestion className='h-4 w-4' />,
     },

--- a/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/-components/product-vulnerability-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/-components/product-vulnerability-table.tsx
@@ -45,6 +45,7 @@ import {
 } from '@/components/ui/table';
 import { calcOverallVulnerability } from '@/helpers/calc-overall-vulnerability';
 import { getVulnerabilityRatingBackgroundColor } from '@/helpers/get-status-class';
+import { updateColumnSorting } from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-to-string';
 import { compareVulnerabilityRating } from '@/helpers/sorting-functions';
 import { VulnerabilityWithRepositoryCount } from '@/hooks/use-vulnerabilities-by-product-suspense';
@@ -238,7 +239,7 @@ export const ProductVulnerabilitiesTable = ({
   );
 
   const sortBy = useMemo(
-    () => (search.sortBy ? [search.sortBy] : undefined),
+    () => (search.sortBy ? search.sortBy : undefined),
     [search.sortBy]
   );
 
@@ -257,7 +258,6 @@ export const ProductVulnerabilitiesTable = ({
     getPaginationRowModel: getPaginationRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getRowCanExpand: () => true,
-    enableMultiSort: false,
   });
 
   return (
@@ -278,7 +278,7 @@ export const ProductVulnerabilitiesTable = ({
         return {
           search: {
             ...search,
-            sortBy: sortBy,
+            sortBy: updateColumnSorting(search.sortBy, sortBy),
           },
         };
       }}

--- a/ui/src/schemas/index.ts
+++ b/ui/src/schemas/index.ts
@@ -45,10 +45,12 @@ export const paginationSearchParameterSchema = z.object({
 // sortBy needs to be of form "columnId.asc" or "columnId.desc"
 export const sortingSearchParameterSchema = z.object({
   sortBy: z
-    .object({
-      id: z.string(),
-      desc: z.boolean(),
-    })
+    .array(
+      z.object({
+        id: z.string(),
+        desc: z.boolean(),
+      })
+    )
     .optional(),
 });
 


### PR DESCRIPTION
This PR implements multisorting for all sortable tables in the UI. For product vulnerabilities, initial multisorting status is by overall vulnerability rating (descending), then by repository count (descending).

![Screenshot from 2024-12-05 08-38-01](https://github.com/user-attachments/assets/22571d91-f28d-45c6-9879-7b8b046baa37)

Please see the commits for details.