### PR TITLE
Optimize access to custom license texts in Reporter

### DIFF
--- a/workers/reporter/src/main/kotlin/reporter/CustomLicenseTextProvider.kt
+++ b/workers/reporter/src/main/kotlin/reporter/CustomLicenseTextProvider.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.reporter
+
+import org.eclipse.apoapsis.ortserver.config.ConfigManager
+import org.eclipse.apoapsis.ortserver.config.Context
+import org.eclipse.apoapsis.ortserver.config.Path
+
+import org.ossreviewtoolkit.reporter.DefaultLicenseTextProvider
+import org.ossreviewtoolkit.reporter.LicenseTextProvider
+
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger(CustomLicenseTextProvider::class.java)
+
+/**
+ * A specialized [LicenseTextProvider] implementation that is used by the [ReporterRunner] to support efficient access
+ * to custom license texts stored in a configuration directory.
+ *
+ * The [LicenseTextProvider] implementations available in ORT expect that license texts are available in a local
+ * folder. For ORT Server, this is not necessarily the case, but depends on the provider for config files. This
+ * implementation therefore uses the configuration manager API to check whether a requested license text is available
+ * in the configuration. If it is, it obtains the license text from the configuration. Otherwise, it delegates to
+ * another [LicenseTextProvider] implementation which searches the default paths used by ORT.
+ */
+internal class CustomLicenseTextProvider(
+    /** The object for accessing the configuration. */
+    val configManager: ConfigManager,
+
+    /** The current configuration context for this ORT run. */
+    val configurationContext: Context?,
+
+    /** The [Path] to the directory in the configuration containing custom license texts. */
+    val licenseTextDir: Path,
+
+    /** A fallback [LicenseTextProvider] to query for license texts not available in the configuration. */
+    val wrappedProvider: LicenseTextProvider = DefaultLicenseTextProvider()
+) : LicenseTextProvider {
+    /** Stores the IDs of the licenses that can be resolved from the config directory. */
+    private val knownLicenseTexts by lazy {
+        val directoryPrefix = "${licenseTextDir.path}/"
+        configManager.listFiles(configurationContext, licenseTextDir)
+            .map { it.path.removePrefix(directoryPrefix) }
+            .also { logger.debug("Found custom license texts: {}.", it) }
+    }
+
+    override fun getLicenseTextReader(licenseId: String): (() -> String)? = {
+        logger.debug("Request for license text of '{}'.", licenseId)
+
+        if (isKnownLicense(licenseId)) {
+            logger.debug("Loading license text of '{}' from config directory.", licenseId)
+            getLicenseTextFromConfig(licenseId)
+        } else {
+            wrappedProvider.getLicenseTextReader(licenseId)?.invoke().orEmpty()
+        }
+    }
+
+    override fun hasLicenseText(licenseId: String): Boolean {
+        return isKnownLicense(licenseId) || wrappedProvider.hasLicenseText(licenseId)
+    }
+
+    /**
+     * Check whether the given [licenseId] can be resolved from the configuration.
+     */
+    private fun isKnownLicense(licenseId: String): Boolean =
+        licenseId in knownLicenseTexts
+
+    /**
+     * Return the license text for the given [licenseId] from the configuration.
+     */
+    private fun getLicenseTextFromConfig(licenseId: String): String =
+        configManager.getFileAsString(configurationContext, Path("${licenseTextDir.path}/$licenseId"))
+}

