### PR TITLE
ui: Enable filtering the vulnerability tables with rating

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/-components/product-vulnerability-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/-components/product-vulnerability-table.tsx
@@ -32,7 +32,7 @@ import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useMemo } from 'react';
 
 import { useVulnerabilitiesServiceGetApiV1ProductsByProductIdVulnerabilitiesSuspense } from '@/api/queries/suspense';
-import { ProductVulnerability } from '@/api/requests';
+import { ProductVulnerability, VulnerabilityRating } from '@/api/requests';
 import { DataTable } from '@/components/data-table/data-table';
 import { MarkdownRenderer } from '@/components/markdown-renderer';
 import { Badge } from '@/components/ui/badge';
@@ -50,6 +50,7 @@ import { updateColumnSorting } from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-to-string';
 import { compareVulnerabilityRating } from '@/helpers/sorting-functions';
 import { ALL_ITEMS } from '@/lib/constants';
+import { vulnerabilityRatingSchema } from '@/schemas';
 
 const defaultPageSize = 10;
 
@@ -163,14 +164,17 @@ const ProductVulnerabilityTableInner = ({
     columnHelper.accessor('rating', {
       id: 'rating',
       header: 'Rating',
-      cell: ({ row }) => {
+      cell: ({ getValue }) => {
         return (
           <Badge
-            className={`${getVulnerabilityRatingBackgroundColor(row.getValue('rating'))}`}
+            className={`${getVulnerabilityRatingBackgroundColor(getValue())}`}
           >
-            {row.getValue('rating')}
+            {getValue()}
           </Badge>
         );
+      },
+      filterFn: (row, _columnId, filterValue): boolean => {
+        return filterValue.includes(row.original.rating);
       },
       sortingFn: (rowA, rowB) => {
         return compareVulnerabilityRating(
@@ -178,7 +182,24 @@ const ProductVulnerabilityTableInner = ({
           rowB.getValue('rating')
         );
       },
-      enableColumnFilter: false,
+      meta: {
+        filter: {
+          filterVariant: 'select',
+          selectOptions: vulnerabilityRatingSchema.options.map((rating) => ({
+            label: rating,
+            value: rating,
+          })),
+          setSelected: (ratings: VulnerabilityRating[]) => {
+            navigate({
+              search: {
+                ...search,
+                page: 1,
+                rating: ratings.length === 0 ? undefined : ratings,
+              },
+            });
+          },
+        },
+      },
     }),
     columnHelper.accessor('repositoriesCount', {
       id: 'count',
@@ -253,13 +274,21 @@ const ProductVulnerabilityTableInner = ({
     [search.pkgId]
   );
 
+  const rating = useMemo(
+    () => (search.rating ? search.rating : undefined),
+    [search.rating]
+  );
+
   const columnFilters = useMemo(() => {
     const filters = [];
     if (packageIdentifier) {
       filters.push({ id: 'packageIdentifier', value: packageIdentifier });
     }
+    if (rating) {
+      filters.push({ id: 'rating', value: rating });
+    }
     return filters;
-  }, [packageIdentifier]);
+  }, [packageIdentifier, rating]);
 
   const sortBy = useMemo(
     () => (search.sortBy ? search.sortBy : undefined),

--- a/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/-components/product-vulnerability-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/-components/product-vulnerability-table.tsx
@@ -22,6 +22,7 @@ import {
   createColumnHelper,
   getCoreRowModel,
   getExpandedRowModel,
+  getFilteredRowModel,
   getPaginationRowModel,
   getSortedRowModel,
   Row,
@@ -53,100 +54,6 @@ import { ALL_ITEMS } from '@/lib/constants';
 const defaultPageSize = 10;
 
 const columnHelper = createColumnHelper<ProductVulnerability>();
-
-const columns = [
-  columnHelper.display({
-    id: 'moreInfo',
-    header: 'Details',
-    size: 50,
-    cell: ({ row }) => {
-      return row.getCanExpand() ? (
-        <Button
-          variant='outline'
-          size='sm'
-          {...{
-            onClick: row.getToggleExpandedHandler(),
-            style: { cursor: 'pointer' },
-          }}
-        >
-          {row.getIsExpanded() ? (
-            <ChevronUp className='h-4 w-4' />
-          ) : (
-            <ChevronDown className='h-4 w-4' />
-          )}
-        </Button>
-      ) : (
-        'No info'
-      );
-    },
-    enableSorting: false,
-    enableColumnFilter: false,
-  }),
-  columnHelper.accessor('rating', {
-    id: 'rating',
-    header: 'Rating',
-    cell: ({ row }) => {
-      return (
-        <Badge
-          className={`${getVulnerabilityRatingBackgroundColor(row.getValue('rating'))}`}
-        >
-          {row.getValue('rating')}
-        </Badge>
-      );
-    },
-    sortingFn: (rowA, rowB) => {
-      return compareVulnerabilityRating(
-        rowA.getValue('rating'),
-        rowB.getValue('rating')
-      );
-    },
-    enableColumnFilter: false,
-  }),
-  columnHelper.accessor('repositoriesCount', {
-    id: 'count',
-    header: 'Repositories',
-    cell: ({ row }) => {
-      return <div>{row.getValue('count')}</div>;
-    },
-    enableColumnFilter: false,
-  }),
-  columnHelper.accessor(
-    (vuln) => {
-      return identifierToString(vuln.identifier);
-    },
-    {
-      id: 'package',
-      header: 'Package',
-      cell: ({ row }) => {
-        return <div className='font-semibold'>{row.getValue('package')}</div>;
-      },
-      enableColumnFilter: false,
-    }
-  ),
-  columnHelper.accessor('vulnerability.externalId', {
-    id: 'externalId',
-    header: 'External ID',
-    cell: ({ row }) => (
-      <Badge className='bg-blue-300 whitespace-nowrap'>
-        {row.getValue('externalId')}
-      </Badge>
-    ),
-    enableColumnFilter: false,
-  }),
-  columnHelper.accessor('vulnerability.summary', {
-    id: 'summary',
-    header: 'Summary',
-    cell: ({ row }) => {
-      return (
-        <div className='text-muted-foreground italic'>
-          {row.getValue('summary')}
-        </div>
-      );
-    },
-    enableSorting: false,
-    enableColumnFilter: false,
-  }),
-];
 
 const renderSubComponent = ({ row }: { row: Row<ProductVulnerability> }) => {
   const vulnerability = row.original.vulnerability;
@@ -223,6 +130,110 @@ const ProductVulnerabilityTableInner = ({
   vulnerabilities: ProductVulnerability[];
 }) => {
   const search = routeApi.useSearch();
+  const navigate = routeApi.useNavigate();
+
+  const columns = [
+    columnHelper.display({
+      id: 'moreInfo',
+      header: 'Details',
+      size: 50,
+      cell: ({ row }) => {
+        return row.getCanExpand() ? (
+          <Button
+            variant='outline'
+            size='sm'
+            {...{
+              onClick: row.getToggleExpandedHandler(),
+              style: { cursor: 'pointer' },
+            }}
+          >
+            {row.getIsExpanded() ? (
+              <ChevronUp className='h-4 w-4' />
+            ) : (
+              <ChevronDown className='h-4 w-4' />
+            )}
+          </Button>
+        ) : (
+          'No info'
+        );
+      },
+      enableSorting: false,
+      enableColumnFilter: false,
+    }),
+    columnHelper.accessor('rating', {
+      id: 'rating',
+      header: 'Rating',
+      cell: ({ row }) => {
+        return (
+          <Badge
+            className={`${getVulnerabilityRatingBackgroundColor(row.getValue('rating'))}`}
+          >
+            {row.getValue('rating')}
+          </Badge>
+        );
+      },
+      sortingFn: (rowA, rowB) => {
+        return compareVulnerabilityRating(
+          rowA.getValue('rating'),
+          rowB.getValue('rating')
+        );
+      },
+      enableColumnFilter: false,
+    }),
+    columnHelper.accessor('repositoriesCount', {
+      id: 'count',
+      header: 'Repositories',
+      cell: ({ row }) => {
+        return <div>{row.getValue('count')}</div>;
+      },
+      enableColumnFilter: false,
+    }),
+    columnHelper.accessor(
+      (vuln) => {
+        return identifierToString(vuln.identifier);
+      },
+      {
+        id: 'packageIdentifier',
+        header: 'Package',
+        cell: ({ getValue }) => {
+          return <div className='font-semibold'>{getValue()}</div>;
+        },
+        meta: {
+          filter: {
+            filterVariant: 'text',
+            setFilterValue: (value: string | undefined) => {
+              navigate({
+                search: { ...search, page: 1, pkgId: value },
+              });
+            },
+          },
+        },
+      }
+    ),
+    columnHelper.accessor('vulnerability.externalId', {
+      id: 'externalId',
+      header: 'External ID',
+      cell: ({ row }) => (
+        <Badge className='bg-blue-300 whitespace-nowrap'>
+          {row.getValue('externalId')}
+        </Badge>
+      ),
+      enableColumnFilter: false,
+    }),
+    columnHelper.accessor('vulnerability.summary', {
+      id: 'summary',
+      header: 'Summary',
+      cell: ({ row }) => {
+        return (
+          <div className='text-muted-foreground italic'>
+            {row.getValue('summary')}
+          </div>
+        );
+      },
+      enableSorting: false,
+      enableColumnFilter: false,
+    }),
+  ];
 
   // All of these need to be memoized to prevent unnecessary re-renders
   // and (at least for Firefox) the browser freezing up.
@@ -237,6 +248,19 @@ const ProductVulnerabilityTableInner = ({
     [search.pageSize]
   );
 
+  const packageIdentifier = useMemo(
+    () => (search.pkgId ? search.pkgId : undefined),
+    [search.pkgId]
+  );
+
+  const columnFilters = useMemo(() => {
+    const filters = [];
+    if (packageIdentifier) {
+      filters.push({ id: 'packageIdentifier', value: packageIdentifier });
+    }
+    return filters;
+  }, [packageIdentifier]);
+
   const sortBy = useMemo(
     () => (search.sortBy ? search.sortBy : undefined),
     [search.sortBy]
@@ -250,10 +274,12 @@ const ProductVulnerabilityTableInner = ({
         pageIndex,
         pageSize,
       },
+      columnFilters,
       sorting: sortBy,
     },
     getCoreRowModel: getCoreRowModel(),
     getExpandedRowModel: getExpandedRowModel(),
+    getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getRowCanExpand: () => true,

--- a/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
@@ -33,6 +33,7 @@ import {
   packageIdentifierSearchParameterSchema,
   paginationSearchParameterSchema,
   sortingSearchParameterSchema,
+  vulnerabilityRatingSearchParameterSchema,
 } from '@/schemas';
 import { ProductVulnerabilityTable } from './-components/product-vulnerability-table';
 
@@ -72,7 +73,8 @@ export const Route = createFileRoute(
 )({
   validateSearch: paginationSearchParameterSchema
     .merge(sortingSearchParameterSchema)
-    .merge(packageIdentifierSearchParameterSchema),
+    .merge(packageIdentifierSearchParameterSchema)
+    .merge(vulnerabilityRatingSearchParameterSchema),
   loader: async ({ context, params }) => {
     await prefetchUseProductsServiceGetApiV1ProductsByProductId(
       context.queryClient,

--- a/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
@@ -30,6 +30,7 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import {
+  packageIdentifierSearchParameterSchema,
   paginationSearchParameterSchema,
   sortingSearchParameterSchema,
 } from '@/schemas';
@@ -69,9 +70,9 @@ const ProductVulnerabilitiesComponent = () => {
 export const Route = createFileRoute(
   '/organizations/$orgId/products/$productId/vulnerabilities/'
 )({
-  validateSearch: paginationSearchParameterSchema.merge(
-    sortingSearchParameterSchema
-  ),
+  validateSearch: paginationSearchParameterSchema
+    .merge(sortingSearchParameterSchema)
+    .merge(packageIdentifierSearchParameterSchema),
   loader: async ({ context, params }) => {
     await prefetchUseProductsServiceGetApiV1ProductsByProductId(
       context.queryClient,

--- a/ui/src/schemas/index.ts
+++ b/ui/src/schemas/index.ts
@@ -19,7 +19,7 @@
 
 import z from 'zod';
 
-import { OrtRunStatus, Severity } from '@/api/requests';
+import { OrtRunStatus, Severity, VulnerabilityRating } from '@/api/requests';
 
 // Enum schema for the groupId parameter of the Groups endpoints
 export const groupsSchema = z.enum(['admins', 'writers', 'readers']);
@@ -34,6 +34,11 @@ export const severitySchema: z.ZodEnum<[Severity, ...Severity[]]> = z.enum([
   'WARNING',
   'ERROR',
 ]);
+
+// Enum schema for the possible values of the advisory overall vulnerability ratings
+export const vulnerabilityRatingSchema: z.ZodEnum<
+  [VulnerabilityRating, ...VulnerabilityRating[]]
+> = z.enum(['NONE', 'LOW', 'MEDIUM', 'HIGH', 'CRITICAL']);
 
 // Enum schema and type for the possible values of the issue categories.
 export const issueCategorySchema = z.enum([
@@ -77,6 +82,10 @@ export const packageIdentifierSearchParameterSchema = z.object({
 
 export const issueCategorySearchParameterSchema = z.object({
   category: z.array(issueCategorySchema).optional(),
+});
+
+export const vulnerabilityRatingSearchParameterSchema = z.object({
+  rating: z.array(vulnerabilityRatingSchema).optional(),
 });
 
 // This schema is used to validate the search parameter for the items marked for inspection


### PR DESCRIPTION
Also add filtering by the package ID to product vulnerability table, which was accidentally omitted from #2049.

![Screenshot from 2025-02-20 11-53-57](https://github.com/user-attachments/assets/96ac4b2c-ff2b-4d95-8e3c-664891ad4e4e)

Please see the commits for details.