### PR TITLE
feat(cli): Add a `--version` option to show the used CLI version

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -46,6 +46,7 @@ application {
 dependencies {
     implementation(projects.api.v1.apiV1Client)
     implementation(projects.api.v1.apiV1Model)
+    implementation(projects.model)
 
     implementation(libs.clikt)
     implementation(libs.kotlinxCoroutines)

--- a/cli/src/main/kotlin/OrtServerMain.kt
+++ b/cli/src/main/kotlin/OrtServerMain.kt
@@ -27,6 +27,7 @@ import com.github.ajalt.clikt.parameters.groups.provideDelegate
 import com.github.ajalt.clikt.parameters.options.convert
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.options.versionOption
 
 import kotlin.system.exitProcess
 
@@ -34,6 +35,7 @@ import kotlinx.serialization.json.Json
 
 import org.eclipse.apoapsis.ortserver.client.OrtServerClient
 import org.eclipse.apoapsis.ortserver.client.OrtServerClientConfig
+import org.eclipse.apoapsis.ortserver.model.ORT_SERVER_VERSION
 
 const val COMMAND_NAME = "ort-server"
 
@@ -47,6 +49,14 @@ class OrtServerMain : SuspendingNoOpCliktCommand(COMMAND_NAME) {
 
     init {
         subcommands(RunsCommand(ortServerConfig))
+
+        versionOption(
+            version = ORT_SERVER_VERSION,
+            names = setOf("--version", "-v"),
+            help = "Show the version and exit.",
+            // TODO: Also add the server version given by `baseUrl` to this output.
+            message = { "$commandName CLI version $it" }
+        )
     }
 }
 


### PR DESCRIPTION
At the moment the CLI and the Server use the same version, therefore this is the version which is printed.