### PR TITLE
test(analyzer): Fix a locally failing test case

### DIFF
--- a/workers/analyzer/src/test/kotlin/AnalyzerDownloaderTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerDownloaderTest.kt
@@ -32,6 +32,10 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 
+import io.mockk.every
+import io.mockk.mockkObject
+import io.mockk.unmockkAll
+
 import java.io.IOException
 
 import org.eclipse.apoapsis.ortserver.model.SubmoduleFetchStrategy
@@ -43,6 +47,10 @@ import org.ossreviewtoolkit.plugins.api.PluginConfig
 
 class AnalyzerDownloaderTest : WordSpec({
     val downloader = AnalyzerDownloader()
+
+    afterEach {
+        unmockkAll()
+    }
 
     "downloadRepository" should {
         "not recursively clone a Git repository if recursiveCheckout is false" {
@@ -208,6 +216,9 @@ class AnalyzerDownloaderTest : WordSpec({
         }
 
         "throw an exception if the VCS type cannot be determined from the URL" {
+            mockkObject(VersionControlSystem)
+            every { VersionControlSystem.forUrl(any(), any()) } returns null
+
             shouldThrow<IllegalArgumentException> {
                 downloader.downloadRepository("https://example.com", "revision")
             }


### PR DESCRIPTION
The test case "throw an exception if the VCS type cannot be determined from the URL" was failing on local execution due to an `IOException` because of a missing local Mercurial installation. To prevent this, use mocking in this case, so that the test does not depend on the local environment.