### PR TITLE
fix(core): Add dedicated permissions for managing groups

### DIFF
--- a/core/src/main/kotlin/api/OrganizationsRoute.kt
+++ b/core/src/main/kotlin/api/OrganizationsRoute.kt
@@ -329,7 +329,7 @@ fun Route.organizations() = route("organizations") {
             // groupId "readers", "writers" or "admins".
             route("{groupId}") {
                 put(putUserToOrganizationGroup) {
-                    requirePermission(OrganizationPermission.WRITE)
+                    requirePermission(OrganizationPermission.MANAGE_GROUPS)
 
                     val user = call.receive<Username>()
                     val organizationId = call.requireIdParameter("organizationId")
@@ -340,7 +340,7 @@ fun Route.organizations() = route("organizations") {
                 }
 
                 delete(deleteUserFromOrganizationGroup) {
-                    requirePermission(OrganizationPermission.WRITE)
+                    requirePermission(OrganizationPermission.MANAGE_GROUPS)
 
                     val user = call.receive<Username>()
                     val organizationId = call.requireIdParameter("organizationId")

--- a/core/src/main/kotlin/api/ProductsRoute.kt
+++ b/core/src/main/kotlin/api/ProductsRoute.kt
@@ -222,7 +222,7 @@ fun Route.products() = route("products/{productId}") {
         // groupId "readers", "writers" or "admins".
         route("{groupId}") {
             put(putUserToProductGroup) {
-                requirePermission(ProductPermission.WRITE)
+                requirePermission(ProductPermission.MANAGE_GROUPS)
 
                 val user = call.receive<Username>()
                 val productId = call.requireIdParameter("productId")
@@ -233,7 +233,7 @@ fun Route.products() = route("products/{productId}") {
             }
 
             delete(deleteUserFromProductGroup) {
-                requirePermission(ProductPermission.WRITE)
+                requirePermission(ProductPermission.MANAGE_GROUPS)
 
                 val user = call.receive<Username>()
                 val productId = call.requireIdParameter("productId")

--- a/core/src/main/kotlin/api/RepositoriesRoute.kt
+++ b/core/src/main/kotlin/api/RepositoriesRoute.kt
@@ -250,7 +250,7 @@ fun Route.repositories() = route("repositories/{repositoryId}") {
         // groupId "readers", "writers" or "admins".
         route("{groupId}") {
             put(putUserToRepositoryGroup) {
-                requirePermission(RepositoryPermission.WRITE)
+                requirePermission(RepositoryPermission.MANAGE_GROUPS)
 
                 val user = call.receive<Username>()
                 val repositoryId = call.requireIdParameter("repositoryId")
@@ -261,7 +261,7 @@ fun Route.repositories() = route("repositories/{repositoryId}") {
             }
 
             delete(deleteUserFromRepositoryGroup) {
-                requirePermission(RepositoryPermission.WRITE)
+                requirePermission(RepositoryPermission.MANAGE_GROUPS)
 
                 val user = call.receive<Username>()
                 val repositoryId = call.requireIdParameter("repositoryId")

--- a/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
@@ -1252,12 +1252,12 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
             row(HttpMethod.Put),
             row(HttpMethod.Delete)
         ) { method ->
-            "require OrganizationPermission.WRITE for method '${method.value}'" {
+            "require OrganizationPermission.MANAGE_GROUPS for method '${method.value}'" {
                 val createdOrg = createOrganization()
                 val user = Username(TEST_USER.username.value)
 
                 requestShouldRequireRole(
-                    OrganizationPermission.WRITE.roleName(createdOrg.id),
+                    OrganizationPermission.MANAGE_GROUPS.roleName(createdOrg.id),
                     HttpStatusCode.NoContent
                 ) {
                     when (method) {

--- a/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
@@ -712,11 +712,11 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
             row(HttpMethod.Put),
             row(HttpMethod.Delete)
         ) { method ->
-            "require ProductPermission.WRITE for method '${method.value}'" {
+            "require ProductPermission.MANAGE_GROUPS for method '${method.value}'" {
                 val createdProd = createProduct()
                 val user = Username(TEST_USER.username.value)
                 requestShouldRequireRole(
-                    ProductPermission.WRITE.roleName(createdProd.id),
+                    ProductPermission.MANAGE_GROUPS.roleName(createdProd.id),
                     HttpStatusCode.NoContent
                 ) {
                     when (method) {

--- a/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
@@ -980,11 +980,11 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
             row(HttpMethod.Put),
             row(HttpMethod.Delete)
         ) { method ->
-            "require ProductPermission.WRITE for method '${method.value}'" {
+            "require ProductPermission.MANAGE_GROUPS for method '${method.value}'" {
                 val createdRepo = createRepository()
                 val user = Username(TEST_USER.username.value)
                 requestShouldRequireRole(
-                    RepositoryPermission.WRITE.roleName(createdRepo.id),
+                    RepositoryPermission.MANAGE_GROUPS.roleName(createdRepo.id),
                     HttpStatusCode.NoContent
                 ) {
                     when (method) {

--- a/model/src/commonMain/kotlin/authorization/OrganizationPermission.kt
+++ b/model/src/commonMain/kotlin/authorization/OrganizationPermission.kt
@@ -38,6 +38,9 @@ enum class OrganizationPermission {
     /** Permission to write the [Organization] secrets. */
     WRITE_SECRETS,
 
+    /** Permission to manage [Organization] groups. */
+    MANAGE_GROUPS,
+
     /** Permission to read the list of [Product]s of the [Organization]. */
     READ_PRODUCTS,
 

--- a/model/src/commonMain/kotlin/authorization/ProductPermission.kt
+++ b/model/src/commonMain/kotlin/authorization/ProductPermission.kt
@@ -37,6 +37,9 @@ enum class ProductPermission {
     /** Permission to write the [Product] secrets. */
     WRITE_SECRETS,
 
+    /** Permission to manage [Product] groups. */
+    MANAGE_GROUPS,
+
     /** Permission to read the list of [repositories][Repository] of the [Product]. */
     READ_REPOSITORIES,
 

--- a/model/src/commonMain/kotlin/authorization/RepositoryPermission.kt
+++ b/model/src/commonMain/kotlin/authorization/RepositoryPermission.kt
@@ -37,6 +37,9 @@ enum class RepositoryPermission {
     /** Permission to write the [Repository] secrets. */
     WRITE_SECRETS,
 
+    /** Permission to manage [Repository] groups. */
+    MANAGE_GROUPS,
+
     /** Permission to read the list of [OrtRun]s of the [Repository]. */
     READ_ORT_RUNS,
 


### PR DESCRIPTION
Add dedicated permissions to add or remove users to the organization, product, and repository groups. The new `MANAGE_GROUPS` permissions are only added to the respective `ADMIN` groups.

Previously, members of the `WRITERS` group could elevate their own permissions by adding themselves to the `ADMIN` group.