### PR TITLE
chore(dao): Remove unnecessary suppression of `DEPRECATION`

### DIFF
--- a/dao/src/main/kotlin/repositories/advisorrun/AdvisorResultsTable.kt
+++ b/dao/src/main/kotlin/repositories/advisorrun/AdvisorResultsTable.kt
@@ -47,7 +47,6 @@ class AdvisorResultDao(id: EntityID<Long>) : LongEntity(id) {
     var advisorRunIdentifier by AdvisorRunIdentifierDao referencedOn AdvisorResultsTable.advisorRunIdentifierId
 
     var advisorName by AdvisorResultsTable.advisorName
-    @Suppress("DEPRECATION") // See https://youtrack.jetbrains.com/issue/EXPOSED-483.
     var capabilities by AdvisorResultsTable.capabilities
         .transform({ it.joinToString(",") }, { it.split(",") })
     var startTime by AdvisorResultsTable.startTime.transformToDatabasePrecision()

--- a/dao/src/main/kotlin/repositories/analyzerrun/AnalyzerConfigurationsTable.kt
+++ b/dao/src/main/kotlin/repositories/analyzerrun/AnalyzerConfigurationsTable.kt
@@ -44,10 +44,8 @@ class AnalyzerConfigurationDao(id: EntityID<Long>) : LongEntity(id) {
     var analyzerRun by AnalyzerRunDao referencedOn AnalyzerConfigurationsTable.analyzerRunId
 
     var allowDynamicVersions by AnalyzerConfigurationsTable.allowDynamicVersions
-    @Suppress("DEPRECATION") // See https://youtrack.jetbrains.com/issue/EXPOSED-483.
     var enabledPackageManagers: List<String>? by AnalyzerConfigurationsTable.enabledPackageManagers
         .transform({ it?.joinToString(",") }, { it?.split(",") })
-    @Suppress("DEPRECATION") // See https://youtrack.jetbrains.com/issue/EXPOSED-483.
     var disabledPackageManagers: List<String>? by AnalyzerConfigurationsTable.disabledPackageManagers
         .transform({ it?.joinToString(",") }, { it?.split(",") })
     var skipExcluded by AnalyzerConfigurationsTable.skipExcluded

--- a/dao/src/main/kotlin/repositories/analyzerrun/PackageManagerConfigurationsTable.kt
+++ b/dao/src/main/kotlin/repositories/analyzerrun/PackageManagerConfigurationsTable.kt
@@ -39,7 +39,6 @@ class PackageManagerConfigurationDao(id: EntityID<Long>) : LongEntity(id) {
     companion object : LongEntityClass<PackageManagerConfigurationDao>(PackageManagerConfigurationsTable)
 
     var name by PackageManagerConfigurationsTable.name
-    @Suppress("DEPRECATION") // See https://youtrack.jetbrains.com/issue/EXPOSED-483.
     var mustRunAfter: List<String>? by PackageManagerConfigurationsTable.mustRunAfter
         .transform({ it?.joinToString(",") }, { it?.split(",") })
     var hasOptions by PackageManagerConfigurationsTable.hasOptions

--- a/dao/src/main/kotlin/repositories/infrastructureservice/InfrastructureServicesTable.kt
+++ b/dao/src/main/kotlin/repositories/infrastructureservice/InfrastructureServicesTable.kt
@@ -103,7 +103,7 @@ class InfrastructureServicesDao(id: EntityID<Long>) : LongEntity(id) {
     var name by InfrastructureServicesTable.name
     var url by InfrastructureServicesTable.url
     var description by InfrastructureServicesTable.description
-    @Suppress("DEPRECATION") // See https://youtrack.jetbrains.com/issue/EXPOSED-483.
+
     var credentialsTypes by InfrastructureServicesTable.credentialsType.transform(
         { toCredentialsTypeString(it) },
         { fromCredentialsTypeString(it) }

--- a/dao/src/main/kotlin/repositories/repositoryconfiguration/LicenseFindingCurationsTable.kt
+++ b/dao/src/main/kotlin/repositories/repositoryconfiguration/LicenseFindingCurationsTable.kt
@@ -85,7 +85,6 @@ class LicenseFindingCurationDao(id: EntityID<Long>) : LongEntity(id) {
     }
 
     var path by LicenseFindingCurationsTable.path
-    @Suppress("DEPRECATION") // See https://youtrack.jetbrains.com/issue/EXPOSED-483.
     var startLines: List<Int>? by LicenseFindingCurationsTable.startLines
         .transform({ it?.joinToString(",") }, ::convertStartLines)
     var lineCount by LicenseFindingCurationsTable.lineCount

--- a/dao/src/main/kotlin/repositories/repositoryconfiguration/RepositoryAnalyzerConfigurationsTable.kt
+++ b/dao/src/main/kotlin/repositories/repositoryconfiguration/RepositoryAnalyzerConfigurationsTable.kt
@@ -86,10 +86,8 @@ class RepositoryAnalyzerConfigurationDao(id: EntityID<Long>) : LongEntity(id) {
     }
 
     var allowDynamicVersions by RepositoryAnalyzerConfigurationsTable.allowDynamicVersions
-    @Suppress("DEPRECATION") // See https://youtrack.jetbrains.com/issue/EXPOSED-483.
     var enabledPackageManagers: List<String>? by RepositoryAnalyzerConfigurationsTable.enabledPackageManagers
         .transform({ it?.joinToString(",") }, { it?.split(",") })
-    @Suppress("DEPRECATION") // See https://youtrack.jetbrains.com/issue/EXPOSED-483.
     var disabledPackageManagers: List<String>? by RepositoryAnalyzerConfigurationsTable.disabledPackageManagers
         .transform({ it?.joinToString(",") }, { it?.split(",") })
     var skipExcluded by RepositoryAnalyzerConfigurationsTable.skipExcluded

--- a/dao/src/main/kotlin/repositories/scannerrun/ScannerConfigurationsTable.kt
+++ b/dao/src/main/kotlin/repositories/scannerrun/ScannerConfigurationsTable.kt
@@ -45,7 +45,6 @@ class ScannerConfigurationDao(id: EntityID<Long>) : LongEntity(id) {
 
     var skipConcluded by ScannerConfigurationsTable.skipConcluded
     var skipExcluded by ScannerConfigurationsTable.skipExcluded
-    @Suppress("DEPRECATION") // See https://youtrack.jetbrains.com/issue/EXPOSED-483.
     var ignorePatterns: List<String>? by ScannerConfigurationsTable.ignorePatterns
         .transform({ it?.joinToString(",") }, { it?.split(",") })
     var detectedLicenseMappings by DetectedLicenseMappingDao via

--- a/dao/src/main/kotlin/utils/Extensions.kt
+++ b/dao/src/main/kotlin/utils/Extensions.kt
@@ -56,7 +56,7 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder.notInList
  * Transform the given column [to database precision][toDatabasePrecision] when creating a DAO object.
  */
 context(EntityClass<*, *>)
-@Suppress("DEPRECATION", "UNCHECKED_CAST") // See https://youtrack.jetbrains.com/issue/EXPOSED-483.
+@Suppress("UNCHECKED_CAST")
 fun <T : Instant?> Column<T>.transformToDatabasePrecision() = transform({ it?.toDatabasePrecision() as T }, { it })
 
 /**


### PR DESCRIPTION
The deprecation of the DAO transform API was reverted in Exposed 0.57.0, see [1] and [2].

[1]: https://github.com/JetBrains/Exposed/blob/main/CHANGELOG.md#0570
[2]: https://github.com/JetBrains/Exposed/pull/2309