### PR TITLE
Extend the packages endpoint with the shortest dependency path

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
@@ -75,6 +75,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.ScannerJob as ApiScannerJob
 import org.eclipse.apoapsis.ortserver.api.v1.model.ScannerJobConfiguration as ApiScannerJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.Secret as ApiSecret
 import org.eclipse.apoapsis.ortserver.api.v1.model.Severity as ApiSeverity
+import org.eclipse.apoapsis.ortserver.api.v1.model.ShortestDependencyPath as ApiShortestDependencyPath
 import org.eclipse.apoapsis.ortserver.api.v1.model.SortDirection as ApiSortDirection
 import org.eclipse.apoapsis.ortserver.api.v1.model.SortProperty as ApiSortProperty
 import org.eclipse.apoapsis.ortserver.api.v1.model.SourceCodeOrigin as ApiSourceCodeOrigin
@@ -131,10 +132,11 @@ import org.eclipse.apoapsis.ortserver.model.VulnerabilityWithIdentifier
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
 import org.eclipse.apoapsis.ortserver.model.runs.OrtRuleViolation
-import org.eclipse.apoapsis.ortserver.model.runs.Package
 import org.eclipse.apoapsis.ortserver.model.runs.PackageManagerConfiguration
+import org.eclipse.apoapsis.ortserver.model.runs.PackageWithShortestDependencyPaths
 import org.eclipse.apoapsis.ortserver.model.runs.ProcessedDeclaredLicense
 import org.eclipse.apoapsis.ortserver.model.runs.RemoteArtifact
+import org.eclipse.apoapsis.ortserver.model.runs.ShortestDependencyPath
 import org.eclipse.apoapsis.ortserver.model.runs.VcsInfo
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.Vulnerability
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.VulnerabilityReference
@@ -533,24 +535,6 @@ fun ApiIdentifier.mapToModel() = Identifier(type, namespace, name, version)
 
 fun VulnerabilityReference.mapToApi() = ApiVulnerabilityReference(url, scoringSystem, severity, score, vector)
 
