### PR TITLE
Revert "fix(ui): Make the favicon path relative"

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -21,7 +21,7 @@ License-Filename: LICENSE
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ORT Server</title>
   </head>


### PR DESCRIPTION
This reverts commit 40fe0e16f7438c6926f257ad07199563b95a428e.

The fix only worked when loading the root URL of the UI, not when loading it from any subpath like `organizations/1`. Revert the change to make the favicon at least work consistently when the UI is not deployed to a subpath.

Relates to #1916.