### PR TITLE
fix(compose): Remove explicit admin credentials

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,8 +86,6 @@ services:
       retries: 15
       start_period: 90s
     environment:
-      KEYCLOAK_ADMIN: admin
-      KEYCLOAK_ADMIN_PASSWORD: admin
       KC_DB: postgres
       KC_DB_USERNAME: postgres
       KC_DB_PASSWORD: postgres


### PR DESCRIPTION
Keycloak 26 introduced a feature to bootstrap admin accounts [1]. This feature seem to interfere with specifying admin credentials explicitly via the Docker Compose environment, leading to

Detail: Key (realm_id, username)=(0b009e14-6671-4ae5-8e3f-ddcc98049624, admin) already exists.

when starting the Keycloak image. Removing these variables prevents that while still being able to log into Keycloak with "admin" / "admin".

Note that at the same time these variables were anyway deprecated in favor of `KC_BOOTSTRAP_ADMIN_USERNAME` / `KC_BOOTSTRAP_ADMIN_PASSWORD`, causing a separate deprecation warning in the logs. However, using those variables does not prevent the above error. But removing the original variables also gets rid of that deprecation warning.

[1]: https://www.keycloak.org/server/bootstrap-admin-recovery