### PR TITLE
chore: Remove redundant qualifier names for `innerJoin`

### DIFF
--- a/dao/src/main/kotlin/repositories/ortrun/DaoOrtRunRepository.kt
+++ b/dao/src/main/kotlin/repositories/ortrun/DaoOrtRunRepository.kt
@@ -193,11 +193,9 @@ class DaoOrtRunRepository(private val db: Database) : OrtRunRepository {
 
     override fun deleteByProduct(productId: Long): Int = db.blockingQuery {
         OrtRunsTable
-            .innerJoin(RepositoriesTable, { repositoryId }, { RepositoriesTable.id })
-            .innerJoin(ProductsTable, { RepositoriesTable.productId }, { ProductsTable.id })
-            .delete(OrtRunsTable) {
-                ProductsTable.id eq productId
-            }
+            .innerJoin(RepositoriesTable, { repositoryId }, { id })
+            .innerJoin(ProductsTable, { RepositoriesTable.productId }, { id })
+            .delete(OrtRunsTable) { ProductsTable.id eq productId }
     }
 }
 

--- a/services/hierarchy/src/main/kotlin/IssueService.kt
+++ b/services/hierarchy/src/main/kotlin/IssueService.kt
@@ -111,7 +111,7 @@ class IssueService(private val db: Database) {
 
     private fun createOrtRunIssuesQuery(ortRunId: Long): Query {
         val issuesIdentifiersJoin = OrtRunsIssuesTable
-            .innerJoin(IssuesTable, { issueId }, { IssuesTable.id })
+            .innerJoin(IssuesTable, { issueId }, { id })
             .join(IdentifiersTable, JoinType.LEFT, OrtRunsIssuesTable.identifierId, IdentifiersTable.id)
         return issuesIdentifiersJoin.select(
             OrtRunsIssuesTable.timestamp,


### PR DESCRIPTION
While at it, make a `delete` call a one-liner.