### PR TITLE
ui: Add statistics cards for organization overview page

### DIFF
--- a/ui/src/routes/organizations/$orgId/-components/organization-issues-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-issues-statistics-card.tsx
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { Bug } from 'lucide-react';
+
+import { useOrganizationsServiceGetOrtRunStatisticsByOrganizationIdSuspense } from '@/api/queries/suspense';
+import { Severity } from '@/api/requests';
+import { StatisticsCard } from '@/components/statistics-card';
+import { getIssueSeverityBackgroundColor } from '@/helpers/get-status-class';
+import { cn } from '@/lib/utils';
+
+type OrganizationIssuesStatisticsCardProps = {
+  organizationId: number;
+  className?: string;
+};
+
+export const OrganizationIssuesStatisticsCard = ({
+  organizationId,
+  className,
+}: OrganizationIssuesStatisticsCardProps) => {
+  const data =
+    useOrganizationsServiceGetOrtRunStatisticsByOrganizationIdSuspense({
+      organizationId: organizationId,
+    });
+
+  const total = data.data.issuesCount;
+  const counts = data.data.issuesCountBySeverity;
+
+  return (
+    <StatisticsCard
+      title='Issues'
+      icon={() => <Bug className='h-4 w-4 text-green-500' />}
+      value={total || '-'}
+      counts={
+        counts
+          ? Object.entries(counts).map(([severity, count]) => ({
+              key: severity,
+              count: count,
+              color: getIssueSeverityBackgroundColor(severity as Severity),
+            }))
+          : []
+      }
+      className={cn('h-full hover:bg-muted/50', className)}
+    />
+  );
+};

--- a/ui/src/routes/organizations/$orgId/-components/organization-packages-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-packages-statistics-card.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { Boxes } from 'lucide-react';
+
+import { useOrganizationsServiceGetOrtRunStatisticsByOrganizationIdSuspense } from '@/api/queries/suspense';
+import { StatisticsCard } from '@/components/statistics-card';
+import { getEcosystemBackgroundColor } from '@/helpers/get-status-class';
+import { cn } from '@/lib/utils';
+
+type OrganizationPackagesStatisticsCardProps = {
+  organizationId: number;
+  className?: string;
+};
+
+export const OrganizationPackagesStatisticsCard = ({
+  organizationId,
+  className,
+}: OrganizationPackagesStatisticsCardProps) => {
+  const data =
+    useOrganizationsServiceGetOrtRunStatisticsByOrganizationIdSuspense({
+      organizationId: organizationId,
+    });
+
+  const total = data.data.packagesCount;
+  const counts = data.data.ecosystems;
+
+  return (
+    <StatisticsCard
+      title='Packages'
+      icon={() => <Boxes className='h-4 w-4 text-green-500' />}
+      value={total || '-'}
+      counts={counts?.map(({ name, count }) => ({
+        key: name,
+        count: count,
+        color: getEcosystemBackgroundColor(name),
+      }))}
+      className={cn('h-full hover:bg-muted/50', className)}
+    />
+  );
+};

--- a/ui/src/routes/organizations/$orgId/-components/organization-violations-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-violations-statistics-card.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { Scale } from 'lucide-react';
+
+import { useOrganizationsServiceGetOrtRunStatisticsByOrganizationIdSuspense } from '@/api/queries/suspense';
+import { Severity } from '@/api/requests';
+import { StatisticsCard } from '@/components/statistics-card';
+import { getRuleViolationSeverityBackgroundColor } from '@/helpers/get-status-class';
+import { cn } from '@/lib/utils';
+
+type OrganizationViolationsStatisticsCardProps = {
+  organizationId: number;
+  className?: string;
+};
+
+export const OrganizationViolationsStatisticsCard = ({
+  organizationId,
+  className,
+}: OrganizationViolationsStatisticsCardProps) => {
+  const data =
+    useOrganizationsServiceGetOrtRunStatisticsByOrganizationIdSuspense({
+      organizationId: organizationId,
+    });
+
+  const total = data.data.ruleViolationsCount;
+  const counts = data.data.ruleViolationsCountBySeverity;
+
+  return (
+    <StatisticsCard
+      title='Rule Violations'
+      icon={() => <Scale className='h-4 w-4 text-green-500' />}
+      value={total || '-'}
+      counts={
+        counts
+          ? Object.entries(counts).map(([severity, count]) => ({
+              key: severity,
+              count: count,
+              color: getRuleViolationSeverityBackgroundColor(
+                severity as Severity
+              ),
+            }))
+          : []
+      }
+      className={cn('h-full hover:bg-muted/50', className)}
+    />
+  );
+};

