### PR TITLE
feat(ui): Hide secret values by default

### DIFF
--- a/ui/src/components/form/password-input.tsx
+++ b/ui/src/components/form/password-input.tsx
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { Eye, EyeOff } from 'lucide-react';
+import { useState } from 'react';
+
+import { Input } from '@/components/ui/input.tsx';
+
+export const PasswordInput = ({ ...props }) => {
+  const [showPassword, setShowPassword] = useState(false);
+
+  return (
+    <div className='relative'>
+      <Input type={showPassword ? 'text' : 'password'} {...props} />
+      <button
+        type='button'
+        className='absolute inset-y-0 right-0 flex items-center px-2'
+        onClick={() => setShowPassword(!showPassword)}
+      >
+        {showPassword ? (
+          <EyeOff className='h-5 w-5' />
+        ) : (
+          <Eye className='h-5 w-5' />
+        )}
+      </button>
+    </div>
+  );
+};

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/$secretName/edit/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/$secretName/edit/index.tsx
@@ -29,6 +29,7 @@ import {
   useSecretsServicePatchSecretByRepositoryIdAndName,
 } from '@/api/queries';
 import { ApiError, SecretsService } from '@/api/requests';
+import { PasswordInput } from '@/components/form/password-input';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { ToastError } from '@/components/toast-error';
 import { Button } from '@/components/ui/button';
@@ -152,7 +153,7 @@ const EditRepositorySecretPage = () => {
                 <FormItem className='mt-0'>
                   <FormLabel>Value</FormLabel>
                   <FormControl autoFocus>
-                    <Input {...field} />
+                    <PasswordInput {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/create-secret/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/create-secret/index.tsx
@@ -25,6 +25,7 @@ import { z } from 'zod';
 
 import { useSecretsServicePostSecretForRepository } from '@/api/queries';
 import { ApiError } from '@/api/requests';
+import { PasswordInput } from '@/components/form/password-input';
 import { ToastError } from '@/components/toast-error';
 import { Button } from '@/components/ui/button';
 import {
@@ -121,7 +122,7 @@ const CreateRepositorySecretPage = () => {
                 <FormItem>
                   <FormLabel>Value</FormLabel>
                   <FormControl>
-                    <Input {...field} />
+                    <PasswordInput {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/ui/src/routes/organizations/$orgId/products/$productId/secrets/$secretName/edit/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/secrets/$secretName/edit/index.tsx
@@ -29,6 +29,7 @@ import {
   useSecretsServicePatchSecretByProductIdAndName,
 } from '@/api/queries';
 import { ApiError, SecretsService } from '@/api/requests';
+import { PasswordInput } from '@/components/form/password-input';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { ToastError } from '@/components/toast-error';
 import { Button } from '@/components/ui/button';
@@ -148,7 +149,7 @@ const EditProductSecretPage = () => {
                 <FormItem className='mt-0'>
                   <FormLabel>Value</FormLabel>
                   <FormControl autoFocus>
-                    <Input {...field} />
+                    <PasswordInput {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/ui/src/routes/organizations/$orgId/products/$productId/secrets/create-secret/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/secrets/create-secret/index.tsx
@@ -25,6 +25,7 @@ import { z } from 'zod';
 
 import { useSecretsServicePostSecretForProduct } from '@/api/queries';
 import { ApiError } from '@/api/requests';
+import { PasswordInput } from '@/components/form/password-input';
 import { ToastError } from '@/components/toast-error';
 import { Button } from '@/components/ui/button';
 import {
@@ -117,7 +118,7 @@ const CreateProductSecretPage = () => {
                 <FormItem>
                   <FormLabel>Value</FormLabel>
                   <FormControl>
-                    <Input {...field} />
+                    <PasswordInput {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/ui/src/routes/organizations/$orgId/secrets/$secretName/edit/index.tsx
+++ b/ui/src/routes/organizations/$orgId/secrets/$secretName/edit/index.tsx
@@ -29,6 +29,7 @@ import {
   useSecretsServicePatchSecretByOrganizationIdAndName,
 } from '@/api/queries';
 import { ApiError, SecretsService } from '@/api/requests';
+import { PasswordInput } from '@/components/form/password-input';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { ToastError } from '@/components/toast-error';
 import { Button } from '@/components/ui/button';
@@ -149,7 +150,7 @@ const EditOrganizationSecretPage = () => {
                 <FormItem className='mt-0'>
                   <FormLabel>Value</FormLabel>
                   <FormControl autoFocus>
-                    <Input {...field} />
+                    <PasswordInput {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/ui/src/routes/organizations/$orgId/secrets/create-secret/index.tsx
+++ b/ui/src/routes/organizations/$orgId/secrets/create-secret/index.tsx
@@ -25,6 +25,7 @@ import { z } from 'zod';
 
 import { useSecretsServicePostSecretForOrganization } from '@/api/queries';
 import { ApiError } from '@/api/requests';
+import { PasswordInput } from '@/components/form/password-input.tsx';
 import { ToastError } from '@/components/toast-error';
 import { Button } from '@/components/ui/button';
 import {
@@ -119,7 +120,7 @@ const CreateOrganizationSecretPage = () => {
                 <FormItem>
                   <FormLabel>Value</FormLabel>
                   <FormControl>
-                    <Input {...field} />
+                    <PasswordInput {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>


### PR DESCRIPTION
Add a new `PasswordInput` component that hides the value by default. The input contains a button to toggle between showing and hiding the input.

Use this component to hide the values of secrets by default.

Fixes #1940.