### PR TITLE
feat(auth): Add "offline_access" scope for long-lived refresh tokens

### DIFF
--- a/api/v1/client/src/commonMain/kotlin/auth/AuthService.kt
+++ b/api/v1/client/src/commonMain/kotlin/auth/AuthService.kt
@@ -35,9 +35,9 @@ class AuthService(
     private val clientId: String
 ) {
     /**
-     * Generate a token for the given [username] and [password].
+     * Generate a token for the given [username] and [password] using password grant type with optional [scopes].
      */
-    suspend fun generateToken(username: String, password: String): TokenInfo =
+    suspend fun generateToken(username: String, password: String, scopes: Set<String> = emptySet()): TokenInfo =
         client.submitForm(
             url = tokenUrl,
             formParameters = Parameters.build {
@@ -45,6 +45,9 @@ class AuthService(
                 append("username", username)
                 append("password", password)
                 append("grant_type", "password")
+                if (scopes.isNotEmpty()) {
+                    append("scope", scopes.joinToString(" "))
+                }
             }
         ).let { response ->
             if (!response.status.isSuccess()) {
@@ -57,15 +60,18 @@ class AuthService(
         }
 
     /**
-     * Refresh the token for the given [refreshToken].
+     * Refresh the tokens for the given [refreshToken] with optional [scopes].
      */
-    suspend fun refreshToken(refreshToken: String): TokenInfo =
+    suspend fun refreshToken(refreshToken: String, scopes: Set<String> = emptySet()): TokenInfo =
         client.submitForm(
             url = tokenUrl,
             formParameters = Parameters.build {
                 append("client_id", clientId)
                 append("refresh_token", refreshToken)
                 append("grant_type", "refresh_token")
+                if (scopes.isNotEmpty()) {
+                    append("scope", scopes.joinToString(" "))
+                }
             }
         ).let { response ->
             if (!response.status.isSuccess()) {

--- a/cli/src/main/kotlin/LoginCommand.kt
+++ b/cli/src/main/kotlin/LoginCommand.kt
@@ -75,7 +75,7 @@ class LoginCommand : SuspendingCliktCommand(name = "login") {
             clientId = clientId
         )
 
-        val tokenInfo = authService.generateToken(username, password)
+        val tokenInfo = authService.generateToken(username, password, setOf("offline_access"))
 
         AuthenticationStorage.store(
             HostAuthenticationDetails(

--- a/cli/src/main/kotlin/utils/AuthenticationUtils.kt
+++ b/cli/src/main/kotlin/utils/AuthenticationUtils.kt
@@ -68,7 +68,7 @@ private fun createOrtServerClient(authDetails: HostAuthenticationDetails): OrtSe
                             clientId = authDetails.clientId
                         )
 
-                        auth.refreshToken(authDetails.tokens.refresh).also {
+                        auth.refreshToken(authDetails.tokens.refresh, setOf("offline_access")).also {
                             val updatedAuthDetails = authDetails.copy(
                                 tokens = Tokens(it.accessToken, it.refreshToken)
                             )

--- a/cli/src/test/kotlin/AuthLoginCommandTest.kt
+++ b/cli/src/test/kotlin/AuthLoginCommandTest.kt
@@ -45,7 +45,9 @@ class AuthLoginCommandTest : StringSpec({
     "Auth login command" should {
         "store the authentication information in a local file" {
             mockkConstructor(AuthService::class)
-            coEvery { anyConstructed<AuthService>().generateToken("testUser", "testPassword") } returns TokenInfo(
+            coEvery {
+                anyConstructed<AuthService>().generateToken("testUser", "testPassword", setOf("offline_access"))
+            } returns TokenInfo(
                 accessToken = "testAccessToken",
                 refreshToken = "testRefreshToken",
                 expiresInSeconds = 3600


### PR DESCRIPTION
Add the `offline_access` scope when requesting authentication and refresh tokens in the CLI. This ensures that the authentication provider issues **long-lived refresh tokens**, allowing the CLI to obtain new access tokens without requiring the user to log in frequently.

This allows for having long-lived refresh tokens for the CLI, while still having the refresh tokens for the web application expire after a shorter period of time in case there is no user activity.

Such refresh token will no langer have a `exp` (expiration) claim. However, in authentication providers like Keycloak there **are** policies that enable to invalidate them nevertheless after a period of time of inactivity. This mechanism allows to have a regular automatic **clean-up of long-lived CLI sessions**, avoiding the number of long-lived sessions to grow in Keycloak without any bounds. 

While for web applications it is good practice to invalidate the refresh token after 15 - 30 minutes of inactivity, for CLIs it is common to have them last for several hours or even days.