### PR TITLE
fix(github): Check issue links in the context of the base of the PR

### DIFF
--- a/.github/workflows/check-issue-links.yml
+++ b/.github/workflows/check-issue-links.yml
@@ -1,7 +1,7 @@
 name: Check Issue Links
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
     - main
 


### PR DESCRIPTION
This should fix another permission issue [1] when creating a PR from a fork, see the docs at [2].

[1]: https://github.com/eclipse-apoapsis/ort-server/actions/runs/12989497197/job/36222632642#step:7:22
[2]: https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#pull_request_target