### PR TITLE
Scan storage read issues optimization

### DIFF
--- a/dao/src/main/kotlin/tables/ScanSummariesTable.kt
+++ b/dao/src/main/kotlin/tables/ScanSummariesTable.kt
@@ -49,28 +49,34 @@ class ScanSummaryDao(id: EntityID<Long>) : LongEntity(id) {
     val issues by ScanSummariesIssuesDao referrersOn ScanSummariesIssuesTable.scanSummaryId
 
     /**
-     * Map this DAO to a [ScanSummary] model object. Based on the [withFindings] flag, either include all findings
-     * or return a summary without findings.
+     * Map this DAO to a [ScanSummary] model object. If the [withRelations] flag is *true*, populate the collections
+     * for findings and issues. (Note that this may cause a larger number of SELECT statements issued to the database
+     * to load all these objects.) If the flag is *false*, only initialize the direct properties and leave the
+     * collections empty.
      */
-    fun mapToModel(withFindings: Boolean = true) = ScanSummary(
+    fun mapToModel(withRelations: Boolean = true) = ScanSummary(
         startTime = startTime,
         endTime = endTime,
         hash = hash,
-        licenseFindings = if (withFindings) {
+        licenseFindings = if (withRelations) {
             licenseFindings.mapTo(mutableSetOf(), LicenseFindingDao::mapToModel)
         } else {
             emptySet()
         },
-        copyrightFindings = if (withFindings) {
+        copyrightFindings = if (withRelations) {
             copyrightFindings.mapTo(mutableSetOf(), CopyrightFindingDao::mapToModel)
         } else {
             emptySet()
         },
-        snippetFindings = if (withFindings) {
+        snippetFindings = if (withRelations) {
             snippetFindings.mapTo(mutableSetOf(), SnippetFindingDao::mapToModel)
         } else {
             emptySet()
         },
-        issues = issues.map(ScanSummariesIssuesDao::mapToModel)
+        issues = if (withRelations) {
+            issues.map(ScanSummariesIssuesDao::mapToModel)
+        } else {
+            emptyList()
+        }
     )
 }

--- a/dao/src/main/kotlin/tables/shared/IssuesTable.kt
+++ b/dao/src/main/kotlin/tables/shared/IssuesTable.kt
@@ -30,6 +30,8 @@ import org.eclipse.apoapsis.ortserver.model.runs.Issue
 
 import org.jetbrains.exposed.dao.LongEntity
 import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.sql.Query
+import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.stringLiteral
 
@@ -63,6 +65,24 @@ class IssueDao(id: EntityID<Long>) : LongEntity(id) {
                 severity = issue.severity
                 affectedPath = issue.affectedPath
             }
+
+        /**
+         * Execute the given [query] and return the result as a list of [Issue] objects. This function allows to
+         * load issues from different sources, e.g. the issues from an ORT run or from a scan result. The query must
+         * return the properties of an issue in the following order:
+         * 1. timestamp
+         * 2. source
+         * 3. message
+         * 4. severity
+         * 5. affectedPath (nullable)
+         * 6. identifier type (nullable)
+         * 7. identifier name (nullable)
+         * 8. identifier namespace (nullable)
+         * 9. identifier version (nullable)
+         * 10. worker (nullable)
+         */
+        fun createFromQuery(query: Query): List<Issue> =
+            query.map(ResultRow::toIssue)
     }
 
     var source by IssuesTable.issueSource
@@ -81,5 +101,38 @@ class IssueDao(id: EntityID<Long>) : LongEntity(id) {
         affectedPath = affectedPath,
         identifier = identifier,
         worker = worker
+    )
+}
+
+/**
+ * Create an [Issue] from the fields of this [ResultRow]. Using this function, issues can be created from query
+ * results that may include other data as well. The fields of the result define the issue; they must appear in the
+ * order as described in [IssueDao.createFromQuery].
+ */
+@Suppress("ComplexCondition")
+fun ResultRow.toIssue(): Issue {
+    // The exposed library seems not to fully support fields on alias queries when unions are used.
+    // Use the field indexes in order to extract the values from the ResultRow instead of the field names.
+    // Disadvantage: More fragility, losing type safety at compile time.
+    val columns = fieldIndex.keys.toList()
+
+    val type = this[columns[5]] as String?
+    val name = this[columns[6]] as String?
+    val namespace = this[columns[7]] as String?
+    val version = this[columns[8]] as String?
+    val identifier = if (type == null || name == null || namespace == null || version == null) {
+        null
+    } else {
+        Identifier(type, namespace, name, version)
+    }
+
+    return Issue(
+        timestamp = this[columns[0]] as Instant,
+        source = this[columns[1]] as String,
+        message = this[columns[2]] as String,
+        severity = this[columns[3]] as Severity,
+        affectedPath = this[columns[4]] as String?,
+        worker = this[columns[9]] as String?,
+        identifier = identifier
     )
 }

--- a/workers/scanner/src/main/kotlin/scanner/OrtServerScanResultStorage.kt
+++ b/workers/scanner/src/main/kotlin/scanner/OrtServerScanResultStorage.kt
@@ -117,7 +117,7 @@ class OrtServerScanResultStorage(
                             version = it.scannerVersion,
                             configuration = it.scannerConfiguration
                         ),
-                        summary = it.scanSummary.mapToModel(withFindings = false).mapToOrt(),
+                        summary = it.scanSummary.mapToModel(withRelations = false).mapToOrt(),
                         additionalData = it.additionalScanResultData?.data.orEmpty()
                     )
                 }.filterValues { scannerMatcher?.matches(it.scanner) != false }