-fun Package.mapToApi() =
-    ApiPackage(
-        identifier.mapToApi(),
-        purl,
-        cpe,
-        authors,
-        declaredLicenses,
-        processedDeclaredLicense.mapToApi(),
-        description,
-        homepageUrl,
-        binaryArtifact.mapToApi(),
-        sourceArtifact.mapToApi(),
-        vcs.mapToApi(),
-        vcsProcessed.mapToApi(),
-        isMetadataOnly,
-        isModified
-    )
-
 fun ProcessedDeclaredLicense.mapToApi() =
     ApiProcessedDeclaredLicense(
         spdxExpression,
@@ -789,3 +773,27 @@ fun ApiSubmoduleFetchStrategy.mapToModel() = when (this) {
     ApiSubmoduleFetchStrategy.TOP_LEVEL_ONLY -> SubmoduleFetchStrategy.TOP_LEVEL_ONLY
     ApiSubmoduleFetchStrategy.FULLY_RECURSIVE -> SubmoduleFetchStrategy.FULLY_RECURSIVE
 }
+
+fun ShortestDependencyPath.mapToApi() = ApiShortestDependencyPath(
+    scope = scope,
+    projectIdentifier = projectIdentifier.mapToApi(),
+    path = path.map { it.mapToApi() }
+)
+
+fun PackageWithShortestDependencyPaths.mapToApi() = ApiPackage(
+    pkg.identifier.mapToApi(),
+    pkg.purl,
+    pkg.cpe,
+    pkg.authors,
+    pkg.declaredLicenses,
+    pkg.processedDeclaredLicense.mapToApi(),
+    pkg.description,
+    pkg.homepageUrl,
+    pkg.binaryArtifact.mapToApi(),
+    pkg.sourceArtifact.mapToApi(),
+    pkg.vcs.mapToApi(),
+    pkg.vcsProcessed.mapToApi(),
+    pkg.isMetadataOnly,
+    pkg.isModified,
+    shortestDependencyPaths.map { it.mapToApi() }
+)

--- a/api/v1/model/src/commonMain/kotlin/ShortestDependencyPath.kt
+++ b/api/v1/model/src/commonMain/kotlin/ShortestDependencyPath.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,21 +21,15 @@ package org.eclipse.apoapsis.ortserver.api.v1.model
 
 import kotlinx.serialization.Serializable
 
+/** The shortest dependency path for a Package. */
 @Serializable
-data class Package(
-    val identifier: Identifier,
-    val purl: String,
-    val cpe: String? = null,
-    val authors: Set<String>,
-    val declaredLicenses: Set<String>,
-    val processedDeclaredLicense: ProcessedDeclaredLicense,
-    val description: String,
-    val homepageUrl: String,
-    val binaryArtifact: RemoteArtifact,
-    val sourceArtifact: RemoteArtifact,
-    val vcs: VcsInfo,
-    val vcsProcessed: VcsInfo,
-    val isMetadataOnly: Boolean = false,
-    val isModified: Boolean = false,
-    val shortestDependencyPaths: List<ShortestDependencyPath>
+data class ShortestDependencyPath(
+    /** The identifier of the root project of this path. */
+    val projectIdentifier: Identifier,
+
+    /** The scope in which this shortest path of the dependency is found in. */
+    val scope: String,
+
+    /** Path of dependency identifiers to the dependency. */
+    val path: List<Identifier>
 )

--- a/core/src/main/kotlin/api/RunsRoute.kt
+++ b/core/src/main/kotlin/api/RunsRoute.kt
@@ -26,7 +26,6 @@ import io.ktor.http.ContentDisposition
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.application.ApplicationCall
-import io.ktor.server.application.call
 import io.ktor.server.response.header
 import io.ktor.server.response.respond
 import io.ktor.server.response.respondFile
@@ -73,7 +72,7 @@ import org.eclipse.apoapsis.ortserver.model.authorization.RepositoryPermission
 import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
 import org.eclipse.apoapsis.ortserver.model.runs.OrtRuleViolation
-import org.eclipse.apoapsis.ortserver.model.runs.Package
+import org.eclipse.apoapsis.ortserver.model.runs.PackageWithShortestDependencyPaths
 import org.eclipse.apoapsis.ortserver.services.IssueService
 import org.eclipse.apoapsis.ortserver.services.OrtRunService
 import org.eclipse.apoapsis.ortserver.services.PackageService
@@ -233,9 +232,10 @@ fun Route.runs() = route("runs") {
 
                     val pagingOptions = call.pagingOptions(SortProperty("purl", SortDirection.ASCENDING))
 
-                    val packagesForOrtRun = packageService.listForOrtRunId(ortRun.id, pagingOptions.mapToModel())
+                    val packagesForOrtRun = packageService
+                        .listForOrtRunId(ortRun.id, pagingOptions.mapToModel())
 
-                    val pagedResponse = packagesForOrtRun.mapToApi(Package::mapToApi)
+                    val pagedResponse = packagesForOrtRun.mapToApi(PackageWithShortestDependencyPaths::mapToApi)
 
                     call.respond(HttpStatusCode.OK, pagedResponse)
                 }

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -47,6 +47,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.RemoteArtifact
 import org.eclipse.apoapsis.ortserver.api.v1.model.RepositoryType
 import org.eclipse.apoapsis.ortserver.api.v1.model.RuleViolation
 import org.eclipse.apoapsis.ortserver.api.v1.model.Severity
+import org.eclipse.apoapsis.ortserver.api.v1.model.ShortestDependencyPath
 import org.eclipse.apoapsis.ortserver.api.v1.model.SortDirection
 import org.eclipse.apoapsis.ortserver.api.v1.model.SortProperty
 import org.eclipse.apoapsis.ortserver.api.v1.model.VcsInfo
@@ -379,8 +380,8 @@ val getPackagesByRunId: OpenApiRoute.() -> Unit = {
                     value = PagedResponse(
                         listOf(
                             Package(
-                                identifier = Identifier("Maven", "org.namespace", "name", "1.0"),
-                                purl = "pkg:maven/org.namespace/name@1.0",
+                                identifier = Identifier("Maven", "org.example", "name", "1.0"),
+                                purl = "pkg:maven/org.example/name@1.0",
                                 cpe = null,
                                 authors = setOf("author1", "author2"),
                                 declaredLicenses = setOf("license1", "license2"),
@@ -397,6 +398,16 @@ val getPackagesByRunId: OpenApiRoute.() -> Unit = {
                                 vcsProcessed = VcsInfo(RepositoryType.GIT.name, "url", "revision", "path"),
                                 isMetadataOnly = false,
                                 isModified = false,
+                                shortestDependencyPaths = listOf(
+                                    ShortestDependencyPath(
+                                        scope = "productionRuntimeClasspath",
+                                        projectIdentifier = Identifier("Gradle", "", "project-name", "1.0"),
+                                        path = listOf(
+                                            Identifier("Maven", "org.example", "some", "1.0"),
+                                            Identifier("Maven", "org.example", "other", "1.0")
+                                        )
+                                    )
+                                )
                             )
                         ),
                         PagingData(

--- a/dao/src/main/kotlin/repositories/analyzerrun/ShortestDependencyPathsTable.kt
+++ b/dao/src/main/kotlin/repositories/analyzerrun/ShortestDependencyPathsTable.kt
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun
+
+import org.eclipse.apoapsis.ortserver.dao.utils.jsonb
+import org.eclipse.apoapsis.ortserver.model.runs.Identifier
+import org.eclipse.apoapsis.ortserver.model.runs.ShortestDependencyPath
+
+import org.jetbrains.exposed.dao.LongEntity
+import org.jetbrains.exposed.dao.LongEntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.LongIdTable
+
+/**
+ * A table to store the shortest dependency path for a package.
+ */
+object ShortestDependencyPathsTable : LongIdTable("shortest_dependency_paths") {
+    val packageId = reference("package_id", PackagesTable)
+    val analyzerRunId = reference("analyzer_run_id", AnalyzerRunsTable)
+    val projectId = reference("project_id", ProjectsTable)
+
+    val scope = text("scope")
+    val path = jsonb<List<Identifier>>("path")
+}
+
+class ShortestDependencyPathDao(id: EntityID<Long>) : LongEntity(id) {
+    companion object : LongEntityClass<ShortestDependencyPathDao>(ShortestDependencyPathsTable)
+
+    var pkg by PackageDao referencedOn ShortestDependencyPathsTable.packageId
+    var analyzerRun by AnalyzerRunDao referencedOn ShortestDependencyPathsTable.analyzerRunId
+    var project by ProjectDao referencedOn ShortestDependencyPathsTable.projectId
+
+    var scope by ShortestDependencyPathsTable.scope
+    var path by ShortestDependencyPathsTable.path
+
+    fun mapToModel() = ShortestDependencyPath(
+        projectIdentifier = project.identifier.mapToModel(),
+        scope = scope,
+        path = path
+    )
+}

--- a/dao/src/main/resources/db/migration/V96__addShortestDependencyPathsTable.sql
+++ b/dao/src/main/resources/db/migration/V96__addShortestDependencyPathsTable.sql
@@ -1,0 +1,11 @@
+-- This migration adds a table for the shortest dependency path for a package.
+
+CREATE TABLE shortest_dependency_paths
+(
+    id              bigserial PRIMARY KEY,
+    package_id      bigint REFERENCES packages                          NOT NULL,
+    analyzer_run_id bigint REFERENCES analyzer_runs ON DELETE CASCADE   NOT NULL,
+    project_id      bigint REFERENCES projects                          NOT NULL,
+    scope           text                                                NOT NULL,
+    path            jsonb                                               NOT NULL
+);

--- a/dao/src/testFixtures/kotlin/Fixtures.kt
+++ b/dao/src/testFixtures/kotlin/Fixtures.kt
@@ -63,7 +63,10 @@ import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
 import org.eclipse.apoapsis.ortserver.model.runs.OrtRuleViolation
 import org.eclipse.apoapsis.ortserver.model.runs.Package
+import org.eclipse.apoapsis.ortserver.model.runs.ProcessedDeclaredLicense
 import org.eclipse.apoapsis.ortserver.model.runs.Project
+import org.eclipse.apoapsis.ortserver.model.runs.ShortestDependencyPath
+import org.eclipse.apoapsis.ortserver.model.runs.VcsInfo
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.AdvisorConfiguration
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.AdvisorResult
 
@@ -221,12 +224,31 @@ class Fixtures(private val db: Database) {
         howToFix = "how to fix"
     )
 
+    fun getProject(identifier: Identifier = Identifier("Gradle", "", "project", "1.0")) =
+        Project(
+            identifier = identifier,
+            definitionFilePath = "build.gradle.kts",
+            authors = emptySet(),
+            declaredLicenses = emptySet(),
+            processedDeclaredLicense = ProcessedDeclaredLicense(
+                null,
+                emptyMap(),
+                emptySet()
+            ),
+            vcs = VcsInfo(RepositoryType.GIT, "https://example.com/git", "revision", ""),
+            vcsProcessed = VcsInfo(RepositoryType.GIT, "https://example.com/git", "revision", ""),
+            description = "",
+            homepageUrl = "https://example.com",
+            scopeNames = setOf("compileClasspath", "runtimeClasspath")
+        )
+
     fun createAnalyzerRun(
         analyzerJobId: Long = analyzerJob.id,
         projects: Set<Project> = emptySet(),
         packages: Set<Package> = emptySet(),
         issues: List<Issue> = emptyList(),
-        dependencyGraphs: Map<String, DependencyGraph> = emptyMap()
+        dependencyGraphs: Map<String, DependencyGraph> = emptyMap(),
+        shortestDependencyPaths: Map<Identifier, List<ShortestDependencyPath>> = emptyMap()
     ) = analyzerRunRepository.create(
         analyzerJobId = analyzerJobId,
         startTime = Clock.System.now(),
@@ -250,7 +272,8 @@ class Fixtures(private val db: Database) {
         projects = projects,
         packages = packages,
         issues = issues,
-        dependencyGraphs = dependencyGraphs
+        dependencyGraphs = dependencyGraphs,
+        shortestDependencyPaths = shortestDependencyPaths
     )
 
     fun createAdvisorRun(

--- a/model/src/commonMain/kotlin/repositories/AnalyzerRunRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/AnalyzerRunRepository.kt
@@ -25,9 +25,11 @@ import org.eclipse.apoapsis.ortserver.model.runs.AnalyzerConfiguration
 import org.eclipse.apoapsis.ortserver.model.runs.AnalyzerRun
 import org.eclipse.apoapsis.ortserver.model.runs.DependencyGraph
 import org.eclipse.apoapsis.ortserver.model.runs.Environment
+import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
 import org.eclipse.apoapsis.ortserver.model.runs.Package
 import org.eclipse.apoapsis.ortserver.model.runs.Project
+import org.eclipse.apoapsis.ortserver.model.runs.ShortestDependencyPath
 
 /**
  * A repository of [analyzer runs][AnalyzerRun].
@@ -45,7 +47,8 @@ interface AnalyzerRunRepository {
         projects: Set<Project>,
         packages: Set<Package>,
         issues: List<Issue>,
-        dependencyGraphs: Map<String, DependencyGraph>
+        dependencyGraphs: Map<String, DependencyGraph>,
+        shortestDependencyPaths: Map<Identifier, List<ShortestDependencyPath>> = emptyMap()
     ): AnalyzerRun
 
     /**

--- a/model/src/commonMain/kotlin/runs/PackageWithShortestDependencyPaths.kt
+++ b/model/src/commonMain/kotlin/runs/PackageWithShortestDependencyPaths.kt
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.model.runs
+
+/**
+ * A data class representing a package, and the shortest dependency path that the package is found in (relative to a
+ * project found in a run).
+ */
+data class PackageWithShortestDependencyPaths(
+    /** A package. */
+    val pkg: Package,
+
+    /** Package ID */
+    val pkgId: Long,
+
+    /** The shortest dependency path for the package. */
+    val shortestDependencyPaths: List<ShortestDependencyPath>
+)

--- a/model/src/commonMain/kotlin/runs/ShortestDependencyPath.kt
+++ b/model/src/commonMain/kotlin/runs/ShortestDependencyPath.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.model.runs
+
+/** The shortest dependency path for a Package. */
+data class ShortestDependencyPath(
+    /** The identifier of the root project of this path. */
+    val projectIdentifier: Identifier,
+
+    /** The scope in which this shortest path of the dependency is found in. */
+    val scope: String,
+
+    /** Path of dependency identifiers to the dependency. */
+    val path: List<Identifier>
+)

--- a/services/hierarchy/src/test/kotlin/PackageServiceTest.kt
+++ b/services/hierarchy/src/test/kotlin/PackageServiceTest.kt
@@ -100,7 +100,7 @@ class PackageServiceTest : WordSpec() {
                                 mappedLicenses = mapOf(
                                     "License 1" to "Mapped License 1",
                                     "License 2" to "Mapped License 2",
-                                    ),
+                                ),
                                 unmappedLicenses = setOf("License 1", "License 2", "License 3", "License 4")
                             ),
                         )
@@ -196,7 +196,7 @@ class PackageServiceTest : WordSpec() {
 
                 service.countForOrtRunIds(ortRun1Id, ortRun2Id) shouldBe 3
             }
-    }
+        }
 
         "countEcosystemsForOrtRunIds" should {
             "list package types and counts for packages found in an ORT run" {

--- a/workers/analyzer/src/main/kotlin/analyzer/Utils.kt
+++ b/workers/analyzer/src/main/kotlin/analyzer/Utils.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.analyzer
+
+import org.eclipse.apoapsis.ortserver.model.runs.Identifier
+import org.eclipse.apoapsis.ortserver.model.runs.ShortestDependencyPath
+import org.eclipse.apoapsis.ortserver.workers.common.mapToModel
+
+import org.ossreviewtoolkit.model.Identifier as OrtIdentifier
+
+/**
+ * Helper function to find the shortest dependency path across scopes for each package identifier.
+ */
+fun getIdentifierToShortestPathsMap(
+    projectIdentifier: Identifier,
+    pathsByScopeMap: Map<String, Map<OrtIdentifier, List<OrtIdentifier>>>
+): Map<Identifier, ShortestDependencyPath> {
+    val map = mutableMapOf<Identifier, ShortestDependencyPath>()
+
+    pathsByScopeMap.forEach { (scope, pathsMap) ->
+        pathsMap.forEach { (pkgIdentifier, pathList) ->
+            val existingEntry = map[pkgIdentifier.mapToModel()]
+
+            if (existingEntry == null || existingEntry.path.size > pathList.size) {
+                map[pkgIdentifier.mapToModel()] =
+                    ShortestDependencyPath(projectIdentifier, scope, pathList.map { it.mapToModel() })
+            }
+        }
+    }
+
+    return map
+}

--- a/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
@@ -120,7 +120,7 @@ class AnalyzerWorkerTest : StringSpec({
             every { getHierarchyForOrtRun(any()) } returns hierarchy
             every { getOrtRun(any()) } returns ortRun
             every { startAnalyzerJob(any()) } returns analyzerJob
-            every { storeAnalyzerRun(any()) } just runs
+            every { storeAnalyzerRun(any(), any()) } just runs
             every { storeRepositoryInformation(any(), any()) } just runs
             every { storeResolvedPackageCurations(any(), any()) } just runs
         }
@@ -163,7 +163,7 @@ class AnalyzerWorkerTest : StringSpec({
             result shouldBe RunResult.Success
 
             verify(exactly = 1) {
-                ortRunService.storeAnalyzerRun(withArg { it.analyzerJobId shouldBe JOB_ID })
+                ortRunService.storeAnalyzerRun(withArg { it.analyzerJobId shouldBe JOB_ID }, any())
                 ortRunService.storeRepositoryInformation(any(), any())
             }
 
@@ -181,7 +181,7 @@ class AnalyzerWorkerTest : StringSpec({
             every { getHierarchyForOrtRun(any()) } returns hierarchy
             every { getOrtRun(any()) } returns ortRun
             every { startAnalyzerJob(any()) } returns analyzerJob
-            every { storeAnalyzerRun(any()) } just runs
+            every { storeAnalyzerRun(any(), any()) } just runs
             every { storeRepositoryInformation(any(), any()) } just runs
             every { storeResolvedPackageCurations(any(), any()) } just runs
         }
@@ -220,7 +220,7 @@ class AnalyzerWorkerTest : StringSpec({
             result shouldBe RunResult.Success
 
             verify(exactly = 1) {
-                ortRunService.storeAnalyzerRun(withArg { it.analyzerJobId shouldBe JOB_ID })
+                ortRunService.storeAnalyzerRun(withArg { it.analyzerJobId shouldBe JOB_ID }, any())
             }
 
             coVerify(exactly = 0) {
@@ -243,7 +243,7 @@ class AnalyzerWorkerTest : StringSpec({
             every { getHierarchyForOrtRun(any()) } returns hierarchy
             every { getOrtRun(any()) } returns ortRun
             every { startAnalyzerJob(any()) } returns job
-            every { storeAnalyzerRun(any()) } just runs
+            every { storeAnalyzerRun(any(), any()) } just runs
             every { storeRepositoryInformation(any(), any()) } just runs
             every { storeResolvedPackageCurations(any(), any()) } just runs
         }
@@ -282,7 +282,7 @@ class AnalyzerWorkerTest : StringSpec({
             result shouldBe RunResult.Success
 
             verify(exactly = 1) {
-                ortRunService.storeAnalyzerRun(withArg { it.analyzerJobId shouldBe JOB_ID })
+                ortRunService.storeAnalyzerRun(withArg { it.analyzerJobId shouldBe JOB_ID }, any())
             }
 
             coVerify {
@@ -301,7 +301,7 @@ class AnalyzerWorkerTest : StringSpec({
             every { getHierarchyForOrtRun(any()) } returns hierarchy
             every { getOrtRun(any()) } returns ortRun
             every { startAnalyzerJob(any()) } returns job
-            every { storeAnalyzerRun(any()) } just runs
+            every { storeAnalyzerRun(any(), any()) } just runs
             every { storeRepositoryInformation(any(), any()) } just runs
             every { storeResolvedPackageCurations(any(), any()) } just runs
         }
@@ -349,7 +349,7 @@ class AnalyzerWorkerTest : StringSpec({
             every { getHierarchyForOrtRun(any()) } returns hierarchy
             every { getOrtRun(any()) } returns ortRun
             every { startAnalyzerJob(any()) } returns analyzerJob
-            every { storeAnalyzerRun(any()) } just runs
+            every { storeAnalyzerRun(any(), any()) } just runs
             every { storeRepositoryInformation(any(), any()) } just runs
             every { storeResolvedPackageCurations(any(), any()) } just runs
         }
@@ -442,7 +442,7 @@ class AnalyzerWorkerTest : StringSpec({
             every { getHierarchyForOrtRun(any()) } returns hierarchy
             every { getOrtRun(any()) } returns ortRun
             every { startAnalyzerJob(any()) } returns analyzerJob
-            every { storeAnalyzerRun(any()) } just runs
+            every { storeAnalyzerRun(any(), any()) } just runs
             every { storeRepositoryInformation(any(), any()) } just runs
             every { storeResolvedPackageCurations(any(), any()) } just runs
         }

--- a/workers/analyzer/src/test/kotlin/UtilsTest.kt
+++ b/workers/analyzer/src/test/kotlin/UtilsTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.analyzer
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+
+import org.eclipse.apoapsis.ortserver.model.runs.Identifier
+
+import org.ossreviewtoolkit.model.Identifier as OrtIdentifier
+
+class UtilsTest : WordSpec({
+    "getIdentifierToShortestPathsMap()" should {
+        "extract the shortest path across scopes for each identifier" {
+            val shortestPathsByScope: Map<String, Map<OrtIdentifier, List<OrtIdentifier>>> =
+                mapOf(
+                    "dependencies" to mapOf(
+                        OrtIdentifier("NPM", "", "acorn", "1.0") to listOf(
+                            OrtIdentifier("NPM", "", "react-scripts", "1.0"),
+                            OrtIdentifier("NPM", "", "eslint", "1.0"),
+                            OrtIdentifier("NPM", "", "espree", "1.0")
+                        ),
+                        OrtIdentifier("NPM", "", "cookie", "1.0") to listOf(
+                            OrtIdentifier("NPM", "", "react-scripts", "1.0"),
+                            OrtIdentifier("NPM", "", "webpack-dev-server", "1.0"),
+                            OrtIdentifier("NPM", "", "express", "1.0")
+                        )
+                    ),
+                    "devDependencies" to mapOf(
+                        OrtIdentifier("NPM", "", "acorn", "1.0") to listOf(
+                            OrtIdentifier("NPM", "", "eslint", "1.0"),
+                            OrtIdentifier("NPM", "", "espree", "1.0")
+                        )
+                    )
+                )
+
+            val identifierToShortestPathMap = getIdentifierToShortestPathsMap(
+                Identifier("NPM", "com.example", "example", "1.0"),
+                shortestPathsByScope
+            )
+
+            identifierToShortestPathMap.size shouldBe 2
+
+            val shortestPath1 = identifierToShortestPathMap[Identifier("NPM", "", "acorn", "1.0")]
+
+            shortestPath1.shouldNotBeNull {
+                scope shouldBe "devDependencies"
+                path.size shouldBe 2
+            }
+
+            val shortestPath2 = identifierToShortestPathMap[Identifier("NPM", "", "cookie", "1.0")]
+
+            shortestPath2.shouldNotBeNull {
+                scope shouldBe "dependencies"
+                path.size shouldBe 3
+            }
+        }
+    }
+})

--- a/workers/common/src/main/kotlin/common/OrtRunService.kt
+++ b/workers/common/src/main/kotlin/common/OrtRunService.kt
@@ -53,7 +53,9 @@ import org.eclipse.apoapsis.ortserver.model.repositories.ScannerRunRepository
 import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.ResolvedConfiguration
 import org.eclipse.apoapsis.ortserver.model.runs.AnalyzerRun
 import org.eclipse.apoapsis.ortserver.model.runs.EvaluatorRun
+import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
+import org.eclipse.apoapsis.ortserver.model.runs.ShortestDependencyPath
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.AdvisorRun
 import org.eclipse.apoapsis.ortserver.model.runs.notifier.NotifierRun
 import org.eclipse.apoapsis.ortserver.model.runs.reporter.ReporterRun
@@ -409,7 +411,10 @@ class OrtRunService(
     /**
      * Store the provided [analyzerRun].
      */
-    fun storeAnalyzerRun(analyzerRun: AnalyzerRun) {
+    fun storeAnalyzerRun(
+        analyzerRun: AnalyzerRun,
+        shortestDependencyPaths: Map<Identifier, List<ShortestDependencyPath>> = emptyMap()
+    ) {
         analyzerRunRepository.create(
             analyzerJobId = analyzerRun.analyzerJobId,
             startTime = analyzerRun.startTime,
@@ -419,7 +424,8 @@ class OrtRunService(
             projects = analyzerRun.projects,
             packages = analyzerRun.packages,
             issues = analyzerRun.issues,
-            dependencyGraphs = analyzerRun.dependencyGraphs
+            dependencyGraphs = analyzerRun.dependencyGraphs,
+            shortestDependencyPaths = shortestDependencyPaths
         )
     }
 


### PR DESCRIPTION
Add information about shortest dependency paths to the packages endpoint response. This will give a quick overview for how deeply nested a dependency is in the project. For simplicity, only one path for a package for each project is returned (only the shortest path across scopes is picked).

Please see the individual commits for details.

![Screenshot from 2025-02-17 15-10-53](https://github.com/user-attachments/assets/9d2dec1f-1116-4d26-b7c0-bcc377d2c5a8)
