### PR TITLE
feat(scanner): Generate .gitconfig file with URL insteadOf sections

### DIFF
--- a/workers/common/src/main/kotlin/common/env/EnvironmentModule.kt
+++ b/workers/common/src/main/kotlin/common/env/EnvironmentModule.kt
@@ -46,6 +46,7 @@ fun buildEnvironmentModule(): Module = module {
             get(),
             listOf(
                 ConanGenerator(),
+                GitConfigGenerator.create(get()),
                 GitCredentialsGenerator(),
                 MavenSettingsGenerator(),
                 NetRcGenerator(),

--- a/workers/common/src/main/kotlin/common/env/GitConfigGenerator.kt
+++ b/workers/common/src/main/kotlin/common/env/GitConfigGenerator.kt
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.common.env
+
+import org.eclipse.apoapsis.ortserver.config.ConfigManager
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
+import org.eclipse.apoapsis.ortserver.utils.config.getStringOrNull
+import org.eclipse.apoapsis.ortserver.workers.common.env.definition.EnvironmentServiceDefinition
+
+import org.slf4j.LoggerFactory
+
+/**
+ * A specialized generator class to generate a Git configuration file.
+ *
+ * Source code repositories may have submodules locations specified using SSH URLs. This imposes a problem, because
+ * the required SSH keys to fetch the submodules are not available in the execution environment. To work around this
+ * issue, Git allows to define URL `insteadOf` sections in the _.gitconfig_ file. This generator creates such
+ * sections from a static configuration file, which can be customized via an environment variable.
+ *
+ * The `insteadOf` sections can either be generated using default values in
+ * `application.conf` or customized via the environment variable
+ * `GIT_CONFIG_URL_INSTEAD_OF`. This allows flexibility in defining what
+ * URL `insteadOf` sections are created in `.gitconfig`.
+ *
+ * The expected format is a comma-separated list of base URLs and their corresponding insteadOf URLs,
+ * separated by an equal sign. For example:
+ * `https://github.com=ssh://git@github.com,https://github.com/=git@github.com:`
+ *
+ * See also: [Git documentation](https://git-scm.com/docs/git-config#Documentation/git-config.txt-urlltbasegtinsteadOf)
+ *
+ * There is a coupling between this generator class and the generator class for Git credentials
+ * [GitCredentialsGenerator]. If Git credentials are generated, then this class also generates a `credential`
+ * section in the Git configuration file _.gitconfig_ in order to reference the generated _.git-credentials_ file.
+ */
+class GitConfigGenerator(private val gitConfigUrlInsteadOfPairs: Map<String, String>) :
+    EnvironmentConfigGenerator<EnvironmentServiceDefinition> {
+    companion object {
+        private const val GIT_CONFIG_FILE_NAME = ".gitconfig"
+
+        private val logger = LoggerFactory.getLogger(GitConfigGenerator::class.java)
+
+        private const val GIT_CONFIG_URL_INSTEAD_OF = "gitConfigUrlInsteadOf"
+
+        /**
+         * Create a new instance of [GitConfigGenerator] that already has parsed the configuration.
+         */
+        fun create(configManager: ConfigManager): GitConfigGenerator {
+            val parsedConfiguration = configManager.config.getStringOrNull(GIT_CONFIG_URL_INSTEAD_OF)
+                ?.let { configUrlInsteadOf ->
+                    parseGitConfigUrlInsteadOf(configUrlInsteadOf)
+                }.orEmpty()
+
+            return GitConfigGenerator(parsedConfiguration)
+        }
+
+        internal fun parseGitConfigUrlInsteadOf(config: String) =
+            config.split(",")
+                .mapIndexedNotNull { index, baseInsteadOfPair ->
+                    if (!baseInsteadOfPair.contains("=")) {
+                        logger.warn(
+                            "Invalid format of base=insteadOf pair #${index + 1}: '$baseInsteadOfPair'. " +
+                                "Ignoring."
+                        )
+                        null
+                    } else {
+                        baseInsteadOfPair
+                    }
+                }.associate { baseInsteadOfPair ->
+                    val (base, url) = baseInsteadOfPair.split("=")
+                    base.trim() to url.trim()
+                }
+
+        internal suspend fun generateGitConfig(
+            builder: ConfigFileBuilder,
+            definitions: Collection<EnvironmentServiceDefinition>,
+            gitConfigUrlInsteadOfPairs: Map<String, String>
+        ) {
+            val hasCredentials = definitions.any { CredentialsType.GIT_CREDENTIALS_FILE in it.credentialsTypes() }
+            if (hasCredentials || gitConfigUrlInsteadOfPairs.isNotEmpty()) {
+                builder.buildInUserHome(GIT_CONFIG_FILE_NAME) {
+                    // If there are any Git credentials defined, create a `[credential]` section.
+                    if (hasCredentials) {
+                        println("[credential]")
+                        println("\thelper = store")
+                    }
+
+                    // Create `url.<base>.insteadOf` sections.
+                    gitConfigUrlInsteadOfPairs.forEach {
+                        println("[url \"${it.key}\"]")
+                        println("\tinsteadOf = \"${it.value}\"")
+                    }
+                }
+                logger.debug(
+                    "Generated .gitconfig file hasCredentials={} insteadOf={}",
+                    hasCredentials,
+                    gitConfigUrlInsteadOfPairs
+                )
+            } else {
+                logger.debug("Not generating .gitconfig file.")
+            }
+        }
+    }
+
+    override val environmentDefinitionType: Class<EnvironmentServiceDefinition> =
+        EnvironmentServiceDefinition::class.java
+
+    override suspend fun generate(builder: ConfigFileBuilder, definitions: Collection<EnvironmentServiceDefinition>) {
+        generateGitConfig(builder, definitions, gitConfigUrlInsteadOfPairs)
+    }
+}

--- a/workers/common/src/main/kotlin/common/env/GitCredentialsGenerator.kt
+++ b/workers/common/src/main/kotlin/common/env/GitCredentialsGenerator.kt
@@ -35,14 +35,14 @@ import org.slf4j.LoggerFactory
  * repository is only possible if the credentials are placed in a _.git-credentials_ file. This generator is able to
  * produce such a file, together with a Git configuration file that references it. It only processes infrastructure
  * services whose credentials types contain [CredentialsType.GIT_CREDENTIALS_FILE].
+ *
+ * There is a dependency to the [GitConfigGenerator] class, which generates a `credential` section in the Git
+ * configuration file _.gitconfig_ in order to reference the generated _.git-credentials_ file.
  */
 class GitCredentialsGenerator : EnvironmentConfigGenerator<EnvironmentServiceDefinition> {
     companion object {
         /** The name of the file storing the actual credentials. */
         private const val GIT_CREDENTIALS_FILE_NAME = ".git-credentials"
-
-        /** The name of the file with the Git configuration. */
-        private const val GIT_CONFIG_FILE_NAME = ".gitconfig"
 
         private val logger = LoggerFactory.getLogger(GitCredentialsGenerator::class.java)
 
@@ -73,7 +73,6 @@ class GitCredentialsGenerator : EnvironmentConfigGenerator<EnvironmentServiceDef
             CredentialsType.GIT_CREDENTIALS_FILE in it.credentialsTypes()
         }.takeUnless { it.isEmpty() }?.let {
             generateGitCredentials(builder, it)
-            generateGitConfig(builder)
         }
     }
 
@@ -87,17 +86,6 @@ class GitCredentialsGenerator : EnvironmentConfigGenerator<EnvironmentServiceDef
         builder.buildInUserHome(GIT_CREDENTIALS_FILE_NAME) {
             definitions.mapNotNull { it.service.urlWithCredentials(builder) }
                 .forEach(this::println)
-        }
-    }
-
-    /**
-     * Generate the (static) content of the _.gitconfig_ file using the given [builder]. In this file, only the
-     * credential store is enabled.
-     */
-    private suspend fun generateGitConfig(builder: ConfigFileBuilder) {
-        builder.buildInUserHome(GIT_CONFIG_FILE_NAME) {
-            println("[credential]")
-            println("\thelper = store")
         }
     }
 }

