### PR TITLE
fix(core): Use `OrtPrincipal` instead of `Application` for logging

### DIFF
--- a/core/src/main/kotlin/plugins/Authentication.kt
+++ b/core/src/main/kotlin/plugins/Authentication.kt
@@ -41,7 +41,7 @@ import org.koin.ktor.ext.inject
 
 import org.slf4j.LoggerFactory
 
-private val logger = LoggerFactory.getLogger(Application::class.java)
+private val logger = LoggerFactory.getLogger(OrtPrincipal::class.java)
 
 /**
  * Configure the authentication for this server application.


### PR DESCRIPTION
Change the logger in the authentication plugin to use the `OrtPrincipal` class instead of Ktor's `Application` class. This makes the debug logs visible, because the minimum log level for Ktor is set to `INFO`. Using `OrtPrincipal` makes sense because all authentication information is stored in that object.