### PR TITLE
build(gradle): Make `detektAll` only run tasks with type resolution

### DIFF
--- a/buildSrc/src/main/kotlin/ort-server-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-kotlin-conventions.gradle.kts
@@ -61,7 +61,7 @@ tasks.withType<Detekt>().configureEach {
 
 tasks.register("detektAll") {
     group = "Verification"
-    description = "Run all detekt tasks with and without type resolution."
+    description = "Run all detekt tasks with type resolution."
 
-    dependsOn(tasks.withType<Detekt>())
+    dependsOn(tasks.withType<Detekt>().filterNot { it.name == "detekt" })
 }


### PR DESCRIPTION
When detekt runs with type resolution, it executes a superset of the rules compared to running without type resolution. So it does not make sense to additionally run the vanilla "detekt" task.