### PR TITLE
Refactor validation of worker job states

### DIFF
--- a/workers/advisor/src/main/kotlin/advisor/AdvisorWorker.kt
+++ b/workers/advisor/src/main/kotlin/advisor/AdvisorWorker.kt
@@ -20,10 +20,9 @@
 package org.eclipse.apoapsis.ortserver.workers.advisor
 
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
-import org.eclipse.apoapsis.ortserver.model.AdvisorJob
-import org.eclipse.apoapsis.ortserver.model.JobStatus
 import org.eclipse.apoapsis.ortserver.workers.common.JobIgnoredException
 import org.eclipse.apoapsis.ortserver.workers.common.OrtRunService
+import org.eclipse.apoapsis.ortserver.workers.common.OrtRunService.Companion.validateForProcessing
 import org.eclipse.apoapsis.ortserver.workers.common.RunResult
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContextFactory
 import org.eclipse.apoapsis.ortserver.workers.common.mapToModel
@@ -36,8 +35,6 @@ import org.ossreviewtoolkit.model.Severity
 import org.slf4j.LoggerFactory
 
 private val logger = LoggerFactory.getLogger(AdvisorWorker::class.java)
-
-private val invalidStates = setOf(JobStatus.FAILED, JobStatus.FINISHED)
 
 internal class AdvisorWorker(
     private val db: Database,
@@ -97,12 +94,5 @@ internal class AdvisorWorker(
     }
 
     private fun getValidAdvisorJob(jobId: Long) =
-        ortRunService.getAdvisorJob(jobId)?.validate()
-            ?: throw IllegalArgumentException("The advisor job '$jobId' does not exist.")
-
-    private fun AdvisorJob.validate() = apply {
-        if (status in invalidStates) {
-            throw JobIgnoredException("Advisor job '$id' status is already set to '$status'.")
-        }
-    }
+        ortRunService.getAdvisorJob(jobId).validateForProcessing(jobId)
 }

--- a/workers/common/src/main/kotlin/common/OrtRunService.kt
+++ b/workers/common/src/main/kotlin/common/OrtRunService.kt
@@ -33,6 +33,7 @@ import org.eclipse.apoapsis.ortserver.model.NotifierJob
 import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.ReporterJob
 import org.eclipse.apoapsis.ortserver.model.ScannerJob
+import org.eclipse.apoapsis.ortserver.model.WorkerJob
 import org.eclipse.apoapsis.ortserver.model.repositories.AdvisorJobRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.AdvisorRunRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.AnalyzerJobRepository
@@ -100,6 +101,20 @@ class OrtRunService(
 ) {
     companion object {
         private const val RUN_ID_LABEL = "runId"
+
+        /**
+         * Validate this [WorkerJob] before it can be processed by the corresponding worker. Check whether the job
+         * exists and has a state that allows it to be processed.
+         */
+        inline fun <reified T : WorkerJob> T?.validateForProcessing(jobId: Long): T {
+            requireNotNull(this) { "The ${T::class.simpleName} '$jobId' does not exist in the database." }
+
+            if (status.final) {
+                throw JobIgnoredException("The ${T::class.simpleName} '$jobId' is in a final state.")
+            }
+
+            return this
+        }
     }
 
     /**

--- a/workers/evaluator/src/main/kotlin/evaluator/EvaluatorWorker.kt
+++ b/workers/evaluator/src/main/kotlin/evaluator/EvaluatorWorker.kt
@@ -20,10 +20,9 @@
 package org.eclipse.apoapsis.ortserver.workers.evaluator
 
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
-import org.eclipse.apoapsis.ortserver.model.EvaluatorJob
-import org.eclipse.apoapsis.ortserver.model.JobStatus
 import org.eclipse.apoapsis.ortserver.workers.common.JobIgnoredException
 import org.eclipse.apoapsis.ortserver.workers.common.OrtRunService
+import org.eclipse.apoapsis.ortserver.workers.common.OrtRunService.Companion.validateForProcessing
 import org.eclipse.apoapsis.ortserver.workers.common.RunResult
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContextFactory
 import org.eclipse.apoapsis.ortserver.workers.common.mapToModel
@@ -35,8 +34,6 @@ import org.ossreviewtoolkit.model.Severity
 import org.slf4j.LoggerFactory
 
 private val logger = LoggerFactory.getLogger(EvaluatorWorker::class.java)
-
-private val invalidStates = setOf(JobStatus.FAILED, JobStatus.FINISHED)
 
 internal class EvaluatorWorker(
     private val db: Database,
@@ -84,12 +81,5 @@ internal class EvaluatorWorker(
     }
 
     private fun getValidEvaluatorJob(jobId: Long) =
-        ortRunService.getEvaluatorJob(jobId)?.validate()
-            ?: throw IllegalArgumentException("The evaluator job '$jobId' does not exist.")
-
-    private fun EvaluatorJob.validate() = apply {
-        if (status in invalidStates) {
-            throw JobIgnoredException("Evaluator job '$id' status is already set to '$status'")
-        }
-    }
+        ortRunService.getEvaluatorJob(jobId).validateForProcessing(jobId)
 }


### PR DESCRIPTION
This PR moves the validation of job status values to a central place in `OrtRunService` to reduce redundancy. Refer to the single commits for further details.