### PR TITLE
ui: Improve validation for item creation and editing

### DIFF
--- a/ui/src/routes/create-organization/index.tsx
+++ b/ui/src/routes/create-organization/index.tsx
@@ -25,6 +25,8 @@ import { z } from 'zod';
 
 import { useOrganizationsServicePostApiV1Organizations } from '@/api/queries';
 import { ApiError } from '@/api/requests';
+import { asOptionalField } from '@/components/form/as-optional-field';
+import { OptionalInput } from '@/components/form/optional-input';
 import { ToastError } from '@/components/toast-error';
 import { Button } from '@/components/ui/button';
 import {
@@ -45,8 +47,8 @@ import { Input } from '@/components/ui/input';
 import { toast } from '@/lib/toast';
 
 const formSchema = z.object({
-  name: z.string(),
-  description: z.string().optional(),
+  name: z.string().min(1),
+  description: asOptionalField(z.string().min(1)),
 });
 
 const CreateOrganizationPage = () => {
@@ -117,7 +119,7 @@ const CreateOrganizationPage = () => {
                 <FormItem>
                   <FormLabel>Description</FormLabel>
                   <FormControl>
-                    <Input {...field} placeholder='(optional)' />
+                    <OptionalInput {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/ui/src/routes/organizations/$orgId/create-product/index.tsx
+++ b/ui/src/routes/organizations/$orgId/create-product/index.tsx
@@ -25,6 +25,8 @@ import { z } from 'zod';
 
 import { useProductsServicePostApiV1OrganizationsByOrganizationIdProducts } from '@/api/queries';
 import { ApiError } from '@/api/requests';
+import { asOptionalField } from '@/components/form/as-optional-field';
+import { OptionalInput } from '@/components/form/optional-input';
 import { ToastError } from '@/components/toast-error';
 import { Button } from '@/components/ui/button';
 import {
@@ -46,8 +48,8 @@ import { Input } from '@/components/ui/input';
 import { toast } from '@/lib/toast';
 
 const formSchema = z.object({
-  name: z.string(),
-  description: z.string().optional(),
+  name: z.string().min(1),
+  description: asOptionalField(z.string().min(1)),
 });
 
 const CreateProductPage = () => {
@@ -122,7 +124,7 @@ const CreateProductPage = () => {
                 <FormItem>
                   <FormLabel>Description</FormLabel>
                   <FormControl>
-                    <Input {...field} placeholder='(optional)' />
+                    <OptionalInput {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/ui/src/routes/organizations/$orgId/products/$productId/create-repository/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/create-repository/index.tsx
@@ -53,7 +53,7 @@ import {
 import { toast } from '@/lib/toast';
 
 const formSchema = z.object({
-  url: z.string(),
+  url: z.string().url(),
   type: z.enum($RepositoryType.enum),
 });
 

--- a/ui/src/routes/organizations/$orgId/products/$productId/settings/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/settings/index.tsx
@@ -52,7 +52,7 @@ import { Input } from '@/components/ui/input';
 import { toast } from '@/lib/toast';
 
 const formSchema = z.object({
-  name: z.string(),
+  name: z.string().min(1),
   description: z.string().optional(),
 });
 

--- a/ui/src/routes/organizations/$orgId/settings/index.tsx
+++ b/ui/src/routes/organizations/$orgId/settings/index.tsx
@@ -52,7 +52,7 @@ import { Input } from '@/components/ui/input';
 import { toast } from '@/lib/toast';
 
 const formSchema = z.object({
-  name: z.string(),
+  name: z.string().min(1),
   description: z.string().optional(),
 });
 


### PR DESCRIPTION
PR #1963 started improving validation for some forms. This PR continues the work by 
- requiring names of organizations and products to be non-empty strings
- getting rid of the React warnings coming from the optional description fields in the organization and product create forms

Please see the commits for details.