### PR TITLE
Scan storage read optimization

### DIFF
--- a/dao/src/main/kotlin/tables/ScanSummariesTable.kt
+++ b/dao/src/main/kotlin/tables/ScanSummariesTable.kt
@@ -46,12 +46,28 @@ class ScanSummaryDao(id: EntityID<Long>) : LongEntity(id) {
     val snippetFindings by SnippetFindingDao referrersOn SnippetFindingsTable.scanSummaryId
     val issues by ScanSummariesIssuesDao referrersOn ScanSummariesIssuesTable.scanSummaryId
 
-    fun mapToModel() = ScanSummary(
+    /**
+     * Map this DAO to a [ScanSummary] model object. Based on the [withFindings] flag, either include all findings
+     * or return a summary without findings.
+     */
+    fun mapToModel(withFindings: Boolean = true) = ScanSummary(
         startTime = startTime,
         endTime = endTime,
-        licenseFindings = licenseFindings.mapTo(mutableSetOf(), LicenseFindingDao::mapToModel),
-        copyrightFindings = copyrightFindings.mapTo(mutableSetOf(), CopyrightFindingDao::mapToModel),
-        snippetFindings = snippetFindings.mapTo(mutableSetOf(), SnippetFindingDao::mapToModel),
+        licenseFindings = if (withFindings) {
+            licenseFindings.mapTo(mutableSetOf(), LicenseFindingDao::mapToModel)
+        } else {
+            emptySet()
+        },
+        copyrightFindings = if (withFindings) {
+            copyrightFindings.mapTo(mutableSetOf(), CopyrightFindingDao::mapToModel)
+        } else {
+            emptySet()
+        },
+        snippetFindings = if (withFindings) {
+            snippetFindings.mapTo(mutableSetOf(), SnippetFindingDao::mapToModel)
+        } else {
+            emptySet()
+        },
         issues = issues.map(ScanSummariesIssuesDao::mapToModel)
     )
 }

--- a/workers/scanner/src/test/kotlin/OrtServerScanResultStorageTest.kt
+++ b/workers/scanner/src/test/kotlin/OrtServerScanResultStorageTest.kt
@@ -41,6 +41,7 @@ import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.createI
 import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.createRepositoryProvenance
 import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.createScanResult
 import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.scannerMatcher
+import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.withoutFindings
 
 import org.ossreviewtoolkit.model.ScanResult as OrtScanResult
 
@@ -80,8 +81,6 @@ class OrtServerScanResultStorageTest : WordSpec() {
                 scanResultStorage.write(scanResult)
 
                 verifyAssociatedScanResults(scannerRun, scanResult)
-
-                scanResultStorage.read(provenance.mapToOrt(), scannerMatcher) shouldBe listOf(scanResult)
             }
 
             "create an artifact provenance scan result in the storage and associate it to the scanner run" {
@@ -90,8 +89,6 @@ class OrtServerScanResultStorageTest : WordSpec() {
                 scanResultStorage.write(scanResult)
 
                 verifyAssociatedScanResults(scannerRun, scanResult)
-
-                scanResultStorage.read(provenance.mapToOrt(), scannerMatcher) shouldBe listOf(scanResult)
             }
 
             "not create duplicate scan results for repository provenances" {
@@ -260,7 +257,10 @@ class OrtServerScanResultStorageTest : WordSpec() {
                 verifyAssociatedScanResults(scannerRun, scanResult1, scanResult2, scanResult3)
 
                 val readResult = scanResultStorage.read(repositoryProvenance.mapToOrt(), scannerMatcher)
-                readResult shouldContainExactlyInAnyOrder listOf(scanResult1, scanResult2)
+                readResult shouldContainExactlyInAnyOrder listOf(
+                    scanResult1.withoutFindings(),
+                    scanResult2.withoutFindings()
+                )
                 readResult shouldNotContain scanResult3
             }
 
@@ -279,7 +279,10 @@ class OrtServerScanResultStorageTest : WordSpec() {
                 verifyAssociatedScanResults(scannerRun, scanResult1, scanResult2, scanResult3)
 
                 val readResult = scanResultStorage.read(artifactProvenance.mapToOrt(), scannerMatcher)
-                readResult shouldContainExactlyInAnyOrder listOf(scanResult1, scanResult2)
+                readResult shouldContainExactlyInAnyOrder listOf(
+                    scanResult1.withoutFindings(),
+                    scanResult2.withoutFindings()
+                )
                 readResult shouldNotContain scanResult3
             }
 
@@ -319,7 +322,7 @@ class OrtServerScanResultStorageTest : WordSpec() {
                 scanResultStorage.write(notMatchingScanResult)
 
                 val readResult = scanResultStorage.read(repositoryProvenance.mapToOrt(), scannerMatcher)
-                readResult shouldContain matchingScanResult
+                readResult shouldContain matchingScanResult.withoutFindings()
                 readResult shouldNotContain notMatchingScanResult
             }
         }

--- a/workers/scanner/src/test/kotlin/ScanResultFixtures.kt
+++ b/workers/scanner/src/test/kotlin/ScanResultFixtures.kt
@@ -149,4 +149,17 @@ internal object ScanResultFixtures {
         additionalData: Map<String, String> = mapOf("additional1" to "data1", "additional2" to "data2")
     ): OrtScanResult =
         createServerScanResult(scannerName, issue, provenance, scannerVersion, scannerConfig, additionalData).mapToOrt()
+
+    /**
+     * Return a copy of this [OrtScanResult] that does not contain any findings.
+     */
+    fun OrtScanResult.withoutFindings(): OrtScanResult {
+        val strippedSummary = summary.copy(
+            licenseFindings = emptySet(),
+            copyrightFindings = emptySet(),
+            snippetFindings = emptySet()
+        )
+
+        return copy(summary = strippedSummary)
+    }
 }


### PR DESCRIPTION
When reading scan results, do not include the findings of the results,
but return stripped down `ScanResult` objects with only basic properties
initialized. The findings are never evaluated because they are already
contained in the database. This is a significant optimization since
loading and mapping large scan results is an expensive operation.