### PR TITLE
feat(core): Add metrics for job durations

### DIFF
--- a/scripts/compose/grafana/provisioning/dashboards/ort-run-and-job-status.json
+++ b/scripts/compose/grafana/provisioning/dashboards/ort-run-and-job-status.json
@@ -18,7 +18,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 6,
+  "id": 2,
   "links": [],
   "panels": [
     {
@@ -957,6 +957,123 @@
       ],
       "title": "$job jobs: failed",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "graphite",
+        "uid": "ee8sngde6uk8wa"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "ms"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 19,
+        "y": 10
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.4.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "graphite",
+            "uid": "ee8sngde6uk8wa"
+          },
+          "refCount": 0,
+          "refId": "A",
+          "target": "movingAverage(seriesByTag('name=ort-server-core.jobs.$job.duration', 'metricattribute=min'), '10min')"
+        },
+        {
+          "datasource": {
+            "type": "graphite",
+            "uid": "ee8sngde6uk8wa"
+          },
+          "hide": false,
+          "refCount": 0,
+          "refId": "B",
+          "target": "movingAverage(seriesByTag('name=ort-server-core.jobs.$job.duration', 'metricattribute=mean'), '10min')",
+          "textEditor": true
+        },
+        {
+          "datasource": {
+            "type": "graphite",
+            "uid": "ee8sngde6uk8wa"
+          },
+          "hide": false,
+          "refCount": 0,
+          "refId": "C",
+          "target": "movingAverage(seriesByTag('name=ort-server-core.jobs.$job.duration', 'metricattribute=max'), '10min')",
+          "textEditor": true
+        }
+      ],
+      "title": "$job jobs durations",
+      "type": "timeseries"
     }
   ],
   "preload": false,
@@ -1019,6 +1136,6 @@
   "timezone": "browser",
   "title": "ORT Run & Job Status",
   "uid": "ce9idjytg88aoe",
-  "version": 4,
+  "version": 5,
   "weekStart": ""
 }


### PR DESCRIPTION
Track the durations of finished jobs using Micrometer `Timers` metrics. Update the durations every 30 seconds, running in the background without blocking the main thread.

The visualization of the job durations is added to the ORT Run & Job Status dashboard.

![Bildschirmfoto 2025-01-21 um 17 34 28](https://github.com/user-attachments/assets/fba5de26-4a84-499c-86cb-f77a03ccbce0)
