### PR TITLE
build: Add Docker-Compose-based IntelliJ run configurations for debugging

### DIFF
--- a/.run/Advisor Worker.run.xml
+++ b/.run/Advisor Worker.run.xml
@@ -1,0 +1,11 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Advisor Worker" type="Remote">
+    <option name="USE_SOCKET_TRANSPORT" value="true" />
+    <option name="SERVER_MODE" value="false" />
+    <option name="SHMEM_ADDRESS" />
+    <option name="HOST" value="localhost" />
+    <option name="PORT" value="5020" />
+    <option name="AUTO_RESTART" value="false" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Analyzer Worker.run.xml
+++ b/.run/Analyzer Worker.run.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Analyzer Worker" type="Remote">
+    <option name="USE_SOCKET_TRANSPORT" value="true" />
+    <option name="SERVER_MODE" value="false" />
+    <option name="SHMEM_ADDRESS" />
+    <option name="HOST" value="localhost" />
+    <option name="PORT" value="5030" />
+    <option name="AUTO_RESTART" value="false" />
+    <RunnerSettings RunnerId="Debug">
+      <option name="DEBUG_PORT" value="5030" />
+      <option name="LOCAL" value="false" />
+    </RunnerSettings>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.run/Compose Latest.run.xml
+++ b/.run/Compose Latest.run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Compose Latest" type="docker-deploy" factoryName="docker-compose.yml" server-name="Docker">
+    <deployment type="docker-compose.yml">
+      <settings>
+        <option name="envFilePath" value="" />
+        <option name="envVars">
+          <list>
+            <DockerEnvVarImpl>
+              <option name="name" value="ORT_SERVER_IMAGE_PREFIX" />
+              <option name="value" value="" />
+            </DockerEnvVarImpl>
+            <DockerEnvVarImpl>
+              <option name="name" value="ORT_SERVER_IMAGE_TAG" />
+              <option name="value" value="latest" />
+            </DockerEnvVarImpl>
+          </list>
+        </option>
+        <option name="sourceFilePath" value="docker-compose.yml" />
+      </settings>
+    </deployment>
+    <method v="2">
+      <option name="Gradle.BeforeRunTask" enabled="true" tasks="buildAllImages" externalProjectPath="$PROJECT_DIR$" vmOptions="" scriptParameters="" />
+    </method>
+  </configuration>
+</component>

--- a/.run/Orchestrator.run.xml
+++ b/.run/Orchestrator.run.xml
@@ -1,0 +1,15 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Orchestrator" type="Remote">
+    <option name="USE_SOCKET_TRANSPORT" value="true" />
+    <option name="SERVER_MODE" value="false" />
+    <option name="SHMEM_ADDRESS" />
+    <option name="HOST" value="localhost" />
+    <option name="PORT" value="5010" />
+    <option name="AUTO_RESTART" value="false" />
+    <RunnerSettings RunnerId="Debug">
+      <option name="DEBUG_PORT" value="5010" />
+      <option name="LOCAL" value="false" />
+    </RunnerSettings>
+    <method v="2" />
+  </configuration>
+</component>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -203,6 +203,8 @@ services:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
+    ports:
+      - "5010:5010"
     environment:
       DB_URL: "jdbc:postgresql://postgres:5432"
       DB_HOST: "postgres"
@@ -266,6 +268,8 @@ services:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
+    ports:
+      - "5020:5020"
     environment:
       DB_URL: "jdbc:postgresql://postgres"
       DB_HOST: "postgres"
@@ -309,6 +313,8 @@ services:
         condition: service_healthy
       rabbitmq:
         condition: service_healthy
+    ports:
+      - "5030:5030"
     environment:
       DB_URL: "jdbc:postgresql://postgres"
       DB_HOST: "postgres"

--- a/orchestrator/build.gradle.kts
+++ b/orchestrator/build.gradle.kts
@@ -66,5 +66,9 @@ jib {
     container {
         mainClass = "org.eclipse.apoapsis.ortserver.orchestrator.EntrypointKt"
         creationTime.set("USE_CURRENT_TIMESTAMP")
+
+        if (System.getProperty("idea.active").toBoolean()) {
+            jvmFlags = listOf("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5010")
+        }
     }
 }

--- a/workers/advisor/build.gradle.kts
+++ b/workers/advisor/build.gradle.kts
@@ -79,5 +79,9 @@ jib {
     container {
         mainClass = "org.eclipse.apoapsis.ortserver.workers.advisor.EntrypointKt"
         creationTime.set("USE_CURRENT_TIMESTAMP")
+
+        if (System.getProperty("idea.active").toBoolean()) {
+            jvmFlags = listOf("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5020")
+        }
     }
 }

--- a/workers/analyzer/build.gradle.kts
+++ b/workers/analyzer/build.gradle.kts
@@ -107,5 +107,9 @@ jib {
     container {
         mainClass = "org.eclipse.apoapsis.ortserver.workers.analyzer.EntrypointKt"
         creationTime.set("USE_CURRENT_TIMESTAMP")
+
+        if (System.getProperty("idea.active").toBoolean()) {
+            jvmFlags = listOf("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5030")
+        }
     }
 }


### PR DESCRIPTION
This adds a bunch of run configurations for local development where everything, incl. the UI, is built from the latest source code. This allows to conveniently set breakpoints e.g. in the backend code, which is triggered by user actions in the frontend running on localhost.

To make this work, a developer first needs to launch the "Compose Latest" run configuration to build all Docker images locally, which will take some time. Once all containers are up, one or multiple of the remote debug configurations can be attached, depending on which Gradle modules the developer wants to be able to hit breakpoints. For now, only three modules are pre-configured: The orchestrator, the analyzer worker, and the advisor worker. Each come with their own remote debugging port configurations which needs to match between `docker-compose.yml` (where the port needs to be exposed) and the debug configuration in IntelliJ.