### PR TITLE
Get projects for run

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
@@ -63,6 +63,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.PluginConfiguration as ApiPlu
 import org.eclipse.apoapsis.ortserver.api.v1.model.ProcessedDeclaredLicense as ApiProcessedDeclaredLicense
 import org.eclipse.apoapsis.ortserver.api.v1.model.Product as ApiProduct
 import org.eclipse.apoapsis.ortserver.api.v1.model.ProductVulnerability as ApiProductVulnerability
+import org.eclipse.apoapsis.ortserver.api.v1.model.Project as ApiProject
 import org.eclipse.apoapsis.ortserver.api.v1.model.ProviderPluginConfiguration as ApiProviderPluginConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.RemoteArtifact as ApiRemoteArtifact
 import org.eclipse.apoapsis.ortserver.api.v1.model.ReporterAsset as ApiReporterAsset
@@ -135,6 +136,7 @@ import org.eclipse.apoapsis.ortserver.model.runs.OrtRuleViolation
 import org.eclipse.apoapsis.ortserver.model.runs.PackageManagerConfiguration
 import org.eclipse.apoapsis.ortserver.model.runs.PackageWithShortestDependencyPaths
 import org.eclipse.apoapsis.ortserver.model.runs.ProcessedDeclaredLicense
+import org.eclipse.apoapsis.ortserver.model.runs.Project
 import org.eclipse.apoapsis.ortserver.model.runs.RemoteArtifact
 import org.eclipse.apoapsis.ortserver.model.runs.ShortestDependencyPath
 import org.eclipse.apoapsis.ortserver.model.runs.VcsInfo
@@ -796,4 +798,18 @@ fun PackageWithShortestDependencyPaths.mapToApi() = ApiPackage(
     pkg.isMetadataOnly,
     pkg.isModified,
     shortestDependencyPaths.map { it.mapToApi() }
+)
+
+fun Project.mapToApi() = ApiProject(
+    identifier.mapToApi(),
+    cpe,
+    definitionFilePath,
+    authors,
+    declaredLicenses,
+    processedDeclaredLicense.mapToApi(),
+    vcs.mapToApi(),
+    vcsProcessed.mapToApi(),
+    description,
+    homepageUrl,
+    scopeNames
 )

--- a/api/v1/model/src/commonMain/kotlin/Project.kt
+++ b/api/v1/model/src/commonMain/kotlin/Project.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.api.v1.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class Project(
+    val identifier: Identifier,
+    val cpe: String? = null,
+    val definitionFilePath: String,
+    val authors: Set<String>,
+    val declaredLicenses: Set<String>,
+    val processedDeclaredLicense: ProcessedDeclaredLicense,
+    val vcs: VcsInfo,
+    val vcsProcessed: VcsInfo,
+    val description: String,
+    val homepageUrl: String,
+    val scopeNames: Set<String>
+)

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -43,6 +43,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.PagedResponse
 import org.eclipse.apoapsis.ortserver.api.v1.model.PagedSearchResponse
 import org.eclipse.apoapsis.ortserver.api.v1.model.PagingData
 import org.eclipse.apoapsis.ortserver.api.v1.model.ProcessedDeclaredLicense
+import org.eclipse.apoapsis.ortserver.api.v1.model.Project
 import org.eclipse.apoapsis.ortserver.api.v1.model.RemoteArtifact
 import org.eclipse.apoapsis.ortserver.api.v1.model.RepositoryType
 import org.eclipse.apoapsis.ortserver.api.v1.model.RuleViolation
@@ -408,6 +409,61 @@ val getPackagesByRunId: OpenApiRoute.() -> Unit = {
                                         )
                                     )
                                 )