--- a/workers/scanner/src/test/kotlin/OrtServerScanResultStorageTest.kt
+++ b/workers/scanner/src/test/kotlin/OrtServerScanResultStorageTest.kt
@@ -42,7 +42,7 @@ import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.createI
 import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.createRepositoryProvenance
 import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.createScanResult
 import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.scannerMatcher
-import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.withoutFindings
+import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.withoutRelations
 
 import org.ossreviewtoolkit.model.ScanResult as OrtScanResult
 
@@ -259,8 +259,8 @@ class OrtServerScanResultStorageTest : WordSpec() {
 
                 val readResult = scanResultStorage.read(repositoryProvenance.mapToOrt(), scannerMatcher)
                 readResult shouldContainExactlyInAnyOrder listOf(
-                    scanResult1.withoutFindings(),
-                    scanResult2.withoutFindings()
+                    scanResult1.withoutRelations(),
+                    scanResult2.withoutRelations()
                 )
                 readResult shouldNotContain scanResult3
             }
@@ -281,8 +281,8 @@ class OrtServerScanResultStorageTest : WordSpec() {
 
                 val readResult = scanResultStorage.read(artifactProvenance.mapToOrt(), scannerMatcher)
                 readResult shouldContainExactlyInAnyOrder listOf(
-                    scanResult1.withoutFindings(),
-                    scanResult2.withoutFindings()
+                    scanResult1.withoutRelations(),
+                    scanResult2.withoutRelations()
                 )
                 readResult shouldNotContain scanResult3
             }
@@ -323,7 +323,7 @@ class OrtServerScanResultStorageTest : WordSpec() {
                 scanResultStorage.write(notMatchingScanResult)
 
                 val readResult = scanResultStorage.read(repositoryProvenance.mapToOrt(), scannerMatcher)
-                readResult shouldContain matchingScanResult.withoutFindings()
+                readResult shouldContain matchingScanResult.withoutRelations()
                 readResult shouldNotContain notMatchingScanResult
             }
         }

--- a/workers/scanner/src/test/kotlin/ScanResultFixtures.kt
+++ b/workers/scanner/src/test/kotlin/ScanResultFixtures.kt
@@ -152,13 +152,14 @@ internal object ScanResultFixtures {
         createServerScanResult(scannerName, issue, provenance, scannerVersion, scannerConfig, additionalData).mapToOrt()
 
     /**
-     * Return a copy of this [OrtScanResult] that does not contain any findings.
+     * Return a copy of this [OrtScanResult] that does not contain any objects from related tables.
      */
-    fun OrtScanResult.withoutFindings(): OrtScanResult {
+    fun OrtScanResult.withoutRelations(): OrtScanResult {
         val strippedSummary = summary.copy(
             licenseFindings = emptySet(),
             copyrightFindings = emptySet(),
-            snippetFindings = emptySet()
+            snippetFindings = emptySet(),
+            issues = emptyList()
         )
 
         return copy(summary = strippedSummary)


### PR DESCRIPTION
This PR further optimizes the storing of scan results by preventing that issues are unnecessarily loaded when constructing an ORT scanner run. Refer to the single commits for further information.