--- a/ui/src/routes/organizations/$orgId/-components/organization-vulnerabilities-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-vulnerabilities-statistics-card.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { ShieldQuestion } from 'lucide-react';
+
+import { useOrganizationsServiceGetOrtRunStatisticsByOrganizationIdSuspense } from '@/api/queries/suspense';
+import { VulnerabilityRating } from '@/api/requests';
+import { StatisticsCard } from '@/components/statistics-card';
+import { getVulnerabilityRatingBackgroundColor } from '@/helpers/get-status-class';
+import { cn } from '@/lib/utils';
+
+type OrganizationVulnerabilitiesStatisticsCardProps = {
+  organizationId: number;
+  className?: string;
+};
+
+export const OrganizationVulnerabilitiesStatisticsCard = ({
+  organizationId,
+  className,
+}: OrganizationVulnerabilitiesStatisticsCardProps) => {
+  const data =
+    useOrganizationsServiceGetOrtRunStatisticsByOrganizationIdSuspense({
+      organizationId: organizationId,
+    });
+
+  const total = data.data.vulnerabilitiesCount;
+  const counts = data.data.vulnerabilitiesCountByRating;
+
+  return (
+    <StatisticsCard
+      title='Vulnerabilities'
+      icon={() => <ShieldQuestion className='h-4 w-4 text-green-500' />}
+      value={total || '-'}
+      counts={
+        counts
+          ? Object.entries(counts).map(([rating, count]) => ({
+              key: rating,
+              count: count,
+              color: getVulnerabilityRatingBackgroundColor(
+                rating as VulnerabilityRating
+              ),
+            }))
+          : []
+      }
+      className={cn('h-full hover:bg-muted/50', className)}
+    />
+  );
+};

--- a/ui/src/routes/organizations/$orgId/index.tsx
+++ b/ui/src/routes/organizations/$orgId/index.tsx
@@ -18,10 +18,13 @@
  */
 
 import { createFileRoute } from '@tanstack/react-router';
+import { Boxes, Bug, Scale, ShieldQuestion } from 'lucide-react';
+import { Suspense } from 'react';
 
 import { useOrganizationsServiceGetOrganizationById } from '@/api/queries';
 import { prefetchUseOrganizationsServiceGetOrganizationById } from '@/api/queries/prefetch';
 import { LoadingIndicator } from '@/components/loading-indicator';
+import { StatisticsCard } from '@/components/statistics-card';
 import { ToastError } from '@/components/toast-error';
 import {
   Card,
@@ -32,8 +35,12 @@ import {
 } from '@/components/ui/card';
 import { toast } from '@/lib/toast';
 import { paginationSearchParameterSchema } from '@/schemas';
+import { OrganizationIssuesStatisticsCard } from './-components/organization-issues-statistics-card';
+import { OrganizationPackagesStatisticsCard } from './-components/organization-packages-statistics-card';
 import { OrganizationProductTable } from './-components/organization-product-table';
 import { OrganizationProductsStatisticsCard } from './-components/organization-products-statistics-card';
+import { OrganizationViolationsStatisticsCard } from './-components/organization-violations-statistics-card';
+import { OrganizationVulnerabilitiesStatisticsCard } from './-components/organization-vulnerabilities-statistics-card';
 
 const OrganizationComponent = () => {
   const params = Route.useParams();
@@ -77,7 +84,65 @@ const OrganizationComponent = () => {
           orgId={params.orgId}
         />
       </div>
-      <div className='grid grid-cols-4 gap-2'></div>
+      <div className='grid grid-cols-4 gap-2'>
+        <Suspense
+          fallback={
+            <StatisticsCard
+              title='Vulnerabilities'
+              icon={() => (
+                <ShieldQuestion className='h-4 w-4 text-orange-500' />
+              )}
+              value={<LoadingIndicator />}
+              className='h-full hover:bg-muted/50'
+            />
+          }
+        >
+          <OrganizationVulnerabilitiesStatisticsCard
+            organizationId={organization.id}
+          />
+        </Suspense>
+
+        <Suspense
+          fallback={
+            <StatisticsCard
+              title='Issues'
+              icon={() => <Bug className='h-4 w-4 text-orange-500' />}
+              value={<LoadingIndicator />}
+              className='h-full hover:bg-muted/50'
+            />
+          }
+        >
+          <OrganizationIssuesStatisticsCard organizationId={organization.id} />
+        </Suspense>
+        <Suspense
+          fallback={
+            <StatisticsCard
+              title='Rule Violations'
+              icon={() => <Scale className='h-4 w-4 text-orange-500' />}
+              value={<LoadingIndicator />}
+              className='h-full hover:bg-muted/50'
+            />
+          }
+        >
+          <OrganizationViolationsStatisticsCard
+            organizationId={organization.id}
+          />
+        </Suspense>
+        <Suspense
+          fallback={
+            <StatisticsCard
+              title='Packages'
+              icon={() => <Boxes className='h-4 w-4 text-orange-500' />}
+              value={<LoadingIndicator />}
+              className='h-full hover:bg-muted/50'
+            />
+          }
+        >
+          <OrganizationPackagesStatisticsCard
+            organizationId={organization.id}
+          />
+        </Suspense>
+      </div>
       <Card>
         <CardContent className='my-4'>
           <OrganizationProductTable />


### PR DESCRIPTION
This PR will further align the organization and product overview pages.

![Screenshot from 2025-01-03 12-28-49](https://github.com/user-attachments/assets/8e974f29-0770-4fd6-8bc3-85b81b1db97e)

Please note that the endpoint for gathering all vulnerabilities in an organization hasn't yet been implemented, so this is yet missing from this overview page.

Please see the commit for details.