### PR TITLE
feat: Forward worker error messages to the orchestrator

### DIFF
--- a/kubernetes/jobmonitor/src/test/kotlin/JobWatchHelperTest.kt
+++ b/kubernetes/jobmonitor/src/test/kotlin/JobWatchHelperTest.kt
@@ -109,7 +109,7 @@ class JobWatchHelperTest : StringSpec({
                 success = false
                 bookmarkEvent
             } else {
-                throw IOException("test exception")
+                throw IOException("Test exception")
             }
         }
 

--- a/model/src/commonMain/kotlin/orchestrator/OrchestratorMessage.kt
+++ b/model/src/commonMain/kotlin/orchestrator/OrchestratorMessage.kt
@@ -24,6 +24,14 @@ import kotlinx.serialization.Serializable
 import org.eclipse.apoapsis.ortserver.model.OrtRun
 
 /**
+ * A common interface for worker errors that may provide an error message. This is used to forward original exception
+ * messages to the orchestrator to create issues with meaningful messages.
+ */
+interface WorkerErrorMessage {
+    val errorMessage: String?
+}
+
+/**
  * Base class for the hierarchy of messages that can be processed by the Orchestrator component.
  */
 @Serializable
@@ -44,8 +52,10 @@ data class ConfigWorkerResult(
 @Serializable
 data class ConfigWorkerError(
     /** The ID of the ORT run on which the worker failed. */
-    val ortRunId: Long
-) : OrchestratorMessage()
+    val ortRunId: Long,
+    /** The message of the error, if any. */
+    override val errorMessage: String? = null
+) : OrchestratorMessage(), WorkerErrorMessage
 
 /**
  * A common interface for messages that are sent by workers to the Orchestrator. The interface allows access to the
@@ -73,8 +83,10 @@ data class AnalyzerWorkerResult(
 @Serializable
 data class AnalyzerWorkerError(
     /** The ID of the Analyzer job, as it is stored in the database. */
-    override val jobId: Long
-) : OrchestratorMessage(), WorkerMessage
+    override val jobId: Long,
+    /** The message of the error, if any. */
+    override val errorMessage: String? = null
+) : OrchestratorMessage(), WorkerMessage, WorkerErrorMessage
 
 /**
  * A message notifying the Orchestrator about a result produced by the Advisor Worker.
@@ -93,8 +105,10 @@ data class AdvisorWorkerResult(
 @Serializable
 data class AdvisorWorkerError(
     /** The ID of the Advisor job, as it is stored in the database. */
-    override val jobId: Long
-) : OrchestratorMessage(), WorkerMessage
+    override val jobId: Long,
+    /** The message of the error, if any. */
+    override val errorMessage: String? = null
+) : OrchestratorMessage(), WorkerMessage, WorkerErrorMessage
 
 /**
  * A message notifying the Orchestrator about a result produced by the Scanner Worker.
@@ -113,8 +127,10 @@ data class ScannerWorkerResult(
 @Serializable
 data class ScannerWorkerError(
     /** The ID of the Scanner job, as it is stored in the database. */
-    override val jobId: Long
-) : OrchestratorMessage(), WorkerMessage
+    override val jobId: Long,
+    /** The message of the error, if any. */
+    override val errorMessage: String? = null
+) : OrchestratorMessage(), WorkerMessage, WorkerErrorMessage
 
 /**
  * A message notifying the Orchestrator about a result produced by the Evaluator Worker.
@@ -133,8 +149,10 @@ data class EvaluatorWorkerResult(
 @Serializable
 data class EvaluatorWorkerError(
     /** The ID of the Evaluator job, as it is stored in the database. */
-    override val jobId: Long
-) : OrchestratorMessage(), WorkerMessage
+    override val jobId: Long,
+    /** The message of the error, if any. */
+    override val errorMessage: String? = null
+) : OrchestratorMessage(), WorkerMessage, WorkerErrorMessage
 
 /**
  * A message notifying the Orchestrator about a result produced by the Reporter Worker.
@@ -153,8 +171,10 @@ data class ReporterWorkerResult(
 @Serializable
 data class ReporterWorkerError(
     /** The ID of the Reporter job, as it is stored in the database. */
