### PR TITLE
fix(logaccess): Do not include empty log files in the log archive

### DIFF
--- a/logaccess/spi/src/main/kotlin/LogFileService.kt
+++ b/logaccess/spi/src/main/kotlin/LogFileService.kt
@@ -121,7 +121,7 @@ class LogFileService private constructor(
             downloadLogFiles(ortRunId, sources, level, startTime, endTime, downloadDir)
 
             val archiveFile = kotlin.io.path.createTempFile(tempDir, "logs", ".zip").toFile()
-            return downloadDir.packZip(archiveFile, overwrite = true)
+            return downloadDir.packZip(archiveFile, overwrite = true, fileFilter = { it.length() > 0 })
         } finally {
             downloadDir.safeDeleteRecursively()
         }


### PR DESCRIPTION
When downloading log file archives the user can specify the components for which logs should be retrieved. If here a worker was specified that did not run, the archive contained an empty log file. Since this is confusing, just filter out empty files when creating the archive with logs.