### PR TITLE
feat(database): Remove entities orphaned with removing ort run

### DIFF
--- a/dao/src/main/resources/db/migration/V93__projectsPackagesCascadeDelete.sql
+++ b/dao/src/main/resources/db/migration/V93__projectsPackagesCascadeDelete.sql
@@ -1,0 +1,59 @@
+-- This migration script modifies the foreign key constraints of the tables that reference projects and packages
+-- to add an ON DELETE CASCADE clause. Cascade deletion is performed only on connecting (associating) tables to prevent
+-- deletion of actual data. Orphaned data removal is performed by another process.
+-- This script also creates necessary indexes to speed up queries.
+
+ALTER TABLE packages_declared_licenses
+    DROP CONSTRAINT packages_declared_licenses_package_id_fkey,
+  ADD CONSTRAINT packages_declared_licenses_package_id_fkey
+    FOREIGN KEY (package_id) REFERENCES packages (id) ON DELETE CASCADE;
+
+ALTER TABLE packages_authors
+    DROP CONSTRAINT packages_authors_package_id_fkey,
+  ADD CONSTRAINT packages_authors_package_id_fkey
+    FOREIGN KEY (package_id) REFERENCES packages (id) ON DELETE CASCADE;
+
+ALTER TABLE projects_declared_licenses
+    DROP CONSTRAINT projects_declared_licenses_project_id_fkey,
+  ADD CONSTRAINT projects_declared_licenses_project_id_fkey
+    FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE;
+
+ALTER TABLE projects_authors
+    DROP CONSTRAINT projects_authors_project_id_fkey,
+  ADD CONSTRAINT projects_authors_project_id_fkey
+    FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE;
+
+ALTER TABLE processed_declared_licenses
+    DROP CONSTRAINT processed_declared_licenses_package_id_fkey,
+  ADD CONSTRAINT processed_declared_licenses_package_id_fkey
+    FOREIGN KEY (package_id) REFERENCES packages (id) ON DELETE CASCADE;
+
+ALTER TABLE processed_declared_licenses
+    DROP CONSTRAINT processed_declared_licenses_project_id_fkey,
+  ADD CONSTRAINT processed_declared_licenses_project_id_fkey
+    FOREIGN KEY (project_id) REFERENCES projects (id) ON DELETE CASCADE;
+
+
+ALTER TABLE processed_declared_licenses_mapped_declared_licenses
+    DROP CONSTRAINT processed_declared_licenses_m_processed_declared_license_i_fkey,
+  ADD CONSTRAINT processed_declared_licenses_m_processed_declared_license_i_fkey
+    FOREIGN KEY (processed_declared_license_id) REFERENCES processed_declared_licenses (id) ON DELETE CASCADE;
+
+
+ALTER TABLE processed_declared_licenses_unmapped_declared_licenses
+    DROP CONSTRAINT processed_declared_licenses_u_processed_declared_license_i_fkey,
+  ADD CONSTRAINT processed_declared_licenses_u_processed_declared_license_i_fkey
+    FOREIGN KEY (processed_declared_license_id) REFERENCES processed_declared_licenses (id) ON DELETE CASCADE;
+
+-- Create necessary indexes to speed up queries
+CREATE INDEX IF NOT EXISTS packages_analyzer_runs_package_id
+    ON packages_analyzer_runs (package_id);
+
+CREATE INDEX IF NOT EXISTS packages_analyzer_runs_analyzer_run_id
+    ON packages_analyzer_runs (analyzer_run_id);
+
+CREATE INDEX IF NOT EXISTS projects_analyzer_runs_package_id
+    ON projects_analyzer_runs (project_id);
+
+CREATE INDEX IF NOT EXISTS projects_analyzer_runs_analyzer_run_id
+    ON projects_analyzer_runs (analyzer_run_id);