-    override val jobId: Long
-) : OrchestratorMessage(), WorkerMessage
+    override val jobId: Long,
+    /** The message of the error, if any. */
+    override val errorMessage: String? = null
+) : OrchestratorMessage(), WorkerMessage, WorkerErrorMessage
 
 /**
  * A message notifying the Orchestrator about a result produced by the Notifier Worker.
@@ -171,8 +191,10 @@ data class NotifierWorkerResult(
 @Serializable
 data class NotifierWorkerError(
     /** The ID of the Notifier job, as it is stored in the database. */
-    override val jobId: Long
-) : OrchestratorMessage(), WorkerMessage
+    override val jobId: Long,
+    /** The message of the error, if any. */
+    override val errorMessage: String? = null
+) : OrchestratorMessage(), WorkerMessage, WorkerErrorMessage
 
 /**
  * A message notifying the Orchestrator about a new ORT run.

--- a/workers/advisor/src/main/kotlin/advisor/AdvisorComponent.kt
+++ b/workers/advisor/src/main/kotlin/advisor/AdvisorComponent.kt
@@ -71,7 +71,7 @@ class AdvisorComponent : EndpointComponent<AdvisorRequest>(AdvisorEndpoint) {
 
                 is RunResult.Failed -> {
                     logger.error("Advisor job '$advisorJobId' failed.", result.error)
-                    Message(message.header, AdvisorWorkerError(advisorJobId))
+                    Message(message.header, AdvisorWorkerError(advisorJobId, result.error.message))
                 }
 
                 is RunResult.Ignored -> null

--- a/workers/advisor/src/test/kotlin/AdvisorEndpointTest.kt
+++ b/workers/advisor/src/test/kotlin/AdvisorEndpointTest.kt
@@ -108,7 +108,7 @@ class AdvisorEndpointTest : KoinTest, StringSpec() {
 
                 val resultMessage = MessageSenderFactoryForTesting.expectMessage(OrchestratorEndpoint)
                 resultMessage.header shouldBe messageHeader
-                resultMessage.payload shouldBe AdvisorWorkerError(ADVISOR_JOB_ID)
+                resultMessage.payload shouldBe AdvisorWorkerError(ADVISOR_JOB_ID, "Test exception")
             }
         }
 

--- a/workers/analyzer/src/main/kotlin/analyzer/AnalyzerComponent.kt
+++ b/workers/analyzer/src/main/kotlin/analyzer/AnalyzerComponent.kt
@@ -64,7 +64,7 @@ class AnalyzerComponent : EndpointComponent<AnalyzerRequest>(AnalyzerEndpoint) {
 
                 is RunResult.Failed -> {
                     logger.error("Analyzer job '$jobId' failed.", result.error)
-                    Message(message.header, AnalyzerWorkerError(jobId))
+                    Message(message.header, AnalyzerWorkerError(jobId, result.error.message))
                 }
 
                 is RunResult.Ignored -> null

--- a/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
@@ -232,7 +232,7 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
 
                 val resultMessage = MessageSenderFactoryForTesting.expectMessage(OrchestratorEndpoint)
                 resultMessage.header shouldBe messageHeader
-                resultMessage.payload shouldBe AnalyzerWorkerError(JOB_ID)
+                resultMessage.payload shouldBe AnalyzerWorkerError(JOB_ID, "Test exception")
             }
         }
 

--- a/workers/config/src/main/kotlin/ConfigComponent.kt
+++ b/workers/config/src/main/kotlin/ConfigComponent.kt
@@ -55,7 +55,7 @@ class ConfigComponent : EndpointComponent<ConfigRequest>(ConfigEndpoint) {
 
             is RunResult.Failed -> {
                 logger.error("Config worker job failed for run '$runId'.", result.error)
-                ConfigWorkerError(runId)
+                ConfigWorkerError(runId, result.error.message)
             }
 
             else -> {

--- a/workers/config/src/test/kotlin/ConfigWorkerTest.kt
+++ b/workers/config/src/test/kotlin/ConfigWorkerTest.kt
@@ -154,7 +154,7 @@ class ConfigWorkerTest : StringSpec({
     "Exceptions during validation should be handled" {
         val (contextFactory, _) = mockContext()
 
-        val configException = ConfigException("test exception", null)
+        val configException = ConfigException("Test exception", null)
         val configManager = mockConfigManager()
         every { configManager.getFileAsString(any(), any()) } throws configException
 

--- a/workers/config/src/test/kotlin/EndpointTest.kt
+++ b/workers/config/src/test/kotlin/EndpointTest.kt
@@ -95,7 +95,7 @@ class EndpointTest : KoinTest, StringSpec() {
 
                 val resultMessage = MessageSenderFactoryForTesting.expectMessage(OrchestratorEndpoint)
                 resultMessage.header shouldBe messageHeader
-                resultMessage.payload shouldBe ConfigWorkerError(RUN_ID)
+                resultMessage.payload shouldBe ConfigWorkerError(RUN_ID, "Test exception")
             }
         }
     }

--- a/workers/config/src/test/kotlin/EndpointTest.kt
+++ b/workers/config/src/test/kotlin/EndpointTest.kt
@@ -88,7 +88,7 @@ class EndpointTest : KoinTest, StringSpec() {
         "A failure result should be sent back if the worker execution is not successful" {
             runEndpointTest {
                 declareMock<ConfigWorker> {
-                    coEvery { run(RUN_ID) } returns RunResult.Failed(IllegalStateException("test exception"))
+                    coEvery { run(RUN_ID) } returns RunResult.Failed(IllegalStateException("Test exception"))
                 }
 
                 sendConfigRequest()

--- a/workers/evaluator/src/main/kotlin/evaluator/EvaluatorComponent.kt
+++ b/workers/evaluator/src/main/kotlin/evaluator/EvaluatorComponent.kt
@@ -64,7 +64,7 @@ class EvaluatorComponent : EndpointComponent<EvaluatorRequest>(EvaluatorEndpoint
 
                 is RunResult.Failed -> {
                     logger.error("Evaluator job '$evaluatorJobId' failed.", result.error)
-                    Message(message.header, EvaluatorWorkerError(evaluatorJobId))
+                    Message(message.header, EvaluatorWorkerError(evaluatorJobId, result.error.message))
                 }
 
                 is RunResult.Ignored -> null

--- a/workers/evaluator/src/test/kotlin/EvaluatorEndpointTest.kt
+++ b/workers/evaluator/src/test/kotlin/EvaluatorEndpointTest.kt
@@ -97,7 +97,7 @@ class EvaluatorEndpointTest : KoinTest, StringSpec() {
 
                 val resultMessage = MessageSenderFactoryForTesting.expectMessage(OrchestratorEndpoint)
                 resultMessage.header shouldBe messageHeader
-                resultMessage.payload shouldBe EvaluatorWorkerError(EVALUATOR_JOB_ID)
+                resultMessage.payload shouldBe EvaluatorWorkerError(EVALUATOR_JOB_ID, "Test Exception")
             }
         }
 

--- a/workers/notifier/src/main/kotlin/notifier/NotifierComponent.kt
+++ b/workers/notifier/src/main/kotlin/notifier/NotifierComponent.kt
@@ -59,7 +59,7 @@ class NotifierComponent : EndpointComponent<NotifierRequest>(NotifierEndpoint) {
 
                 is RunResult.Failed -> {
                     logger.error("Notifier job '$notifierJobId' failed.", result.error)
-                    Message(message.header, NotifierWorkerError(notifierJobId))
+                    Message(message.header, NotifierWorkerError(notifierJobId, result.error.message))
                 }
 
                 is RunResult.Ignored -> null

--- a/workers/notifier/src/test/kotlin/NotifierEndpointTest.kt
+++ b/workers/notifier/src/test/kotlin/NotifierEndpointTest.kt
@@ -97,7 +97,7 @@ class NotifierEndpointTest : KoinTest, StringSpec() {
 
                 val resultMessage = MessageSenderFactoryForTesting.expectMessage(OrchestratorEndpoint)
                 resultMessage.header shouldBe messageHeader
-                resultMessage.payload shouldBe NotifierWorkerError(NOTIFIER_JOB_ID)
+                resultMessage.payload shouldBe NotifierWorkerError(NOTIFIER_JOB_ID, "Test Exception")
             }
         }
 

--- a/workers/reporter/src/main/kotlin/reporter/ReporterComponent.kt
+++ b/workers/reporter/src/main/kotlin/reporter/ReporterComponent.kt
@@ -109,7 +109,7 @@ class ReporterComponent : EndpointComponent<ReporterRequest>(ReporterEndpoint) {
 
                 is RunResult.Failed -> {
                     logger.error("Reporter job '$reporterJobId' failed.", result.error)
-                    Message(message.header, ReporterWorkerError(reporterJobId))
+                    Message(message.header, ReporterWorkerError(reporterJobId, result.error.message))
                 }
 
                 is RunResult.Ignored -> null

--- a/workers/reporter/src/test/kotlin/reporter/ReporterComponentTest.kt
+++ b/workers/reporter/src/test/kotlin/reporter/ReporterComponentTest.kt
@@ -119,7 +119,7 @@ class ReporterComponentTest : KoinTest, StringSpec() {
 
                 val resultMessage = MessageSenderFactoryForTesting.expectMessage(OrchestratorEndpoint)
                 resultMessage.header shouldBe messageHeader
-                resultMessage.payload shouldBe ReporterWorkerError(REPORTER_JOB_ID)
+                resultMessage.payload shouldBe ReporterWorkerError(REPORTER_JOB_ID, "Test Exception")
             }
         }
 

--- a/workers/reporter/src/test/kotlin/reporter/ReporterEndpointTest.kt
+++ b/workers/reporter/src/test/kotlin/reporter/ReporterEndpointTest.kt
@@ -103,7 +103,7 @@ class ReporterEndpointTest : KoinTest, StringSpec() {
 
                 val resultMessage = MessageSenderFactoryForTesting.expectMessage(OrchestratorEndpoint)
                 resultMessage.header shouldBe messageHeader
-                resultMessage.payload shouldBe ReporterWorkerError(REPORTER_JOB_ID)
+                resultMessage.payload shouldBe ReporterWorkerError(REPORTER_JOB_ID, "Test Exception")
             }
         }
 

--- a/workers/scanner/src/main/kotlin/scanner/ScannerComponent.kt
+++ b/workers/scanner/src/main/kotlin/scanner/ScannerComponent.kt
@@ -66,7 +66,7 @@ class ScannerComponent : EndpointComponent<ScannerRequest>(ScannerEndpoint) {
 
                 is RunResult.Failed -> {
                     logger.error("Scanner job '$scannerJobId' failed.", result.error)
-                    Message(message.header, ScannerWorkerError(scannerJobId))
+                    Message(message.header, ScannerWorkerError(scannerJobId, result.error.message))
                 }
 
                 is RunResult.Ignored -> null

--- a/workers/scanner/src/test/kotlin/ScannerEndpointTest.kt
+++ b/workers/scanner/src/test/kotlin/ScannerEndpointTest.kt
@@ -99,7 +99,7 @@ class ScannerEndpointTest : KoinTest, StringSpec() {
 
                 val resultMessage = MessageSenderFactoryForTesting.expectMessage(OrchestratorEndpoint)
                 resultMessage.header shouldBe messageHeader
-                resultMessage.payload shouldBe ScannerWorkerError(SCANNER_JOB_ID)
+                resultMessage.payload shouldBe ScannerWorkerError(SCANNER_JOB_ID, "Test Exception")
             }
         }
 


### PR DESCRIPTION
Previously, the orchestrator just created generic issues like "The analyzer worker failed due to an unexpected error", swallowing the message of the underyling exception that occurred in the worker.

This change adds code to forward exception messages to be able to create meaningful issue messages.

Resolves #2034.