### PR TITLE
feat(cli): Accept CreateOrtRun object in run command

### DIFF
--- a/cli/src/test/kotlin/StartCommandTest.kt
+++ b/cli/src/test/kotlin/StartCommandTest.kt
@@ -92,7 +92,7 @@ class StartCommandTest : StringSpec({
                 "runs",
                 "start",
                 "--repository-id", "$repositoryId",
-                "--vcs-revision", revision
+                "--parameters", """{"revision": "$revision", "jobConfigs": {}}"""
             )
         )
 
@@ -160,7 +160,7 @@ class StartCommandTest : StringSpec({
                 "runs",
                 "start",
                 "--repository-id", "$repositoryId",
-                "--vcs-revision", revision,
+                "--parameters", """{"revision": "$revision", "jobConfigs": {}}""",
                 "--wait"
             )
         )
@@ -206,7 +206,7 @@ class StartCommandTest : StringSpec({
                     "runs",
                     "start",
                     "--repository-id", "$repositoryId",
-                    "--vcs-revision", revision
+                    "--parameters", """{"revision": "$revision", "jobConfigs": {}}"""
                 )
             )
 


### PR DESCRIPTION
The command now accepts the CreateOrtRun object either as a JSON string or as a path to a JSON file.