### PR TITLE
Refactor run statistics count functions to take in multiple run IDs

### DIFF
--- a/core/src/main/kotlin/api/RunsRoute.kt
+++ b/core/src/main/kotlin/api/RunsRoute.kt
@@ -277,12 +277,10 @@ fun Route.runs() = route("runs") {
 
                     val jobs = repositoryService.getJobs(ortRun.repositoryId, ortRun.index)
 
-                    val finishedStateSet: Set<JobStatus> = setOf(JobStatus.FINISHED, JobStatus.FINISHED_WITH_ISSUES)
-
-                    val analyzerJobInFinalState = jobs?.analyzer?.status in finishedStateSet.plus(JobStatus.FAILED)
-                    val analyzerJobInFinishedState = jobs?.analyzer?.status in finishedStateSet
-                    val advisorJobInFinishedState = jobs?.advisor?.status in finishedStateSet
-                    val evaluatorJobInFinishedState = jobs?.evaluator?.status in finishedStateSet
+                    val analyzerJobInFinalState = jobs?.analyzer?.status in JobStatus.FINAL_STATUSES
+                    val analyzerJobInFinishedState = jobs?.analyzer?.status in JobStatus.SUCCESSFUL_STATUSES
+                    val advisorJobInFinishedState = jobs?.advisor?.status in JobStatus.SUCCESSFUL_STATUSES
+                    val evaluatorJobInFinishedState = jobs?.evaluator?.status in JobStatus.SUCCESSFUL_STATUSES
 
                     val issuesCount = if (analyzerJobInFinalState) issueService.countForOrtRunId(ortRun.id) else null
 

--- a/core/src/main/kotlin/api/RunsRoute.kt
+++ b/core/src/main/kotlin/api/RunsRoute.kt
@@ -282,13 +282,13 @@ fun Route.runs() = route("runs") {
                     val advisorJobInFinishedState = jobs?.advisor?.status in JobStatus.SUCCESSFUL_STATUSES
                     val evaluatorJobInFinishedState = jobs?.evaluator?.status in JobStatus.SUCCESSFUL_STATUSES
 
-                    val issuesCount = if (analyzerJobInFinalState) issueService.countForOrtRunId(ortRun.id) else null
+                    val issuesCount = if (analyzerJobInFinalState) issueService.countForOrtRunIds(ortRun.id) else null
 
                     val packagesCount =
-                        if (analyzerJobInFinishedState) packageService.countForOrtRunId(ortRun.id) else null
+                        if (analyzerJobInFinishedState) packageService.countForOrtRunIds(ortRun.id) else null
 
                     val ecosystems = if (analyzerJobInFinishedState) {
-                        packageService.countEcosystemsForOrtRun(ortRun.id).map { ecosystemStats ->
+                        packageService.countEcosystemsForOrtRunIds(ortRun.id).map { ecosystemStats ->
                             ecosystemStats.mapToApi()
                         }
                     } else {
@@ -296,10 +296,10 @@ fun Route.runs() = route("runs") {
                     }
 
                     val vulnerabilitiesCount =
-                        if (advisorJobInFinishedState) vulnerabilityService.countForOrtRunId(ortRun.id) else null
+                        if (advisorJobInFinishedState) vulnerabilityService.countForOrtRunIds(ortRun.id) else null
 
                     val ruleViolationsCount =
-                        if (evaluatorJobInFinishedState) ruleViolationService.countForOrtRunId(ortRun.id) else null
+                        if (evaluatorJobInFinishedState) ruleViolationService.countForOrtRunIds(ortRun.id) else null
 
                     call.respond(
                         HttpStatusCode.OK,

--- a/dao/src/testFixtures/kotlin/Fixtures.kt
+++ b/dao/src/testFixtures/kotlin/Fixtures.kt
@@ -198,12 +198,7 @@ class Fixtures(private val db: Database) {
             "identifier_version"
         )
     ): Identifier = db.blockingQuery {
-        IdentifierDao.new {
-            type = identifier.type
-            namespace = identifier.namespace
-            name = identifier.name
-            version = identifier.version
-        }.mapToModel()
+        IdentifierDao.getOrPut(identifier).mapToModel()
     }
 
     fun getViolation() = OrtRuleViolation(

--- a/services/hierarchy/src/main/kotlin/IssueService.kt
+++ b/services/hierarchy/src/main/kotlin/IssueService.kt
@@ -81,10 +81,11 @@ class IssueService(private val db: Database) {
         )
     }
 
-    suspend fun countForOrtRunId(ortRunId: Long): Long = db.dbQuery {
+    /** Count issues found in provided ORT runs. */
+    suspend fun countForOrtRunIds(vararg ortRunIds: Long): Long = db.dbQuery {
         OrtRunsIssuesTable
             .select(OrtRunsIssuesTable.id)
-            .where { OrtRunsIssuesTable.ortRunId eq ortRunId }
+            .where { OrtRunsIssuesTable.ortRunId inList ortRunIds.asList() }
             .count()
     }
 

--- a/services/hierarchy/src/main/kotlin/RuleViolationService.kt
+++ b/services/hierarchy/src/main/kotlin/RuleViolationService.kt
@@ -58,13 +58,15 @@ class RuleViolationService(private val db: Database) {
         ListQueryResult(ruleViolationQueryResult.data, parameters, ruleViolationQueryResult.totalCount)
     }
 
-    suspend fun countForOrtRunId(ortRunId: Long): Long = db.dbQuery {
+    /** Count rule violations found in provided ORT runs. */
+    suspend fun countForOrtRunIds(vararg ortRunIds: Long): Long = db.dbQuery {
         RuleViolationsTable
             .innerJoin(EvaluatorRunsRuleViolationsTable)
             .innerJoin(EvaluatorRunsTable)
             .innerJoin(EvaluatorJobsTable)
             .select(RuleViolationsTable.id)
-            .where { EvaluatorJobsTable.ortRunId eq ortRunId }
+            .where { EvaluatorJobsTable.ortRunId inList ortRunIds.asList() }
+            .withDistinct()
             .count()
     }
 }

--- a/services/hierarchy/src/main/kotlin/VulnerabilityService.kt
+++ b/services/hierarchy/src/main/kotlin/VulnerabilityService.kt
@@ -125,15 +125,18 @@ class VulnerabilityService(private val db: Database) {
         }
     }
 
-    suspend fun countForOrtRunId(ortRunId: Long): Long = db.dbQuery {
+    /** Count vulnerabilities found in provided ORT runs. */
+    suspend fun countForOrtRunIds(vararg ortRunIds: Long): Long = db.dbQuery {
         VulnerabilitiesTable
             .innerJoin(AdvisorResultsVulnerabilitiesTable)
             .innerJoin(AdvisorResultsTable)
             .innerJoin(AdvisorRunsIdentifiersTable)
             .innerJoin(AdvisorRunsTable)
             .innerJoin(AdvisorJobsTable)
+            .innerJoin(IdentifiersTable)
             .select(VulnerabilitiesTable.id)
-            .where { AdvisorJobsTable.ortRunId eq ortRunId }
+            .where { AdvisorJobsTable.ortRunId inList ortRunIds.asList() }
+            .groupBy(VulnerabilitiesTable.id, IdentifiersTable.id)
             .count()
     }
 }

--- a/services/hierarchy/src/test/kotlin/IssueServiceTest.kt
+++ b/services/hierarchy/src/test/kotlin/IssueServiceTest.kt
@@ -58,12 +58,35 @@ class IssueServiceTest : WordSpec() {
             }
         }
 
-        "countForOrtRunId" should {
+        "countForOrtRunIds" should {
             "return issue count for ORT run" {
                 val service = IssueService(db)
                 val ortRun = createOrtRunWithIssues()
 
-                service.countForOrtRunId(ortRun.id) shouldBe 3
+                service.countForOrtRunIds(ortRun.id) shouldBe 3
+            }
+
+            "return count of issues found in ORT runs" {
+                val service = IssueService(db)
+                val repositoryId = fixtures.createRepository().id
+
+                val ortRun1Id = createOrtRunWithIssues(repositoryId).id
+
+                val ortRun2Id = createOrtRunWithIssues(
+                    repositoryId,
+                    generateIssues().plus(
+                        Issue(
+                            timestamp = Clock.System.now(),
+                            source = "Scanner",
+                            message = "Issue",
+                            severity = Severity.WARNING,
+                            affectedPath = "path",
+                            identifier = Identifier("Maven", "com.example", "example", "1.0")
+                        )
+                    )
+                ).id
+
+                service.countForOrtRunIds(ortRun1Id, ortRun2Id) shouldBe 7
             }
         }
     }

--- a/services/hierarchy/src/test/kotlin/PackageServiceTest.kt
+++ b/services/hierarchy/src/test/kotlin/PackageServiceTest.kt
@@ -63,58 +63,12 @@ class PackageServiceTest : WordSpec() {
             "return the packages for the given ORT run id" {
                 val service = PackageService(db)
 
-                val pkg1 = Package(
-                    Identifier("Maven", "com.example", "example", "1.0"),
-                    purl = "pkg:maven/com.example/example@1.0",
-                    cpe = null,
-                    authors = emptySet(),
-                    declaredLicenses = emptySet(),
-                    ProcessedDeclaredLicense(
-                        spdxExpression = "Expression",
-                        mappedLicenses = emptyMap(),
-                        unmappedLicenses = emptySet()
-                    ),
-                    description = "An example package",
-                    homepageUrl = "https://example.com",
-                    binaryArtifact = RemoteArtifact(
-                        "https://example.com/example-1.0.jar",
-                        "sha1:binary",
-                        "SHA-1"
-                    ),
-                    sourceArtifact = RemoteArtifact(
-                        "https://example.com/example-1.0-sources.jar",
-                        "sha1:source",
-                        "SHA-1"
-                    ),
-                    vcs = VcsInfo(
-                        RepositoryType(""),
-                        "https://example.com/git",
-                        "revision1",
-                        "path"
-                    ),
-                    vcsProcessed = VcsInfo(
-                        RepositoryType("GIT"),
-                        "https://example.com/git",
-                        "revision2",
-                        "path"
-                    ),
-                    isMetadataOnly = false,
-                    isModified = false
-                )
+                val pkg1 = generatePackage(Identifier("Maven", "com.example", "example", "1.0"))
 
-                val pkg2 = Package(
-                    Identifier("Maven", "com.example", "example2", "1.0"),
-                    purl = "pkg:maven/com.example/example2@1.0",
-                    cpe = null,
-                    authors = emptySet(),
-                    declaredLicenses = emptySet(),
-                    ProcessedDeclaredLicense(
-                        spdxExpression = "Expression",
-                        mappedLicenses = emptyMap(),
-                        unmappedLicenses = emptySet()
-                    ),
+                val pkg2 = generatePackage(
+                    identifier = Identifier("Maven", "com.example", "example2", "1.0"),
                     description = "Another example package",
-                    homepageUrl = "https://example.com",
+                    homepageUrl = "https://example2.com",
                     binaryArtifact = RemoteArtifact(
                         "https://example.com/example2-1.0.jar",
                         "sha1:binary",
@@ -124,21 +78,7 @@ class PackageServiceTest : WordSpec() {
                         "https://example.com/example2-1.0-sources.jar",
                         "sha1:source",
                         "SHA-1"
-                    ),
-                    vcs = VcsInfo(
-                        RepositoryType("GIT"),
-                        "https://example.com/git",
-                        "revision",
-                        "path"
-                    ),
-                    vcsProcessed = VcsInfo(
-                        RepositoryType("GIT"),
-                        "https://example.com/git",
-                        "revision",
-                        "path"
-                    ),
-                    isMetadataOnly = false,
-                    isModified = false
+                    )
                 )
 
                 val ortRunId = createAnalyzerRunWithPackages(setOf(pkg1, pkg2)).id
@@ -151,13 +91,11 @@ class PackageServiceTest : WordSpec() {
 
                 val ortRunId = createAnalyzerRunWithPackages(
                     setOf(
-                        Package(
-                            Identifier("Maven", "com.example", "example", "1.0"),
-                            purl = "pkg:maven/com.example/example@1.0",
-                            cpe = null,
+                        generatePackage(
+                            identifier = Identifier("Maven", "com.example", "example", "1.0"),
                             authors = setOf("Author One", "Author Two", "Author Three"),
                             declaredLicenses = setOf("License 1", "License 2", "License 3", "License 4"),
-                            ProcessedDeclaredLicense(
+                            processedDeclaredLicense = ProcessedDeclaredLicense(
                                 spdxExpression = "License Expression",
                                 mappedLicenses = mapOf(
                                     "License 1" to "Mapped License 1",
@@ -165,32 +103,6 @@ class PackageServiceTest : WordSpec() {
                                     ),
                                 unmappedLicenses = setOf("License 1", "License 2", "License 3", "License 4")
                             ),
-                            description = "An example package",
-                            homepageUrl = "https://example.com",
-                            binaryArtifact = RemoteArtifact(
-                                "https://example.com/example-1.0.jar",
-                                "sha1:value",
-                                "SHA-1"
-                            ),
-                            sourceArtifact = RemoteArtifact(
-                                "https://example.com/example-1.0-sources.jar",
-                                "sha1:value",
-                                "SHA-1"
-                            ),
-                            vcs = VcsInfo(
-                                RepositoryType("GIT"),
-                                "https://example.com/git",
-                                "revision",
-                                "path"
-                            ),
-                            vcsProcessed = VcsInfo(
-                                RepositoryType("GIT"),
-                                "https://example.com/git",
-                                "revision",
-                                "path"
-                            ),
-                            isMetadataOnly = false,
-                            isModified = false
                         )
                     )
                 ).id
@@ -222,120 +134,9 @@ class PackageServiceTest : WordSpec() {
 
                 val ortRunId = createAnalyzerRunWithPackages(
                     setOf(
-                        Package(
-                            Identifier("Maven", "com.example", "example", "1.0"),
-                            purl = "pkg:maven/com.example/example@1.0",
-                            cpe = null,
-                            authors = emptySet(),
-                            declaredLicenses = emptySet(),
-                            ProcessedDeclaredLicense(
-                                spdxExpression = "Expression",
-                                mappedLicenses = emptyMap(),
-                                unmappedLicenses = emptySet()
-                            ),
-                            description = "An example package",
-                            homepageUrl = "https://example.com",
-                            binaryArtifact = RemoteArtifact(
-                                "https://example.com/example-1.0.jar",
-                                "sha1:value",
-                                "SHA-1"
-                            ),
-                            sourceArtifact = RemoteArtifact(
-                                "https://example.com/example-1.0-sources.jar",
-                                "sha1:value",
-                                "SHA-1"
-                            ),
-                            vcs = VcsInfo(
-                                RepositoryType("GIT"),
-                                "https://example.com/git",
-                                "revision",
-                                "path"
-                            ),
-                            vcsProcessed = VcsInfo(
-                                RepositoryType("GIT"),
-                                "https://example.com/git",
-                                "revision",
-                                "path"
-                            ),
-                            isMetadataOnly = false,
-                            isModified = false
-                        ),
-                        Package(
-                            Identifier("Maven", "com.example", "example2", "1.0"),
-                            purl = "pkg:maven/com.example/example2@1.0",
-                            cpe = null,
-                            authors = emptySet(),
-                            declaredLicenses = emptySet(),
-                            ProcessedDeclaredLicense(
-                                spdxExpression = "Expression",
-                                mappedLicenses = emptyMap(),
-                                unmappedLicenses = emptySet()
-                            ),
-                            description = "Another example package",
-                            homepageUrl = "https://example.com",
-                            binaryArtifact = RemoteArtifact(
-                                "https://example.com/example2-1.0.jar",
-                                "sha1:value",
-                                "SHA-1"
-                            ),
-                            sourceArtifact = RemoteArtifact(
-                                "https://example.com/example2-1.0-sources.jar",
-                                "sha1:value",
-                                "SHA-1"
-                            ),
-                            vcs = VcsInfo(
-                                RepositoryType("GIT"),
-                                "https://example.com/git",
-                                "revision",
-                                "path"
-                            ),
-                            vcsProcessed = VcsInfo(
-                                RepositoryType("GIT"),
-                                "https://example.com/git",
-                                "revision",
-                                "path"
-                            ),
-                            isMetadataOnly = false,
-                            isModified = false
-                        ),
-                        Package(
-                            Identifier("Maven", "com.example", "example3", "1.0"),
-                            purl = "pkg:maven/com.example/example3@1.0",
-                            cpe = null,
-                            authors = emptySet(),
-                            declaredLicenses = emptySet(),
-                            ProcessedDeclaredLicense(
-                                spdxExpression = "Expression",
-                                mappedLicenses = emptyMap(),
-                                unmappedLicenses = emptySet()
-                            ),
-                            description = "Yet another example package",
-                            homepageUrl = "https://example.com",
-                            binaryArtifact = RemoteArtifact(
-                                "https://example.com/example3-1.0.jar",
-                                "sha1:value",
-                                "SHA-1"
-                            ),
-                            sourceArtifact = RemoteArtifact(
-                                "https://example.com/example3-1.0-sources.jar",
-                                "sha1:value",
-                                "SHA-1"
-                            ),
-                            vcs = VcsInfo(
-                                RepositoryType("GIT"),
-                                "https://example.com/git",
-                                "revision",
-                                "path"
-                            ),
-                            vcsProcessed = VcsInfo(
-                                RepositoryType("GIT"),
-                                "https://example.com/git",
-                                "revision",
-                                "path"
-                            ),
-                            isMetadataOnly = false,
-                            isModified = false
-                        )
+                        generatePackage(Identifier("Maven", "com.example", "example", "1.0")),
+                        generatePackage(Identifier("Maven", "com.example", "example2", "1.0")),
+                        generatePackage(Identifier("Maven", "com.example", "example3", "1.0"))
                     )
                 ).id
 
@@ -373,82 +174,8 @@ class PackageServiceTest : WordSpec() {
 
                 val ortRunId = createAnalyzerRunWithPackages(
                     setOf(
-                        Package(
-                            Identifier("Maven", "com.example", "example", "1.0"),
-                            purl = "pkg:maven/com.example/example@1.0",
-                            cpe = null,
-                            authors = emptySet(),
-                            declaredLicenses = emptySet(),
-                            ProcessedDeclaredLicense(
-                                spdxExpression = null,
-                                mappedLicenses = emptyMap(),
-                                unmappedLicenses = emptySet()
-                            ),
-                            description = "An example package",
-                            homepageUrl = "https://example.com",
-                            binaryArtifact = RemoteArtifact(
-                                "https://example.com/example-1.0.jar",
-                                "sha1:value",
-                                "SHA-1"
-                            ),
-                            sourceArtifact = RemoteArtifact(
-                                "https://example.com/example-1.0-sources.jar",
-                                "sha1:value",
-                                "SHA-1"
-                            ),
-                            vcs = VcsInfo(
-                                RepositoryType("GIT"),
-                                "https://example.com/git",
-                                "revision",
-                                "path"
-                            ),
-                            vcsProcessed = VcsInfo(
-                                RepositoryType("GIT"),
-                                "https://example.com/git",
-                                "revision",
-                                "path"
-                            ),
-                            isMetadataOnly = false,
-                            isModified = false
-                        ),
-                        Package(
-                            Identifier("NPM", "com.example", "example2", "1.0"),
-                            purl = "pkg:npm/com.example/example2@1.0",
-                            cpe = null,
-                            authors = emptySet(),
-                            declaredLicenses = emptySet(),
-                            ProcessedDeclaredLicense(
-                                spdxExpression = null,
-                                mappedLicenses = emptyMap(),
-                                unmappedLicenses = emptySet()
-                            ),
-                            description = "Another example package",
-                            homepageUrl = "https://example.com",
-                            binaryArtifact = RemoteArtifact(
-                                "https://example.com/example2-1.0.jar",
-                                "sha1:value",
-                                "SHA-1"
-                            ),
-                            sourceArtifact = RemoteArtifact(
-                                "https://example.com/example2-1.0-sources.jar",
-                                "sha1:value",
-                                "SHA-1"
-                            ),
-                            vcs = VcsInfo(
-                                RepositoryType("GIT"),
-                                "https://example.com/git",
-                                "revision",
-                                "path"
-                            ),
-                            vcsProcessed = VcsInfo(
-                                RepositoryType("GIT"),
-                                "https://example.com/git",
-                                "revision",
-                                "path"
-                            ),
-                            isMetadataOnly = false,
-                            isModified = false
-                        ),
+                        generatePackage(Identifier("Maven", "com.example", "example", "1.0")),
+                        generatePackage(Identifier("NPM", "com.example", "example2", "1.0"))
                     )
                 ).id
 
@@ -462,120 +189,9 @@ class PackageServiceTest : WordSpec() {
 
                 val ortRunId = createAnalyzerRunWithPackages(
                     setOf(
-                        Package(
-                            Identifier("Maven", "com.example", "example", "1.0"),
-                            purl = "pkg:maven/com.example/example@1.0",
-                            cpe = null,
-                            authors = emptySet(),
-                            declaredLicenses = emptySet(),
-                            ProcessedDeclaredLicense(
-                                spdxExpression = "Expression",
-                                mappedLicenses = emptyMap(),
-                                unmappedLicenses = emptySet()
-                            ),
-                            description = "An example package",
-                            homepageUrl = "https://example.com",
-                            binaryArtifact = RemoteArtifact(
-                                "https://example.com/example-1.0.jar",
-                                "sha1:value",
-                                "SHA-1"
-                            ),
-                            sourceArtifact = RemoteArtifact(
-                                "https://example.com/example-1.0-sources.jar",
-                                "sha1:value",
-                                "SHA-1"
-                            ),
-                            vcs = VcsInfo(
-                                RepositoryType("GIT"),
-                                "https://example.com/git",
-                                "revision",
-                                "path"
-                            ),
-                            vcsProcessed = VcsInfo(
-                                RepositoryType("GIT"),
-                                "https://example.com/git",
-                                "revision",
-                                "path"
-                            ),
-                            isMetadataOnly = false,
-                            isModified = false
-                        ),
-                        Package(
-                            Identifier("NPM", "com.example", "example2", "1.0"),
-                            purl = "pkg:npm/com.example/example2@1.0",
-                            cpe = null,
-                            authors = emptySet(),
-                            declaredLicenses = emptySet(),
-                            ProcessedDeclaredLicense(
-                                spdxExpression = "Expression",
-                                mappedLicenses = emptyMap(),
-                                unmappedLicenses = emptySet()
-                            ),
-                            description = "Another example package",
-                            homepageUrl = "https://example.com",
-                            binaryArtifact = RemoteArtifact(
-                                "https://example.com/example2-1.0.jar",
-                                "sha1:value",
-                                "SHA-1"
-                            ),
-                            sourceArtifact = RemoteArtifact(
-                                "https://example.com/example2-1.0-sources.jar",
-                                "sha1:value",
-                                "SHA-1"
-                            ),
-                            vcs = VcsInfo(
-                                RepositoryType("GIT"),
-                                "https://example.com/git",
-                                "revision",
-                                "path"
-                            ),
-                            vcsProcessed = VcsInfo(
-                                RepositoryType("GIT"),
-                                "https://example.com/git",
-                                "revision",
-                                "path"
-                            ),
-                            isMetadataOnly = false,
-                            isModified = false
-                        ),
-                        Package(
-                            Identifier("Maven", "com.example", "example3", "1.0"),
-                            purl = "pkg:maven/com.example/example3@1.0",
-                            cpe = null,
-                            authors = emptySet(),
-                            declaredLicenses = emptySet(),
-                            ProcessedDeclaredLicense(
-                                spdxExpression = "Expression",
-                                mappedLicenses = emptyMap(),
-                                unmappedLicenses = emptySet()
-                            ),
-                            description = "Yet another example package",
-                            homepageUrl = "https://example.com",
-                            binaryArtifact = RemoteArtifact(
-                                "https://example.com/example3-1.0.jar",
-                                "sha1:value",
-                                "SHA-1"
-                            ),
-                            sourceArtifact = RemoteArtifact(
-                                "https://example.com/example3-1.0-sources.jar",
-                                "sha1:value",
-                                "SHA-1"
-                            ),
-                            vcs = VcsInfo(
-                                RepositoryType("GIT"),
-                                "https://example.com/git",
-                                "revision",
-                                "path"
-                            ),
-                            vcsProcessed = VcsInfo(
-                                RepositoryType("GIT"),
-                                "https://example.com/git",
-                                "revision",
-                                "path"
-                            ),
-                            isMetadataOnly = false,
-                            isModified = false
-                        )
+                        generatePackage(Identifier("Maven", "com.example", "example", "1.0")),
+                        generatePackage(Identifier("NPM", "com.example", "example2", "1.0")),
+                        generatePackage(Identifier("Maven", "com.example", "example3", "1.0"))
                     )
                 ).id
 
@@ -632,4 +248,54 @@ class PackageServiceTest : WordSpec() {
 
         return ortRun
     }
+
+    private fun generatePackage(
+        identifier: Identifier,
+        authors: Set<String> = emptySet(),
+        declaredLicenses: Set<String> = emptySet(),
+        processedDeclaredLicense: ProcessedDeclaredLicense = ProcessedDeclaredLicense(
+            spdxExpression = null,
+            mappedLicenses = emptyMap(),
+            unmappedLicenses = emptySet()
+        ),
+        description: String = "Example package",
+        homepageUrl: String = "https://example.com",
+        binaryArtifact: RemoteArtifact = RemoteArtifact(
+            "https://example.com/example-1.0.jar",
+            "sha1:value",
+            "SHA-1"
+        ),
+        sourceArtifact: RemoteArtifact = RemoteArtifact(
+            "https://example.com/example-1.0-sources.jar",
+            "sha1:value",
+            "SHA-1"
+        ),
+        vcs: VcsInfo = VcsInfo(
+            RepositoryType("GIT"),
+            "https://example.com/git",
+            "revision",
+            "path"
+        ),
+        vcsProcessed: VcsInfo = VcsInfo(
+            RepositoryType("GIT"),
+            "https://example.com/git",
+            "revision",
+            "path"
+        )
+    ) = Package(
+        identifier = identifier,
+        purl = "pkg:${identifier.type}/${identifier.namespace}/${identifier.name}@${identifier.version}",
+        cpe = null,
+        authors = authors,
+        declaredLicenses = declaredLicenses,
+        processedDeclaredLicense = processedDeclaredLicense,
+        description = description,
+        homepageUrl = homepageUrl,
+        binaryArtifact = binaryArtifact,
+        sourceArtifact = sourceArtifact,
+        vcs = vcs,
+        vcsProcessed = vcsProcessed,
+        isMetadataOnly = false,
+        isModified = false
+    )
 }

--- a/services/hierarchy/src/test/kotlin/VulnerabilityServiceTest.kt
+++ b/services/hierarchy/src/test/kotlin/VulnerabilityServiceTest.kt
@@ -229,7 +229,32 @@ class VulnerabilityServiceTest : WordSpec() {
                 val advisorResult = createAdvisorResults(vulnerabilities)
                 val ortRun = createVulnerabilityEntries(advisorResult)
 
-                service.countForOrtRunId(ortRun.id) shouldBe 4
+                service.countForOrtRunIds(ortRun.id) shouldBe 4
+            }
+
+            "return count of unique vulnerabilities found in ORT runs" {
+                val service = VulnerabilityService(db)
+
+                val repositoryId = fixtures.createRepository().id
+
+                val vulnerabilities = createVulnerabilities(
+                    Triple(
+                        Identifier("Maven", "org.apache.logging.log4j", "log4j-core", "2.14.0"),
+                        listOf("CVE-2018-14721", "CVE-2018-14722", "CVE-2021-45046", "CVE-2024-31573"),
+                        listOf(4.2, 1.2, 10.0, 9.0)
+                    ),
+                    Triple(
+                        Identifier("Maven", "org.apache.logging.log4j", "log4j-api", "2.14.0"),
+                        listOf("CVE-2018-14721"),
+                        listOf(4.2, 1.2, 10.0, 9.0)
+                    )
+                )
+
+                val advisorResult = createAdvisorResults(vulnerabilities)
+                val ortRun1Id = createVulnerabilityEntries(advisorResult, repositoryId).id
+                val ortRun2Id = createVulnerabilityEntries(advisorResult, repositoryId).id
+
+                service.countForOrtRunIds(ortRun1Id, ortRun2Id) shouldBe 5
             }
         }
 
@@ -577,11 +602,12 @@ class VulnerabilityServiceTest : WordSpec() {
     /**
      * Create an ORT run with an advisor result containing vulnerabilities in the database.
      */
-    private fun createVulnerabilityEntries(advisorResults: Map<Identifier, List<AdvisorResult>>): OrtRun {
-        val repository = fixtures.createRepository()
-
+    private fun createVulnerabilityEntries(
+        advisorResults: Map<Identifier, List<AdvisorResult>>,
+        repositoryId: Long = fixtures.createRepository().id
+    ): OrtRun {
         val ortRun = fixtures.createOrtRun(
-            repositoryId = repository.id,
+            repositoryId = repositoryId,
             revision = "revision",
             jobConfigurations = JobConfigurations()
         )


### PR DESCRIPTION
Edit the count functions to count items for multiple runs to make the functions reusable for statistics endpoints on the product and organization levels. 
- The issues count is accumulated as a total sum from issues in all runs (as I wasn't sure if there should be some deduplication here)
- The vulnerabilities are counted as number of unique vulnerability+identifier pairs (could also be counted as vulnerabilities with unique external IDs, ignoring the identifiers?)
- The rule violations are counted as distinct rule violations found in runs
- The packages are counted as distinct packages found in runs, and ecosystems are counted similarly from distinct packages

Let me know if you think any of these should be counted differently.

Please see the individual commits for more details.