### PR TITLE
chore(ui): Remove the note about the analyzer job being mandatory

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -362,10 +362,6 @@ const CreateRunPage = () => {
             <div className='text-sm text-gray-500'>
               Configure the jobs to be included in the ORT Run.
             </div>
-            <div className='text-sm text-gray-500'>
-              NOTE: Currently, the Analyzer needs to always run as part of an
-              ORT Run.
-            </div>
             <Accordion
               type='multiple'
               value={openAccordions}


### PR DESCRIPTION
The note sounded a bit as if there were immediate plans to be able to run without the analyzer, but this is not the case.