--- a/workers/common/src/test/kotlin/common/env/GitConfigGeneratorTest.kt
+++ b/workers/common/src/test/kotlin/common/env/GitConfigGeneratorTest.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.common.env
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+import java.util.EnumSet
+
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
+import org.eclipse.apoapsis.ortserver.workers.common.env.MockConfigFileBuilder.Companion.createInfrastructureService
+import org.eclipse.apoapsis.ortserver.workers.common.env.MockConfigFileBuilder.Companion.createSecret
+import org.eclipse.apoapsis.ortserver.workers.common.env.definition.EnvironmentServiceDefinition
+
+class GitConfigGeneratorTest : WordSpec({
+    "Git config file .gitconfig" should {
+        "be generated" {
+            val mockBuilder = MockConfigFileBuilder()
+            val definitions = emptyList<EnvironmentServiceDefinition>()
+            val parsedConfig = mapOf(
+                "https://github.com" to "ssh://git@github.com",
+                "https://github.com/" to "git@github.com:"
+            )
+
+            GitConfigGenerator.generateGitConfig(mockBuilder.builder, definitions, parsedConfig)
+
+            mockBuilder.homeFileNames shouldContainExactlyInAnyOrder listOf(".gitconfig")
+
+            val lines = mockBuilder.generatedLinesFor(homeFileName = ".gitconfig")
+
+            lines shouldContainExactly listOf(
+                "[url \"https://github.com\"]",
+                "\tinsteadOf = \"ssh://git@github.com\"",
+                "[url \"https://github.com/\"]",
+                "\tinsteadOf = \"git@github.com:\""
+            )
+        }
+
+        "only be generated if services with Git configs exist" {
+            val mockBuilder = MockConfigFileBuilder()
+            val definitions = emptyList<EnvironmentServiceDefinition>()
+            val parsedConfig = emptyMap<String, String>()
+
+            GitConfigGenerator.generateGitConfig(mockBuilder.builder, definitions, parsedConfig)
+
+            mockBuilder.homeFileNames should beEmpty()
+        }
+
+        "be generated if there are any Git credentials defined" {
+            val mockBuilder = MockConfigFileBuilder()
+            val definitions = listOf(
+                EnvironmentServiceDefinition(
+                    createInfrastructureService(
+                        "https://repo.example.org",
+                        createSecret("s1"),
+                        createSecret("s2"),
+                        EnumSet.of(CredentialsType.GIT_CREDENTIALS_FILE)
+                    )
+                )
+            )
+            val parsedConfig = emptyMap<String, String>()
+
+            GitConfigGenerator.generateGitConfig(mockBuilder.builder, definitions, parsedConfig)
+            val lines = mockBuilder.generatedLinesFor(homeFileName = ".gitconfig")
+
+            lines shouldContainExactly listOf(
+                "[credential]",
+                "\thelper = store"
+            )
+        }
+
+        "be generated if there are any Git credentials defined and Git config definitions" {
+            val mockBuilder = MockConfigFileBuilder()
+            val definitions = listOf(
+                EnvironmentServiceDefinition(
+                    createInfrastructureService(
+                        "https://repo.example.org",
+                        createSecret("s1"),
+                        createSecret("s2"),
+                        EnumSet.of(CredentialsType.GIT_CREDENTIALS_FILE)
+                    )
+                )
+            )
+            val parsedConfig = mapOf(
+                "https://github.com" to "ssh://git@github.com",
+                "https://github.com/" to "git@github.com:"
+            )
+
+            GitConfigGenerator.generateGitConfig(mockBuilder.builder, definitions, parsedConfig)
+            val lines = mockBuilder.generatedLinesFor(homeFileName = ".gitconfig")
+
+            lines shouldContainExactly listOf(
+                "[credential]",
+                "\thelper = store",
+                "[url \"https://github.com\"]",
+                "\tinsteadOf = \"ssh://git@github.com\"",
+                "[url \"https://github.com/\"]",
+                "\tinsteadOf = \"git@github.com:\""
+            )
+        }
+    }
+
+    "parseGitConfigUrlInsteadOf" should {
+        "gracefully handle an empty configuration" {
+            val configLine = ""
+
+            val result = GitConfigGenerator.parseGitConfigUrlInsteadOf(configLine)
+
+            result shouldBe emptyMap()
+        }
+
+        "gracefully handle a partly invalid configuration" {
+            val configLine = "https://github.com*ssh://git@github.com,https://github.com/=git@github.com:"
+
+            val result = GitConfigGenerator.parseGitConfigUrlInsteadOf(configLine)
+
+            result shouldContainExactly mapOf(
+                "https://github.com/" to "git@github.com:"
+            )
+        }
+
+        "parse a syntactically correct configuration with 1 entry" {
+            val configLine = " https://github.com = ssh://git@github.com "
+
+            val result = GitConfigGenerator.parseGitConfigUrlInsteadOf(configLine)
+
+            result shouldContainExactly mapOf(
+                "https://github.com" to "ssh://git@github.com"
+            )
+        }
+
+        "parse a syntactically correct configuration with 2 entries" {
+            val configLine = " https://github.com = ssh://git@github.com , https://github.com/ = git@github.com: "
+
+            val result = GitConfigGenerator.parseGitConfigUrlInsteadOf(configLine)
+
+            result shouldContainExactly mapOf(
+                "https://github.com" to "ssh://git@github.com",
+                "https://github.com/" to "git@github.com:"
+            )
+        }
+    }
+})

