### PR TITLE
feat: Return overall vulnerability rating for vulnerabilities of a run

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
@@ -515,7 +515,7 @@ fun ApiScannerJobConfiguration.mapToModel() = ScannerJobConfiguration(
 fun Secret.mapToApi() = ApiSecret(name, description)
 
 fun VulnerabilityWithIdentifier.mapToApi() =
-    ApiVulnerabilityWithIdentifier(vulnerability.mapToApi(), identifier.mapToApi())
+    ApiVulnerabilityWithIdentifier(vulnerability.mapToApi(), identifier.mapToApi(), rating.mapToApi())
 
 fun Vulnerability.mapToApi() = ApiVulnerability(externalId, summary, description, references.map { it.mapToApi() })
 

--- a/api/v1/model/src/commonMain/kotlin/VulnerabilityWithIdentifier.kt
+++ b/api/v1/model/src/commonMain/kotlin/VulnerabilityWithIdentifier.kt
@@ -27,5 +27,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class VulnerabilityWithIdentifier(
     val vulnerability: Vulnerability,
-    val identifier: Identifier
+    val identifier: Identifier,
+
+    /** An advisory rating for the [Vulnerability], derived from the individual references of the [Vulnerability]. */
+    val rating: VulnerabilityRating,
 )

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -267,7 +267,8 @@ val getVulnerabilitiesByRunId: OpenApiRoute.() -> Unit = {
                                         )
                                     )
                                 ),
-                                identifier = Identifier("Maven", "org.namespace", "name", "1.0")
+                                identifier = Identifier("Maven", "org.namespace", "name", "1.0"),
+                                rating = VulnerabilityRating.HIGH
                             )
                         ),
                         PagingData(

--- a/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
@@ -590,7 +590,22 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                                         externalId = "CVE-2021-1234",
                                         summary = "A vulnerability",
                                         description = "A description",
-                                        references = emptyList()
+                                        references = listOf(
+                                            VulnerabilityReference(
+                                                url = "https://example.com",
+                                                scoringSystem = "CVSS",
+                                                severity = "LOW",
+                                                score = 1.2f,
+                                                vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                                            ),
+                                            VulnerabilityReference(
+                                                url = "https://example.com",
+                                                scoringSystem = "CVSS",
+                                                severity = "MEDIUM",
+                                                score = 4.2f,
+                                                vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                                            )
+                                        )
                                     )
                                 )
                             )
