### PR TITLE
chore(reuse): Use the default "precedence" of "closest"

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -7,216 +7,180 @@ SPDX-PackageDownloadLocation = "https://github.com/oss-review-toolkit/ort-server
 
 [[annotations]]
 path = "**.dockerignore"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ".git**"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2022 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "**.gitignore"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ".detekt.license.template"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2022 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ".env.development"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2022 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ".idea/icon*.png"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ".mailmap"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = ".run/*.xml"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2022 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "gradle/gradle-daemon-jvm.properties"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "CONTRIBUTING.md"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "NOTICE"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2022 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "README.md"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2022 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "renovate.json"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "**/package.json"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "**/pnpm-lock.yaml"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "**/README.md"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2022 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "**/tsconfig.*json"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "assets/**"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "**/config/**/*.txt"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2022 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "docs/**"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2022 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "scripts/**"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2022 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "**/resources/**/*.rules.kts"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2022 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "**/resources/**/*.sql"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2022 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "**/resources/**/*.template"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2022 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "**/resources/**/*.yml"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2022 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "**/resources/*config*"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2022 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "**/resources/META-INF/services/*"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2022 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "ui/.prettier*"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "ui/components.json"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "ui/public/**"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "ui/src/api/**"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "ui/src/routeTree.gen.ts"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "website/**"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "website/static/img/ort-logo.svg"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2017 The ORT Project Authors (see <https://github.com/oss-review-toolkit/ort/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "gradlew*"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2007-2021 The original author or authors <info@gradle.com>"
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
 path = "gradle/wrapper/**"
-precedence = "aggregate"
 SPDX-FileCopyrightText = "2007-2021 The original author or authors <info@gradle.com>"
 SPDX-License-Identifier = "Apache-2.0"


### PR DESCRIPTION
The migration in 6a9e50a added `precedence = "aggregate"`, probably to resemble the old behavior. However, the most natural and also new default behavior is to use the license declaration that is closest [1] to the file.

[1]: https://reuse.software/spec-3.3/#reusetoml