### PR TITLE
fix(s3): Provide a checksum when uploading data

### DIFF
--- a/storage/s3/build.gradle.kts
+++ b/storage/s3/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     implementation(projects.utils.config)
     implementation(projects.utils.logging)
 
+    implementation(libs.ortUtils)
     implementation(libs.s3)
 
     testImplementation(libs.kotestAssertionsCore)


### PR DESCRIPTION
New versions of the AWS SDK changed the default integrity protection, see [1]. This caused errors in our environment using Dell ECS when uploading reports as described under [2].

The upload works again when providing a checksum. Therefore, calculate such a checksum and specify it when uploading data.

[1]: https://github.com/awslabs/aws-sdk-kotlin/discussions/1504
[2]: https://github.com/aws/aws-sdk-java-v2/issues/5711