### PR TITLE
fix(ui): Make the favicon path relative

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -21,7 +21,7 @@ License-Filename: LICENSE
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ORT Server</title>
   </head>


### PR DESCRIPTION
This fixes loading the favicon if the UI is not hosted at the root of a domain.