### PR TITLE
ui: Show the shortest dependency paths

### DIFF
--- a/ui/src/components/dependency-paths.tsx
+++ b/ui/src/components/dependency-paths.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { MoveRight } from 'lucide-react';
+
+import { Identifier, Package, ShortestDependencyPath } from '@/api/requests';
+import { identifierToString } from '@/helpers/identifier-to-string';
+import { cn } from '@/lib/utils';
+
+type DependencyPathsProps = {
+  pkg: Package;
+  className?: string;
+};
+
+export const DependencyPaths = ({ pkg, className }: DependencyPathsProps) => {
+  return (
+    <div className={className}>
+      {pkg.shortestDependencyPaths.map((path, index) => (
+        <div key={index}>
+          <DependencyPath
+            shortestPath={path}
+            pkgId={pkg.identifier}
+            className='ml-2'
+          />
+        </div>
+      ))}
+    </div>
+  );
+};
+
+const DependencyPath = ({
+  shortestPath,
+  pkgId,
+  className,
+}: {
+  shortestPath: ShortestDependencyPath;
+  pkgId: Identifier;
+  className: string;
+}) => {
+  return (
+    <div className={cn('flex flex-wrap gap-x-2 align-middle', className)}>
+      <div>{identifierToString(shortestPath.projectIdentifier)}</div>
+      <div className='text-muted-foreground'>
+        (scope '{shortestPath.scope}')
+      </div>
+      {shortestPath.path.map((path, index) => (
+        <div className='flex flex-wrap gap-x-2 align-middle' key={index}>
+          <MoveRight size={20} />
+          <div>{identifierToString(path)}</div>
+        </div>
+      ))}
+      <div className='flex flex-wrap gap-x-2 align-middle'>
+        <MoveRight size={20} />
+        <div>{identifierToString(pkgId)}</div>
+      </div>
+    </div>
+  );
+};

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/index.tsx
@@ -139,7 +139,6 @@ const RunComponent = () => {
               </div>
               {ortRun.path && (
                 <div className='text-sm'>
-                  prefetchUseRepositoriesServiceGetOrtRunByIndex
                   <Label className='font-semibold'>Path:</Label> {ortRun.path}
                 </div>
               )}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
@@ -32,6 +32,7 @@ import { prefetchUseRepositoriesServiceGetApiV1RepositoriesByRepositoryIdRunsByO
 import { useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdRunsByOrtRunIndexSuspense } from '@/api/queries/suspense';
 import { Package } from '@/api/requests';
 import { DataTable } from '@/components/data-table/data-table';
+import { DependencyPaths } from '@/components/dependency-paths';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { ToastError } from '@/components/toast-error';
 import { Button } from '@/components/ui/button';
@@ -180,6 +181,12 @@ const renderSubComponent = ({ row }: { row: Row<Package> }) => {
           <div className='ml-2'>No source artifact found.</div>
         )}
       </div>
+      {pkg.shortestDependencyPaths.length > 0 && (
+        <div>
+          <div className='font-semibold'>Shortest dependency paths</div>
+          <DependencyPaths pkg={pkg} className='flex flex-col gap-2' />
+        </div>
+      )}
     </div>
   );
 };

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
@@ -123,17 +123,16 @@ const renderSubComponent = ({ row }: { row: Row<Package> }) => {
 
   return (
     <div className='flex flex-col gap-4'>
-      <div className='text-lg font-semibold'>Details</div>
-      <div className='flex flex-col gap-2'>
-        <div>
-          <div className='font-semibold'>Description</div>
-          <div className='break-all'>
-            {pkg.description || 'No description available'}
-          </div>
+      <div>
+        <div className='font-semibold'>Description</div>
+        <div className='ml-2 break-all'>
+          {pkg.description || 'No description available.'}
         </div>
-        <div>
-          <div className='font-semibold'>Repository</div>
-          <div className='ml-2'>
+      </div>
+      <div>
+        <div className='font-semibold'>Repository</div>
+        <div className='ml-2'>
+          {pkg.vcsProcessed.url && (
             <div className='flex gap-2'>
               <div className='font-semibold'>URL:</div>
               <a
@@ -145,39 +144,41 @@ const renderSubComponent = ({ row }: { row: Row<Package> }) => {
                 {pkg.vcsProcessed.url}
               </a>
             </div>
-            {pkg.vcsProcessed.type && (
-              <div className='flex gap-2'>
-                <div className='font-semibold'>Type:</div>
-                <div>{pkg.vcsProcessed.type}</div>
-              </div>
-            )}
-            {pkg.vcsProcessed.revision && (
-              <div className='flex gap-2'>
-                <div className='font-semibold'>Revision:</div>
-                <div>{pkg.vcsProcessed.revision}</div>
-              </div>
-            )}
-            {pkg.vcsProcessed.path && (
-              <div className='flex gap-2'>
-                <div className='font-semibold'>Path:</div>
-                <div>{pkg.vcsProcessed.path} </div>
-              </div>
-            )}
-          </div>
-        </div>
-        <div>
-          <div className='font-semibold'>Source Artifact</div>
-          {pkg.isMetadataOnly ? (
-            'This is a metadata-only package.'
-          ) : (
-            <a
-              href={pkg.sourceArtifact.url}
-              className='text-blue-400 hover:underline'
-            >
-              {pkg.sourceArtifact.url}
-            </a>
+          )}
+          {pkg.vcsProcessed.type && (
+            <div className='flex gap-2'>
+              <div className='font-semibold'>Type:</div>
+              <div>{pkg.vcsProcessed.type}</div>
+            </div>
+          )}
+          {pkg.vcsProcessed.revision && (
+            <div className='flex gap-2'>
+              <div className='font-semibold'>Revision:</div>
+              <div>{pkg.vcsProcessed.revision}</div>
+            </div>
+          )}
+          {pkg.vcsProcessed.path && (
+            <div className='flex gap-2'>
+              <div className='font-semibold'>Path:</div>
+              <div>{pkg.vcsProcessed.path} </div>
+            </div>
           )}
         </div>
+      </div>
+      <div>
+        <div className='font-semibold'>Source Artifact</div>
+        {pkg.isMetadataOnly ? (
+          <div className='ml-2'>This is a metadata-only package.</div>
+        ) : pkg.sourceArtifact.url.length > 0 ? (
+          <a
+            href={pkg.sourceArtifact.url}
+            className='ml-2 text-blue-400 hover:underline'
+          >
+            {pkg.sourceArtifact.url}
+          </a>
+        ) : (
+          <div className='ml-2'>No source artifact found.</div>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
This is the UI counterpart for #1882. Please note that this whole package details section will be revamped in later PRs, so this is only the initial/minimal implementation for the UI.

![Screenshot from 2025-02-20 08-38-38](https://github.com/user-attachments/assets/b4297d13-f712-4ac9-a6f3-b936ffb84684)

Question: Do we always want to show the "Shortest dependency paths" section in the package details, and notify the user in case there are none found? The most prominent reason for this being that the run is so old that the data isn't available, so the user should rerun to get the paths.

Please see the commits for details.