### PR TITLE
fix(workers): Add system utils as default imports for validation script

### DIFF
--- a/workers/config/src/main/kotlin/ValidationScriptTemplate.kt
+++ b/workers/config/src/main/kotlin/ValidationScriptTemplate.kt
@@ -56,6 +56,7 @@ class ValidationScriptCompilationConfiguration : ScriptCompilationConfiguration(
         defaultImports(
             "org.eclipse.apoapsis.ortserver.model.*",
             "org.eclipse.apoapsis.ortserver.model.runs.*",
+            "org.eclipse.apoapsis.ortserver.utils.system.*",
             "org.eclipse.apoapsis.ortserver.workers.config.*"
         )
     }


### PR DESCRIPTION
In [1] `ORT_SERVER_VERSION` was moved from the `model` module to a new systems utils module. As `model` was imported before, add the new location to the default imports of the validation script as well.

[1]: https://github.com/eclipse-apoapsis/ort-server/commit/a0a86