### PR TITLE
ui: Add dependency tree deduplication option for WebApp

### DIFF
--- a/ui/src/helpers/get-status-class.ts
+++ b/ui/src/helpers/get-status-class.ts
@@ -23,7 +23,7 @@ import {
   Severity,
   VulnerabilityRating,
 } from '@/api/requests';
-import { PackageManager } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/-types';
+import { PackageManagerId } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/-types';
 
 // Combine statuses reported either by ORT Runs or the individual jobs within them.
 export type Status = JobStatus | OrtRunStatus | undefined;
@@ -165,7 +165,7 @@ export function getIssueSeverityBackgroundColor(severity: Severity): string {
 // 3. Package managers which belong to the same group are chosen from inside
 //    these 14 color palettes in a way that the colors are visually distinct.
 export function getEcosystemBackgroundColor(
-  ecosystem: PackageManager | string
+  ecosystem: PackageManagerId | string
 ): string {
   switch (ecosystem) {
     case 'Bazel':

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/package-manager-field.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/package-manager-field.tsx
@@ -41,11 +41,11 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
-import { packageManagers } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/-types';
 import {
-  CreateRunFormValues,
   PackageManagerId,
-} from '../_repo-layout/create-run/-create-run-utils';
+  packageManagers,
+} from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/-types';
+import { CreateRunFormValues } from '../_repo-layout/create-run/-create-run-utils';
 
 type PackageManagerFieldProps = {
   form: UseFormReturn<CreateRunFormValues>;

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/reporter-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/reporter-fields.tsx
@@ -25,7 +25,13 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from '@/components/ui/accordion';
-import { FormControl, FormField } from '@/components/ui/form';
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+} from '@/components/ui/form';
 import { Switch } from '@/components/ui/switch';
 import { reportFormats } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/-types';
 import { CreateRunFormValues } from '../_repo-layout/create-run/-create-run-utils';
@@ -68,6 +74,37 @@ export const ReporterFields = ({
             }
             options={reportFormats}
           />
+          {form.getValues('jobConfigs.reporter.formats').includes('WebApp') && (
+            <FormField
+              control={form.control}
+              name='jobConfigs.reporter.deduplicateDependencyTree'
+              render={({ field }) => (
+                <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
+                  <div className='space-y-0.5'>
+                    <FormLabel>Deduplicate dependency tree</FormLabel>
+                    <FormDescription>
+                      A flag to control whether subtrees occurring multiple
+                      times in the dependency tree are stripped.
+                    </FormDescription>
+                    <FormDescription>
+                      This will significantly reduce memory consumption of the
+                      Reporter and might alleviate some out-of-memory issues.
+                    </FormDescription>
+                    <FormDescription>
+                      NOTE: This option is currently effective only for the
+                      WebApp report format.
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          )}
         </AccordionContent>
       </AccordionItem>
     </div>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-types.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-types.ts
@@ -142,7 +142,7 @@ export const packageManagers = [
 
 // To make sure the package manager ids are used type-safely elsewhere,
 // export them as a type.
-export type PackageManager = (typeof packageManagers)[number]['id'];
+export type PackageManagerId = (typeof packageManagers)[number]['id'];
 
 export const reportFormats = [
   {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
@@ -26,7 +26,7 @@ import {
   OrtRun,
   ReporterJobConfiguration,
 } from '@/api/requests';
-import { packageManagers } from '../../-types';
+import { PackageManagerId, packageManagers } from '../../-types';
 
 const keyValueSchema = z.object({
   key: z.string(),
@@ -233,9 +233,6 @@ export const flattenErrors = (
 
   return result;
 };
-
-// Derive the type of packageManagerId from the ids of packageManagers
-export type PackageManagerId = (typeof packageManagers)[number]['id'];
 
 /**
  * Get the default values for the create run form. The form can be provided with a previously run


### PR DESCRIPTION
This PR adds an option (off by default) to deduplicate the dependency tree for the different reports. This is a global option currently, but only used for the WebApp due to none of the other supported reports having the option implemented in ORT. 

![Screenshot from 2025-02-05 08-50-32](https://github.com/user-attachments/assets/bae8b2e9-72b5-4d4c-b32b-8d38f5a91575)
![Screenshot from 2025-02-05 08-51-23](https://github.com/user-attachments/assets/b4405cdf-a490-40e6-98d0-7b134874c37b)

When creating a new ORT run from scratch, the option needs to specifically be set to on, and even then it will only affect the WebApp, so there shouldn't be any side effects for any other reports as such.

Please see the commits for details.