### PR TITLE
Use all available credentials for repository download

### DIFF
--- a/dao/src/main/kotlin/repositories/infrastructureservice/DaoInfrastructureServiceRepository.kt
+++ b/dao/src/main/kotlin/repositories/infrastructureservice/DaoInfrastructureServiceRepository.kt
@@ -19,8 +19,6 @@
 
 package org.eclipse.apoapsis.ortserver.dao.repositories.infrastructureservice
 
-import java.net.URI
-
 import org.eclipse.apoapsis.ortserver.dao.ConditionBuilder
 import org.eclipse.apoapsis.ortserver.dao.blockingQuery
 import org.eclipse.apoapsis.ortserver.dao.findSingle
@@ -172,21 +170,6 @@ class DaoInfrastructureServiceRepository(private val db: Database) : Infrastruct
 
             list(parameters) { InfrastructureServicesTable.id inSubQuery subQuery }
         }
-
-    override fun listForRepositoryUrl(
-        repositoryUrl: String,
-        organizationId: Long,
-        productId: Long
-    ): List<InfrastructureService> = db.blockingQuery {
-        val repositoryHost = URI.create(repositoryUrl).host
-        val hostPattern = "%$repositoryHost%"
-        list(ListQueryParameters.DEFAULT) {
-            InfrastructureServicesTable.url like hostPattern and (
-                    (InfrastructureServicesTable.productId eq productId) or
-                            (InfrastructureServicesTable.organizationId eq organizationId)
-                    )
-        }
-    }
 
     override fun listForHierarchy(
         organizationId: Long,

--- a/dao/src/test/kotlin/repositories/infrastructureservice/DaoInfrastructureServiceRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/infrastructureservice/DaoInfrastructureServiceRepositoryTest.kt
@@ -488,59 +488,6 @@ class DaoInfrastructureServiceRepositoryTest : WordSpec() {
             }
         }
 
