### PR TITLE
chore(dev): Share the default Apache-2.0 license header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,12 @@
-/.idea/
 /.kotlin/
 .gradle/
 build/
 out/
 /*.iml
+
+# Intellij IDEA
+/.idea/*
+!.idea/copyright/
 
 # Kotest temporary directory
 .kotest/

--- a/.idea/copyright/Apache_2_0_ORT_Server.xml
+++ b/.idea/copyright/Apache_2_0_ORT_Server.xml
@@ -1,0 +1,6 @@
+<component name="CopyrightManager">
+  <copyright>
+    <option name="notice" value="Copyright (C) &amp;#36;today.year The ORT Server Authors (See &lt;https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE&gt;)&#10;&#10;Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);&#10;you may not use this file except in compliance with the License.&#10;You may obtain a copy of the License at&#10;&#10;    https://www.apache.org/licenses/LICENSE-2.0&#10;&#10;Unless required by applicable law or agreed to in writing, software&#10;distributed under the License is distributed on an &quot;AS IS&quot; BASIS,&#10;WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.&#10;See the License for the specific language governing permissions and&#10;limitations under the License.&#10;&#10;SPDX-License-Identifier: Apache-2.0&#10;License-Filename: LICENSE" />
+    <option name="myName" value="Apache-2.0-ORT-Server" />
+  </copyright>
+</component>

--- a/.idea/copyright/profiles_settings.xml
+++ b/.idea/copyright/profiles_settings.xml
@@ -1,0 +1,3 @@
+<component name="CopyrightManager">
+  <settings default="Apache-2.0-ORT-Server" />
+</component>

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -36,6 +36,11 @@ SPDX-FileCopyrightText = "2024 The ORT Server Authors (See <https://github.com/e
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
+path = ".idea/copyright/*"
+SPDX-FileCopyrightText = "2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
+SPDX-License-Identifier = "Apache-2.0"
+
+[[annotations]]
 path = ".mailmap"
 SPDX-FileCopyrightText = "2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)"
 SPDX-License-Identifier = "Apache-2.0"


### PR DESCRIPTION
Define and configure Apache-2.0 with ORT Server Authors' copyright as the default copyright header in IntelliJ IDEA.