### PR TITLE
fix(analyzer): Use the latest version of corepack

### DIFF
--- a/workers/analyzer/docker/Analyzer.Dockerfile
+++ b/workers/analyzer/docker/Analyzer.Dockerfile
@@ -204,9 +204,8 @@ RUN . $NVM_DIR/nvm.sh \
     && nvm install "$NODEJS_VERSION" \
     && nvm alias default "$NODEJS_VERSION" \
     && nvm use default \
-    && npm install --global npm@$NPM_VERSION bower@$BOWER_VERSION \
-    && corepack enable \
-    && corepack prepare pnpm@9.15.4 --activate
+    && npm install --global npm@$NPM_VERSION bower@$BOWER_VERSION corepack@latest \
+    && corepack enable
 
 FROM scratch AS node
 COPY --from=nodebuild $NVM_DIR $NVM_DIR


### PR DESCRIPTION
The workaround introduced by e53580ac had no effect on some projects; corepack was still unable to install PNPM dynamically. Another approach described at [1] does the trick by explicitly installing the latest version of corepack. This version has been updated to accept the changed
 certificates.

 [1]: https://github.com/nodejs/corepack/issues/612#issuecomment-2629496091