### PR TITLE
Start untangling orchestrator

### DIFF
--- a/orchestrator/src/main/kotlin/Orchestrator.kt
+++ b/orchestrator/src/main/kotlin/Orchestrator.kt
@@ -404,9 +404,7 @@ class Orchestrator(
 
             val ortRunStatus = when {
                 context.isFailed() -> OrtRunStatus.FAILED
-
                 context.isFinishedWithIssues() -> OrtRunStatus.FINISHED_WITH_ISSUES
-
                 else -> OrtRunStatus.FINISHED
             }
 

--- a/orchestrator/src/main/kotlin/Orchestrator.kt
+++ b/orchestrator/src/main/kotlin/Orchestrator.kt
@@ -78,7 +78,7 @@ private val log = LoggerFactory.getLogger(Orchestrator::class.java)
  * It creates jobs for the single processing steps and passes them to the corresponding workers. It collects the results
  * produced by the workers until the complete ORT result is available or the run has failed.
  */
-@Suppress("LongParameterList", "TooManyFunctions")
+@Suppress("TooManyFunctions")
 class Orchestrator(
     private val db: Database,
     private val workerJobRepositories: WorkerJobRepositories,

--- a/orchestrator/src/main/kotlin/Orchestrator.kt
+++ b/orchestrator/src/main/kotlin/Orchestrator.kt
@@ -99,10 +99,7 @@ class Orchestrator(
                 "Repository '${ortRun.repositoryId}' not found."
             }
 
-            val context = WorkerScheduleContext(ortRun, workerJobRepositories, publisher, header, emptyMap())
-            context to listOf { scheduleConfigWorkerJob(ortRun, header, updateRun = true) }
-        }.onSuccess { (context, schedules) ->
-            scheduleCreatedJobs(context, schedules)
+            scheduleConfigWorkerJob(ortRun, header, updateRun = true)
         }.onFailure {
             log.warn("Failed to handle 'CreateOrtRun' message.", it)
         }
@@ -115,9 +112,9 @@ class Orchestrator(
         db.blockingQueryCatching(transactionIsolation = isolationLevel) {
             val ortRun = getOrtRun(configWorkerResult.ortRunId)
 
-            nextJobsToSchedule(ConfigEndpoint, ortRun.id, header, jobs = emptyMap())
-        }.onSuccess { (context, schedules) ->
-            scheduleCreatedJobs(context, schedules)
+            createWorkerScheduleContext(ortRun, header)
+        }.onSuccess { context ->
+            scheduleNextJobs(context)
         }.onFailure {
             log.warn("Failed to handle 'ConfigWorkerResult' message.", it)
         }
@@ -252,12 +249,11 @@ class Orchestrator(
                     "ORT run '$ortRunId' not found."
                 }
 
-                repository.tryComplete(job.id, Clock.System.now(), JobStatus.FAILED)?.let {
-                    nextJobsToSchedule(Endpoint.fromConfigPrefix(workerError.endpointName), job.ortRunId, header)
-                }
-            } ?: (createWorkerScheduleContext(getOrtRun(ortRunId), header, failed = true) to emptyList())
-        }.onSuccess { (context, schedules) ->
-            scheduleCreatedJobs(context, schedules)
+                repository.tryComplete(job.id, Clock.System.now(), JobStatus.FAILED)
+                createWorkerScheduleContext(getOrtRun(ortRunId), header)
+            } ?: createWorkerScheduleContext(getOrtRun(ortRunId), header, failed = true)
+        }.onSuccess { context ->
+            scheduleNextJobs(context)
         }.onFailure {
             log.warn("Failed to handle 'WorkerError' message.", it)
         }