@@ -606,6 +621,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                 with(vulnerabilities.data) {
                     shouldHaveSize(1)
                     first().vulnerability.externalId shouldBe "CVE-2021-1234"
+                    first().rating shouldBe VulnerabilityRating.MEDIUM
 
                     with(first().identifier) {
                         type shouldBe "Maven"

--- a/model/src/commonMain/kotlin/VulnerabilityWithIdentifier.kt
+++ b/model/src/commonMain/kotlin/VulnerabilityWithIdentifier.kt
@@ -27,5 +27,8 @@ import org.eclipse.apoapsis.ortserver.model.runs.advisor.Vulnerability
  */
 data class VulnerabilityWithIdentifier(
     val vulnerability: Vulnerability,
-    val identifier: Identifier
+    val identifier: Identifier,
+
+    /** An advisory rating for the [Vulnerability], derived from the individual references of the [Vulnerability]. */
+    val rating: VulnerabilityRating,
 )

--- a/services/hierarchy/src/main/kotlin/VulnerabilityService.kt
+++ b/services/hierarchy/src/main/kotlin/VulnerabilityService.kt
@@ -66,6 +66,8 @@ class VulnerabilityService(private val db: Database) {
         ortRunId: Long,
         parameters: ListQueryParameters = ListQueryParameters.DEFAULT
     ): ListQueryResult<VulnerabilityWithIdentifier> = db.dbQuery {
+        val ratingAlias = ratingAlias()
+
         VulnerabilityDao.listCustomQuery(parameters, ResultRow::toVulnerabilityWithIdentifierAndReference) {
             VulnerabilitiesTable
                 .innerJoin(AdvisorResultsVulnerabilitiesTable)
@@ -74,8 +76,10 @@ class VulnerabilityService(private val db: Database) {
                 .innerJoin(AdvisorRunsTable)
                 .innerJoin(AdvisorJobsTable)
                 .innerJoin(IdentifiersTable)
-                .select(VulnerabilitiesTable.columns + IdentifiersTable.columns)
+                .innerJoin(VulnerabilityReferencesTable)
+                .select(VulnerabilitiesTable.columns + IdentifiersTable.columns + ratingAlias)
                 .where { AdvisorJobsTable.ortRunId eq ortRunId }
+                .groupBy(VulnerabilitiesTable.id, IdentifiersTable.id)
         }
     }
 
@@ -210,5 +214,6 @@ private fun ResultRow.toVulnerabilityWithAccumulatedData() = VulnerabilityWithAc
 
 private fun ResultRow.toVulnerabilityWithIdentifierAndReference() = VulnerabilityWithIdentifier(
     vulnerability = VulnerabilityDao.wrapRow(this).mapToModel(),
-    identifier = IdentifierDao.wrapRow(this).mapToModel()
+    identifier = IdentifierDao.wrapRow(this).mapToModel(),
+    rating = VulnerabilityRating.entries[(this[ratingAlias()] ?: 0)]
 )

--- a/services/hierarchy/src/test/kotlin/VulnerabilityServiceTest.kt
+++ b/services/hierarchy/src/test/kotlin/VulnerabilityServiceTest.kt
@@ -214,6 +214,92 @@ class VulnerabilityServiceTest : WordSpec() {
 
                 results should beEmpty()
             }
+
+            "return the overall rating for vulnerabilities" {
+                val service = VulnerabilityService(db)
+
+                val runId = fixtures.createOrtRun().id
+
+                val references1 = listOf(
+                    VulnerabilityReference(
+                        url = "https://example.com",
+                        scoringSystem = "CVSS",
+                        severity = "MEDIUM",
+                        score = 4.2f,
+                        vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                    ),
+                    VulnerabilityReference(
+                        url = "https://example.com",
+                        scoringSystem = "CVSS",
+                        severity = "LOW",
+                        score = 1.2f,
+                        vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                    )
+                )
+
+                val references2 = listOf(
+                    VulnerabilityReference(
+                        url = "https://example.com",
+                        scoringSystem = "CVSS",
+                        severity = "HIGH",
+                        score = 8.9f,
+                        vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                    ),
+                    VulnerabilityReference(
+                        url = "https://example.com",
+                        scoringSystem = "CVSS",
+                        severity = "CRITICAL",
+                        score = 10.0f,
+                        vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                    )
+                )
+
+                val vulnerabilities = mapOf(
+                    Identifier("Maven", "com.fasterxml.jackson.core", "jackson-databind", "2.9.6") to
+                            listOf(
+                                Vulnerability(
+                                    externalId = "CVE-2018-14721",
+                                    summary = "A vulnerability",
+                                    description = "A description",
+                                    references = references1
+                                )
+                            ),
+                    Identifier("Maven", "org.apache.logging.log4j", "log4j-core", "2.14.0") to
+                            listOf(
+                                Vulnerability(
+                                    externalId = "CVE-2022-14345",
+                                    summary = "A vulnerability",
+                                    description = "A description",
+                                    references = references2
+                                )
+                            )
+                )
+
+                val advJobId = fixtures.createAdvisorJob(
+                    ortRunId = runId,
+                    configuration = AdvisorJobConfiguration(config = advisorConfig())
+                ).id
+                fixtures.createAdvisorRun(
+                    advJobId,
+                    createAdvisorResults(vulnerabilities)
+                )
+
+                val results = service.listForOrtRunId(runId)
+
+                results.data.size shouldBe 2
+
+                with(results.data.first()) {
+                    vulnerability.externalId shouldBe "CVE-2018-14721"
+                    vulnerability.references shouldContainExactlyInAnyOrder references1
+                    rating shouldBe VulnerabilityRating.MEDIUM
+                }
+
+                with(results.data.last()) {
+                    vulnerability.externalId shouldBe "CVE-2022-14345"
+                    vulnerability.references shouldContainExactlyInAnyOrder references2
+                    rating shouldBe VulnerabilityRating.CRITICAL
+                }
+            }
         }
 
         "countForOrtRunId" should {


### PR DESCRIPTION
Calculate the overall rating for the vulnerability from the vulnerability references in the database query, and return this rating in the response of the vulnerabilities endpoint. This will allow for removing the calculation from the frontend side, and any future improvements in the calculation of the rating can be done in one place on the backend side.

Resolves #1839.