### PR TITLE
refactor(services): Reverse entries order in maps

### DIFF
--- a/services/hierarchy/src/main/kotlin/IssueService.kt
+++ b/services/hierarchy/src/main/kotlin/IssueService.kt
@@ -95,7 +95,7 @@ class IssueService(private val db: Database) {
     suspend fun countBySeverityForOrtRunIds(vararg ortRunIds: Long): CountByCategory<Severity> = db.dbQuery {
         val countAlias = Count(OrtRunsIssuesTable.id, true)
 
-        val severityToCountMap = Severity.entries.associateWithTo(mutableMapOf()) { 0L }
+        val severityToCountMap = Severity.entries.reversed().associateWithTo(mutableMapOf()) { 0L }
 
         OrtRunsIssuesTable
             .innerJoin(IssuesTable)

--- a/services/hierarchy/src/main/kotlin/RuleViolationService.kt
+++ b/services/hierarchy/src/main/kotlin/RuleViolationService.kt
@@ -77,7 +77,7 @@ class RuleViolationService(private val db: Database) {
     suspend fun countBySeverityForOrtRunIds(vararg ortRunIds: Long): CountByCategory<Severity> = db.dbQuery {
         val countAlias = Count(RuleViolationsTable.id, true)
 
-        val severityToCountMap = Severity.entries.associateWithTo(mutableMapOf()) { 0L }
+        val severityToCountMap = Severity.entries.reversed().associateWithTo(mutableMapOf()) { 0L }
 
         RuleViolationsTable
             .innerJoin(EvaluatorRunsRuleViolationsTable)

--- a/services/hierarchy/src/main/kotlin/VulnerabilityService.kt
+++ b/services/hierarchy/src/main/kotlin/VulnerabilityService.kt
@@ -147,7 +147,7 @@ class VulnerabilityService(private val db: Database) {
         val countAlias = Count(stringLiteral("*")).alias("count")
         val ratingAlias = ratingAlias()
 
-        val ratingToCountMap = VulnerabilityRating.entries.associateWithTo(mutableMapOf()) { 0L }
+        val ratingToCountMap = VulnerabilityRating.entries.reversed().associateWithTo(mutableMapOf()) { 0L }
 
         val subQuery = VulnerabilitiesTable
             .innerJoin(AdvisorResultsVulnerabilitiesTable)


### PR DESCRIPTION
Reverse order of severities and vulnerability ratings in maps so they are ordered from most severe to least severe, and will be rendered in this order everywhere in the UI as well where the colored bars showcasing the distributions are rendered.