### PR TITLE
fix(ui): Prevent a React error for input fields

### DIFF
--- a/ui/src/components/ui/input.tsx
+++ b/ui/src/components/ui/input.tsx
@@ -14,7 +14,7 @@ import { cn } from '@/lib/utils';
 export type InputProps = React.InputHTMLAttributes<HTMLInputElement>;
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
-  ({ className, type, ...props }, ref) => {
+  ({ className, type, value = '', ...props }, ref) => {
     return (
       <input
         type={type}
@@ -23,6 +23,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
           className
         )}
         ref={ref}
+        value={value}
         {...props}
       />
     );


### PR DESCRIPTION
Make sure that the input value is never null, this prevents the error:

    A component is changing an uncontrolled input to be controlled.