### PR TITLE
fix(loki): Fix log level filter

### DIFF
--- a/logaccess/loki/src/main/kotlin/LokiLogFileProvider.kt
+++ b/logaccess/loki/src/main/kotlin/LokiLogFileProvider.kt
@@ -159,7 +159,7 @@ class LokiLogFileProvider(
         source: LogSource,
         levels: Set<LogLevel>
     ): String {
-        val levelCriterion = levels.joinToString("|") { it.name }
+        val levelCriterion = levels.joinToString(separator = "|", prefix = "(", postfix = ")") { it.name }
         return """{namespace="${config.namespace}",component="${source.component}"}""" +
                 """ |~ "level=$levelCriterion" |~ "ortRunId=$ortRunId""""
     }

--- a/logaccess/loki/src/test/kotlin/LokiLogFileProviderTest.kt
+++ b/logaccess/loki/src/test/kotlin/LokiLogFileProviderTest.kt
@@ -457,4 +457,4 @@ private fun LogData.isContainedInLogFile(file: File): Boolean {
  * Generate a query string for the given [source] and [log level criterion][levelCriterion].
  */
 private fun generateQuery(source: LogSource, levelCriterion: String): String =
-    """{namespace="$NAMESPACE",component="${source.component}"} |~ "level=$levelCriterion" |~ "ortRunId=$RUN_ID""""
+    """{namespace="$NAMESPACE",component="${source.component}"} |~ "level=($levelCriterion)" |~ "ortRunId=$RUN_ID""""


### PR DESCRIPTION
Surround the regular expression to match log levels with parenthesis to not include the prefix `level=` in the first option. For example, instead of `level=INFO|WARN` the expression is now `level=(INFO|WARN)`. The old expression accidentally matched all log lines containing the string `WARN`.