### PR TITLE
Make deleting old ort runs more efficient

### DIFF
--- a/model/src/commonMain/kotlin/repositories/OrtRunRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/OrtRunRepository.kt
@@ -77,11 +77,6 @@ interface OrtRunRepository {
     ): ListQueryResult<OrtRun>
 
     /**
-     * List all finished ORT runs before [before].
-     */
-    fun listRunsBefore(before: Instant): ListQueryResult<OrtRun>
-
-    /**
      * List all ORT runs for a [repository][repositoryId] according to the given [parameters].
      */
     fun listForRepository(
@@ -103,6 +98,11 @@ interface OrtRunRepository {
      * `ACTIVE` and `CREATED`.
      */
     fun listActiveRuns(): List<ActiveOrtRun>
+
+    /**
+     * Return a [List] with the IDs of all ORT runs that have finished before [before].
+     */
+    fun findRunsBefore(before: Instant): List<Long>
 
     /**
      * Update an ORT run by [id] with the [present][OptionalValue.Present] values. If [issues] or [labels] are

--- a/services/hierarchy/src/main/kotlin/OrtRunService.kt
+++ b/services/hierarchy/src/main/kotlin/OrtRunService.kt
@@ -81,13 +81,13 @@ class OrtRunService(
      * their reports are deleted from storage.
      */
     suspend fun deleteRunsCreatedBefore(before: Instant) {
-        val runs = ortRunRepository.listRunsBefore(before)
+        val runIds = ortRunRepository.findRunsBefore(before)
 
-        logger.info("Deleting ${runs.totalCount} ORT runs older than $before.")
+        logger.info("Deleting ${runIds.size} ORT runs older than $before.")
 
-        runs.data.forEach { run ->
+        runIds.forEach { runId ->
             runCatching {
-                deleteOrtRun(run.id)
+                deleteOrtRun(runId)
             }
         }
     }

--- a/services/hierarchy/src/main/kotlin/OrtRunService.kt
+++ b/services/hierarchy/src/main/kotlin/OrtRunService.kt
@@ -85,10 +85,16 @@ class OrtRunService(
 
         logger.info("Deleting ${runIds.size} ORT runs older than $before.")
 
+        var failureCount = 0
         runIds.forEach { runId ->
             runCatching {
                 deleteOrtRun(runId)
-            }
+            }.onFailure { failureCount++ }
+        }
+
+        logger.info("Deleted ${runIds.size - failureCount} old ORT runs successfully.")
+        if (failureCount > 0) {
+            logger.warn("Failed to delete $failureCount old ORT runs.")
         }
     }
 }


### PR DESCRIPTION
This PR introduces a new function to find ORT runs before a given reference time that only returns the IDs of matched runs. For the use case of deleting old ORT runs, this is way more efficient. Previously, fully initialized ORT run objects were retrieved with all their associations. For a larger number of affected runs, this took very long and consumed lot of resources.