### PR TITLE
feat(ui): Use "Package ID" for package identifiers

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues/index.tsx
@@ -213,7 +213,7 @@ const IssuesComponent = () => {
       },
       {
         id: 'packageIdentifier',
-        header: 'Package',
+        header: 'Package ID',
         cell: ({ getValue }) => {
           return <div className='font-semibold'>{getValue()}</div>;
         },

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
@@ -159,7 +159,7 @@ const RuleViolationsComponent = () => {
       },
       {
         id: 'packageIdentifier',
-        header: 'Package',
+        header: 'Package ID',
         cell: ({ getValue }) => {
           return <div className='font-semibold'>{getValue()}</div>;
         },

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
@@ -207,7 +207,7 @@ const VulnerabilitiesComponent = () => {
       },
       {
         id: 'packageIdentifier',
-        header: 'Package',
+        header: 'Package ID',
         cell: ({ getValue }) => {
           return <div className='font-semibold'>{getValue()}</div>;
         },

--- a/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/-components/product-vulnerability-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/-components/product-vulnerability-table.tsx
@@ -215,7 +215,7 @@ const ProductVulnerabilityTableInner = ({
       },
       {
         id: 'packageIdentifier',
-        header: 'Package',
+        header: 'Package ID',
         cell: ({ getValue }) => {
           return <div className='font-semibold'>{getValue()}</div>;
         },


### PR DESCRIPTION
As per Double Open's team decision, use "Package ID" consistently in  every place where package's identifier information is shown. This is more descriptive than a mere "Package", because we are showing identifying information for the package rather than the whole package's representation.