--- a/workers/common/src/test/kotlin/common/env/GitCredentialsGeneratorTest.kt
+++ b/workers/common/src/test/kotlin/common/env/GitCredentialsGeneratorTest.kt
@@ -47,7 +47,7 @@ class GitCredentialsGeneratorTest : StringSpec({
 
         GitCredentialsGenerator().generate(mockBuilder.builder, listOf(definition))
 
-        mockBuilder.homeFileNames shouldContainExactlyInAnyOrder listOf(".git-credentials", ".gitconfig")
+        mockBuilder.homeFileNames shouldContainExactlyInAnyOrder listOf(".git-credentials")
     }
 
     "Files should only be generated if services with Git credentials exist" {
@@ -97,26 +97,6 @@ class GitCredentialsGeneratorTest : StringSpec({
         lines shouldContainExactlyInAnyOrder listOf(
             "https://${testSecretRef(secUser1)}:${testSecretRef(secPass1)}@repo1.example.org",
             "http://${testSecretRef(secUser2)}:${testSecretRef(secPass2)}@repo2.example.org:444/orga/repo.git"
-        )
-    }
-
-    "A correct .gitconfig file should be generated" {
-        val mockBuilder = MockConfigFileBuilder()
-        val definition = EnvironmentServiceDefinition(
-            createInfrastructureService(
-                "https://repo.example.org",
-                createSecret("s1"),
-                createSecret("s2"),
-                EnumSet.of(CredentialsType.GIT_CREDENTIALS_FILE)
-            )
-        )
-
-        GitCredentialsGenerator().generate(mockBuilder.builder, listOf(definition))
-        val lines = mockBuilder.generatedLinesFor(homeFileName = ".gitconfig")
-
-        lines shouldContainExactly listOf(
-            "[credential]",
-            "\thelper = store"
         )
     }
 

--- a/workers/scanner/src/main/resources/application.conf
+++ b/workers/scanner/src/main/resources/application.conf
@@ -48,3 +48,7 @@ scanner {
     password = ${?SCANNER_RECEIVER_TRANSPORT_PASSWORD}
   }
 }
+
+# gitConfigUrlInsteadOf = "https://github.com=ssh://git@github.com,https://github.com/=git@github.com:"
+gitConfigUrlInsteadOf = ""
+gitConfigUrlInsteadOf = ${?GIT_CONFIG_URL_INSTEAD_OF}


### PR DESCRIPTION
Before a scan starts in a Scanner pod, generate a `.gitconfig` environment file containing URL `insteadOf` sections. These are required if the repository contains submodules specified using SSH URLs.

The `insteadOf` sections can either be generated using default values in `application.conf` or customized via the environment variable `GIT_CONFIG_URL_INSTEAD_OF`. This allows flexibility in defining what URL `insteadOf` sections are created in `.gitconfig`.