### PR TITLE
chore(ui): Remove the title from the SBOM page

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/sbom/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/sbom/index.tsx
@@ -113,9 +113,6 @@ const SBOMComponent = () => {
 
   return (
     <div className='flex flex-col gap-4'>
-      <h3 className='font-semibold leading-none tracking-tight'>
-        Download SBOM reports from run {ortRun.index}
-      </h3>
       <div className='grid grid-cols-2 gap-4'>
         <Card>
           <CardHeader className='text-center'>


### PR DESCRIPTION
Create a slicker look by not using a title. All information is included elsewhere (breadcrumb bar, menu item) anyway.