+                            )
+                        ),
+                        PagingData(
+                            limit = 20,
+                            offset = 0,
+                            totalCount = 1,
+                            sortProperties = listOf(SortProperty("purl", SortDirection.ASCENDING))
+                        )
+                    )
+                }
+            }
+        }
+
+        HttpStatusCode.NotFound to {
+            description = "The ORT run does not exist."
+        }
+    }
+}
+
+val getProjectsByRunId: OpenApiRoute.() -> Unit = {
+    operationId = "GetProjectsByRunId"
+    summary = "Get the projects found in an ORT run."
+    tags = listOf("Projects")
+
+    request {
+        pathParameter<Long>("runId") {
+            description = "The ID of the ORT run."
+        }
+
+        standardListQueryParameters()
+    }
+
+    response {
+        HttpStatusCode.OK to {
+            description = "Success."
+            jsonBody<PagedResponse<Project>> {
+                example("Get project for an ORT run") {
+                    value = PagedResponse(
+                        listOf(
+                            Project(
+                                identifier = Identifier("Maven", "org.namespace", "name", "1.0"),
+                                cpe = null,
+                                definitionFilePath = "path/to/definition",
+                                authors = setOf("author1", "author2"),
+                                declaredLicenses = setOf("license1", "license2"),
+                                processedDeclaredLicense = ProcessedDeclaredLicense(
+                                    spdxExpression = "Expression",
+                                    mappedLicenses = emptyMap(),
+                                    unmappedLicenses = emptySet()
+                                ),
+                                vcs = VcsInfo(RepositoryType.GIT.name, "url", "revision", "path"),
+                                vcsProcessed = VcsInfo(RepositoryType.GIT.name, "url", "revision", "path"),
+                                description = "A description",
+                                homepageUrl = "https://example.com/namespace/name",
+                                scopeNames = setOf("scope1", "scope2")
                             )
                         ),
                         PagingData(

--- a/core/src/main/kotlin/di/Module.kt
+++ b/core/src/main/kotlin/di/Module.kt
@@ -70,6 +70,7 @@ import org.eclipse.apoapsis.ortserver.services.OrganizationService
 import org.eclipse.apoapsis.ortserver.services.OrtRunService
 import org.eclipse.apoapsis.ortserver.services.PackageService
 import org.eclipse.apoapsis.ortserver.services.ProductService
+import org.eclipse.apoapsis.ortserver.services.ProjectService
 import org.eclipse.apoapsis.ortserver.services.ReportStorageService
 import org.eclipse.apoapsis.ortserver.services.RepositoryService
 import org.eclipse.apoapsis.ortserver.services.RuleViolationService
@@ -131,6 +132,7 @@ fun ortServerModule(config: ApplicationConfig) = module {
     single { IssueService(get()) }
     single { RuleViolationService(get()) }
     single { PackageService(get()) }
+    single { ProjectService(get()) }
     single { UserService(get()) }
     single { OrtRunService(get(), get(), get(), get()) }
     singleOf(::ReportStorageService)

--- a/dao/src/main/kotlin/repositories/analyzerrun/ProjectsTable.kt
+++ b/dao/src/main/kotlin/repositories/analyzerrun/ProjectsTable.kt
@@ -27,12 +27,12 @@ import org.eclipse.apoapsis.ortserver.dao.tables.shared.VcsInfoDao
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.VcsInfoTable
 import org.eclipse.apoapsis.ortserver.dao.utils.ArrayAggColumnEquals
 import org.eclipse.apoapsis.ortserver.dao.utils.ArrayAggTwoColumnsEquals
+import org.eclipse.apoapsis.ortserver.dao.utils.SortableEntityClass
+import org.eclipse.apoapsis.ortserver.dao.utils.SortableTable
 import org.eclipse.apoapsis.ortserver.model.runs.Project
 
 import org.jetbrains.exposed.dao.LongEntity
-import org.jetbrains.exposed.dao.LongEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
-import org.jetbrains.exposed.dao.id.LongIdTable
 import org.jetbrains.exposed.sql.JoinType
 import org.jetbrains.exposed.sql.alias
 import org.jetbrains.exposed.sql.andHaving
@@ -41,7 +41,8 @@ import org.jetbrains.exposed.sql.andWhere
 /**
  * A table to represent a software package as a project.
  */
-object ProjectsTable : LongIdTable("projects") {
+object ProjectsTable : SortableTable("projects") {
+    val sortableId = id.sortable()
     val identifierId = reference("identifier_id", IdentifiersTable)
     val vcsId = reference("vcs_id", VcsInfoTable)
     val vcsProcessedId = reference("vcs_processed_id", VcsInfoTable)
@@ -53,7 +54,7 @@ object ProjectsTable : LongIdTable("projects") {
 }
 
 class ProjectDao(id: EntityID<Long>) : LongEntity(id) {
-    companion object : LongEntityClass<ProjectDao>(ProjectsTable) {
+    companion object : SortableEntityClass<ProjectDao>(ProjectsTable) {
         fun findByProject(project: Project): ProjectDao? {
             val vcsProcessed = VcsInfoTable.alias("vcs_processed_info")
             val query = ProjectsTable

--- a/services/hierarchy/src/main/kotlin/ProjectService.kt
+++ b/services/hierarchy/src/main/kotlin/ProjectService.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.services
+
+import org.eclipse.apoapsis.ortserver.dao.dbQuery
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerjob.AnalyzerJobsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.AnalyzerRunsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ProjectDao
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ProjectsAnalyzerRunsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ProjectsTable
+import org.eclipse.apoapsis.ortserver.dao.utils.listCustomQuery
+import org.eclipse.apoapsis.ortserver.model.runs.Project
+import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
+import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
+
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.ResultRow
+
+/**
+ * A service to interact with projects.
+ */
+class ProjectService(private val db: Database) {
+    /**
+     * Return a list of projects for the given ORT [ortRunId] according to the given [parameters].
+     */
+    suspend fun listForOrtRunId(
+        ortRunId: Long,
+        parameters: ListQueryParameters = ListQueryParameters.DEFAULT
+    ): ListQueryResult<Project> = db.dbQuery {
+        ProjectDao.listCustomQuery(parameters, ResultRow::toProject) {
+            ProjectsTable.joinAnalyzerTables()
+                .select(ProjectsTable.columns)
+                .where { AnalyzerJobsTable.ortRunId eq ortRunId }
+        }
+    }
+}
+
+private fun ResultRow.toProject(): Project = ProjectDao.wrapRow(this).mapToModel()
+
+private fun ProjectsTable.joinAnalyzerTables() =
+    innerJoin(ProjectsAnalyzerRunsTable)
+        .innerJoin(AnalyzerRunsTable)
+        .innerJoin(AnalyzerJobsTable)

--- a/services/hierarchy/src/test/kotlin/ProjectServiceTest.kt
+++ b/services/hierarchy/src/test/kotlin/ProjectServiceTest.kt
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.services
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+import kotlinx.datetime.Clock
+
+import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
+import org.eclipse.apoapsis.ortserver.dao.test.Fixtures
+import org.eclipse.apoapsis.ortserver.model.OrtRun
+import org.eclipse.apoapsis.ortserver.model.RepositoryType
+import org.eclipse.apoapsis.ortserver.model.runs.AnalyzerConfiguration
+import org.eclipse.apoapsis.ortserver.model.runs.Environment
+import org.eclipse.apoapsis.ortserver.model.runs.Identifier
+import org.eclipse.apoapsis.ortserver.model.runs.ProcessedDeclaredLicense
+import org.eclipse.apoapsis.ortserver.model.runs.Project
+import org.eclipse.apoapsis.ortserver.model.runs.VcsInfo
+
+import org.jetbrains.exposed.sql.Database
+
+class ProjectServiceTest : WordSpec() {
+    private val dbExtension = extension(DatabaseTestExtension())
+
+    private lateinit var db: Database
+    private lateinit var fixtures: Fixtures
+
+    init {
+        beforeEach {
+            db = dbExtension.db
+            fixtures = dbExtension.fixtures
+        }
+
+        "listForOrtRunId" should {
+            "return projects for the given ORT run ID, ignoring projects from other runs" {
+                val service = ProjectService(db)
+
+                val projects1 = createProjects(
+                    listOf(
+                        Identifier("Maven", "com.example1", "project1", "1.1.5"),
+                        Identifier("Maven", "com.example2", "project2", "2.0.1"),
+                        Identifier("Maven", "com.example3", "project3", "3.5.2")
+                    )
+                )
+
+                val projects2 = createProjects(
+                    listOf(
+                        Identifier("Maven", "com.example4", "project4", "4.0.5")
+                    )
+                )
+                createAnalyzerRunWithProjects(projects2)
+
+                val ortRunId = createAnalyzerRunWithProjects(projects1).id
+
+                val results = service.listForOrtRunId(ortRunId).data
+
+                results shouldHaveSize projects1.size
+                results.map { it.identifier } shouldContainExactlyInAnyOrder projects1.map { it.identifier }
+
+                with(results.first()) {
+                    authors shouldContainExactlyInAnyOrder setOf("Author1", "Author2")
+                    declaredLicenses shouldBe setOf("Apache-2.0")
+                    identifier.type shouldBe "Maven"
+                    identifier.namespace shouldBe "com.example1"
+                    identifier.name shouldBe "project1"
+                    identifier.version shouldBe "1.1.5"
+                }
+            }
+        }
+    }
+
+    private fun createProjects(identifiers: List<Identifier>): Set<Project> =
+        identifiers.map { identifier ->
+            Project(
+                identifier = identifier,
+                definitionFilePath = "pom.xml",
+                authors = setOf("Author1", "Author2"),
+                declaredLicenses = setOf("Apache-2.0"),
+                processedDeclaredLicense = ProcessedDeclaredLicense("Apache-2.0", emptyMap(), emptySet()),
+                vcs = VcsInfo(RepositoryType.GIT, "https://example.com", "main", "v1.0.0"),
+                vcsProcessed = VcsInfo(RepositoryType.GIT, "https://example.com", "main", "v1.0.0"),
+                description = "Description",
+                homepageUrl = "https://example.com",
+                scopeNames = setOf("Compile")
+            )
+        }.toSet()
+
+    private fun createAnalyzerRunWithProjects(projects: Set<Project>): OrtRun {
+        val ortRun = fixtures.createOrtRun()
+        val analyzerJob = fixtures.createAnalyzerJob(ortRun.id)
+
+        fixtures.analyzerRunRepository.create(
+            analyzerJobId = analyzerJob.id,
+            startTime = Clock.System.now(),
+            endTime = Clock.System.now(),
+            environment = Environment(
+                ortVersion = "1.0",
+                javaVersion = "11.0.16",
+                os = "Linux",
+                processors = 8,
+                maxMemory = 8321499136,
+                variables = emptyMap(),
+                toolVersions = emptyMap()
+            ),
+            config = AnalyzerConfiguration(
+                allowDynamicVersions = true,
+                enabledPackageManagers = emptyList(),
+                disabledPackageManagers = emptyList(),
+                packageManagers = emptyMap(),
+                skipExcluded = true
+            ),
+            projects = projects,
+            packages = emptySet(),
+            issues = emptyList(),
+            dependencyGraphs = emptyMap()
+        )
+
+        return ortRun
+    }
+}


### PR DESCRIPTION
Introduce a new endpoint to retrieve the projects associated with an ORT run. 

To enable sorting on the primary key column, the helper variable `sortableId` is introduced by wrapping the default id column with the sortable() extension. This change allows the primary key to be sorted in queries just like any other column. Every other column in the table is not unique.

Resolves #1613 