### PR TITLE
Revert "build(gradle): Force to use Exposed 0.52.0"

### DIFF
--- a/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-conventions.gradle.kts
@@ -96,12 +96,3 @@ tasks.withType<Test>().configureEach {
         showStandardStreams = false
     }
 }
-
-configurations.all {
-    resolutionStrategy.eachDependency {
-        if (requested.group == "org.jetbrains.exposed") {
-            useVersion(libs.versions.exposed.get())
-            because("https://youtrack.jetbrains.com/issue/EXPOSED-483")
-        }
-    }
-}


### PR DESCRIPTION
This reverts commit 085e70b as both ORT core and ORT server by now use Exposed 0.57.0.