--- a/services/hierarchy/src/main/kotlin/OrphanRemovalService.kt
+++ b/services/hierarchy/src/main/kotlin/OrphanRemovalService.kt
@@ -1,0 +1,305 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.services
+
+import org.eclipse.apoapsis.ortserver.dao.dbQuery
+import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.AdvisorRunsIdentifiersTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.AuthorsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesAnalyzerRunsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesAuthorsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesDeclaredLicensesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ProjectsAnalyzerRunsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ProjectsAuthorsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ProjectsDeclaredLicensesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ProjectsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.evaluatorrun.RuleViolationsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.ortrun.OrtRunsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.product.ProductsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageConfigurationsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageCurationDataAuthors
+import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageCurationDataTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageCurationsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageLicenseChoicesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsScannersTable
+import org.eclipse.apoapsis.ortserver.dao.tables.NestedProvenanceSubRepositoriesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.NestedProvenancesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.NestedRepositoriesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.PackageProvenancesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.SnippetsTable
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.DeclaredLicensesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersIssuesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.OrtRunsIssuesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.RemoteArtifactsTable
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.VcsInfoTable
+
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.isNotNull
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.notInSubQuery
+import org.jetbrains.exposed.sql.alias
+import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.union
+
+import org.slf4j.LoggerFactory
+
+/**
+ * Maintenance service to remove orphaned entities.
+ */
+class OrphanRemovalService(
+    private val db: Database
+) {
+    private val logger = LoggerFactory.getLogger(OrphanRemovalService::class.java)
+
+    /**
+     * Delete orphaned entities of ORT runs.
+     * Method uses heavy SQL queries, so it is not recommended to run it very often or under high DB loads.
+     */
+    suspend fun deleteRunsOrphanedEntities() {
+        logger.info("Deleting orphaned children of ORT runs.")
+
+        logger.info("Deleted {} records from {}", deleteOrphanedPackages(), PackagesTable.tableName)
+        logger.info("Deleted {} records from {}", deleteOrphanedProjects(), ProductsTable.tableName)
+        logger.info("Deleted {} records from {}", deleteOrphanedAuthors(), AuthorsTable.tableName)
+        logger.info("Deleted {} records from {}", deleteOrphanedDeclaredLicenses(), DeclaredLicensesTable.tableName)
+        logger.info("Deleted {} records from {}", deleteOrphanedIdentifiers(), IdentifiersTable.tableName)
+        logger.info("Deleted {} records from {}", deleteOrphanedVcsInfo(), VcsInfoTable.tableName)
+        logger.info("Deleted {} records from {}", deleteOrphanedRemoteArtifacts(), RemoteArtifactsTable.tableName)
+
+        logger.info("Deleting orphaned children of ORT runs finished.")
+    }
+
+    private suspend fun deleteOrphanedPackages() =
+        db.dbQuery {
+            PackagesTable.deleteWhere {
+                id notInSubQuery (
+                    PackagesAnalyzerRunsTable
+                        .select(PackagesAnalyzerRunsTable.packageId.alias("id"))
+                        .where(PackagesAnalyzerRunsTable.packageId.isNotNull())
+                    )
+            }
+        }
+
+    private suspend fun deleteOrphanedProjects() =
+        db.dbQuery {
+            ProjectsTable.deleteWhere {
+                id notInSubQuery (
+                    ProjectsAnalyzerRunsTable
+                        .select(ProjectsAnalyzerRunsTable.projectId.alias("id"))
+                        .where(ProjectsAnalyzerRunsTable.projectId.isNotNull())
+                    )
+            }
+        }
+
+    private suspend fun deleteOrphanedAuthors() =
+        db.dbQuery {
+            AuthorsTable.deleteWhere {
+                id notInSubQuery (
+                    PackagesAuthorsTable
+                        .select(PackagesAuthorsTable.authorId.alias("id"))
+                        .where(PackagesAuthorsTable.authorId.isNotNull())
+                        .union(
+                            ProjectsAuthorsTable
+                                .select(ProjectsAuthorsTable.authorId.alias("id"))
+                                .where(ProjectsAuthorsTable.authorId.isNotNull())
+                        )
+                        .union(
+                            PackageCurationDataAuthors
+                                .select(PackageCurationDataAuthors.authorId.alias("id"))
+                                .where(PackageCurationDataAuthors.authorId.isNotNull())
+                        )
+                    )
+            }
+        }
+
+    private suspend fun deleteOrphanedDeclaredLicenses() =
+        db.dbQuery {
+            DeclaredLicensesTable.deleteWhere {
+                id notInSubQuery (
+                    PackagesDeclaredLicensesTable
+                        .select(PackagesDeclaredLicensesTable.declaredLicenseId.alias("id"))
+                        .where(PackagesDeclaredLicensesTable.declaredLicenseId.isNotNull())
+                        .union(
+                            ProjectsDeclaredLicensesTable
+                                .select(ProjectsDeclaredLicensesTable.declaredLicenseId.alias("id"))
+                                .where(ProjectsDeclaredLicensesTable.declaredLicenseId.isNotNull())
+                        )
+                    )
+            }
+        }
+
+    private suspend fun deleteOrphanedIdentifiers() =
+        db.dbQuery {
+            IdentifiersTable.deleteWhere {
+                id notInSubQuery (
+                    ProjectsTable
+                        .select(ProjectsTable.identifierId.alias("id"))
+                        .where(ProjectsTable.identifierId.isNotNull())
+                        .union(
+                            PackagesTable
+                                .select(PackagesTable.identifierId.alias("id"))
+                                .where(PackagesTable.identifierId.isNotNull())
+                        )
+                        .union(
+                            IdentifiersIssuesTable
+                                .select(IdentifiersIssuesTable.identifierId.alias("id"))
+                                .where(IdentifiersIssuesTable.identifierId.isNotNull())
+                        )
+                        .union(
+                            AdvisorRunsIdentifiersTable
+                                .select(AdvisorRunsIdentifiersTable.identifierId.alias("id"))
+                                .where(AdvisorRunsIdentifiersTable.identifierId.isNotNull())
+                        )
+                        .union(
+                            PackageProvenancesTable
+                                .select(PackageProvenancesTable.identifierId.alias("id"))
+                                .where(PackageProvenancesTable.identifierId.isNotNull())
+                        )
+                        .union(
+                            RuleViolationsTable
+                                .select(RuleViolationsTable.packageIdentifierId.alias("id"))
+                                .where(RuleViolationsTable.packageIdentifierId.isNotNull())
+                        )
+                        .union(
+                            PackageCurationsTable
+                                .select(PackageCurationsTable.identifierId.alias("id"))
+                                .where(PackageCurationsTable.identifierId.isNotNull())
+                        )
+                        .union(
+                            PackageConfigurationsTable
+                                .select(PackageConfigurationsTable.identifierId.alias("id"))
+                                .where(PackageConfigurationsTable.identifierId.isNotNull())
+                        )
+                        .union(
+                            PackageLicenseChoicesTable
+                                .select(PackageLicenseChoicesTable.identifierId.alias("id"))
+                                .where(PackageLicenseChoicesTable.identifierId.isNotNull())
+                        )
+                        .union(
+                            ScannerRunsScannersTable
+                                .select(ScannerRunsScannersTable.identifierId.alias("id"))
+                                .where(ScannerRunsScannersTable.identifierId.isNotNull())
+                        )
+                        .union(
+                            OrtRunsIssuesTable
+                                .select(OrtRunsIssuesTable.identifierId.alias("id"))
+                                .where(OrtRunsIssuesTable.identifierId.isNotNull())
+                        )
+                    )
+            }
+        }
+
+    private suspend fun deleteOrphanedVcsInfo() =
+        db.dbQuery {
+            VcsInfoTable.deleteWhere {
+                VcsInfoTable.id notInSubQuery (
+                    OrtRunsTable
+                        .select(OrtRunsTable.vcsId.alias("vcs_id"))
+                        .where(OrtRunsTable.vcsId.isNotNull())
+                        .union(
+                            OrtRunsTable
+                                .select(OrtRunsTable.vcsProcessedId.alias("vcs_id"))
+                                .where(OrtRunsTable.vcsProcessedId.isNotNull())
+                        )
+                        .union(
+                            ProjectsTable
+                                .select(ProjectsTable.vcsId.alias("vcs_id"))
+                                .where(ProjectsTable.vcsId.isNotNull())
+                        )
+                        .union(
+                            ProjectsTable
+                                .select(ProjectsTable.vcsProcessedId.alias("vcs_id"))
+                                .where(ProjectsTable.vcsProcessedId.isNotNull())
+                        )
+                        .union(
+                            PackagesTable
+                                .select(PackagesTable.vcsId.alias("vcs_id"))
+                                .where(PackagesTable.vcsId.isNotNull())
+                        )
+                        .union(
+                            PackagesTable
+                                .select(PackagesTable.vcsProcessedId.alias("id"))
+                                .where(PackagesTable.vcsProcessedId.isNotNull())
+                        )
+                        .union(
+                            NestedProvenancesTable
+                                .select(NestedProvenancesTable.rootVcsId.alias("id"))
+                                .where(NestedProvenancesTable.rootVcsId.isNotNull())
+                        )
+                        .union(
+                            NestedProvenanceSubRepositoriesTable
+                                .select(NestedProvenanceSubRepositoriesTable.vcsId.alias("id"))
+                                .where(NestedProvenanceSubRepositoriesTable.vcsId.isNotNull())
+                        )
+                        .union(
+                            PackageProvenancesTable
+                                .select(PackageProvenancesTable.vcsId.alias("id"))
+                                .where(PackageProvenancesTable.vcsId.isNotNull())
+                        )
+                        .union(
+                            NestedRepositoriesTable
+                                .select(NestedRepositoriesTable.vcsId.alias("id"))
+                                .where(NestedRepositoriesTable.vcsId.isNotNull())
+                        )
+                        .union(
+                            SnippetsTable
+                                .select(SnippetsTable.vcsId.alias("id"))
+                                .where(SnippetsTable.vcsId.isNotNull())
+                        )
+                    )
+            }
+        }
+
+    private suspend fun deleteOrphanedRemoteArtifacts() =
+        db.dbQuery {
+            RemoteArtifactsTable.deleteWhere {
+                id notInSubQuery (
+                    PackagesTable
+                        .select(PackagesTable.binaryArtifactId.alias("id"))
+                        .where(PackagesTable.binaryArtifactId.isNotNull())
+                        .union(
+                            PackagesTable
+                                .select(PackagesTable.sourceArtifactId.alias("id"))
+                                .where(PackagesTable.sourceArtifactId.isNotNull())
+                        )
+                        .union(
+                            PackageProvenancesTable
+                                .select(PackageProvenancesTable.artifactId.alias("id"))
+                                .where(PackageProvenancesTable.artifactId.isNotNull())
+                        )
+                        .union(
+                            PackageCurationDataTable
+                                .select(PackageCurationDataTable.binaryArtifactId.alias("id"))
+                                .where(PackageCurationDataTable.binaryArtifactId.isNotNull())
+                        )
+                        .union(
+                            PackageCurationDataTable
+                                .select(PackageCurationDataTable.sourceArtifactId.alias("id"))
+                                .where(PackageCurationDataTable.sourceArtifactId.isNotNull())
+                        )
+                        .union(
+                            SnippetsTable
+                                .select(SnippetsTable.artifactId.alias("id"))
+                                .where(SnippetsTable.artifactId.isNotNull())
+                        )
+                    )
+            }
+        }
+}

