### PR TITLE
ci(docker): Fix calculating the ORT Server version

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -84,6 +84,8 @@ jobs:
     steps:
     - name: Checkout Repository
       uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      with:
+        fetch-depth: 0
 
     - name: Free Disk Space
       if: ${{ matrix.docker.freeDiskSpace }}


### PR DESCRIPTION
Set `fetch-depth` to `0` to checkout the whole commit history including tags. This is required to correctly calculate the ORT Server version.

Fixes #1610.