### PR TITLE
Add a task to delete old ORT runs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -49,6 +49,8 @@ jobs:
           task: :orchestrator:jibDockerBuild
         - jibImage: kubernetes-jobmonitor
           task: :kubernetes:jobmonitor:jibDockerBuild
+        - jibImage: maintenance-tasks
+          task: :tasks:jibDockerBuild
         - jibImage: advisor-worker
           task: :workers:advisor:jibDockerBuild
         - image: analyzer-worker-base-image

--- a/tasks/build.gradle.kts
+++ b/tasks/build.gradle.kts
@@ -41,11 +41,16 @@ dependencies {
     implementation(projects.config.configSpi)
     implementation(projects.dao)
     implementation(projects.services.hierarchyService)
+    implementation(projects.services.reportStorageService)
+    implementation(projects.storage.storageSpi)
 
     implementation(libs.koinCore)
     implementation(libs.kotlinxCoroutines)
     implementation(libs.logback)
     implementation(libs.typesafeConfig)
+
+    runtimeOnly(platform(projects.storage))
+    runtimeOnly(platform(projects.config))
 
     testImplementation(testFixtures(projects.dao))
 

--- a/tasks/build.gradle.kts
+++ b/tasks/build.gradle.kts
@@ -40,6 +40,7 @@ tasks.withType<JibTask> {
 dependencies {
     implementation(projects.config.configSpi)
     implementation(projects.dao)
+    implementation(projects.services.hierarchyService)
 
     implementation(libs.koinCore)
     implementation(libs.kotlinxCoroutines)

--- a/tasks/src/main/kotlin/impl/DeleteOldOrtRunsTask.kt
+++ b/tasks/src/main/kotlin/impl/DeleteOldOrtRunsTask.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.tasks.impl
+
+import kotlin.time.Duration.Companion.days
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+import org.eclipse.apoapsis.ortserver.config.ConfigManager
+import org.eclipse.apoapsis.ortserver.services.OrtRunService
+import org.eclipse.apoapsis.ortserver.tasks.Task
+
+import org.slf4j.LoggerFactory
+
+/**
+ * A task class that handles the deletion of old ORT runs according to the configured data retention policy. The task
+ * delegates to [OrtRunService] to trigger the deletion of old ORT runs finished before the number of days defined by
+ * the retention policy.
+ *
+ * The task is configured in a section named `dataRetention`. It evaluates the following properties:
+ * - `ortRunDays`: The number of days to keep ORT runs. This can be overridden by the `DATA_RETENTION_ORT_RUN_DAYS`
+ *   environment variable.
+ */
+class DeleteOldOrtRunsTask(
+    /** The service for deleting old runs. */
+    private val ortRunService: OrtRunService,
+
+    /** The threshold for the maximum age of ORT runs to delete. */
+    private val ortRunMaxAgeThreshold: Instant
+) : Task {
+    companion object {
+        private val logger = LoggerFactory.getLogger(DeleteOldOrtRunsTask::class.java)
+
+        /**
+         * Create a new instance of [DeleteOldOrtRunsTask] with the configuration obtained from the given
+         * [configManager] that uses the given [ortRunService].
+         */
+        fun create(configManager: ConfigManager, ortRunService: OrtRunService): DeleteOldOrtRunsTask {
+            val ortRunMaxAgeThreshold = Clock.System.now() - configManager.getInt("dataRetention.ortRunDays").days
+            return DeleteOldOrtRunsTask(ortRunService, ortRunMaxAgeThreshold)
+        }
+    }
+
+    override suspend fun execute() {
+        logger.info("Deleting ORT runs that finished before $ortRunMaxAgeThreshold.")
+
+        ortRunService.deleteRunsCreatedBefore(ortRunMaxAgeThreshold)
+    }
+}

--- a/tasks/src/main/resources/application.conf
+++ b/tasks/src/main/resources/application.conf
@@ -18,3 +18,8 @@
 taskRunner {
   tasks = ${?TASKS}
 }
+
+dataRetention {
+  ortRunDays = 90
+  ortRunDays = ${?DATA_RETENTION_ORT_RUN_DAYS}
+}

--- a/tasks/src/main/resources/application.conf
+++ b/tasks/src/main/resources/application.conf
@@ -19,6 +19,29 @@ taskRunner {
   tasks = ${?TASKS}
 }
 
+configManager {
+  secretProvider = ${?TASKS_SECRET_PROVIDER}
+  configSecretFileList = ${?TASKS_SECRET_FILES}
+  allowSecretsFromConfig = ${?ALLOW_SECRETS_FROM_CONFIG}
+}
+
+reportStorage {
+  name = "database"
+  name = ${?REPORT_STORAGE_NAME}
+  namespace = "reports"
+  namespace = ${?REPORT_STORAGE_NAMESPACE}
+  inMemoryLimit = 1048576
+  inMemoryLimit = ${?REPORT_STORAGE_IN_MEMORY_LIMIT}
+  azureBlobContainerName = ${?REPORT_STORAGE_CONTAINER_NAME}
+  azureBlobEndpointUrl = ${?REPORT_STORAGE_ENDPOINT_URL}
+  azureBlobStorageAccountName = ${?REPORT_STORAGE_STORAGE_ACCOUNT_NAME}
+  s3AccessKey = ${?REPORT_STORAGE_ACCESS_KEY}
+  s3SecretKey = ${?REPORT_STORAGE_SECRET_KEY}
+  s3Region = ${?REPORT_STORAGE_REGION}
+  s3BucketName = ${?REPORT_STORAGE_BUCKET_NAME}
+  s3EndpointUrl = ${?REPORT_STORAGE_ENDPOINT_URL}
+}
+
 dataRetention {
   ortRunDays = 90
   ortRunDays = ${?DATA_RETENTION_ORT_RUN_DAYS}

--- a/tasks/src/test/kotlin/TaskRunnerTest.kt
+++ b/tasks/src/test/kotlin/TaskRunnerTest.kt
@@ -25,6 +25,8 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.should
+import io.kotest.matchers.types.beInstanceOf
 
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -41,6 +43,7 @@ import java.util.concurrent.ConcurrentMap
 import org.eclipse.apoapsis.ortserver.dao.test.mockDatabaseModule
 import org.eclipse.apoapsis.ortserver.dao.test.unmockDatabaseModule
 import org.eclipse.apoapsis.ortserver.dao.test.verifyDatabaseModuleIncluded
+import org.eclipse.apoapsis.ortserver.tasks.impl.DeleteOldOrtRunsTask
 
 import org.koin.core.Koin
 import org.koin.core.context.startKoin
@@ -90,6 +93,15 @@ class TaskRunnerTest : KoinTest, WordSpec() {
             "call runTasks with a database module" {
                 checkMain { koin ->
                     verifyDatabaseModuleIncluded()
+                }
+            }
+        }
+
+        "the task module" should {
+            "include a task to delete old ORT runs" {
+                checkMain { koin ->
+                    val task = koin.get<Task>(named("delete-old-ort-runs"))
+                    task should beInstanceOf<DeleteOldOrtRunsTask>()
                 }
             }
         }

--- a/tasks/src/test/kotlin/impl/DeleteOldOrtRunsTaskTest.kt
+++ b/tasks/src/test/kotlin/impl/DeleteOldOrtRunsTaskTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.tasks.impl
+
+import com.typesafe.config.ConfigFactory
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.extensions.system.withEnvironment
+import io.kotest.matchers.comparables.shouldBeLessThan
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+
+import kotlin.math.abs
+import kotlin.time.Duration.Companion.days
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+import org.eclipse.apoapsis.ortserver.config.ConfigManager
+import org.eclipse.apoapsis.ortserver.services.OrtRunService
+
+class DeleteOldOrtRunsTaskTest : StringSpec({
+    "Old ORT runs should be deleted according to the configured retention policy" {
+        val ortRunRetentionDays = 77
+        val configMap = mapOf("dataRetention.ortRunDays" to ortRunRetentionDays.toString())
+        val configManager = ConfigManager.create(ConfigFactory.parseMap(configMap))
+        val ortRunService = createOrtRunService()
+
+        val task = DeleteOldOrtRunsTask.create(configManager, ortRunService)
+        task.execute()
+
+        checkDeleteInvocation(ortRunService, ortRunRetentionDays)
+    }
+
+    "Old ORT runs should be deleted according to the config overridden by an environment variable" {
+        val ortRunRetentionDays = 44
+        val envMap = mapOf("DATA_RETENTION_ORT_RUN_DAYS" to ortRunRetentionDays.toString())
+
+        withEnvironment(envMap) {
+            ConfigFactory.invalidateCaches()
+            val configManager = ConfigManager.create(ConfigFactory.load())
+            val ortRunService = createOrtRunService()
+
+            val task = DeleteOldOrtRunsTask.create(configManager, ortRunService)
+            task.execute()
+
+            checkDeleteInvocation(ortRunService, ortRunRetentionDays)
+        }
+    }
+})
+
+/**
+ * Create a mock for [OrtRunService] and prepare it to expect a call to delete old ORT runs.
+ */
+private fun createOrtRunService(): OrtRunService =
+    mockk<OrtRunService> {
+    coEvery { deleteRunsCreatedBefore(any()) } just runs
+}
+
+/**
+ * Check whether the given [ortRunService] mock was correctly invoked to delete ORT runs older than [expectedDays].
+ */
+private fun checkDeleteInvocation(ortRunService: OrtRunService, expectedDays: Int) {
+    val slot = slot<Instant>()
+    coVerify {
+        ortRunService.deleteRunsCreatedBefore(capture(slot))
+    }
+
+    val delta = abs((Clock.System.now() - expectedDays.days - slot.captured).inWholeSeconds)
+    delta shouldBeLessThan 5
+}


### PR DESCRIPTION
This PR adds a first task to the recently introduced project for maintenance tasks which enforces the data retention policy for ORT runs.