@@ -274,13 +270,14 @@ class Orchestrator(
             val ortRun = getOrtRun(lostSchedule.ortRunId)
             val context = createWorkerScheduleContext(ortRun, header)
 
-            if (context.jobs.isNotEmpty()) {
-                fetchNextJobs(context)
+            if (context.jobs.isEmpty()) {
+                scheduleConfigWorkerJob(ortRun, header, updateRun = false)
+                null
             } else {
-                context to listOf { scheduleConfigWorkerJob(ortRun, header, updateRun = false) }
+                context
             }
-        }.onSuccess { (context, schedules) ->
-            scheduleCreatedJobs(context, schedules)
+        }.onSuccess { context ->
+            context?.let { scheduleNextJobs(context) }
         }.onFailure {
             log.warn("Failed to handle 'LostSchedule' message.", it)
         }
@@ -340,32 +337,12 @@ class Orchestrator(
             val job = workerJobRepositories.updateJobStatus(endpoint, message.jobId, status)
             if (issues.isNotEmpty()) ortRunRepository.update(job.ortRunId, issues = issues.asPresent())
 
-            nextJobsToSchedule(endpoint, job.ortRunId, header)
-        }.onSuccess { (context, schedules) ->
-            scheduleCreatedJobs(context, schedules)
+            createWorkerScheduleContext(getOrtRun(job.ortRunId), header)
+        }.onSuccess { context ->
+            scheduleNextJobs(context)
         }.onFailure {
             log.warn("Failed to handle '{}' message.", message::class.java.simpleName, it)
         }
-    }
-
-    /**
-     * Determine the next jobs that can be scheduled after a job for the given [endpoint] for the run with the given
-     * [ortRunId] has completed. Use the given [header] to send messages to the worker endpoints. Optionally,
-     * accept a map with the [jobs] that have been run. Return a list with the new jobs to schedule and the current
-     * [WorkerScheduleContext].
-     */
-    private fun nextJobsToSchedule(
-        endpoint: Endpoint<*>,
-        ortRunId: Long,
-        header: MessageHeader,
-        jobs: Map<String, WorkerJob>? = null
-    ): Pair<WorkerScheduleContext, List<JobScheduleFunc>> {
-        log.info("Handling a completed job for endpoint '{}' and ORT run {}.", endpoint.configPrefix, ortRunId)
-
-        val ortRun = getOrtRun(ortRunId)
-        val scheduleContext = createWorkerScheduleContext(ortRun, header, workerJobs = jobs)
-
-        return fetchNextJobs(scheduleContext)
     }
 
     /**
@@ -386,16 +363,36 @@ class Orchestrator(
         return WorkerScheduleContext(ortRun, workerJobRepositories, publisher, header, jobs, failed)
     }
 
-    /**
-     * Trigger the scheduling of the given new [createdJobs] for the ORT run contained in the given [context]. This
-     * also includes sending corresponding messages to the worker endpoints.
-     */
-    private fun scheduleCreatedJobs(context: WorkerScheduleContext, createdJobs: CreatedJobs) {
-        // TODO: Handle errors during job scheduling.
+    /** Schedule the next jobs for the current ORT run based on the current state of the run. */
+    private fun scheduleNextJobs(context: WorkerScheduleContext) {
+        val configuredJobs = WorkerScheduleInfo.entries.filterTo(mutableSetOf()) {
+            it.isConfigured(context.jobConfigs())
+        }
 
-        createdJobs.forEach { it() }
+        val jobInfos = configuredJobs.mapNotNull {
+            context.jobs[it.endpoint.configPrefix]?.let { job ->
+                it to WorkerJobInfo(job.id, job.status)
+            }
+        }.toMap()
 
-        if (createdJobs.isEmpty() && !context.hasRunningJobs()) {
+        val ortRunInfo = OrtRunInfo(context.ortRun.id, context.failed, configuredJobs, jobInfos)
+
+        val nextJobs = ortRunInfo.getNextJobs()
+
+        nextJobs.forEach { info ->
+            info.createJob(context)?.let { job ->
+                // TODO: Handle errors during job scheduling.
+                info.publishJob(context, job)
+                context.workerJobRepositories.updateJobStatus(
+                    info.endpoint,
+                    job.id,
+                    JobStatus.SCHEDULED,
+                    finished = false
+                )
+            }
+        }
+
+        if (nextJobs.isEmpty() && !context.hasRunningJobs()) {
             cleanupJobs(context.ortRun.id)
 
             val ortRunStatus = when {
@@ -461,11 +458,6 @@ class Orchestrator(
 }
 
 /**
- * Type definition to represent a list of jobs that have been created and must be scheduled.
- */
-typealias CreatedJobs = List<JobScheduleFunc>
-
-/**
  * Create an [Issue] object representing an error that occurred in any [Endpoint].
  */
 fun <T : Any> Endpoint<T>.createErrorIssue(): Issue = Issue(
@@ -474,12 +466,3 @@ fun <T : Any> Endpoint<T>.createErrorIssue(): Issue = Issue(
     message = "The $configPrefix worker failed due to an unexpected error.",
     severity = Severity.ERROR
 )
-
-/**
- * Return a [Pair] with the given [scheduleContext] and the list of jobs that can be scheduled in the current phase
- * of the affected ORT run.
- */
-private fun fetchNextJobs(
-    scheduleContext: WorkerScheduleContext
-): Pair<WorkerScheduleContext, List<JobScheduleFunc>> =
-    scheduleContext to WorkerScheduleInfo.entries.mapNotNull { it.createAndScheduleJobIfPossible(scheduleContext) }

--- a/orchestrator/src/main/kotlin/Orchestrator.kt
+++ b/orchestrator/src/main/kotlin/Orchestrator.kt
@@ -251,7 +251,7 @@ class Orchestrator(
                 repository.tryComplete(job.id, Clock.System.now(), JobStatus.FAILED)?.let {
                     nextJobsToSchedule(Endpoint.fromConfigPrefix(workerError.endpointName), job.ortRunId, header)
                 }
-            } ?: (createWorkerSchedulerContext(getCurrentOrtRun(ortRunId), header, failed = true) to emptyList())
+            } ?: (createWorkerScheduleContext(getCurrentOrtRun(ortRunId), header, failed = true) to emptyList())
         }.scheduleNextJobs {
             log.warn("Failed to handle 'WorkerError' message.", it)
         }
@@ -266,7 +266,7 @@ class Orchestrator(
 
         db.blockingQueryCatching(transactionIsolation = isolationLevel) {
             val ortRun = getCurrentOrtRun(lostSchedule.ortRunId)
-            val context = createWorkerSchedulerContext(ortRun, header)
+            val context = createWorkerScheduleContext(ortRun, header)
 
             if (context.jobs.isNotEmpty()) {
                 fetchNextJobs(context)
@@ -353,7 +353,7 @@ class Orchestrator(
         log.info("Handling a completed job for endpoint '{}' and ORT run {}.", endpoint.configPrefix, ortRunId)
 
         val ortRun = getCurrentOrtRun(ortRunId)
-        val scheduleContext = createWorkerSchedulerContext(ortRun, header, workerJobs = jobs)
+        val scheduleContext = createWorkerScheduleContext(ortRun, header, workerJobs = jobs)
 
         return fetchNextJobs(scheduleContext)
     }
@@ -377,7 +377,7 @@ class Orchestrator(
      * The context is initialized with the status of all jobs for this run, either from the given [workerJobs]
      * parameter or by loading the job status from the database.
      */
-    private fun createWorkerSchedulerContext(
+    private fun createWorkerScheduleContext(
         ortRun: OrtRun,
         header: MessageHeader,
         failed: Boolean = false,

--- a/orchestrator/src/main/kotlin/OrtRunInfo.kt
+++ b/orchestrator/src/main/kotlin/OrtRunInfo.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.orchestrator
+
+import org.eclipse.apoapsis.ortserver.model.JobStatus
+
+/** A class to store the required information to determine which jobs can be run. */
+internal class OrtRunInfo(
+    /** The ORT run ID. */
+    val id: Long,
+
+    /** Whether the config worker has failed. */
+    val configWorkerFailed: Boolean,
+
+    /** The jobs configured to run in this ORT run. */
+    val configuredJobs: Set<WorkerScheduleInfo>,
+
+    /** Status information for already created jobs. */
+    val jobInfos: Map<WorkerScheduleInfo, WorkerJobInfo>
+) {
+    /** Get the next jobs that can be run. */
+    fun getNextJobs(): Set<WorkerScheduleInfo> = WorkerScheduleInfo.entries.filterTo(mutableSetOf()) { canRun(it) }
+
+    /** Return true if the job can be run. */
+    private fun canRun(info: WorkerScheduleInfo): Boolean =
+        isConfigured(info) &&
+                !wasScheduled(info) &&
+                canRunIfPreviousJobFailed(info) &&
+                info.dependsOn.all { isCompleted(it) } &&
+                info.runsAfterTransitively.none { isPending(it) }
+
+    /** Return true if no previous job has failed or if the job is configured to run after a failure. */
+    private fun canRunIfPreviousJobFailed(info: WorkerScheduleInfo): Boolean = info.runAfterFailure || !isFailed()
+
+    /** Return true if the job has been completed. */
+    private fun isCompleted(info: WorkerScheduleInfo): Boolean = jobInfos[info]?.status?.final == true
+
+    /** Return true if the job is configured to run. */
+    private fun isConfigured(info: WorkerScheduleInfo): Boolean = info in configuredJobs
+
+    /** Return true if any job has failed. */
+    private fun isFailed(): Boolean = configWorkerFailed || jobInfos.any { it.value.status == JobStatus.FAILED }
+
+    /** Return true if the job is pending execution. */
+    private fun isPending(info: WorkerScheduleInfo): Boolean =
+        isConfigured(info) &&
+                !isCompleted(info) &&
+                canRunIfPreviousJobFailed(info) &&
+                info.dependsOn.all { wasScheduled(it) || isPending(it) }
+
+    /** Return true if the job has been scheduled. */
+    private fun wasScheduled(info: WorkerScheduleInfo): Boolean = jobInfos.containsKey(info)
+}
+
+/** A class to store information of a worker job required by [OrtRunInfo]. */
+internal class WorkerJobInfo(
+    /** The job ID. */
+    val id: Long,
+
+    /** The job status. */
+    val status: JobStatus
+)

--- a/orchestrator/src/main/kotlin/WorkerScheduleContext.kt
+++ b/orchestrator/src/main/kotlin/WorkerScheduleContext.kt
@@ -60,7 +60,7 @@ internal class WorkerScheduleContext(
      * jobs that have been run. With this flag, this mechanism can be overridden, which is necessary for workers that
      * do not spawn jobs like the Config worker.
      */
-    private val failed: Boolean = false
+    val failed: Boolean = false
 ) {
     /**
      * Return the [JobConfigurations] object for the current run. Prefer the resolved configurations if available;
@@ -88,19 +88,6 @@ internal class WorkerScheduleContext(
      */
     fun hasRunningJobs(): Boolean =
         jobs.values.any { !it.isCompleted() }
-
-    /**
-     * Return a flag whether the worker job for the given [endpoint] was scheduled for the current ORT run. It may
-     * still be running or have finished already.
-     */
-    fun wasScheduled(endpoint: Endpoint<*>): Boolean =
-        endpoint.configPrefix in jobs
-
-    /**
-     * Return a flag whether the worker job for the given [endpoint] has already completed.
-     */
-    fun isJobCompleted(endpoint: Endpoint<*>): Boolean =
-        jobs[endpoint.configPrefix]?.isCompleted() ?: false
 
     /**
      * Return a flag whether this [OrtRun] has failed, i.e. it has at least one job in failed state.

--- a/orchestrator/src/main/kotlin/WorkerScheduleContext.kt
+++ b/orchestrator/src/main/kotlin/WorkerScheduleContext.kt
@@ -87,7 +87,7 @@ internal class WorkerScheduleContext(
      * Return a flag whether the current [OrtRun] has at least one running job.
      */
     fun hasRunningJobs(): Boolean =
-        jobs.values.any { !it.isCompleted() }
+        jobs.values.any { !it.status.final }
 
     /**
      * Return a flag whether this [OrtRun] has failed, i.e. it has at least one job in failed state.
@@ -101,9 +101,3 @@ internal class WorkerScheduleContext(
     fun isFinishedWithIssues(): Boolean =
         !isFailed() && jobs.values.any { it.status == JobStatus.FINISHED_WITH_ISSUES }
 }
-
-/**
- * Return a flag whether this [WorkerJob] is already completed.
- */
-private fun WorkerJob.isCompleted(): Boolean =
-    status == JobStatus.FINISHED || status == JobStatus.FAILED || status == JobStatus.FINISHED_WITH_ISSUES

--- a/orchestrator/src/main/kotlin/WorkerScheduleInfo.kt
+++ b/orchestrator/src/main/kotlin/WorkerScheduleInfo.kt
@@ -56,18 +56,18 @@ internal enum class WorkerScheduleInfo(
      * A list defining the worker jobs that this job depends on. This job will only be executed after all the
      * dependencies have been successfully completed.
      */
-    private val dependsOn: List<WorkerScheduleInfo> = emptyList(),
+    val dependsOn: List<WorkerScheduleInfo> = emptyList(),
 
     /**
      * A list defining the worker jobs that must run before this job. The difference to [dependsOn] is that this job
      * can also run if these other jobs will not be executed. It is only guaranteed that it runs after all of them.
      */
-    private val runsAfter: List<WorkerScheduleInfo> = emptyList(),
+    val runsAfter: List<WorkerScheduleInfo> = emptyList(),
 
     /**
      * A flag determining whether the represented worker should be run even if previous workers have already failed.
      */
-    private val runAfterFailure: Boolean = false
+    val runAfterFailure: Boolean = false
 ) {
     ANALYZER(AnalyzerEndpoint) {
         override fun createJob(context: WorkerScheduleContext): WorkerJob =
@@ -159,7 +159,7 @@ internal enum class WorkerScheduleInfo(
      * no cycles exist in the dependency graph of workers; otherwise, the scheduler algorithm would have a severe
      * problem.
      */
-    private val runsAfterTransitively: Set<WorkerScheduleInfo>
+    val runsAfterTransitively: Set<WorkerScheduleInfo>
         get() = (runsAfter + dependsOn).flatMapTo(mutableSetOf()) { it.runsAfterTransitively + it }
 
     /**

--- a/orchestrator/src/main/kotlin/WorkerScheduleInfo.kt
+++ b/orchestrator/src/main/kotlin/WorkerScheduleInfo.kt
@@ -125,7 +125,7 @@ internal enum class WorkerScheduleInfo(
             configs.evaluator != null
     },
 
-    REPORTER(ReporterEndpoint, runsAfter = listOf(EVALUATOR), runAfterFailure = true) {
+    REPORTER(ReporterEndpoint, dependsOn = listOf(ANALYZER), runsAfter = listOf(EVALUATOR), runAfterFailure = true) {
         override fun createJob(context: WorkerScheduleContext): WorkerJob? =
             context.jobConfigs().reporter?.let { config ->
                 context.workerJobRepositories.reporterJobRepository.create(context.ortRun.id, config)

--- a/orchestrator/src/main/kotlin/WorkerScheduleInfo.kt
+++ b/orchestrator/src/main/kotlin/WorkerScheduleInfo.kt
@@ -56,13 +56,13 @@ internal enum class WorkerScheduleInfo(
      * A list defining the worker jobs that this job depends on. This job will only be executed after all the
      * dependencies have been successfully completed.
      */
-    private val dependsOn: List<Endpoint<*>> = emptyList(),
+    private val dependsOn: List<WorkerScheduleInfo> = emptyList(),
 
     /**
      * A list defining the worker jobs that must run before this job. The difference to [dependsOn] is that this job
      * can also run if these other jobs will not be executed. It is only guaranteed that it runs after all of them.
      */
-    private val runsAfter: List<Endpoint<*>> = emptyList(),
+    private val runsAfter: List<WorkerScheduleInfo> = emptyList(),
 
     /**
      * A flag determining whether the represented worker should be run even if previous workers have already failed.
@@ -83,7 +83,7 @@ internal enum class WorkerScheduleInfo(
         override fun isConfigured(configs: JobConfigurations): Boolean = true
     },
 
-    ADVISOR(AdvisorEndpoint, dependsOn = listOf(AnalyzerEndpoint)) {
+    ADVISOR(AdvisorEndpoint, dependsOn = listOf(ANALYZER)) {
         override fun createJob(context: WorkerScheduleContext): WorkerJob? =
             context.jobConfigs().advisor?.let { config ->
                 context.workerJobRepositories.advisorJobRepository.create(context.ortRun.id, config)
@@ -97,7 +97,7 @@ internal enum class WorkerScheduleInfo(
             configs.advisor != null
     },
 
-    SCANNER(ScannerEndpoint, dependsOn = listOf(AnalyzerEndpoint)) {
+    SCANNER(ScannerEndpoint, dependsOn = listOf(ANALYZER)) {
         override fun createJob(context: WorkerScheduleContext): WorkerJob? =
             context.jobConfigs().scanner?.let { config ->
                 context.workerJobRepositories.scannerJobRepository.create(context.ortRun.id, config)
@@ -111,7 +111,7 @@ internal enum class WorkerScheduleInfo(
             configs.scanner != null
     },
 
-    EVALUATOR(EvaluatorEndpoint, runsAfter = listOf(AdvisorEndpoint, ScannerEndpoint)) {
+    EVALUATOR(EvaluatorEndpoint, runsAfter = listOf(ADVISOR, SCANNER)) {
         override fun createJob(context: WorkerScheduleContext): WorkerJob? =
             context.jobConfigs().evaluator?.let { config ->
                 context.workerJobRepositories.evaluatorJobRepository.create(context.ortRun.id, config)
@@ -125,7 +125,7 @@ internal enum class WorkerScheduleInfo(
             configs.evaluator != null
     },
 
-    REPORTER(ReporterEndpoint, runsAfter = listOf(EvaluatorEndpoint), runAfterFailure = true) {
+    REPORTER(ReporterEndpoint, runsAfter = listOf(EVALUATOR), runAfterFailure = true) {
         override fun createJob(context: WorkerScheduleContext): WorkerJob? =
             context.jobConfigs().reporter?.let { config ->
                 context.workerJobRepositories.reporterJobRepository.create(context.ortRun.id, config)
@@ -139,7 +139,7 @@ internal enum class WorkerScheduleInfo(
             configs.reporter != null
     },
 
-    NOTIFIER(NotifierEndpoint, dependsOn = listOf(ReporterEndpoint), runAfterFailure = true) {
+    NOTIFIER(NotifierEndpoint, dependsOn = listOf(REPORTER), runAfterFailure = true) {
         override fun createJob(context: WorkerScheduleContext): WorkerJob? =
             context.jobConfigs().notifier?.let { config ->
                 context.workerJobRepositories.notifierJobRepository.create(context.ortRun.id, config)
@@ -153,20 +153,14 @@ internal enum class WorkerScheduleInfo(
             configs.notifier != null
     };
 
-    companion object {
-        private val entriesByPrefix = entries.associateBy { it.endpoint.configPrefix }
-
-        operator fun get(endpoint: Endpoint<*>): WorkerScheduleInfo = entriesByPrefix.getValue(endpoint.configPrefix)
-    }
-
     /**
      * Return the transitive set of the workers that must complete before this one can run. This is necessary to
      * determine whether this worker can be started in the current phase of an ORT run. Note that it is assumed that
      * no cycles exist in the dependency graph of workers; otherwise, the scheduler algorithm would have a severe
      * problem.
      */
-    private val runsAfterTransitively: Set<Endpoint<*>>
-        get() = (runsAfter + dependsOn).flatMapTo(mutableSetOf()) { WorkerScheduleInfo[it].runsAfterTransitively + it }
+    private val runsAfterTransitively: Set<WorkerScheduleInfo>
+        get() = (runsAfter + dependsOn).flatMapTo(mutableSetOf()) { it.runsAfterTransitively + it }
 
     /**
      * Check whether a job for the represented worker can be scheduled now based on the given [context]. If so, create
@@ -209,8 +203,8 @@ internal enum class WorkerScheduleInfo(
         isConfigured(context.jobConfigs()) &&
                 !context.wasScheduled(endpoint) &&
                 canRunWithFailureState(context) &&
-                dependsOn.all { context.isJobCompleted(it) } &&
-                runsAfterTransitively.none { WorkerScheduleInfo[it].isPending(context) }
+                dependsOn.all { context.isJobCompleted(it.endpoint) } &&
+                runsAfterTransitively.none { it.isPending(context) }
 
     /**
      * Check whether the represented worker is pending for the current ORT run based on the given [context]. This
@@ -220,10 +214,7 @@ internal enum class WorkerScheduleInfo(
         isConfigured(context.jobConfigs()) &&
                 !context.isJobCompleted(endpoint) &&
                 canRunWithFailureState(context) &&
-                dependsOn.all {
-                    context.wasScheduled(it) ||
-                            WorkerScheduleInfo[it].isPending(context)
-                }
+                dependsOn.all { context.wasScheduled(it.endpoint) || it.isPending(context) }
 
     /**
      * Check whether the represented worker can be executed for the failure state stored in the given [context]. Here

--- a/orchestrator/src/test/kotlin/OrtRunInfoTest.kt
+++ b/orchestrator/src/test/kotlin/OrtRunInfoTest.kt
@@ -144,7 +144,7 @@ class OrtRunInfoTest : WordSpec({
             ortRunInfo.getNextJobs() should containExactly(WorkerScheduleInfo.REPORTER)
         }
 
-        "return REPORTER if config worker failed" {
+        "return nothing if config worker failed" {
             val ortRunInfo = OrtRunInfo(
                 id = 1,
                 configWorkerFailed = true,
@@ -152,7 +152,7 @@ class OrtRunInfoTest : WordSpec({
                 jobInfos = emptyMap()
             )
 
-            ortRunInfo.getNextJobs() should containExactly(WorkerScheduleInfo.REPORTER)
+            ortRunInfo.getNextJobs() should beEmpty()
         }
 
         "return REPORTER if ANALYZER failed" {

--- a/orchestrator/src/test/kotlin/OrtRunInfoTest.kt
+++ b/orchestrator/src/test/kotlin/OrtRunInfoTest.kt
@@ -1,0 +1,346 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.orchestrator
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.should
+
+import org.eclipse.apoapsis.ortserver.model.JobStatus
+
+class OrtRunInfoTest : WordSpec({
+    "getNextJobs() with all jobs configured" should {
+        val configuredJobs = WorkerScheduleInfo.entries.toSet()
+
+        "return ANALYZER if no job was created yet" {
+            val ortRunInfo = OrtRunInfo(
+                id = 1,
+                configWorkerFailed = false,
+                configuredJobs = configuredJobs,
+                jobInfos = emptyMap()
+            )
+
+            ortRunInfo.getNextJobs() should containExactly(WorkerScheduleInfo.ANALYZER)
+        }
+
+        "return nothing if ANALYZER is still running" {
+            val ortRunInfo = OrtRunInfo(
+                id = 1,
+                configWorkerFailed = false,
+                configuredJobs = configuredJobs,
+                jobInfos = mapOf(
+                    WorkerScheduleInfo.ANALYZER to WorkerJobInfo(id = 1, status = JobStatus.RUNNING)
+                )
+            )
+
+            ortRunInfo.getNextJobs() should beEmpty()
+        }
+
+        "return ADVISOR and SCANNER if all previous jobs finished" {
+            val ortRunInfo = OrtRunInfo(
+                id = 1,
+                configWorkerFailed = false,
+                configuredJobs = configuredJobs,
+                jobInfos = mapOf(
+                    WorkerScheduleInfo.ANALYZER to WorkerJobInfo(id = 1, status = JobStatus.FINISHED)
+                )
+            )
+
+            ortRunInfo.getNextJobs() should containExactly(WorkerScheduleInfo.ADVISOR, WorkerScheduleInfo.SCANNER)
+        }
+
+        "return nothing if ADVISOR is still running" {
+            val ortRunInfo = OrtRunInfo(
+                id = 1,
+                configWorkerFailed = false,
+                configuredJobs = configuredJobs,
+                jobInfos = mapOf(
+                    WorkerScheduleInfo.ANALYZER to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.ADVISOR to WorkerJobInfo(id = 1, status = JobStatus.RUNNING),
+                    WorkerScheduleInfo.SCANNER to WorkerJobInfo(id = 1, status = JobStatus.FINISHED)
+                )
+            )
+
+            ortRunInfo.getNextJobs() should beEmpty()
+        }
+
+        "return nothing if SCANNER is still running" {
+            val ortRunInfo = OrtRunInfo(
+                id = 1,
+                configWorkerFailed = false,
+                configuredJobs = configuredJobs,
+                jobInfos = mapOf(
+                    WorkerScheduleInfo.ANALYZER to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.ADVISOR to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.SCANNER to WorkerJobInfo(id = 1, status = JobStatus.RUNNING)
+                )
+            )
+
+            ortRunInfo.getNextJobs() should beEmpty()
+        }
+
+        "return EVALUATOR if all previous jobs finished" {
+            val ortRunInfo = OrtRunInfo(
+                id = 1,
+                configWorkerFailed = false,
+                configuredJobs = configuredJobs,
+                jobInfos = mapOf(
+                    WorkerScheduleInfo.ANALYZER to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.ADVISOR to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.SCANNER to WorkerJobInfo(id = 1, status = JobStatus.FINISHED)
+                )
+            )
+
+            ortRunInfo.getNextJobs() should containExactly(WorkerScheduleInfo.EVALUATOR)
+        }
+
+        "return nothing if EVALUATOR is still running" {
+            val ortRunInfo = OrtRunInfo(
+                id = 1,
+                configWorkerFailed = false,
+                configuredJobs = configuredJobs,
+                jobInfos = mapOf(
+                    WorkerScheduleInfo.ANALYZER to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.ADVISOR to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.SCANNER to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.EVALUATOR to WorkerJobInfo(id = 1, status = JobStatus.RUNNING)
+                )
+            )
+
+            ortRunInfo.getNextJobs() should beEmpty()
+        }
+
+        "return REPORTER if all previous jobs finished" {
+            val ortRunInfo = OrtRunInfo(
+                id = 1,
+                configWorkerFailed = false,
+                configuredJobs = configuredJobs,
+                jobInfos = mapOf(
+                    WorkerScheduleInfo.ANALYZER to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.ADVISOR to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.SCANNER to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.EVALUATOR to WorkerJobInfo(id = 1, status = JobStatus.FINISHED)
+                )
+            )
+
+            ortRunInfo.getNextJobs() should containExactly(WorkerScheduleInfo.REPORTER)
+        }
+
+        "return REPORTER if config worker failed" {
+            val ortRunInfo = OrtRunInfo(
+                id = 1,
+                configWorkerFailed = true,
+                configuredJobs = configuredJobs,
+                jobInfos = emptyMap()
+            )
+
+            ortRunInfo.getNextJobs() should containExactly(WorkerScheduleInfo.REPORTER)
+        }
+
+        "return REPORTER if ANALYZER failed" {
+            val ortRunInfo = OrtRunInfo(
+                id = 1,
+                configWorkerFailed = false,
+                configuredJobs = configuredJobs,
+                jobInfos = mapOf(
+                    WorkerScheduleInfo.ANALYZER to WorkerJobInfo(id = 1, status = JobStatus.FAILED)
+                )
+            )
+
+            ortRunInfo.getNextJobs() should containExactly(WorkerScheduleInfo.REPORTER)
+        }
+
+        "return REPORTER if ADVISOR failed" {
+            val ortRunInfo = OrtRunInfo(
+                id = 1,
+                configWorkerFailed = false,
+                configuredJobs = configuredJobs,
+                jobInfos = mapOf(
+                    WorkerScheduleInfo.ANALYZER to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.ADVISOR to WorkerJobInfo(id = 1, status = JobStatus.FAILED),
+                    WorkerScheduleInfo.SCANNER to WorkerJobInfo(id = 1, status = JobStatus.FINISHED)
+                )
+            )
+
+            ortRunInfo.getNextJobs() should containExactly(WorkerScheduleInfo.REPORTER)
+        }
+
+        "return REPORTER if SCANNER failed" {
+            val ortRunInfo = OrtRunInfo(
+                id = 1,
+                configWorkerFailed = false,
+                configuredJobs = configuredJobs,
+                jobInfos = mapOf(
+                    WorkerScheduleInfo.ANALYZER to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.ADVISOR to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.SCANNER to WorkerJobInfo(id = 1, status = JobStatus.FAILED)
+                )
+            )
+
+            ortRunInfo.getNextJobs() should containExactly(WorkerScheduleInfo.REPORTER)
+        }
+
+        "return REPORTER if EVALUATOR failed" {
+            val ortRunInfo = OrtRunInfo(
+                id = 1,
+                configWorkerFailed = false,
+                configuredJobs = configuredJobs,
+                jobInfos = mapOf(
+                    WorkerScheduleInfo.ANALYZER to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.ADVISOR to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.SCANNER to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.EVALUATOR to WorkerJobInfo(id = 1, status = JobStatus.FAILED)
+                )
+            )
+
+            ortRunInfo.getNextJobs() should containExactly(WorkerScheduleInfo.REPORTER)
+        }
+
+        "return NOTIFIER if REPORTER finished" {
+            val ortRunInfo = OrtRunInfo(
+                id = 1,
+                configWorkerFailed = false,
+                configuredJobs = configuredJobs,
+                jobInfos = mapOf(
+                    WorkerScheduleInfo.ANALYZER to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.ADVISOR to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.SCANNER to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.EVALUATOR to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.REPORTER to WorkerJobInfo(id = 1, status = JobStatus.FINISHED)
+                )
+            )
+
+            ortRunInfo.getNextJobs() should containExactly(WorkerScheduleInfo.NOTIFIER)
+        }
+
+        "return NOTIFIER if REPORTER failed" {
+            val ortRunInfo = OrtRunInfo(
+                id = 1,
+                configWorkerFailed = false,
+                configuredJobs = configuredJobs,
+                jobInfos = mapOf(
+                    WorkerScheduleInfo.ANALYZER to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.ADVISOR to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.SCANNER to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.EVALUATOR to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.REPORTER to WorkerJobInfo(id = 1, status = JobStatus.FAILED)
+                )
+            )
+
+            ortRunInfo.getNextJobs() should containExactly(WorkerScheduleInfo.NOTIFIER)
+        }
+
+        "return nothing if all jobs finished" {
+            val ortRunInfo = OrtRunInfo(
+                id = 1,
+                configWorkerFailed = false,
+                configuredJobs = configuredJobs,
+                jobInfos = WorkerScheduleInfo.entries.associateWith {
+                    WorkerJobInfo(id = 1, status = JobStatus.FINISHED)
+                }
+            )
+
+            ortRunInfo.getNextJobs() should beEmpty()
+        }
+    }
+
+    "getNextJobs() with only ANALYZER and EVALUATOR configured" should {
+        val configuredJobs = setOf(WorkerScheduleInfo.ANALYZER, WorkerScheduleInfo.EVALUATOR)
+
+        "return ANALYZER if no job was created yet" {
+            val ortRunInfo = OrtRunInfo(
+                id = 1,
+                configWorkerFailed = false,
+                configuredJobs = configuredJobs,
+                jobInfos = emptyMap()
+            )
+
+            ortRunInfo.getNextJobs() should containExactly(WorkerScheduleInfo.ANALYZER)
+        }
+
+        "return nothing if ANALYZER is still running" {
+            val ortRunInfo = OrtRunInfo(
+                id = 1,
+                configWorkerFailed = false,
+                configuredJobs = configuredJobs,
+                jobInfos = mapOf(
+                    WorkerScheduleInfo.ANALYZER to WorkerJobInfo(id = 1, status = JobStatus.RUNNING)
+                )
+            )
+
+            ortRunInfo.getNextJobs() should beEmpty()
+        }
+
+        "return nothing if ANALYZER failed" {
+            val ortRunInfo = OrtRunInfo(
+                id = 1,
+                configWorkerFailed = false,
+                configuredJobs = configuredJobs,
+                jobInfos = mapOf(
+                    WorkerScheduleInfo.ANALYZER to WorkerJobInfo(id = 1, status = JobStatus.FAILED)
+                )
+            )
+
+            ortRunInfo.getNextJobs() should beEmpty()
+        }
+
+        "return EVALUATOR if ANALYZER finished" {
+            val ortRunInfo = OrtRunInfo(
+                id = 1,
+                configWorkerFailed = false,
+                configuredJobs = configuredJobs,
+                jobInfos = mapOf(
+                    WorkerScheduleInfo.ANALYZER to WorkerJobInfo(id = 1, status = JobStatus.FINISHED)
+                )
+            )
+
+            ortRunInfo.getNextJobs() should containExactly(WorkerScheduleInfo.EVALUATOR)
+        }
+
+        "return nothing if EVALUATOR is still running" {
+            val ortRunInfo = OrtRunInfo(
+                id = 1,
+                configWorkerFailed = false,
+                configuredJobs = configuredJobs,
+                jobInfos = mapOf(
+                    WorkerScheduleInfo.ANALYZER to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.EVALUATOR to WorkerJobInfo(id = 1, status = JobStatus.RUNNING)
+                )
+            )
+
+            ortRunInfo.getNextJobs() should beEmpty()
+        }
+
+        "return nothing if all jobs finished" {
+            val ortRunInfo = OrtRunInfo(
+                id = 1,
+                configWorkerFailed = false,
+                configuredJobs = configuredJobs,
+                jobInfos = mapOf(
+                    WorkerScheduleInfo.ANALYZER to WorkerJobInfo(id = 1, status = JobStatus.FINISHED),
+                    WorkerScheduleInfo.EVALUATOR to WorkerJobInfo(id = 1, status = JobStatus.FINISHED)
+                )
+            )
+
+            ortRunInfo.getNextJobs() should beEmpty()
+        }
+    }
+})


### PR DESCRIPTION
The few classes in the `orchestrator` currently have a very high degree of coupling and no clear separation of concerns. For example:
* The logic to determine the next jobs is partly implemented in `WorkerScheduleInfo` and partly in `WorkerScheduleContext`.
* Messaging is handled by `Orchestrator`, `WorkerScheduleContext`, and `WorkerScheduleInfo`.
* `Orchestrator`, `WorkerJobRepositories`, and `WorkerScheduleInfo` all interact with the repositories to create jobs or update their status.

Besides some minor clean ups, this PR separates the logic to determine the next jobs into a new class that has no dependencies on infrastructure. It is the first in a series of changes to untangle the different responsibilities of the orchestrator to make them testable in isolation and improve overview.