### PR TITLE
Handle missed schedules in Orchestrator

### DIFF
--- a/dao/src/main/kotlin/repositories/ortrun/DaoOrtRunRepository.kt
+++ b/dao/src/main/kotlin/repositories/ortrun/DaoOrtRunRepository.kt
@@ -31,6 +31,7 @@ import org.eclipse.apoapsis.ortserver.dao.tables.shared.OrtRunIssueDao
 import org.eclipse.apoapsis.ortserver.dao.utils.applyFilter
 import org.eclipse.apoapsis.ortserver.dao.utils.listQuery
 import org.eclipse.apoapsis.ortserver.dao.utils.toDatabasePrecision
+import org.eclipse.apoapsis.ortserver.model.ActiveOrtRun
 import org.eclipse.apoapsis.ortserver.model.JobConfigurations
 import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.OrtRunFilters
@@ -138,6 +139,12 @@ class DaoOrtRunRepository(private val db: Database) : OrtRunRepository {
             ListQueryResult(emptyList(), parameters, 0L)
         }
 
+    override fun listActiveRuns(): List<ActiveOrtRun> = db.blockingQuery {
+        OrtRunDao.find {
+            OrtRunsTable.status inList activeRunStatuses
+        }.map { ActiveOrtRun(it.id.value, it.createdAt, it.traceId) }
+    }
+
     override fun update(
         id: Long,
         status: OptionalValue<OrtRunStatus>,
@@ -199,3 +206,6 @@ class DaoOrtRunRepository(private val db: Database) : OrtRunRepository {
  */
 private fun getLabelDao(entry: Map.Entry<String, String>): LabelDao =
     LabelDao.getOrPut(entry.key, entry.value)
+
+/** A collection with the statuses in which an ORT run is considered active. */
+private val activeRunStatuses = setOf(OrtRunStatus.CREATED, OrtRunStatus.ACTIVE)

--- a/kubernetes/jobmonitor/src/main/kotlin/FailedJobNotifier.kt
+++ b/kubernetes/jobmonitor/src/main/kotlin/FailedJobNotifier.kt
@@ -23,6 +23,8 @@ import io.kubernetes.client.openapi.models.V1Job
 
 import org.eclipse.apoapsis.ortserver.kubernetes.jobmonitor.JobHandler.Companion.ortRunId
 import org.eclipse.apoapsis.ortserver.kubernetes.jobmonitor.JobHandler.Companion.traceId
+import org.eclipse.apoapsis.ortserver.model.ActiveOrtRun
+import org.eclipse.apoapsis.ortserver.model.orchestrator.LostSchedule
 import org.eclipse.apoapsis.ortserver.model.orchestrator.OrchestratorMessage
 import org.eclipse.apoapsis.ortserver.model.orchestrator.WorkerError
 import org.eclipse.apoapsis.ortserver.transport.Endpoint
@@ -65,6 +67,17 @@ internal class FailedJobNotifier(
     fun sendLostJobNotification(ortRunId: Long, endpoint: Endpoint<*>) {
         val header = MessageHeader(traceId = "", ortRunId)
         val message = Message(header, WorkerError(endpoint.configPrefix))
+
+        sendToOrchestrator(message)
+    }
+
+    /**
+     * Send a notification about an ORT run without active schedules for the given [ortRun]. This is used to notify
+     * the Orchestrator that it has to reschedule jobs for the affected run.
+     */
+    fun sendLostScheduleNotification(ortRun: ActiveOrtRun) {
+        val header = MessageHeader(ortRun.traceId.orEmpty(), ortRun.runId)
+        val message = Message(header, LostSchedule(ortRun.runId))
 
         sendToOrchestrator(message)
     }

--- a/kubernetes/jobmonitor/src/test/kotlin/MonitorComponentTest.kt
+++ b/kubernetes/jobmonitor/src/test/kotlin/MonitorComponentTest.kt
@@ -67,6 +67,7 @@ import org.eclipse.apoapsis.ortserver.model.repositories.AdvisorJobRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.AnalyzerJobRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.EvaluatorJobRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.NotifierJobRepository
+import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.ReporterJobRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.ScannerJobRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.WorkerJobRepository
@@ -239,6 +240,10 @@ class MonitorComponentTest : KoinTest, StringSpec() {
                 declareRepositoryMock<EvaluatorJob, EvaluatorJobRepository>()
                 declareRepositoryMock<ReporterJob, ReporterJobRepository>()
                 declareRepositoryMock<NotifierJob, NotifierJobRepository>()
+
+                declareMock<OrtRunRepository> {
+                    every { listActiveRuns() } returns emptyList()
+                }
 
                 val scheduler = declareMock<Scheduler> {
                     initSchedulerMock(this)

--- a/model/src/commonMain/kotlin/ActiveOrtRun.kt
+++ b/model/src/commonMain/kotlin/ActiveOrtRun.kt
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.model
+
+import kotlinx.datetime.Instant
+
+/**
+ * A data class holding a minimal set of properties to reference an active ORT run.
+ */
+data class ActiveOrtRun(
+    /** The ID of the ORT run. */
+    val runId: Long,
+
+    /** The creation time of this run. */
+    val createdAt: Instant,
+
+    /** The trace ID for this run. */
+    val traceId: String?
+)

--- a/model/src/commonMain/kotlin/orchestrator/OrchestratorMessage.kt
+++ b/model/src/commonMain/kotlin/orchestrator/OrchestratorMessage.kt
@@ -190,3 +190,13 @@ data class WorkerError(
     /** The name of the endpoint where the error has happened. */
     val endpointName: String,
 ) : OrchestratorMessage()
+
+/**
+ * A message notifying the Orchestrator about an ORT run for which scheduling of worker jobs has failed. It is
+ * triggered for ORT runs in state ACTIVE for which no jobs are running. The message is typically processed by
+ * rescheduling the jobs.
+ */
+@Serializable
+data class LostSchedule(
+    val ortRunId: Long
+) : OrchestratorMessage()

--- a/model/src/commonMain/kotlin/repositories/OrtRunRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/OrtRunRepository.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.apoapsis.ortserver.model.repositories
 
+import org.eclipse.apoapsis.ortserver.model.ActiveOrtRun
 import org.eclipse.apoapsis.ortserver.model.JobConfigurations
 import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.OrtRunFilters
@@ -89,6 +90,12 @@ interface OrtRunRepository {
         repositoryId: Long,
         parameters: ListQueryParameters = ListQueryParameters.DEFAULT
     ): ListQueryResult<OrtRunSummary>
+
+    /**
+     * Return a list with information about all currently active ORT runs. The list contains all the runs in the states
+     * `ACTIVE` and `CREATED`.
+     */
+    fun listActiveRuns(): List<ActiveOrtRun>
 
     /**
      * Update an ORT run by [id] with the [present][OptionalValue.Present] values. If [issues] or [labels] are

--- a/orchestrator/src/main/kotlin/Entrypoint.kt
+++ b/orchestrator/src/main/kotlin/Entrypoint.kt
@@ -40,6 +40,7 @@ import org.eclipse.apoapsis.ortserver.model.orchestrator.ConfigWorkerResult
 import org.eclipse.apoapsis.ortserver.model.orchestrator.CreateOrtRun
 import org.eclipse.apoapsis.ortserver.model.orchestrator.EvaluatorWorkerError
 import org.eclipse.apoapsis.ortserver.model.orchestrator.EvaluatorWorkerResult
+import org.eclipse.apoapsis.ortserver.model.orchestrator.LostSchedule
 import org.eclipse.apoapsis.ortserver.model.orchestrator.NotifierWorkerError
 import org.eclipse.apoapsis.ortserver.model.orchestrator.NotifierWorkerResult
 import org.eclipse.apoapsis.ortserver.model.orchestrator.OrchestratorMessage
@@ -101,6 +102,7 @@ class OrchestratorComponent : EndpointComponent<OrchestratorMessage>(Orchestrato
             is NotifierWorkerResult -> orchestrator.handleNotifierWorkerResult(message.header, payload)
             is NotifierWorkerError -> orchestrator.handleNotifierWorkerError(message.header, payload)
             is WorkerError -> orchestrator.handleWorkerError(message.header, payload)
+            is LostSchedule -> orchestrator.handleLostSchedule(message.header, payload)
         }
     }
 

--- a/orchestrator/src/test/kotlin/OrchestratorEndpointTest.kt
+++ b/orchestrator/src/test/kotlin/OrchestratorEndpointTest.kt
@@ -47,6 +47,7 @@ import org.eclipse.apoapsis.ortserver.model.orchestrator.ConfigWorkerResult
 import org.eclipse.apoapsis.ortserver.model.orchestrator.CreateOrtRun
 import org.eclipse.apoapsis.ortserver.model.orchestrator.EvaluatorWorkerError
 import org.eclipse.apoapsis.ortserver.model.orchestrator.EvaluatorWorkerResult
+import org.eclipse.apoapsis.ortserver.model.orchestrator.LostSchedule
 import org.eclipse.apoapsis.ortserver.model.orchestrator.ReporterWorkerError
 import org.eclipse.apoapsis.ortserver.model.orchestrator.ReporterWorkerResult
 import org.eclipse.apoapsis.ortserver.model.orchestrator.ScannerWorkerError
@@ -436,6 +437,23 @@ class OrchestratorEndpointTest : KoinTest, StringSpec() {
 
                 verify {
                     orchestrator.handleWorkerError(msgHeader, workerError)
+                }
+            }
+        }
+
+        "LostSchedule messages should be handled" {
+            val lostSchedule = LostSchedule(20241211081733L)
+            val message = Message(msgHeader, lostSchedule)
+
+            runEndpointTest {
+                val orchestrator = declareMock<Orchestrator> {
+                    every { handleLostSchedule(any(), any()) } just runs
+                }
+
+                MessageReceiverFactoryForTesting.receive(OrchestratorEndpoint, message)
+
+                verify {
+                    orchestrator.handleLostSchedule(msgHeader, lostSchedule)
                 }
             }
         }


### PR DESCRIPTION
This PR addresses a problem with Orchestrator. Under specific conditions, it is possible that a schedule of a worker job gets lost. The affected ORT run then stays in ACTIVE state forever. Kubernetes Job Monitor was not able to detect this situation.

Refer to the individual commits for further information.