### PR TITLE
fix(mapping): Fix mapping of environment variable declarations

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
@@ -598,7 +598,7 @@ fun ApiInfrastructureService.mapToModel() =
 fun InfrastructureServiceDeclaration.mapToApi() =
     ApiInfrastructureService(name, url, description, usernameSecret, passwordSecret, credentialsTypes.mapToApi())
 
-fun ApiEnvironmentVariableDeclaration.mapToModel() = EnvironmentVariableDeclaration(name, secretName)
+fun ApiEnvironmentVariableDeclaration.mapToModel() = EnvironmentVariableDeclaration(name, secretName, value)
 
 fun EnvironmentVariableDeclaration.mapToApi() = ApiEnvironmentVariableDeclaration(name, secretName, value)
 

--- a/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
@@ -608,7 +608,8 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                     "maven" to listOf(mapOf("id" to "repositoryServer"))
                 )
                 val environmentVariables = listOf(
-                    ApiEnvironmentVariableDeclaration("MY_ENV_VAR", "mySecret")
+                    ApiEnvironmentVariableDeclaration("MY_ENV_VAR", "mySecret"),
+                    ApiEnvironmentVariableDeclaration("MY_OTHER_ENV_VAR", value = "nonSensitiveData")
                 )
                 val envConfig = EnvironmentConfig(
                     infrastructureServices = listOf(service),
@@ -663,7 +664,8 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                     jobConfig.environmentDefinitions shouldBe environmentDefinitions
                     jobConfig.infrastructureServices shouldContainExactly listOf(serviceDeclaration)
                     jobConfig.environmentVariables shouldContainExactly listOf(
-                        EnvironmentVariableDeclaration("MY_ENV_VAR", "mySecret")
+                        EnvironmentVariableDeclaration("MY_ENV_VAR", "mySecret"),
+                        EnvironmentVariableDeclaration("MY_OTHER_ENV_VAR", value = "nonSensitiveData")
                     )
                 }
 


### PR DESCRIPTION
The `value` property was not mapped when converting an API object to a model object.

Fixes #1894.