--- a/services/hierarchy/src/test/kotlin/OrphanRemovalServiceTest.kt
+++ b/services/hierarchy/src/test/kotlin/OrphanRemovalServiceTest.kt
@@ -1,0 +1,942 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.services
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldStartWith
+
+import java.security.MessageDigest
+
+import kotlin.random.Random
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+import org.eclipse.apoapsis.ortserver.dao.dbQuery
+import org.eclipse.apoapsis.ortserver.dao.repositories.advisorjob.AdvisorJobsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.AdvisorRunsIdentifiersTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.AdvisorRunsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerjob.AnalyzerJobsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.AnalyzerRunsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.AuthorsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.MappedDeclaredLicensesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesAnalyzerRunsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesAuthorsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesDeclaredLicensesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ProcessedDeclaredLicensesMappedDeclaredLicensesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ProcessedDeclaredLicensesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ProcessedDeclaredLicensesUnmappedDeclaredLicensesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ProjectsAnalyzerRunsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ProjectsAuthorsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ProjectsDeclaredLicensesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ProjectsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.UnmappedDeclaredLicensesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.evaluatorrun.RuleViolationsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.organization.OrganizationsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.ortrun.OrtRunsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.product.ProductsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.repository.RepositoriesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageConfigurationsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageCurationDataAuthors
+import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageCurationDataTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageCurationsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageLicenseChoicesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.VcsInfoCurationDataTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.VcsMatchersTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.scannerjob.ScannerJobsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsScannersTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsTable
+import org.eclipse.apoapsis.ortserver.dao.tables.NestedRepositoriesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.PackageProvenancesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.SnippetsTable
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.DeclaredLicensesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.EnvironmentsTable
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersIssuesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.IssuesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.OrtRunsIssuesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.RemoteArtifactsTable
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.VcsInfoTable
+import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
+import org.eclipse.apoapsis.ortserver.model.AdvisorJobConfiguration
+import org.eclipse.apoapsis.ortserver.model.AnalyzerJobConfiguration
+import org.eclipse.apoapsis.ortserver.model.JobConfigurations
+import org.eclipse.apoapsis.ortserver.model.JobStatus
+import org.eclipse.apoapsis.ortserver.model.OrtRunStatus
+import org.eclipse.apoapsis.ortserver.model.ScannerJobConfiguration
+import org.eclipse.apoapsis.ortserver.model.Severity
+import org.eclipse.apoapsis.ortserver.model.runs.DependencyGraphsWrapper
+
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+
+@Suppress("LargeClass")
+class OrphanRemovalServiceTest : WordSpec() {
+    private val dbExtension = extension(DatabaseTestExtension())
+
+    private lateinit var db: Database
+    private lateinit var service: OrphanRemovalService
+
+    init {
+        beforeEach {
+            db = dbExtension.db
+            service = OrphanRemovalService(db)
+        }
+
+        "deleteOrphanedEntities" should {
+            "delete packages that are not associated with any other entity" {
+                db.dbQuery {
+                    // Orphan entries - should be deleted by removal process.
+                    createPackagesTableEntry(purl = "to.delete.1")
+
+                    // Packages in relation, that should not be removed.
+                    createPackageAnalyzerRunsTableEntry(
+                        createPackagesTableEntry(purl = "not.to.delete.1").value,
+                        createAnalyzerRunTableEntry().value
+                    )
+
+                    createProcessedDeclaredLicensesTableEntry(
+                        packageId = createPackagesTableEntry(purl = "to.delete.2").value
+                    )
+
+                    createPackagesDeclaredLicensesTableEntry(
+                        packageId = createPackagesTableEntry(purl = "to.delete.2").value
+                    )
+
+                    createPackagesAuthorsTableEntry(
+                        packageId = createPackagesTableEntry(purl = "to.delete.3").value
+                    )
+
+                    createProcessedDeclaredLicensesMappedDeclaredLicensesTableEntry(
+                        mappedDeclaredLicenseId = createMappedDeclaredLicenseTableEntry(
+                            declaredLicense = "not.to.delete.1",
+                            mappedLicense = "not.to.delete.2"
+                        ).value,
+                        processedDeclaredLicenseId = createProcessedDeclaredLicensesTableEntry(
+                            packageId = createPackagesTableEntry(purl = "to.delete.3").value
+                        ).value
+                    )
+
+                    createProcessedDeclaredLicensesUnmappedDeclaredLicensesTableEntry(
+                        processedDeclaredLicenseId = createProcessedDeclaredLicensesTableEntry(
+                            createPackagesTableEntry(purl = "to.delete.4").value,
+                            createProjectsTableEntry(homepageUrl = "to.delete.1").value
+                        ).value,
+                        unmappedDeclaredLicenseId = createUnmappedDeclaredLicenseTableEntry(
+                            unmappedLicense = "not.to.delete.1"
+                        ).value
+                    )
+
+                    // Orphan entries - should be deleted by removal process.
+                    createPackagesTableEntry(purl = "to.delete.4")
+                    createPackagesTableEntry(purl = "to.delete.5")
+
+                    // Check packages number before cleanup.
+                    PackagesTable.selectAll().count() shouldBe 9
+                    MappedDeclaredLicensesTable.selectAll().count() shouldBe 1
+                    UnmappedDeclaredLicensesTable.selectAll().count() shouldBe 1
+                    ProcessedDeclaredLicensesTable.selectAll().count() shouldBe 3
+                }
+
+                service.deleteRunsOrphanedEntities()
+
+                db.dbQuery {
+                    PackagesTable.selectAll().count() shouldBe 1
+                    PackagesTable.selectAll().toList().forEach {
+                        it[PackagesTable.purl] shouldStartWith "not.to.delete"
+                    }
+
+                    MappedDeclaredLicensesTable.selectAll().count() shouldBe 1
+                    UnmappedDeclaredLicensesTable.selectAll().count() shouldBe 1
+                    ProcessedDeclaredLicensesTable.selectAll().count() shouldBe 0
+                }
+            }
+
+            "delete projects that are not associated with any other entity" {
+                db.dbQuery {
+                    // Orphan entry - should be deleted by removal process
+                    createProjectsTableEntry(homepageUrl = "to.delete.1")
+
+                    // Projects in relation, that should not be removed.
+                    createProjectsAnalyzerRunsTableEntry(
+                        createProjectsTableEntry(homepageUrl = "not.to.delete.1").value,
+                        createAnalyzerRunTableEntry().value
+                    )
+
+                    createProjectsDeclaredLicensesTableEntry(
+                        createProjectsTableEntry(homepageUrl = "to.delete.2").value,
+                        createDeclaredLicensesTableEntry().value
+                    )
+
+                    createProjectsAuthorsTableEntry(
+                        createProjectsTableEntry(homepageUrl = "to.delete.3").value,
+                        createAuthorsTableEntry().value
+                    )
+
+                    createProcessedDeclaredLicensesTableEntry(
+                        projectId = createProjectsTableEntry(homepageUrl = "to.delete.3").value
+                    )
+
+                    createProcessedDeclaredLicensesUnmappedDeclaredLicensesTableEntry(
+                        processedDeclaredLicenseId = createProcessedDeclaredLicensesTableEntry(
+                            createPackagesTableEntry(purl = "to.delete.4").value,
+                            createProjectsTableEntry(homepageUrl = "to.delete.4").value
+                        ).value,
+                        unmappedDeclaredLicenseId = createUnmappedDeclaredLicenseTableEntry(
+                            unmappedLicense = "not.to.delete.1"
+                        ).value
+                    )
+
+                    // Orphan entries - should be deleted by removal process
+                    createProjectsTableEntry(homepageUrl = "to.delete.5")
+                    createProjectsTableEntry(homepageUrl = "to.delete.6")
+
+                    ProjectsTable.selectAll().count() shouldBe 8
+                    ProcessedDeclaredLicensesTable.selectAll().count() shouldBe 2
+                    UnmappedDeclaredLicensesTable.selectAll().count() shouldBe 1
+                }
+
+                service.deleteRunsOrphanedEntities()
+
+                db.dbQuery {
+                    ProjectsTable.selectAll().count() shouldBe 1
+                    ProjectsTable.selectAll().toList().forEach {
+                        it[ProjectsTable.homepageUrl] shouldStartWith "not.to.delete"
+                    }
+                    ProcessedDeclaredLicensesTable.selectAll().count() shouldBe 0
+                    UnmappedDeclaredLicensesTable.selectAll().count() shouldBe 1
+                }
+            }
+
+            "delete authors that are not associated with any other entity" {
+                db.dbQuery {
+                    createAuthorsTableEntry(name = "to.delete.1")
+
+                    createPackagesAuthorsTableEntry(
+                        authorId = createAuthorsTableEntry("to.delete.2").value
+                    )
+
+                    createProjectsAuthorsTableEntry(
+                        authorId = createAuthorsTableEntry("to.delete.3").value
+                    )
+
+                    createPackageCurationDataAuthorsTableEntry(
+                        authorId = createAuthorsTableEntry("not.to.delete.1").value
+                    )
+
+                    val package1Id = createPackagesTableEntry().value
+                    createPackageAnalyzerRunsTableEntry(
+                        packageId = package1Id,
+                        analyzerRunId = createAnalyzerRunTableEntry().value
+                    )
+                    createPackagesAuthorsTableEntry(
+                        authorId = createAuthorsTableEntry("not.to.delete.2").value,
+                        packageId = package1Id
+                    )
+
+                    val project1Id = createProjectsTableEntry().value
+                    createProjectsAnalyzerRunsTableEntry(
+                        projectId = project1Id
+                    )
+                    createProjectsAuthorsTableEntry(
+                        authorId = createAuthorsTableEntry("not.to.delete.3").value,
+                        projectId = project1Id
+                    )
+
+                    createAuthorsTableEntry(name = "to.delete.4")
+                    createAuthorsTableEntry(name = "to.delete.5")
+
+                    AuthorsTable.selectAll().count() shouldBe 8
+                }
+
+                service.deleteRunsOrphanedEntities()
+
+                db.dbQuery {
+                    AuthorsTable.selectAll().count() shouldBe 3
+                    AuthorsTable.selectAll().toList().forEach {
+                        it[AuthorsTable.name] shouldStartWith "not.to.delete"
+                    }
+                }
+            }
+
+            "delete declared licenses that are not associated with any other entity" {
+                db.dbQuery {
+                    createDeclaredLicensesTableEntry(name = "to.delete.1")
+
+                    createPackagesDeclaredLicensesTableEntry(
+                        declaredLicenseId = createDeclaredLicensesTableEntry("to.delete.2").value
+                    )
+
+                    createProjectsDeclaredLicensesTableEntry(
+                        declaredLicenseId = createDeclaredLicensesTableEntry("to.delete.3").value
+                    )
+
+                    val project1Id = createProjectsTableEntry().value
+                    createProjectsAnalyzerRunsTableEntry(
+                        projectId = project1Id
+                    )
+
+                    createProjectsDeclaredLicensesTableEntry(
+                        declaredLicenseId = createDeclaredLicensesTableEntry("not.to.delete.1").value,
+                        projectId = project1Id
+                    )
+
+                    val package1Id = createPackagesTableEntry().value
+                    createPackageAnalyzerRunsTableEntry(
+                        packageId = package1Id,
+                        analyzerRunId = createAnalyzerRunTableEntry().value
+                    )
+
+                    createPackagesDeclaredLicensesTableEntry(
+                        declaredLicenseId = createDeclaredLicensesTableEntry("not.to.delete.2").value,
+                        packageId = package1Id
+                    )
+
+                    createDeclaredLicensesTableEntry(name = "to.delete.4")
+                    createDeclaredLicensesTableEntry(name = "to.delete.5")
+
+                    DeclaredLicensesTable.selectAll().count() shouldBe 7
+                }
+
+                service.deleteRunsOrphanedEntities()
+
+                db.dbQuery {
+                    DeclaredLicensesTable.selectAll().count() shouldBe 2
+                    DeclaredLicensesTable.selectAll().toList().forEach {
+                        it[DeclaredLicensesTable.name] shouldStartWith "not.to.delete"
+                    }
+                }
+            }
+
+            "delete identifiers that are not associated with any other entity" {
+                db.dbQuery {
+                    createIdentifierTableEntry(name = "to.delete.1")
+
+                    // Wrapped, to prevent deletion identifier with project
+                    createProjectsAnalyzerRunsTableEntry(
+                        projectId = createProjectsTableEntry(
+                            identifierId = createIdentifierTableEntry(name = "not.to.delete.1").value
+                        ).value
+                    )
+
+                    // Wrapped, to prevent deletion identifier with package
+                    createPackageAnalyzerRunsTableEntry(
+                        createPackagesTableEntry(
+                            identifierId = createIdentifierTableEntry(name = "not.to.delete.2").value
+                        ).value,
+                        createAnalyzerRunTableEntry().value
+                    )
+
+                    createIdentifiersIssuesTableEntry(
+                        identifierId = createIdentifierTableEntry(name = "not.to.delete.3").value
+                    )
+
+                    createAdvisorRunsIdentifiersTableEntry(
+                        identifierId = createIdentifierTableEntry(name = "not.to.delete.4").value
+                    )
+
+                    createPackageProvenancesTableEntry(
+                        identifierId = createIdentifierTableEntry(name = "not.to.delete.5").value
+                    )
+
+                    createRuleViolationsTableEntry(
+                        packageIdentifierId = createIdentifierTableEntry(name = "not.to.delete.6").value
+                    )
+
+                    createPackageCurationsTableEntry(
+                        identifierId = createIdentifierTableEntry(name = "not.to.delete.7").value
+                    )
+
+                    createPackageConfigurationsTableEntry(
+                        identifierId = createIdentifierTableEntry(name = "not.to.delete.8").value
+                    )
+
+                    createPackageLicenseChoicesTableEntry(
+                        identifierId = createIdentifierTableEntry(name = "not.to.delete.9").value
+                    )
+
+                    createScannerRunsScannersTableEntry(
+                        identifierId = createIdentifierTableEntry(name = "not.to.delete.10").value
+                    )
+
+                    createOrtRunsIssuesTableEntry(
+                        identifierId = createIdentifierTableEntry(name = "not.to.delete.11").value
+                    )
+
+                    createIdentifierTableEntry(name = "to.delete.2")
+                    createIdentifierTableEntry(name = "to.delete.3")
+
+                    IdentifiersTable.selectAll().count() shouldBe 14
+                }
+
+                service.deleteRunsOrphanedEntities()
+
+                db.dbQuery {
+                    IdentifiersTable.selectAll().count() shouldBe 11
+                    IdentifiersTable.selectAll().toList().forEach {
+                        it[IdentifiersTable.name] shouldStartWith "not.to.delete"
+                    }
+                }
+            }
+
+            "delete vcsInfos that are not associated with any other entity" {
+                db.dbQuery {
+                    // Orphan entries - should be deleted by removal process
+                    createVcsInfoTableEntry(url = "to.delete1")
+                    createVcsInfoTableEntry(url = "to.delete2")
+
+                    createOrtRunTableEntry(
+                        vcsId = createVcsInfoTableEntry(url = "not.to.delete_1").value,
+                        vcsProcessedId = null
+                    )
+
+                    createOrtRunTableEntry(
+                        vcsId = null,
+                        vcsProcessedId = createVcsInfoTableEntry(url = "not.to.delete_2").value
+                    )
+
+                    // Project wrapped with author to prevent cascade deletion
+                    createProjectsAnalyzerRunsTableEntry(
+                        projectId = createProjectsTableEntry(
+                            vcsId = createVcsInfoTableEntry(url = "not.to.delete_3").value,
+                            vcsProcessedId = createVcsInfoTableEntry(url = "not.to.delete_4").value
+                        ).value
+                    )
+
+                    // Package wrapped in run to prevent cascade deletion.
+                    createPackageAnalyzerRunsTableEntry(
+                        createPackagesTableEntry(
+                            vcsId = createVcsInfoTableEntry(url = "not.to.delete_5").value,
+                            vcsProcessedId = createVcsInfoTableEntry(url = "not.to.delete_6").value
+                        ).value,
+                        createAnalyzerRunTableEntry().value
+                    )
+
+                    createNestedRepositoriesTableEntry(
+                        vcsId = createVcsInfoTableEntry(url = "not.to.delete_7").value
+                    )
+
+                    createSnippetsTableEntry(
+                        vcsId = createVcsInfoTableEntry(url = "not.to.delete_8").value
+                    )
+
+                    // More orphan entries - should be deleted by removal process
+                    createVcsInfoTableEntry(url = "to.delete3")
+
+                    VcsInfoTable.selectAll().count() shouldBe 11
+                }
+
+                service.deleteRunsOrphanedEntities()
+
+                db.dbQuery {
+                    VcsInfoTable.selectAll().count() shouldBe 8
+                    VcsInfoTable.selectAll().toList().forEach {
+                        it[VcsInfoTable.url] shouldStartWith "not.to.delete"
+                    }
+                }
+            }
+
+            "delete remote artifacts that are not associated with any other entity" {
+                db.dbQuery {
+                    createRemoteArtifactsTableEntry(url = "to.delete.1")
+
+                    // Package-related entries wrapped to prevent cascade deletion with package
+                    createPackageAnalyzerRunsTableEntry(
+                        packageId = createPackagesTableEntry(
+                            binaryArtifactId = createRemoteArtifactsTableEntry(url = "not.to.delete.1").value,
+                            sourceArtifactId = createRemoteArtifactsTableEntry(url = "not.to.delete.2").value
+                        ).value,
+                        createAnalyzerRunTableEntry().value
+                    )
+
+                    createPackageProvenancesTableEntry(
+                        artifactId = createRemoteArtifactsTableEntry("not.to.delete.3").value
+                    )
+
+                    createPackageCurationDataTableEntry(
+                        binaryArtifactId = createRemoteArtifactsTableEntry(url = "not.to.delete.4").value,
+                        sourceArtifactId = createRemoteArtifactsTableEntry(url = "not.to.delete.5").value
+                    )
+
+                    createSnippetsTableEntry(
+                        artifactId = createRemoteArtifactsTableEntry(url = "not.to.delete.6").value
+                    )
+
+                    createRemoteArtifactsTableEntry(url = "to.delete.2")
+                    createRemoteArtifactsTableEntry(url = "to.delete.3")
+
+                    RemoteArtifactsTable.selectAll().count() shouldBe 9
+                }
+
+                service.deleteRunsOrphanedEntities()
+
+                db.dbQuery {
+                    RemoteArtifactsTable.selectAll().count() shouldBe 6
+                    RemoteArtifactsTable.selectAll().toList().forEach {
+                        it[RemoteArtifactsTable.url] shouldStartWith "not.to.delete"
+                    }
+                }
+            }
+        }
+    }
+
+    @Suppress("LongParameterList")
+    private fun createOrtRunTableEntry(
+        index: Long = Random.nextLong(1, 10000),
+        repositoryId: Long = createRepositoryTableEntry().value,
+        revision: String = "rev1",
+        createdAt: Instant = Clock.System.now(),
+        jobConfigs: JobConfigurations = JobConfigurations(),
+        status: OrtRunStatus = OrtRunStatus.CREATED,
+        vcsId: Long? = null,
+        vcsProcessedId: Long? = null
+    ) = OrtRunsTable.insert {
+        it[this.index] = index
+        it[this.repositoryId] = repositoryId
+        it[this.revision] = revision
+        it[this.createdAt] = createdAt
+        it[this.jobConfigs] = jobConfigs
+        it[this.status] = status
+        it[this.vcsId] = vcsId
+        it[this.vcsProcessedId] = vcsProcessedId
+    } get OrtRunsTable.id
+
+    private fun createVcsInfoTableEntry(
+        type: String = "type_" + Random.nextLong(1, 10000),
+        url: String = "url_" + Random.nextLong(1, 10000),
+        revision: String = "rev_" + Random.nextLong(1, 10000),
+        path: String = "path/" + Random.nextLong(1, 10000)
+    ) = VcsInfoTable.insert {
+        it[this.type] = type
+        it[this.url] = url
+        it[this.revision] = revision
+        it[this.path] = path
+    } get VcsInfoTable.id
+
+    private fun createRepositoryTableEntry(
+        type: String = "GIT",
+        url: String = "http://some.%d.url".format(Random.nextInt(0, 10000)),
+        productId: Long = createProductTableEntry().value
+    ) = RepositoriesTable.insert {
+        it[this.type] = type
+        it[this.url] = url
+        it[this.productId] = productId
+    } get RepositoriesTable.id
+
+    private fun createProductTableEntry(
+        name: String = "Prodct_" + Random.nextInt(0, 10000),
+        organizationId: Long = createOrganizationsTableEntry().value
+    ) = ProductsTable.insert {
+        it[this.name] = name
+        it[this.organizationId] = organizationId
+    } get ProductsTable.id
+
+    private fun createOrganizationsTableEntry(
+        name: String = "Org_" + Random.nextInt(0, 10000)
+    ) = OrganizationsTable.insert {
+        it[this.name] = name
+    } get OrganizationsTable.id
+
+    private fun createProjectsTableEntry(
+        identifierId: Long = createIdentifierTableEntry().value,
+        vcsId: Long = createVcsInfoTableEntry().value,
+        vcsProcessedId: Long = createVcsInfoTableEntry().value,
+        homepageUrl: String = "http://homepage.%d.url".format(Random.nextInt(0, 10000)),
+        definitionFilePath: String = "path_" + Random.nextInt(0, 10000)
+    ) = ProjectsTable.insert {
+        it[this.identifierId] = identifierId
+        it[this.vcsId] = vcsId
+        it[this.vcsProcessedId] = vcsProcessedId
+        it[this.homepageUrl] = homepageUrl
+        it[this.definitionFilePath] = definitionFilePath
+    } get ProjectsTable.id
+
+    private fun createAuthorsTableEntry(
+        name: String = "author_" + Random.nextInt(0, 10000)
+    ) = AuthorsTable.insert {
+        it[this.name] = name
+    } get AuthorsTable.id
+
+    private fun createProjectsAuthorsTableEntry(
+        projectId: Long = createProjectsTableEntry().value,
+        authorId: Long = createAuthorsTableEntry().value
+    ) = ProjectsAuthorsTable.insert {
+        it[this.projectId] = projectId
+        it[this.authorId] = authorId
+    }
+
+    private fun createPackagesAuthorsTableEntry(
+        authorId: Long = createAuthorsTableEntry().value,
+        packageId: Long = createPackagesTableEntry().value
+    ) = PackagesAuthorsTable.insert {
+        it[this.authorId] = authorId
+        it[this.packageId] = packageId
+    }
+
+    private fun createPackageCurationDataAuthorsTableEntry(
+        authorId: Long = createAuthorsTableEntry().value,
+        packageCurationDataId: Long = createPackageCurationDataTableEntry().value
+    ) = PackageCurationDataAuthors.insert {
+        it[this.authorId] = authorId
+        it[this.packageCurationDataId] = packageCurationDataId
+    }
+
+    private fun createPackageCurationDataTableEntry() =
+        PackageCurationDataTable.insert {
+            it[this.binaryArtifactId] = createRemoteArtifactsTableEntry()
+            it[this.sourceArtifactId] = createRemoteArtifactsTableEntry()
+        } get PackageCurationDataTable.id
+
+    private fun createProjectsAnalyzerRunsTableEntry(
+        projectId: Long = createProjectsTableEntry().value,
+        analyzerRunId: Long = createAnalyzerRunTableEntry().value
+    ) = ProjectsAnalyzerRunsTable.insert {
+        it[this.projectId] = projectId
+        it[this.analyzerRunId] = analyzerRunId
+    }
+
+    private fun createIdentifierTableEntry(
+        type: String = "type_" + Random.nextInt(0, 10000),
+        namespace: String = "namespace_" + Random.nextInt(0, 10000),
+        name: String = "name_" + Random.nextInt(0, 10000),
+        version: String = "version_" + Random.nextInt(0, 10000)
+    ) = IdentifiersTable.insert {
+        it[this.type] = type
+        it[this.namespace] = namespace
+        it[this.name] = name
+        it[this.version] = version
+    } get IdentifiersTable.id
+
+    private fun createIdentifiersIssuesTableEntry(
+        identifierId: Long = createIdentifierTableEntry().value,
+        issueId: Long = createIssuesTableEntry().value
+    ) = IdentifiersIssuesTable.insert {
+        it[this.identifierId] = identifierId
+        it[this.issueId] = issueId
+    } get IdentifiersIssuesTable.id
+
+    private fun createIssuesTableEntry() =
+        IssuesTable.insert {
+            it[this.issueSource] = "src_" + Random.nextInt(0, 10000)
+            it[this.message] = "msg_" + Random.nextInt(0, 10000)
+            it[this.severity] = Severity.ERROR
+            it[this.affectedPath] = "path/" + Random.nextInt(0, 10000)
+        } get IssuesTable.id
+
+    private fun createAdvisorRunsIdentifiersTableEntry(
+        advisorRunId: Long = createAdvisorRunsTableEntry().value,
+        identifierId: Long = createIdentifierTableEntry().value,
+    ) = AdvisorRunsIdentifiersTable.insert {
+        it[this.advisorRunId] = advisorRunId
+        it[this.identifierId] = identifierId
+    }
+
+    private fun createAdvisorRunsTableEntry() =
+        AdvisorRunsTable.insert {
+            it[this.advisorJobId] = createAdvisorJobsTableEntry().value
+            it[this.environmentId] = createEnvironmentTableEntry().value
+            it[this.startTime] = Clock.System.now()
+            it[this.endTime] = Clock.System.now()
+        } get AdvisorRunsTable.id
+
+    private fun createAdvisorJobsTableEntry() =
+        AdvisorJobsTable.insert {
+            it[this.ortRunId] = createOrtRunTableEntry().value
+            it[this.createdAt] = Clock.System.now()
+            it[this.configuration] = AdvisorJobConfiguration()
+            it[this.status] = JobStatus.FINISHED
+        } get AdvisorJobsTable.id
+
+    private fun createPackageProvenancesTableEntry(
+        identifierId: Long = createIdentifierTableEntry().value,
+        artifactId: Long = createRemoteArtifactsTableEntry().value,
+        vcsId: Long = createVcsInfoTableEntry().value
+    ) = PackageProvenancesTable.insert {
+        it[this.identifierId] = identifierId
+        it[this.artifactId] = artifactId
+        it[this.vcsId] = vcsId
+    } get PackageProvenancesTable.id
+
+    private fun createRuleViolationsTableEntry(
+        rule: String = "rule_" + Random.nextInt(0, 10000),
+        packageIdentifierId: Long = createIdentifierTableEntry().value,
+        severity: Severity = Severity.WARNING,
+        message: String = "msg_" + Random.nextInt(0, 10000),
+        howToFix: String = "howhow_" + Random.nextInt(0, 10000)
+
+    ) = RuleViolationsTable.insert {
+        it[this.rule] = rule
+        it[this.packageIdentifierId] = packageIdentifierId
+        it[this.severity] = severity
+        it[this.message] = message
+        it[this.howToFix] = howToFix
+    } get RuleViolationsTable.id
+
+    private fun createPackageCurationsTableEntry(
+        identifierId: Long = createIdentifierTableEntry().value,
+        packageCurationDataId: Long = createPackageCurationDataTableEntry().value
+    ) = PackageCurationsTable.insert {
+        it[this.identifierId] = identifierId
+        it[this.packageCurationDataId] = packageCurationDataId
+    } get PackageCurationsTable.id
+
+    private fun createPackageCurationDataTableEntry(
+        binaryArtifactId: Long = createRemoteArtifactsTableEntry().value,
+        sourceArtifactId: Long = createRemoteArtifactsTableEntry().value,
+        vcsInfoCurationDataId: Long = createVcsInfoCurationDataTableEntry().value,
+        hasAuthors: Boolean = false,
+    ) = PackageCurationDataTable.insert {
+        it[this.binaryArtifactId] = binaryArtifactId
+        it[this.sourceArtifactId] = sourceArtifactId
+        it[this.vcsInfoCurationDataId] = vcsInfoCurationDataId
+        it[this.hasAuthors] = hasAuthors
+    } get PackageCurationDataTable.id
+
+    private fun createVcsInfoCurationDataTableEntry() =
+        VcsInfoCurationDataTable.insert {
+            it[this.type] = "type_" + Random.nextInt(0, 10000)
+            it[this.url] = "http://homepage.%d.url".format(Random.nextInt(0, 10000))
+            it[this.revision] = "rev_" + Random.nextInt(0, 10000)
+            it[this.path] = "path/" + Random.nextInt(0, 10000)
+        } get VcsInfoCurationDataTable.id
+
+    private fun createPackageConfigurationsTableEntry(
+        identifierId: Long = createIdentifierTableEntry().value,
+        vcsMatcherId: Long = createVcsMatchersTableEntry().value
+    ) = PackageConfigurationsTable.insert {
+        it[this.identifierId] = identifierId
+        it[this.vcsMatcherId] = vcsMatcherId
+    } get PackageConfigurationsTable.id
+
+    private fun createVcsMatchersTableEntry() =
+        VcsMatchersTable.insert {
+            it[this.type] = "type_" + Random.nextInt(0, 10000)
+            it[this.url] = "http://homepage.%d.url".format(Random.nextInt(0, 10000))
+            it[this.revision] = "rev_" + Random.nextInt(0, 10000)
+        } get VcsMatchersTable.id
+
+    private fun createPackageLicenseChoicesTableEntry(
+        identifierId: Long = createIdentifierTableEntry().value
+    ) = PackageLicenseChoicesTable.insert {
+        it[this.identifierId] = identifierId
+    } get PackageLicenseChoicesTable.id
+
+    private fun createScannerRunsScannersTableEntry(
+        scannerRunId: Long = createScannerRunsTableEntry().value,
+        identifierId: Long = createIdentifierTableEntry().value,
+        scannerName: String = "name_" + Random.nextInt(0, 10000)
+    ) = ScannerRunsScannersTable.insert {
+        it[this.scannerRunId] = scannerRunId
+        it[this.identifierId] = identifierId
+        it[this.scannerName] = scannerName
+    } get ScannerRunsScannersTable.id
+
+    private fun createScannerRunsTableEntry() =
+        ScannerRunsTable.insert {
+            it[this.scannerJobId] = createScannerJobsTableEntry()
+            it[this.environmentId] = createEnvironmentTableEntry()
+        } get ScannerRunsTable.id
+
+    private fun createScannerJobsTableEntry() =
+        ScannerJobsTable.insert {
+            it[this.ortRunId] = createOrtRunTableEntry()
+            it[this.createdAt] = Clock.System.now()
+            it[this.configuration] = ScannerJobConfiguration()
+            it[this.status] = JobStatus.CREATED
+        } get ScannerJobsTable.id
+
+    private fun createOrtRunsIssuesTableEntry(
+        ortRunId: Long = createOrtRunTableEntry().value,
+        issueId: Long = createIssuesTableEntry().value,
+        identifierId: Long = createIdentifierTableEntry().value
+    ) = OrtRunsIssuesTable.insert {
+        it[this.ortRunId] = ortRunId
+        it[this.issueId] = issueId
+        it[this.identifierId] = identifierId
+        it[this.timestamp] = Clock.System.now()
+    } get OrtRunsIssuesTable.id
+
+    @Suppress("LongParameterList")
+    private fun createPackagesTableEntry(
+        identifierId: Long = createIdentifierTableEntry().value,
+        vcsId: Long = createVcsInfoTableEntry().value,
+        vcsProcessedId: Long = createVcsInfoTableEntry().value,
+        binaryArtifactId: Long = createRemoteArtifactsTableEntry().value,
+        sourceArtifactId: Long = createRemoteArtifactsTableEntry().value,
+        purl: String = "purl_" + Random.nextInt(0, 10000),
+        cpe: String = "cpe_" + Random.nextInt(0, 10000),
+        description: String = "description_" + Random.nextInt(0, 10000),
+        homepageUrl: String = "some.nome_%d.url".format(Random.nextInt(0, 10000)),
+        isMetadataOnly: Boolean = false,
+        isModified: Boolean = false
+    ) = PackagesTable.insert {
+        it[this.identifierId] = identifierId
+        it[this.vcsId] = vcsId
+        it[this.vcsProcessedId] = vcsProcessedId
+        it[this.binaryArtifactId] = binaryArtifactId
+        it[this.sourceArtifactId] = sourceArtifactId
+        it[this.purl] = purl
+        it[this.cpe] = cpe
+        it[this.description] = description
+        it[this.homepageUrl] = homepageUrl
+        it[this.isMetadataOnly] = isMetadataOnly
+        it[this.isModified] = isModified
+    } get PackagesTable.id
+
+    private fun createProcessedDeclaredLicensesTableEntry(
+        packageId: Long = createPackagesTableEntry().value,
+        projectId: Long = createProjectsTableEntry().value,
+        spdxExpression: String = "spdx_expression_" + Random.nextInt(0, 10000)
+    ) = ProcessedDeclaredLicensesTable.insert {
+        it[this.packageId] = packageId
+        it[this.projectId] = projectId
+        it[this.spdxExpression] = spdxExpression
+    } get ProcessedDeclaredLicensesTable.id
+
+    private fun createPackageAnalyzerRunsTableEntry(
+        packageId: Long,
+        analyzerRunId: Long
+    ) = PackagesAnalyzerRunsTable.insert {
+        it[this.packageId] = packageId
+        it[this.analyzerRunId] = analyzerRunId
+    }
+
+    private fun createAnalyzerJobTableEntry() =
+        AnalyzerJobsTable.insert {
+            it[this.ortRunId] = createOrtRunTableEntry()
+            it[this.createdAt] = Clock.System.now()
+            it[this.configuration] = AnalyzerJobConfiguration()
+            it[this.status] = JobStatus.CREATED
+        } get AnalyzerJobsTable.id
+
+    private fun createAnalyzerRunTableEntry() =
+        AnalyzerRunsTable.insert {
+            it[this.analyzerJobId] = createAnalyzerJobTableEntry()
+            it[this.environmentId] = createEnvironmentTableEntry()
+            it[this.startTime] = Clock.System.now()
+            it[this.endTime] = Clock.System.now()
+            it[this.dependencyGraphs] = DependencyGraphsWrapper(emptyMap())
+        } get AnalyzerRunsTable.id
+
+    private fun createEnvironmentTableEntry() =
+        EnvironmentsTable.insert {
+            it[this.ortVersion] = "ver_" + Random.nextInt(0, 10000)
+            it[this.javaVersion] = "22"
+            it[this.os] = "Linux"
+            it[this.processors] = 1
+            it[this.maxMemory] = Random.nextLong(100, 10000)
+        } get EnvironmentsTable.id
+
+    private fun createNestedRepositoriesTableEntry(
+        ortRunId: Long = createOrtRunTableEntry().value,
+        path: String = "path/" + Random.nextInt(0, 10000),
+        vcsId: Long = createVcsInfoTableEntry().value
+    ) = NestedRepositoriesTable.insert {
+        it[this.ortRunId] = ortRunId
+        it[this.path] = path
+        it[this.vcsId] = vcsId
+    } get NestedRepositoriesTable.id
+
+    @Suppress("LongParameterList")
+    private fun createSnippetsTableEntry(
+        purl: String = "purl_" + Random.nextInt(0, 10000),
+        artifactId: Long = createRemoteArtifactsTableEntry().value,
+        vcsId: Long = createVcsInfoTableEntry().value,
+        path: String = "path/" + Random.nextInt(0, 10000),
+        startLine: Int = Random.nextInt(0, 10000),
+        endLine: Int = Random.nextInt(0, 10000),
+        license: String = "Lic_" + Random.nextInt(0, 10000),
+        score: Float = Random.nextFloat()
+    ) = SnippetsTable.insert {
+        it[this.purl] = purl
+        it[this.artifactId] = artifactId
+        it[this.vcsId] = vcsId
+        it[this.path] = path
+        it[this.startLine] = startLine
+        it[this.endLine] = endLine
+        it[this.license] = license
+        it[this.score] = score
+    } get SnippetsTable.id
+
+    private fun createRemoteArtifactsTableEntry(
+        url: String = "git.someurl.org",
+        hashValue: String = MessageDigest.getInstance("SHA-1").digest(url.toByteArray()).toString(),
+        hashAlgorithm: String = "SHA1"
+    ) = RemoteArtifactsTable.insert {
+        it[this.url] = url
+        it[this.hashValue] = hashValue
+        it[this.hashAlgorithm] = hashAlgorithm
+    } get RemoteArtifactsTable.id
+
+    private fun createDeclaredLicensesTableEntry(
+        name: String = "name_" + Random.nextInt(0, 10000)
+    ) = DeclaredLicensesTable.insert {
+        it[this.name] = name
+    } get DeclaredLicensesTable.id
+
+    private fun createPackagesDeclaredLicensesTableEntry(
+        packageId: Long = createPackagesTableEntry().value,
+        declaredLicenseId: Long = createDeclaredLicensesTableEntry().value
+    ) = PackagesDeclaredLicensesTable.insert {
+        it[this.packageId] = packageId
+        it[this.declaredLicenseId] = declaredLicenseId
+    }
+
+    private fun createProjectsDeclaredLicensesTableEntry(
+        projectId: Long = createProjectsTableEntry().value,
+        declaredLicenseId: Long = createDeclaredLicensesTableEntry().value
+    ) = ProjectsDeclaredLicensesTable.insert {
+        it[this.projectId] = projectId
+        it[this.declaredLicenseId] = declaredLicenseId
+    }
+
+    private fun createProcessedDeclaredLicensesMappedDeclaredLicensesTableEntry(
+        mappedDeclaredLicenseId: Long = createMappedDeclaredLicenseTableEntry().value,
+        processedDeclaredLicenseId: Long = createProcessedDeclaredLicensesTableEntry().value
+    ) = ProcessedDeclaredLicensesMappedDeclaredLicensesTable.insert {
+        it[this.mappedDeclaredLicenseId] = mappedDeclaredLicenseId
+        it[this.processedDeclaredLicenseId] = processedDeclaredLicenseId
+    }
+
+    private fun createProcessedDeclaredLicensesUnmappedDeclaredLicensesTableEntry(
+        unmappedDeclaredLicenseId: Long = createUnmappedDeclaredLicenseTableEntry().value,
+        processedDeclaredLicenseId: Long = createProcessedDeclaredLicensesTableEntry().value
+    ) = ProcessedDeclaredLicensesUnmappedDeclaredLicensesTable.insert {
+        it[this.unmappedDeclaredLicenseId] = unmappedDeclaredLicenseId
+        it[this.processedDeclaredLicenseId] = processedDeclaredLicenseId
+    }
+
+    private fun createMappedDeclaredLicenseTableEntry(
+        declaredLicense: String = "license_" + Random.nextInt(0, 10000),
+        mappedLicense: String = "license_" + Random.nextInt(0, 10000)
+    ) = MappedDeclaredLicensesTable.insert {
+        it[this.declaredLicense] = declaredLicense
+        it[this.mappedLicense] = mappedLicense
+    } get MappedDeclaredLicensesTable.id
+
+    private fun createUnmappedDeclaredLicenseTableEntry(
+        unmappedLicense: String = "license_" + Random.nextInt(0, 10000)
+    ) = UnmappedDeclaredLicensesTable.insert {
+        it[this.unmappedLicense] = unmappedLicense
+    } get UnmappedDeclaredLicensesTable.id
+}


### PR DESCRIPTION
When archive scans are removed from database, some of orphaned entities stays in database, just occupying space, and deteriorating performance. To prevent this, obsolete (orphaned) records are deleted.