### PR TITLE
ci(docker): Always load the base images to the local registry

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -142,7 +142,7 @@ jobs:
         context: ${{ matrix.docker.context }}
         file: ${{ matrix.docker.context }}/${{ matrix.docker.dockerfile }}
         push: ${{ !env.IS_PR }}
-        load: ${{ env.IS_PR }}
+        load: true
         tags: ${{ steps.meta-base.outputs.tags }}
         labels: ${{ steps.meta-base.outputs.labels }}
         cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/ort-server-${{ matrix.docker.image }}:cache


### PR DESCRIPTION
Always load the base images to the local registry as this is where Jib is looking for them since 808a3fc.