### PR TITLE
ui: More report formats

### DIFF
--- a/.github/ort/config.yml
+++ b/.github/ort/config.yml
@@ -9,7 +9,7 @@ ort:
     skipExcluded: true
   reporter:
     config:
-      CycloneDx:
+      CycloneDX:
         output.file.formats: JSON
       SpdxDocument:
         creationInfo.organization: Eclipse Apoapsis

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-types.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-types.ts
@@ -146,7 +146,7 @@ export type PackageManager = (typeof packageManagers)[number]['id'];
 
 export const reportFormats = [
   {
-    id: 'CycloneDx',
+    id: 'CycloneDX',
     label: 'CycloneDX SBOM',
   },
   {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-types.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-types.ts
@@ -147,15 +147,15 @@ export type PackageManager = (typeof packageManagers)[number]['id'];
 export const reportFormats = [
   {
     id: 'CycloneDX',
-    label: 'CycloneDX SBOM',
+    label: 'CycloneDX SBOM (JSON and XML formats)',
   },
   {
     id: 'SpdxDocument',
-    label: 'SPDX Document',
+    label: 'SPDX SBOM (JSON and YAML formats)',
   },
   {
     id: 'PlainTextTemplate',
-    label: 'NOTICE file',
+    label: 'NOTICE file (DEFAULT and SUMMARY formats)',
   },
   {
     id: 'WebApp',

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
@@ -539,6 +539,10 @@ export function formValuesToPayload(
     return Object.keys(options).length > 0 ? options : undefined;
   };
 
+  //
+  // Analyzer configuration
+  //
+
   // In ORT Server, running or not running a job for and ORT Run is decided
   // based on the presence or absence of the corresponding job configuration
   // in the request body. If a job is disabled in the UI, we pass "undefined"
@@ -562,12 +566,20 @@ export function formValuesToPayload(
     ),
   };
 
+  //
+  // Advisor configuration
+  //
+
   const advisorConfig = values.jobConfigs.advisor.enabled
     ? {
         skipExcluded: values.jobConfigs.advisor.skipExcluded,
         advisors: values.jobConfigs.advisor.advisors,
       }
     : undefined;
+
+  //
+  // Scanner configuration
+  //
 
   const scannerConfig = values.jobConfigs.scanner.enabled
     ? {
@@ -576,6 +588,10 @@ export function formValuesToPayload(
         skipExcluded: values.jobConfigs.scanner.skipExcluded,
       }
     : undefined;
+
+  //
+  // Evaluator configuration
+  //
 
   const evaluatorConfig = values.jobConfigs.evaluator.enabled
     ? {
@@ -592,11 +608,19 @@ export function formValuesToPayload(
       }
     : undefined;
 
+  //
+  // Reporter configuration
+  //
+
   const reporterConfig = values.jobConfigs.reporter.enabled
     ? {
         formats: values.jobConfigs.reporter.formats,
       }
     : undefined;
+
+  //
+  // Notifier configuration
+  //
 
   // Convert the recipient addresses back to an array of strings, as expected by the back-end.
   const addresses = values.jobConfigs.notifier.mail.recipientAddresses
@@ -641,6 +665,10 @@ export function formValuesToPayload(
         },
       }
     : undefined;
+
+  //
+  // Create the payload from worker configurations
+  //
 
   // Convert the parameters and labels arrays back to objects, as expected by the back-end.
   const parameters = values.jobConfigs.parameters

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
@@ -304,7 +304,7 @@ export function defaultValues(
       },
       reporter: {
         enabled: true,
-        formats: ['CycloneDx', 'SpdxDocument', 'WebApp'],
+        formats: ['CycloneDX', 'SpdxDocument', 'WebApp'],
       },
       notifier: {
         enabled: false,


### PR DESCRIPTION
This PR adds more output formats to CycloneDX, SPDX, and NOTICE file in Reporter.

![Screenshot from 2025-01-08 10-49-33](https://github.com/user-attachments/assets/d5d3a584-c8ef-470f-ab91-ca36efcdd07b)

Note: please also see issue #1745.  Earlier in ORT core, plugin naming was following the class naming convention, and therefore, `CycloneDx` was used as an id. With the new plugin structure in ORT core, each plugin should have an id which should be used when configuring the plugin for an ORT Run.  For CycloneDX, [the correct id is actually now "CycloneDX"](https://github.com/oss-review-toolkit/ort/blob/8ebd8c0aea0ffb0770edc92a8c477a4e2f4f0586/plugins/reporters/cyclonedx/src/main/kotlin/CycloneDxReporter.kt#L98-L103), not "CycloneDx". Therefore, it needed to be changed in the UI as well, which is done as part of this PR.