### PR TITLE
Run some workflows only in the original repository

### DIFF
--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -11,6 +11,7 @@ concurrency:
 
 jobs:
   build:
+    if: github.repository == 'eclipse-apoapsis/ort-server'
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout Repository
@@ -51,6 +52,7 @@ jobs:
         path: website/build
 
   deploy:
+    if: github.repository == 'eclipse-apoapsis/ort-server'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ env:
 
 jobs:
   publish:
+    if: github.repository == 'eclipse-apoapsis/ort-server'
     env:
       ORT_SERVER_VERSION: ${{ inputs.tag || github.ref_name }}
     permissions:


### PR DESCRIPTION
This avoids these workflows to always fail when doing testing in a forked repository. See the commit messages for details.