### PR TITLE
ci(docker): Improve the Docker job names

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   build:
-    name: Build Docker Image
+    name: Build ${{ matrix.docker.jibImage || matrix.docker.image }} Docker Image
     runs-on: ubuntu-24.04
     permissions:
       packages: write


### PR DESCRIPTION
Use individual names for the Docker build jobs as the auto-generated unique names are based on the matrix parameters and are too long which makes it difficult to configure the required checks.