### PR TITLE
ui: Save some user preferences to browser's local storage

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -52,7 +52,8 @@
     "react-oidc-context": "^3.0.0",
     "sonner": "^1.5.0",
     "tailwind-merge": "^3.0.0",
-    "zod": "^3.23.3"
+    "zod": "^3.23.3",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@7nohe/openapi-react-query-codegen": "^1.0.0",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -119,6 +119,9 @@ importers:
       zod:
         specifier: ^3.23.3
         version: 3.24.1
+      zustand:
+        specifier: ^5.0.3
+        version: 5.0.3(@types/react@19.0.8)(react@19.0.0)(use-sync-external-store@1.4.0(react@19.0.0))
     devDependencies:
       '@7nohe/openapi-react-query-codegen':
         specifier: ^1.0.0
@@ -3253,6 +3256,24 @@ packages:
 
   zod@3.24.1:
     resolution: {integrity: sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==}
+
+  zustand@5.0.3:
+    resolution: {integrity: sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -6391,5 +6412,11 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@3.24.1: {}
+
+  zustand@5.0.3(@types/react@19.0.8)(react@19.0.0)(use-sync-external-store@1.4.0(react@19.0.0)):
+    optionalDependencies:
+      '@types/react': 19.0.8
+      react: 19.0.0
+      use-sync-external-store: 1.4.0(react@19.0.0)
 
   zwitch@2.0.4: {}

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -44,8 +44,10 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { paginationSearchParameterSchema } from '@/schemas';
+import { useTablePrefsStore } from '@/store/table-prefs.store';
 
-const defaultPageSize = 10;
+// Fetch the default page size to loader from the store.
+const defaultPageSize = useTablePrefsStore.getState().orgPageSize;
 
 const columns: ColumnDef<Organization>[] = [
   {
@@ -71,9 +73,11 @@ const columns: ColumnDef<Organization>[] = [
 ];
 
 export const IndexPage = () => {
+  const orgPageSize = useTablePrefsStore((state) => state.orgPageSize);
+  const setOrgPageSize = useTablePrefsStore((state) => state.setOrgPageSize);
   const search = Route.useSearch();
   const pageIndex = search.page ? search.page - 1 : 0;
-  const pageSize = search.pageSize ? search.pageSize : defaultPageSize;
+  const pageSize = search.pageSize ? search.pageSize : orgPageSize;
 
   const { data } = useOrganizationsServiceGetOrganizationsSuspense({
     limit: pageSize,
@@ -127,6 +131,8 @@ export const IndexPage = () => {
             };
           }}
           setPageSizeOptions={(size) => {
+            // Persist the user preference for page size to local storage.
+            setOrgPageSize(size);
             return {
               to: Route.to,
               search: { ...search, page: 1, pageSize: size },

--- a/ui/src/routes/organizations/$orgId/-components/organization-product-table.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-product-table.tsx
@@ -34,12 +34,11 @@ import { DataTable } from '@/components/data-table/data-table';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { ToastError } from '@/components/toast-error';
 import { toast } from '@/lib/toast';
+import { useTablePrefsStore } from '@/store/table-prefs.store';
 import { LastJobStatus } from '../products/$productId/-components/last-job-status';
 import { LastRunDate } from '../products/$productId/-components/last-run-date';
 import { LastRunStatus } from '../products/$productId/-components/last-run-status';
 import { TotalRuns } from '../products/$productId/-components/total-runs';
-
-const defaultPageSize = 5;
 
 const columnHelper = createColumnHelper<Product>();
 
@@ -181,10 +180,11 @@ const columns = [
 const routeApi = getRouteApi('/organizations/$orgId/');
 
 export const OrganizationProductTable = () => {
+  const prodPageSize = useTablePrefsStore((state) => state.prodPageSize);
   const params = routeApi.useParams();
   const search = routeApi.useSearch();
   const pageIndex = search.page ? search.page - 1 : 0;
-  const pageSize = search.pageSize ? search.pageSize : defaultPageSize;
+  const pageSize = search.pageSize ? search.pageSize : prodPageSize;
 
   const {
     data: products,
@@ -213,17 +213,25 @@ export const OrganizationProductTable = () => {
     return;
   }
 
-  return <OrganizationProductTableInner products={products} />;
+  return (
+    <OrganizationProductTableInner
+      products={products}
+      prodPageSize={prodPageSize}
+    />
+  );
 };
 
 const OrganizationProductTableInner = ({
   products,
+  prodPageSize,
 }: {
   products: PagedResponse_Product;
+  prodPageSize: number;
 }) => {
+  const setProdPageSize = useTablePrefsStore((state) => state.setProdPageSize);
   const search = routeApi.useSearch();
   const pageIndex = search.page ? search.page - 1 : 0;
-  const pageSize = search.pageSize ? search.pageSize : defaultPageSize;
+  const pageSize = search.pageSize ? search.pageSize : prodPageSize;
 
   const table = useReactTable({
     data: products?.data || [],
@@ -248,6 +256,7 @@ const OrganizationProductTableInner = ({
         };
       }}
       setPageSizeOptions={(size) => {
+        setProdPageSize(size);
         return {
           search: { ...search, page: 1, pageSize: size },
         };

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repository-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repository-table.tsx
@@ -30,12 +30,11 @@ import { DataTable } from '@/components/data-table/data-table';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { ToastError } from '@/components/toast-error';
 import { toast } from '@/lib/toast';
+import { useTablePrefsStore } from '@/store/table-prefs.store';
 import { LastJobStatus } from './last-job-status';
 import { LastRunDate } from './last-run-date';
 import { LastRunStatus } from './last-run-status';
 import { TotalRuns } from './total-runs';
-
-const defaultPageSize = 5;
 
 const columnHelper = createColumnHelper<Repository>();
 
@@ -112,10 +111,11 @@ const columns = [
 const routeApi = getRouteApi('/organizations/$orgId/products/$productId/');
 
 export const ProductRepositoryTable = () => {
+  const repoPageSize = useTablePrefsStore((state) => state.repoPageSize);
   const params = routeApi.useParams();
   const search = routeApi.useSearch();
   const pageIndex = search.page ? search.page - 1 : 0;
-  const pageSize = search.pageSize ? search.pageSize : defaultPageSize;
+  const pageSize = search.pageSize ? search.pageSize : repoPageSize;
 
   const {
     data: repositories,
@@ -144,17 +144,25 @@ export const ProductRepositoryTable = () => {
     return;
   }
 
-  return <ProductRepositoryTableInner repositories={repositories} />;
+  return (
+    <ProductRepositoryTableInner
+      repositories={repositories}
+      repoPageSize={repoPageSize}
+    />
+  );
 };
 
 const ProductRepositoryTableInner = ({
   repositories,
+  repoPageSize,
 }: {
   repositories: PagedResponse_Repository;
+  repoPageSize: number;
 }) => {
+  const setRepoPageSize = useTablePrefsStore((state) => state.setRepoPageSize);
   const search = routeApi.useSearch();
   const pageIndex = search.page ? search.page - 1 : 0;
-  const pageSize = search.pageSize ? search.pageSize : defaultPageSize;
+  const pageSize = search.pageSize ? search.pageSize : repoPageSize;
 
   const table = useReactTable({
     data: repositories?.data || [],
@@ -179,6 +187,7 @@ const ProductRepositoryTableInner = ({
         };
       }}
       setPageSizeOptions={(size) => {
+        setRepoPageSize(size);
         return {
           search: { ...search, page: 1, pageSize: size },
         };

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/repository-runs-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/repository-runs-table.tsx
@@ -51,6 +51,7 @@ import {
 import { config } from '@/config';
 import { getStatusBackgroundColor } from '@/helpers/get-status-class';
 import { toast } from '@/lib/toast';
+import { useTablePrefsStore } from '@/store/table-prefs.store';
 
 type RepositoryTableProps = {
   repoId: string;
@@ -241,6 +242,7 @@ export const RepositoryRunsTable = ({
   pageSize,
   search,
 }: RepositoryTableProps) => {
+  const setRunPageSize = useTablePrefsStore((state) => state.setRunPageSize);
   const {
     data: runs,
     error: runsError,
@@ -298,6 +300,7 @@ export const RepositoryRunsTable = ({
         };
       }}
       setPageSizeOptions={(size) => {
+        setRunPageSize(size);
         return {
           search: { ...search, page: 1, pageSize: size },
         };

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/runs/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/runs/index.tsx
@@ -42,15 +42,17 @@ import {
 } from '@/components/ui/tooltip';
 import { toast } from '@/lib/toast';
 import { paginationSearchParameterSchema } from '@/schemas';
+import { useTablePrefsStore } from '@/store/table-prefs.store';
 import { RepositoryRunsTable } from '../../-components/repository-runs-table';
 
-const defaultPageSize = 10;
+const defaultPageSize = useTablePrefsStore.getState().repoPageSize;
 
 const RepositoryRunsComponent = () => {
+  const runPageSize = useTablePrefsStore.getState().runPageSize;
   const params = Route.useParams();
   const search = Route.useSearch();
   const pageIndex = search.page ? search.page - 1 : 0;
-  const pageSize = search.pageSize ? search.pageSize : defaultPageSize;
+  const pageSize = search.pageSize ? search.pageSize : runPageSize;
 
   const {
     data: repo,

--- a/ui/src/store/table-prefs.store.ts
+++ b/ui/src/store/table-prefs.store.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+type State = {
+  orgPageSize: number;
+  prodPageSize: number;
+  repoPageSize: number;
+  runPageSize: number;
+};
+
+type Actions = {
+  setOrgPageSize: (pageSize: number) => void;
+  setProdPageSize: (pageSize: number) => void;
+  setRepoPageSize: (pageSize: number) => void;
+  setRunPageSize: (pageSize: number) => void;
+};
+
+export const useTablePrefsStore = create<State & Actions>()(
+  persist(
+    (set) => ({
+      orgPageSize: 10,
+      prodPageSize: 5,
+      repoPageSize: 5,
+      runPageSize: 10,
+      setOrgPageSize: (pageSize) => set({ orgPageSize: pageSize }),
+      setProdPageSize: (pageSize) => set({ prodPageSize: pageSize }),
+      setRepoPageSize: (pageSize) => set({ repoPageSize: pageSize }),
+      setRunPageSize: (pageSize) => set({ runPageSize: pageSize }),
+    }),
+    {
+      name: 'table-prefs-storage',
+      version: 1,
+    }
+  )
+);


### PR DESCRIPTION
With this PR, user's choices for the page sizes of organizations, products, repositories and ORT runs data tables are seamlessly saved and persisted to browser's local storage, to improve the UX for ORT Server UI.

Please see the commits for details.
