### PR TITLE
ui: Improve form handling

### DIFF
--- a/ui/src/components/form/as-optional-field.ts
+++ b/ui/src/components/form/as-optional-field.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { z } from 'zod';
+
+const emptyStringToUndefined = z.literal('').transform(() => undefined);
+
+// This function will allow to have optional fields in the form, which also
+// contain restricting Zod validation schemas.
+//
+// Example usage:
+//
+// const formSchema = z.object({
+//   name: asOptionalField(z.string().min(5)),
+// });
+//
+// defines "name" as an optional field, so it can be empty (transforming to undefined),
+// but if it is not empty, it must be at least 5 characters long.
+export function asOptionalField<T extends z.ZodTypeAny>(schema: T) {
+  return schema.optional().or(emptyStringToUndefined);
+}

--- a/ui/src/components/form/optional-input.tsx
+++ b/ui/src/components/form/optional-input.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { Input } from '@/components/ui/input.tsx';
+
+export const OptionalInput = ({ ...props }) => {
+  return (
+    <Input {...props} placeholder='(optional)' value={props.value ?? ''} />
+  );
+};

--- a/ui/src/routes/admin/users/create-user/index.tsx
+++ b/ui/src/routes/admin/users/create-user/index.tsx
@@ -83,6 +83,7 @@ const CreateUser = () => {
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
+      username: '',
       temporary: true,
     },
   });

--- a/ui/src/routes/admin/users/create-user/index.tsx
+++ b/ui/src/routes/admin/users/create-user/index.tsx
@@ -25,6 +25,7 @@ import { z } from 'zod';
 
 import { useAdminServicePostUsers } from '@/api/queries';
 import { ApiError } from '@/api/requests';
+import { PasswordInput } from '@/components/form/password-input';
 import { ToastError } from '@/components/toast-error';
 import { Button } from '@/components/ui/button';
 import {
@@ -166,11 +167,7 @@ const CreateUser = () => {
                 <FormItem>
                   <FormLabel>Password</FormLabel>
                   <FormControl>
-                    <Input
-                      type='password'
-                      {...field}
-                      placeholder='(optional)'
-                    />
+                    <PasswordInput {...field} placeholder='(optional)' />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/ui/src/routes/admin/users/create-user/index.tsx
+++ b/ui/src/routes/admin/users/create-user/index.tsx
@@ -25,6 +25,8 @@ import { z } from 'zod';
 
 import { useAdminServicePostUsers } from '@/api/queries';
 import { ApiError } from '@/api/requests';
+import { asOptionalField } from '@/components/form/as-optional-field';
+import { OptionalInput } from '@/components/form/optional-input';
 import { PasswordInput } from '@/components/form/password-input';
 import { ToastError } from '@/components/toast-error';
 import { Button } from '@/components/ui/button';
@@ -48,11 +50,11 @@ import { Input } from '@/components/ui/input';
 import { toast } from '@/lib/toast';
 
 const formSchema = z.object({
-  username: z.string(),
-  firstName: z.string().optional(),
-  lastName: z.string().optional(),
-  email: z.string().email().optional(),
-  password: z.string().optional(),
+  username: z.string().min(1),
+  firstName: asOptionalField(z.string().min(1)),
+  lastName: asOptionalField(z.string().min(1)),
+  email: asOptionalField(z.string().email()),
+  password: asOptionalField(z.string().min(1)),
   temporary: z.boolean(),
 });
 
@@ -129,7 +131,7 @@ const CreateUser = () => {
                 <FormItem>
                   <FormLabel>First name</FormLabel>
                   <FormControl>
-                    <Input {...field} placeholder='(optional)' />
+                    <OptionalInput {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -142,7 +144,7 @@ const CreateUser = () => {
                 <FormItem>
                   <FormLabel>Last name</FormLabel>
                   <FormControl>
-                    <Input {...field} placeholder='(optional)' />
+                    <OptionalInput {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>
@@ -155,7 +157,7 @@ const CreateUser = () => {
                 <FormItem>
                   <FormLabel>Email address</FormLabel>
                   <FormControl>
-                    <Input type='email' {...field} placeholder='(optional)' />
+                    <OptionalInput type='email' {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/ui/src/routes/create-organization/index.tsx
+++ b/ui/src/routes/create-organization/index.tsx
@@ -76,6 +76,9 @@ const CreateOrganizationPage = () => {
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: '',
+    },
   });
 
   async function onSubmit(values: z.infer<typeof formSchema>) {

--- a/ui/src/routes/organizations/$orgId/create-product/index.tsx
+++ b/ui/src/routes/organizations/$orgId/create-product/index.tsx
@@ -78,6 +78,9 @@ const CreateProductPage = () => {
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: '',
+    },
   });
 
   async function onSubmit(values: z.infer<typeof formSchema>) {

--- a/ui/src/routes/organizations/$orgId/infrastructure-services/create/index.tsx
+++ b/ui/src/routes/organizations/$orgId/infrastructure-services/create/index.tsx
@@ -91,7 +91,6 @@ const CreateInfrastructureServicePage = () => {
     defaultValues: {
       name: '',
       url: '',
-      description: '',
       usernameSecretRef: '',
       passwordSecretRef: '',
       credentialsTypes: ['NETRC_FILE'],

--- a/ui/src/routes/organizations/$orgId/products/$productId/create-repository/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/create-repository/index.tsx
@@ -90,6 +90,7 @@ const CreateRepositoryPage = () => {
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
+      url: '',
       type: 'GIT',
     },
   });

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/create-secret/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/create-secret/index.tsx
@@ -83,6 +83,10 @@ const CreateRepositorySecretPage = () => {
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: '',
+      value: '',
+    },
   });
 
   async function onSubmit(values: z.infer<typeof formSchema>) {

--- a/ui/src/routes/organizations/$orgId/products/$productId/secrets/create-secret/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/secrets/create-secret/index.tsx
@@ -79,6 +79,10 @@ const CreateProductSecretPage = () => {
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: '',
+      value: '',
+    },
   });
 
   async function onSubmit(values: z.infer<typeof formSchema>) {

--- a/ui/src/routes/organizations/$orgId/secrets/create-secret/index.tsx
+++ b/ui/src/routes/organizations/$orgId/secrets/create-secret/index.tsx
@@ -81,6 +81,10 @@ const CreateOrganizationSecretPage = () => {
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
+    defaultValues: {
+      name: '',
+      value: '',
+    },
   });
 
   async function onSubmit(values: z.infer<typeof formSchema>) {


### PR DESCRIPTION
This PR gets rid of most React warnings about form components transferring from `uncontrolled` to `controlled` state by:
1. Providing default values for mandatory form fields.
2. Handling optional fields in a special way, also allowing proper `Zod` validation for optional fields, whenever user inputs something to them.

As an example of handling optional fields, the user creation form is modified accordingly. If this approach is acceptable, other forms would be fixed in a follow-up PR.

This is a more proper alternative to #1946.

Please see the commits for details.