--- a/workers/reporter/src/test/kotlin/reporter/CustomLicenseTextProviderTest.kt
+++ b/workers/reporter/src/test/kotlin/reporter/CustomLicenseTextProviderTest.kt
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.reporter
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.nulls.beNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNot
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+import org.eclipse.apoapsis.ortserver.config.ConfigManager
+import org.eclipse.apoapsis.ortserver.config.Context
+import org.eclipse.apoapsis.ortserver.config.Path
+
+import org.ossreviewtoolkit.reporter.LicenseTextProvider
+
+class CustomLicenseTextProviderTest : WordSpec({
+    "getLicenseTextReader" should {
+        "load data only on demand" {
+            val configManager = mockk<ConfigManager>()
+
+            val provider = CustomLicenseTextProvider(configManager, configContext, licenseDir)
+            // Since the mock is not configured, this will fail if data is already loaded.
+            val reader = provider.getLicenseTextReader("someLicenseID")
+
+            reader shouldNot beNull()
+        }
+
+        "return a license from the config directory" {
+            val configManager = createConfigManagerMock()
+            every {
+                configManager.getFileAsString(configContext, Path("${licenseDir.path}/$LICENSE_ID"))
+            } returns LICENSE_TEXT
+
+            val provider = CustomLicenseTextProvider(configManager, configContext, licenseDir, mockk())
+            val reader = provider.getLicenseTextReader(LICENSE_ID)
+
+            reader?.invoke() shouldBe LICENSE_TEXT
+        }
+
+        "return a license not available in the config directory from the wrapped provider" {
+            val otherLicenseId = "someOtherLicenseId"
+            val wrappedProvider = mockk<LicenseTextProvider>()
+            every { wrappedProvider.getLicenseTextReader(otherLicenseId) } returns { LICENSE_TEXT }
+
+            val provider = CustomLicenseTextProvider(
+                createConfigManagerMock(),
+                configContext,
+                licenseDir,
+                wrappedProvider
+            )
+            val reader = provider.getLicenseTextReader(otherLicenseId)
+
+            reader?.invoke() shouldBe LICENSE_TEXT
+        }
+
+        "handle a null response from the wrapped provider correctly" {
+            val unknownLicenseId = "unknownLicenseId"
+            val wrappedProvider = mockk<LicenseTextProvider>()
+            every { wrappedProvider.getLicenseTextReader(unknownLicenseId) } returns null
+
+            val provider = CustomLicenseTextProvider(
+                createConfigManagerMock(),
+                configContext,
+                licenseDir,
+                wrappedProvider
+            )
+            val reader = provider.getLicenseTextReader(unknownLicenseId)
+
+            reader?.invoke() shouldBe ""
+        }
+    }
+
+    "hasLicenseText" should {
+        "return true if the license is available from the config repository" {
+            val provider = CustomLicenseTextProvider(createConfigManagerMock(), configContext, licenseDir, mockk())
+
+            provider.hasLicenseText(LICENSE_ID) shouldBe true
+        }
+
+        "query the wrapped provider if the license is not available from the config repository" {
+            val otherLicenseId = "someOtherLicenseId"
+            val wrappedProvider = mockk<LicenseTextProvider>()
+            every { wrappedProvider.hasLicenseText(otherLicenseId) } returns false
+
+            val provider = CustomLicenseTextProvider(
+                createConfigManagerMock(),
+                configContext,
+                licenseDir,
+                wrappedProvider
+            )
+
+            provider.hasLicenseText(otherLicenseId) shouldBe false
+
+            verify {
+                wrappedProvider.hasLicenseText(otherLicenseId)
+            }
+        }
+    }
+})
+
+/** A test license ID that can be resolved by the config manager. */
+private const val LICENSE_ID = "LicenseRef-My-Custom-License"
+
+/** A test custom license text. */
+private const val LICENSE_TEXT = "This is a custom license text."
+
+/** The path that contains the custom license texts. */
+private val licenseDir = Path("path/to/custom/licenses")
+
+/** The current configuration context. */
+private val configContext = Context("theCurrentContext")
+
+/**
+ * Return a mock for the [ConfigManager] that is prepared to list the content of the directory with custom license
+ * files. It returns a list containing only the test license ID.
+ */
+private fun createConfigManagerMock(): ConfigManager =
+    mockk {
+        every { listFiles(configContext, licenseDir) } returns setOf(Path("${licenseDir.path}/$LICENSE_ID"))
+    }


### PR DESCRIPTION
This PR adds a special `LicenseTextProvider` implementation that optimizes loading of license texts from the config repository.