### PR TITLE
ui: Show number of items matching filters in the title of run results table pages

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues/index.tsx
@@ -353,11 +353,16 @@ const IssuesComponent = () => {
     });
     return;
   }
+  const filtersInUse = table.getState().columnFilters.length > 0;
+  const matching = `, ${table.getPrePaginationRowModel().rows.length} matching filters`;
 
   return (
     <Card className='h-fit'>
       <CardHeader>
-        <CardTitle>Issues ({issues.pagination.totalCount} in total)</CardTitle>
+        <CardTitle>
+          Issues ({issues.pagination.totalCount} in total
+          {filtersInUse && matching})
+        </CardTitle>
         <CardDescription>
           This view shows any technical issues that were discovered by the
           respective source. As technical issues might have an impact on the

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
@@ -256,12 +256,15 @@ const RuleViolationsComponent = () => {
     getSortedRowModel: getSortedRowModel(),
     getRowCanExpand: () => true,
   });
+  const filtersInUse = table.getState().columnFilters.length > 0;
+  const matching = `, ${table.getPrePaginationRowModel().rows.length} matching filters`;
 
   return (
     <Card className='h-fit'>
       <CardHeader>
         <CardTitle>
-          Rule violations ({ruleViolations.pagination.totalCount} in total)
+          Rule violations ({ruleViolations.pagination.totalCount} in total
+          {filtersInUse && matching})
         </CardTitle>
         <CardDescription>
           This view shows all violations that go against the rules defined in

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
@@ -344,12 +344,15 @@ const VulnerabilitiesComponent = () => {
     });
     return;
   }
+  const filtersInUse = table.getState().columnFilters.length > 0;
+  const matching = `, ${table.getPrePaginationRowModel().rows.length} matching filters`;
 
   return (
     <Card className='h-fit'>
       <CardHeader>
         <CardTitle>
-          Vulnerabilities ({vulnerabilities.pagination.totalCount} in total)
+          Vulnerabilities ({vulnerabilities.pagination.totalCount} in total
+          {filtersInUse && matching})
         </CardTitle>
         <CardDescription>
           This view shows the vulnerabilities found in any of the packages used


### PR DESCRIPTION
Please see the commits for details.

![Screenshot from 2025-02-20 16-22-19](https://github.com/user-attachments/assets/e23d9a7d-2e05-4b60-9585-310fa7df5d3d)

Please note that the products vulnerability table's component structure is different than the ORT result's item tables, and needs to be handled differently, which will be done in a follow-up PR.