### PR TITLE
feat(cli): Change the name of the ORT Server CLI executable

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -39,7 +39,7 @@ tasks.withType<JibTask> {
 }
 
 application {
-    applicationName = "ort-server"
+    applicationName = "osc"
     mainClass = "org.eclipse.apoapsis.ortserver.cli.OrtServerMainKt"
 }
 

--- a/cli/src/main/kotlin/OrtServerMain.kt
+++ b/cli/src/main/kotlin/OrtServerMain.kt
@@ -37,7 +37,7 @@ import org.eclipse.apoapsis.ortserver.client.OrtServerClient
 import org.eclipse.apoapsis.ortserver.client.OrtServerClientConfig
 import org.eclipse.apoapsis.ortserver.model.ORT_SERVER_VERSION
 
-const val COMMAND_NAME = "ort-server"
+const val COMMAND_NAME = "osc"
 
 suspend fun main(args: Array<String>) {
     OrtServerMain().main(args)

--- a/cli/src/main/kotlin/OrtServerMain.kt
+++ b/cli/src/main/kotlin/OrtServerMain.kt
@@ -21,6 +21,7 @@ package org.eclipse.apoapsis.ortserver.cli
 
 import com.github.ajalt.clikt.command.SuspendingNoOpCliktCommand
 import com.github.ajalt.clikt.command.main
+import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.subcommands
 import com.github.ajalt.clikt.parameters.groups.OptionGroup
 import com.github.ajalt.clikt.parameters.groups.provideDelegate
@@ -58,6 +59,10 @@ class OrtServerMain : SuspendingNoOpCliktCommand(COMMAND_NAME) {
             message = { "$commandName CLI version $it" }
         )
     }
+
+    override fun help(context: Context) = """
+        The ORT Server Client (OSC) is a Command Line Interface (CLI) to interact with an ORT Server instance.
+    """.trimIndent()
 }
 
 class OrtServerOptions : OptionGroup(


### PR DESCRIPTION
The new name is `osc` which was decided in a public vote, see [1].

[1]: https://github.com/eclipse-apoapsis/ort-server/discussions/1794