-        "listForRepositoryUrl" should {
-            "find all services matching the repository host" {
-                val repositoryUrl = "https://repo.example.org/test/repo/"
-                val otherProduct = fixtures.createProduct("anotherProduct")
-
-                val match1 = createInfrastructureService("matching1", organization = fixtures.organization)
-                val match2 = createInfrastructureService("matching2", product = fixtures.product)
-                val match3 = createInfrastructureService(
-                    "matching3",
-                    url = "http://repo.example.org:443",
-                    organization = fixtures.organization
-                )
-                val match4 = createInfrastructureService(
-                    "matching4",
-                    url = "https://repo.example.org/test/repo/test.git",
-                    product = fixtures.product
-                )
-
-                val noMatch1 = createInfrastructureService(
-                    "non-matching1",
-                    url = "https://repo2.example.org/test/repo",
-                    organization = fixtures.organization
-                )
-                val noMatch2 = createInfrastructureService(
-                    name = "non-matching2",
-                    url = repositoryUrl,
-                    product = otherProduct
-                )
-
-                listOf(match1, match2, match3, match4, noMatch1, noMatch2).forEach {
-                    infrastructureServicesRepository.create(it)
-                }
-
-                val services = infrastructureServicesRepository.listForRepositoryUrl(
-                    repositoryUrl,
-                    fixtures.organization.id,
-                    fixtures.product.id
-                )
-
-                services shouldContainExactlyInAnyOrder listOf(match1, match2, match3, match4)
-            }
-
-            "throw when passed an invalid repository URL" {
-                shouldThrow<IllegalArgumentException> {
-                    infrastructureServicesRepository.listForRepositoryUrl(
-                        "?!invalid URL!?",
-                        fixtures.organization.id,
-                        fixtures.product.id
-                    )
-                }
-            }
-        }
-
         "listForHierarchy" should {
             "return all services for the provided IDs" {
                 val repositoryUrl = "https://repo.example.org/test/repo/"

--- a/model/src/commonMain/kotlin/repositories/InfrastructureServiceRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/InfrastructureServiceRepository.kt
@@ -142,6 +142,13 @@ interface InfrastructureServiceRepository {
     fun listForRepositoryUrl(repositoryUrl: String, organizationId: Long, productId: Long): List<InfrastructureService>
 
     /**
+     * Return a list with [InfrastructureService]s that are associated with the given [organizationId], or
+     * [productId]. If there are multiple services with the same URL, instances on a lower level of
+     * the hierarchy are preferred, and others are dropped. This corresponds to an override semantics.
+     */
+    fun listForHierarchy(organizationId: Long, productId: Long): List<InfrastructureService>
+
+    /**
      * Return a list with the [InfrastructureService]s that are associated with the given [Secret][secretId].
      */
     fun listForSecret(secretId: Long): List<InfrastructureService>

--- a/model/src/commonMain/kotlin/repositories/InfrastructureServiceRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/InfrastructureServiceRepository.kt
@@ -134,14 +134,6 @@ interface InfrastructureServiceRepository {
     ): List<InfrastructureService>
 
     /**
-     * Return a list with the [InfrastructureService]s that are associated with the given
-     * [organization][organizationId] or [product][productId] and whose URL matches the given [repositoryUrl]. The
-     * match is done via the host name of the URLs, so things like paths, protocols, or ports are ignored.
-     * Note: If [repositoryUrl] is not a valid URL, an exception is thrown.
-     */
-    fun listForRepositoryUrl(repositoryUrl: String, organizationId: Long, productId: Long): List<InfrastructureService>
-
-    /**
      * Return a list with [InfrastructureService]s that are associated with the given [organizationId], or
      * [productId]. If there are multiple services with the same URL, instances on a lower level of
      * the hierarchy are preferred, and others are dropped. This corresponds to an override semantics.

--- a/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
@@ -366,7 +366,7 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
             val environmentService by inject<EnvironmentService>()
 
             withSystemProperties(properties, mode = OverrideMode.SetOrOverride) {
-                environmentService.setUpEnvironment(context, repositoryFolder, null, null)
+                environmentService.setUpEnvironment(context, repositoryFolder, null, emptyList())
             }
 
             block(homeFolder)

--- a/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
@@ -139,12 +139,12 @@ class AnalyzerWorkerTest : StringSpec({
             every { createContext(analyzerJob.ortRunId) } returns context
         }
 
-        val infrastructureService = mockk<InfrastructureService>()
+        val infrastructureServices = listOf<InfrastructureService>(mockk(relaxed = true), mockk(relaxed = true))
         val envService = mockk<EnvironmentService> {
-            every { findInfrastructureServiceForRepository(context) } returns infrastructureService
-            coEvery { generateNetRcFile(context, listOf(infrastructureService)) } just runs
+            every { findInfrastructureServicesForRepository(context, null) } returns infrastructureServices
+            coEvery { generateNetRcFile(context, infrastructureServices) } just runs
             coEvery {
-                setUpEnvironment(context, projectDir, null, infrastructureService)
+                setUpEnvironment(context, projectDir, null, infrastructureServices)
             } returns ResolvedEnvironmentConfig()
         }
 
@@ -168,9 +168,9 @@ class AnalyzerWorkerTest : StringSpec({
             }
 
             coVerifyOrder {
-                envService.generateNetRcFile(context, listOf(infrastructureService))
+                envService.generateNetRcFile(context, infrastructureServices)
                 downloader.downloadRepository(repository.url, ortRun.revision)
-                envService.setUpEnvironment(context, projectDir, null, infrastructureService)
+                envService.setUpEnvironment(context, projectDir, null, infrastructureServices)
             }
         }
     }
@@ -201,8 +201,8 @@ class AnalyzerWorkerTest : StringSpec({
         }
 
         val envService = mockk<EnvironmentService> {
-            every { findInfrastructureServiceForRepository(context) } returns null
-            coEvery { setUpEnvironment(context, projectDir, null, null) } returns ResolvedEnvironmentConfig()
+            every { findInfrastructureServicesForRepository(context, null) } returns emptyList()
+            coEvery { setUpEnvironment(context, projectDir, null, emptyList()) } returns ResolvedEnvironmentConfig()
         }
 
         val worker = AnalyzerWorker(
@@ -228,7 +228,7 @@ class AnalyzerWorkerTest : StringSpec({
             }
 
             coVerify {
-                envService.setUpEnvironment(context, projectDir, null, null)
+                envService.setUpEnvironment(context, projectDir, null, emptyList())
             }
         }
     }
@@ -261,9 +261,10 @@ class AnalyzerWorkerTest : StringSpec({
         }
 
         val envService = mockk<EnvironmentService> {
-            every { findInfrastructureServiceForRepository(context) } returns null
-            every { findInfrastructureServiceForRepository(context, envConfig) } returns null
-            coEvery { setUpEnvironment(context, projectDir, envConfig, null) } returns ResolvedEnvironmentConfig()
+            every { findInfrastructureServicesForRepository(context, envConfig) } returns emptyList()
+            coEvery {
+                setUpEnvironment(context, projectDir, envConfig, emptyList())
+            } returns ResolvedEnvironmentConfig()
         }
 
         val worker = AnalyzerWorker(
@@ -285,7 +286,7 @@ class AnalyzerWorkerTest : StringSpec({
             }
 
             coVerify {
-                envService.setUpEnvironment(context, projectDir, envConfig, null)
+                envService.setUpEnvironment(context, projectDir, envConfig, emptyList())
             }
         }
     }
@@ -316,9 +317,8 @@ class AnalyzerWorkerTest : StringSpec({
 
         val resolvedEnvConfig = mockk<ResolvedEnvironmentConfig>()
         val envService = mockk<EnvironmentService> {
-            every { findInfrastructureServiceForRepository(context) } returns null
-            every { findInfrastructureServiceForRepository(context, envConfig) } returns null
-            coEvery { setUpEnvironment(context, projectDir, envConfig, null) } returns resolvedEnvConfig
+            every { findInfrastructureServicesForRepository(context, envConfig) } returns emptyList()
+            coEvery { setUpEnvironment(context, projectDir, envConfig, emptyList()) } returns resolvedEnvConfig
         }
 
         val testException = IllegalStateException("AnalyzerRunner test exception")
@@ -365,9 +365,8 @@ class AnalyzerWorkerTest : StringSpec({
 
         val resolvedEnvConfig = mockk<ResolvedEnvironmentConfig>()
         val envService = mockk<EnvironmentService> {
-            every { findInfrastructureServiceForRepository(context) } returns null
-            every { findInfrastructureServiceForRepository(context, any()) } returns null
-            coEvery { setUpEnvironment(context, projectDir, null, null) } returns resolvedEnvConfig
+            every { findInfrastructureServicesForRepository(context, any()) } returns emptyList()
+            coEvery { setUpEnvironment(context, projectDir, null, emptyList()) } returns resolvedEnvConfig
         }
 
         val testException = IllegalStateException("AnalyzerRunner test exception")
@@ -463,8 +462,8 @@ class AnalyzerWorkerTest : StringSpec({
         }
 
         val envService = mockk<EnvironmentService> {
-            every { findInfrastructureServiceForRepository(context) } returns null
-            coEvery { setUpEnvironment(context, projectDir, null, null) } returns ResolvedEnvironmentConfig()
+            every { findInfrastructureServicesForRepository(context, null) } returns emptyList()
+            coEvery { setUpEnvironment(context, projectDir, null, emptyList()) } returns ResolvedEnvironmentConfig()
         }
 
         val runnerMock = spyk(AnalyzerRunner(ConfigFactory.empty())) {


### PR DESCRIPTION
Instead of using a single `InfrastructureService` that matches the
repository, obtain all known services to generate the `.netrc` file
for checking out the repository. This is needed if the repository has
submodules that require additional credentials.