### PR TITLE
CLI: Store some contextual information for easier usage

### DIFF
--- a/cli/src/commonMain/kotlin/ContextStorage.kt
+++ b/cli/src/commonMain/kotlin/ContextStorage.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.cli
+
+import com.charleskorn.kaml.Yaml
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+
+import org.eclipse.apoapsis.ortserver.cli.utils.configDir
+import org.eclipse.apoapsis.ortserver.cli.utils.exists
+import org.eclipse.apoapsis.ortserver.cli.utils.toSource
+import org.eclipse.apoapsis.ortserver.cli.utils.write
+
+private const val CONTEXT_FILE_NAME = "context.yml"
+
+/**
+ * Data class to store contextual information about the CLI's current state.
+ */
+@Serializable
+internal data class ContextData(
+    val run: RunData? = null,
+)
+
+/**
+ * Data class to store contextual information about ORT runs.
+ */
+@Serializable
+internal data class RunData(
+    /* The ID of the latest run started by the CLI. */
+    val latestId: Long? = null
+)
+
+/**
+ * Object to manage the storage and retrieval of contextual information.
+ */
+internal object ContextStorage {
+    private val contextFile = configDir.resolve(CONTEXT_FILE_NAME)
+    private var storage: ContextData = ContextData()
+    private var yaml = Yaml()
+
+    init {
+        if (contextFile.exists()) {
+            storage = yaml.decodeFromSource(contextFile.toSource())
+        }
+    }
+
+    fun get() = storage
+
+    fun saveLatestRunId(runId: Long) {
+        val runData = storage.run ?: RunData()
+
+        saveContext(storage.copy(run = runData.copy(latestId = runId)))
+    }
+
+    private fun saveContext(context: ContextData) {
+        storage = context
+
+        saveToFile()
+    }
+
+    private fun saveToFile() = contextFile.write(yaml.encodeToString(storage))
+}

--- a/cli/src/commonMain/kotlin/Extensions.kt
+++ b/cli/src/commonMain/kotlin/Extensions.kt
@@ -19,6 +19,9 @@
 
 package org.eclipse.apoapsis.ortserver.cli
 
+import com.github.ajalt.clikt.parameters.options.NullableOption
+import com.github.ajalt.clikt.parameters.options.transformAll
+
 import org.eclipse.apoapsis.ortserver.cli.utils.getHomeDirectory
 
 /**
@@ -41,3 +44,9 @@ fun String.expandTilde() =
     } else {
         this
     }
+
+/**
+ * If no option is given, fall back to the [fallback] value, return null if the [fallback] is null.
+ */
+fun <EachT : Any, ValueT> NullableOption<EachT, ValueT>.withFallback(fallback: EachT?): NullableOption<EachT, ValueT> =
+    transformAll { it.lastOrNull() ?: fallback }

--- a/cli/src/commonMain/kotlin/InfoCommand.kt
+++ b/cli/src/commonMain/kotlin/InfoCommand.kt
@@ -38,6 +38,7 @@ class InfoCommand : SuspendingCliktCommand(name = "info") {
         envvar = "OSC_RUN_ID",
         help = "The ID of the ORT run."
     ).long()
+        .withFallback(ContextStorage.get().run?.latestId)
 
     private val ortRunByIndex by OrtRunByIndexOptions().cooccurring()
 

--- a/cli/src/commonMain/kotlin/LogsCommand.kt
+++ b/cli/src/commonMain/kotlin/LogsCommand.kt
@@ -52,6 +52,7 @@ class LogsCommand : SuspendingCliktCommand() {
         envvar = "OSC_RUN_ID",
         help = "The ID of the ORT run."
     ).long()
+        .withFallback(ContextStorage.get().run?.latestId)
 
     private val ortRunByIndex by OrtRunByIndexOptions().cooccurring()
 

--- a/cli/src/commonMain/kotlin/ReportsCommand.kt
+++ b/cli/src/commonMain/kotlin/ReportsCommand.kt
@@ -46,8 +46,9 @@ class ReportsCommand : SuspendingCliktCommand(name = "reports") {
     private val runId by option(
         "--run-id",
         envvar = "OSC_RUN_ID",
-        help = "The ID of the ORT run."
+        help = "The ID of the ORT run, or the latest one started via $COMMAND_NAME."
     ).long()
+        .withFallback(ContextStorage.get().run?.latestId)
 
     private val ortRunByIndex by OrtRunByIndexOptions().cooccurring()
 

--- a/cli/src/commonMain/kotlin/StartCommand.kt
+++ b/cli/src/commonMain/kotlin/StartCommand.kt
@@ -83,6 +83,8 @@ class StartCommand : SuspendingCliktCommand(name = "start") {
             ortRun = createOrtRun
         )
 
+        ContextStorage.saveLatestRunId(ortRun.id)
+
         echo(json.encodeToString(ortRun))
 
         if (wait) {


### PR DESCRIPTION
Before this change, when running in a CI/CD environment, the `osc` user has to use `jq` or similar tools to store the ORT Run ID if they want to be able to e.g. retrieve the reports after the run succeeded.

Remove this requirement, by storing the run ID started by the CLI, in a context file, which is then used in subsequent commands.