### PR TITLE
fix(ui): Convert Tailwind CSS config to ESM

### DIFF
--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -17,8 +17,11 @@
  * License-Filename: LICENSE
  */
 
+import tailwindcssTypography from '@tailwindcss/typography';
+import tailwindcssAnimate from 'tailwindcss-animate';
+
 /** @type {import('tailwindcss').Config} */
-module.exports = {
+export default {
   darkMode: ['class'],
   content: ['./src/**/*.{ts,tsx}'],
   theme: {
@@ -98,5 +101,5 @@ module.exports = {
       },
     },
   },
-  plugins: [require('tailwindcss-animate'), require('@tailwindcss/typography')],
+  plugins: [tailwindcssAnimate, tailwindcssTypography],
 };


### PR DESCRIPTION
Convert the Tailwind CSS config file from CJS to ESM syntax to fix the build with Node 22.12.0 [1].

[1]: https://github.com/nodejs/node/issues/56155