### PR TITLE
fix(api): Additionally return Scanner issues for ORT runs

### DIFF
--- a/services/hierarchy/src/main/kotlin/IssueService.kt
+++ b/services/hierarchy/src/main/kotlin/IssueService.kt
@@ -21,12 +21,18 @@ package org.eclipse.apoapsis.ortserver.services
 
 import org.eclipse.apoapsis.ortserver.dao.QueryParametersException
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
+import org.eclipse.apoapsis.ortserver.dao.repositories.scannerjob.ScannerJobsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsScanResultsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsTable
+import org.eclipse.apoapsis.ortserver.dao.tables.ScanResultsTable
+import org.eclipse.apoapsis.ortserver.dao.tables.ScanSummariesIssuesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IssueDao
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IssuesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.OrtRunsIssuesTable
 import org.eclipse.apoapsis.ortserver.model.CountByCategory
 import org.eclipse.apoapsis.ortserver.model.Severity
+import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
@@ -34,12 +40,14 @@ import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
 import org.eclipse.apoapsis.ortserver.model.util.OrderDirection.DESCENDING
 import org.eclipse.apoapsis.ortserver.model.util.OrderField
 
-import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.Count
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.JoinType
+import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.Query
 import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.alias
+import org.jetbrains.exposed.sql.count
 import org.jetbrains.exposed.sql.innerJoin
 
 /**
@@ -51,7 +59,12 @@ class IssueService(private val db: Database) {
         parameters: ListQueryParameters = ListQueryParameters.DEFAULT
     ): ListQueryResult<Issue> = db.dbQuery {
         val ortRunIssuesQuery = createOrtRunIssuesQuery(ortRunId)
-        val totalCount = ortRunIssuesQuery.count()
+        val scanSummaryIssuesQuery = createScanSummaryIssuesQuery(ortRunId)
+
+        val totalCount = ortRunIssuesQuery.count() + scanSummaryIssuesQuery.count()
+        val totalIssues =
+            IssueDao.createFromQuery(ortRunIssuesQuery) +
+            IssueDao.createFromQuery(scanSummaryIssuesQuery)
 
         // There always has to be some sort order defined, else the rows would be returned in random order
         // and tests that rely on a deterministic order would fail.
@@ -59,22 +72,8 @@ class IssueService(private val db: Database) {
             listOf(OrderField("timestamp", DESCENDING))
         }
 
-        // For sorting we need to find the corresponding columns in the query.
-        // TODO: Find a mechanism that does not rely on the internal names of table columns.
-        val sortColumns = ortRunIssuesQuery.set.fields.mapNotNull { it as? Column }.associateBy { it.name }
-        val orders = sortFields.map { sortField ->
-            val column = sortColumns[sortField.name]
-                ?: throw QueryParametersException("Field for sorting not found in query alias: '${sortField.name}'.")
-            column to sortField.direction.toSortOrder()
-        }.toTypedArray()
-
-        val orderedQuery = ortRunIssuesQuery.orderBy(*orders)
-
-        val paginatedQuery = parameters.limit?.let { orderedQuery.limit(it).offset(parameters.offset ?: 0) }
-            ?: orderedQuery
-
         ListQueryResult(
-            IssueDao.createFromQuery(paginatedQuery),
+            totalIssues.sort(sortFields).paginate(parameters),
             parameters,
             totalCount
         )
@@ -82,14 +81,23 @@ class IssueService(private val db: Database) {
 
     /** Count issues found in provided ORT runs. */
     suspend fun countForOrtRunIds(vararg ortRunIds: Long): Long = db.dbQuery {
-        OrtRunsIssuesTable
+        val cntOrtRunsIssues = OrtRunsIssuesTable
             .select(OrtRunsIssuesTable.id)
             .where { OrtRunsIssuesTable.ortRunId inList ortRunIds.asList() }
             .count()
+
+        val cntScanSummariesIssues = createScanSummaryIssuesJoin()
+            .select(ScanSummariesIssuesTable.id)
+            .where { ScannerJobsTable.ortRunId inList ortRunIds.asList() }
+            .count()
+
+        cntOrtRunsIssues + cntScanSummariesIssues
     }
 
-    /** Count issues by severity for provided ORT runs. */
-    suspend fun countBySeverityForOrtRunIds(vararg ortRunIds: Long): CountByCategory<Severity> = db.dbQuery {
+    /**
+     * Count issues by severity for provided ORT runs, based on the [OrtRunsIssuesTable].
+     */
+    private suspend fun countOrtRunsIssuesBySeverity(vararg ortRunIds: Long): CountByCategory<Severity> = db.dbQuery {
         val countAlias = Count(OrtRunsIssuesTable.id, true)
 
         val severityToCountMap = Severity.entries.associateWithTo(mutableMapOf()) { 0L }
@@ -104,6 +112,42 @@ class IssueService(private val db: Database) {
             }
 
         CountByCategory(severityToCountMap)
+    }
+
+    /**
+     * Count issues by severity for provided ORT runs, based on the [ScanSummariesIssuesTable].
+     */
+    private suspend fun countScanSummariesIssuesBySeverity(vararg ortRunIds: Long): CountByCategory<Severity> =
+        db.dbQuery {
+            val countAlias = Count(ScanSummariesIssuesTable.id, true)
+
+            val severityToCountMap = Severity.entries.associateWithTo(mutableMapOf()) { 0L }
+
+            createScanSummaryIssuesJoin()
+                .select(IssuesTable.severity, countAlias)
+                .where { ScannerJobsTable.ortRunId inList ortRunIds.asList() }
+                .groupBy(IssuesTable.severity)
+                .map { row ->
+                    severityToCountMap.put(row[IssuesTable.severity], row[countAlias])
+                }
+
+            CountByCategory(severityToCountMap)
+        }
+
+    /**
+     * Count overall issues by severity for provided ORT runs.
+     */
+    suspend fun countBySeverityForOrtRunIds(vararg ortRunIds: Long): CountByCategory<Severity> {
+        val countByCategoryForOrtRunsIssues = countOrtRunsIssuesBySeverity(*ortRunIds)
+        val countByCategoryForScanSummariesIssues = countScanSummariesIssuesBySeverity(*ortRunIds)
+
+        val mergedSeverityCounts = countByCategoryForOrtRunsIssues.map.toMutableMap()
+
+        countByCategoryForScanSummariesIssues.map.forEach { (severity, count) ->
+            mergedSeverityCounts[severity] = mergedSeverityCounts.getOrDefault(severity, 0L) + count
+        }
+
+        return CountByCategory(mergedSeverityCounts)
     }
 
     private fun createOrtRunIssuesQuery(ortRunId: Long): Query {
@@ -123,7 +167,37 @@ class IssueService(private val db: Database) {
             OrtRunsIssuesTable.worker
         ).where { OrtRunsIssuesTable.ortRunId eq ortRunId }
     }
-}
+
+    /**
+     * Create a [Join][org.jetbrains.exposed.sql.Join] relation to get the issues from the scan summaries.
+     */
+    private fun createScanSummaryIssuesJoin() =
+        ScannerJobsTable
+            .innerJoin(ScannerRunsTable, { ScannerJobsTable.id }, { scannerJobId })
+            .innerJoin(ScannerRunsScanResultsTable, { ScannerRunsTable.id }, { scannerRunId })
+            .innerJoin(ScanResultsTable, { ScannerRunsScanResultsTable.scanResultId }, { ScanResultsTable.id })
+            .innerJoin(ScanSummariesIssuesTable, { ScanResultsTable.id }, { scanSummaryId })
+            .innerJoin(IssuesTable, { ScanSummariesIssuesTable.issueId }, { IssuesTable.id })
+
+    /**
+     * Create a [Query] to get the issues from the scan summaries. In order to be able to directly merge the results
+     * to the issues return of the query created by [createOrtRunIssuesQuery], the columns have to be the same,
+     * and for this reason some colum values are set to NULL.
+     */
+    private fun createScanSummaryIssuesQuery(ortRunId: Long) =
+        createScanSummaryIssuesJoin().select(
+            ScanSummariesIssuesTable.timestamp,
+            IssuesTable.issueSource,
+            IssuesTable.message,
+            IssuesTable.severity,
+            IssuesTable.affectedPath,
+            Op.nullOp<Unit>().alias("identifier_type"),
+            Op.nullOp<Unit>().alias("identifier_name"),
+            Op.nullOp<Unit>().alias("identifier_namespace"),
+            Op.nullOp<Unit>().alias("identifier_version"),
+            Op.nullOp<Unit>().alias("worker")
+        ).where { ScannerJobsTable.ortRunId eq ortRunId }
+    }
 
 /**
  * Convert this [OrderDirection] constant to the corresponding [SortOrder].
@@ -133,3 +207,44 @@ fun OrderDirection.toSortOrder(): SortOrder =
         OrderDirection.ASCENDING -> SortOrder.ASC
         OrderDirection.DESCENDING -> SortOrder.DESC
     }
+
+internal fun Identifier.toConcatenatedString() = "$type $namespace $name $version"
+
+/**
+ * Sort the list of issues by the given [sortFields], also using the hash code of the issue as a second sort criterion
+ * to get a stable sort order. Although the API supports to have more than one sort order field, this implementation
+ * only supports a single sort field.
+ */
+internal fun List<Issue>.sort(sortFields: List<OrderField>): List<Issue> {
+    require(sortFields.isNotEmpty()) {
+        "At least one sort field must be defined."
+    }
+
+    // Explicitly only support a single sort field
+    val sortField = sortFields.first()
+
+    when (sortField.name) {
+        "timestamp" -> compareBy<Issue> { it.timestamp }
+        "source" -> compareBy<Issue> { it.source }
+        "message" -> compareBy<Issue> { it.message }
+        "severity" -> compareBy<Issue> { it.severity }
+        "affectedPath" -> compareBy<Issue> { it.affectedPath }
+        "identifier" -> compareBy<Issue> { it.identifier?.toConcatenatedString() }
+        "worker" -> compareBy<Issue> { it.worker }
+        else -> throw QueryParametersException("Unknown sort field '${sortField.name}'.")
+    }.let {
+        sortedWith(it.thenBy { issue -> issue.hashCode() })
+    }.let {
+        return if (sortField.direction == DESCENDING) it.reversed() else it
+    }
+}
+
+/**
+ * Paginate the list of issues by the given [parameters].
+ */
+internal fun List<Issue>.paginate(parameters: ListQueryParameters): List<Issue> {
+    val offset = parameters.offset ?: 0L
+    val limit = parameters.limit ?: ListQueryParameters.DEFAULT_LIMIT
+
+    return drop(offset.toInt()).take(limit)
+}

--- a/services/hierarchy/src/test/kotlin/IssueServiceTest.kt
+++ b/services/hierarchy/src/test/kotlin/IssueServiceTest.kt
@@ -23,6 +23,8 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 
+import kotlin.time.Duration.Companion.seconds
+
 import kotlinx.datetime.Clock
 
 import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
@@ -31,7 +33,9 @@ import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.Severity
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
+import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
+import org.eclipse.apoapsis.ortserver.model.util.OrderField
 import org.eclipse.apoapsis.ortserver.model.util.asPresent
 
 import org.jetbrains.exposed.sql.Database
@@ -64,7 +68,7 @@ class IssueServiceTest : WordSpec() {
                 val service = IssueService(db)
                 val ortRun = createOrtRunWithIssues()
 
-                service.countForOrtRunIds(ortRun.id) shouldBe 3
+                service.countForOrtRunIds(ortRun.id) shouldBe 4
             }
 
             "return count of issues found in ORT runs" {
@@ -87,7 +91,7 @@ class IssueServiceTest : WordSpec() {
                     )
                 ).id
 
-                service.countForOrtRunIds(ortRun1Id, ortRun2Id) shouldBe 7
+                service.countForOrtRunIds(ortRun1Id, ortRun2Id) shouldBe 9
             }
         }
 
@@ -129,7 +133,7 @@ class IssueServiceTest : WordSpec() {
                 severitiesToCounts.map.keys shouldContainExactlyInAnyOrder Severity.entries
                 severitiesToCounts.getCount(Severity.HINT) shouldBe 1
                 severitiesToCounts.getCount(Severity.WARNING) shouldBe 3
-                severitiesToCounts.getCount(Severity.ERROR) shouldBe 4
+                severitiesToCounts.getCount(Severity.ERROR) shouldBe 6
             }
 
             "return counts by severity that sum up to the count returned by countForOrtRunIds" {
@@ -169,6 +173,115 @@ class IssueServiceTest : WordSpec() {
                 severitiesToCounts.map.values.sum() shouldBe 0
             }
         }
+
+        "List<Issue>.sort" should {
+            "sort issues by timestamp in ascending order" {
+                val issues = generateIssues()
+
+                val sortedIssues = issues.sort(listOf(OrderField("timestamp", OrderDirection.ASCENDING)))
+
+                sortedIssues shouldBe issues.sortedWith(compareBy<Issue> { it.timestamp }.thenBy { it.hashCode() })
+            }
+
+            "sort issues by timestamp in descending order" {
+                val issues = generateIssues()
+
+                val sortedIssues = issues.sort(listOf(OrderField("timestamp", OrderDirection.DESCENDING)))
+
+                sortedIssues shouldBe issues.sortedWith(
+                    compareBy<Issue> { it.timestamp }.thenBy { it.hashCode() }
+                ).reversed()
+            }
+
+            "sort issues by severity in ascending order" {
+                val issues = generateIssues()
+
+                val sortedIssues = issues.sort(listOf(OrderField("severity", OrderDirection.ASCENDING)))
+
+                sortedIssues shouldBe issues.sortedWith(compareBy<Issue> { it.severity }.thenBy { it.hashCode() })
+            }
+
+            "sort issues by severity in descending order" {
+                val issues = generateIssues()
+
+                val sortedIssues = issues.sort(listOf(OrderField("severity", OrderDirection.DESCENDING)))
+
+                sortedIssues shouldBe issues.sortedWith(
+                    compareBy<Issue> { it.severity }.thenBy { it.hashCode() }
+                ).reversed()
+            }
+
+            "sort issues by identifier in ascending order" {
+                val issues = generateIssues()
+
+                val sortedIssues = issues.sort(listOf(OrderField("identifier", OrderDirection.ASCENDING)))
+
+                sortedIssues shouldBe issues.sortedWith(
+                    compareBy<Issue> { it.identifier?.toConcatenatedString() }.thenBy { it.hashCode() }
+                )
+            }
+
+            "sort issues by identifier in descending order" {
+                val issues = generateIssues()
+
+                val sortedIssues = issues.sort(listOf(OrderField("identifier", OrderDirection.DESCENDING)))
+
+                sortedIssues shouldBe issues.sortedWith(
+                    compareBy<Issue> { it.identifier?.toConcatenatedString() }.thenBy { it.hashCode() }
+                ).reversed()
+            }
+        }
+
+        "List<Issue>.paginate" should {
+            "apply default pagination when offset and limit are null" {
+                val issues = generateIssues()
+                val parameters = ListQueryParameters()
+
+                val paginatedIssues = issues.paginate(parameters)
+
+                paginatedIssues.size shouldBe issues.size.coerceAtMost(ListQueryParameters.DEFAULT_LIMIT)
+            }
+
+            "return the first issue when offset is 0 and limit is 1" {
+                val issues = generateIssues()
+                val parameters = ListQueryParameters(offset = 0, limit = 1)
+
+                val paginatedIssues = issues.paginate(parameters)
+
+                paginatedIssues.size shouldBe 1
+                paginatedIssues[0] shouldBe issues[0]
+            }
+
+            "return the second issue when offset is 1 and limit is 1" {
+                val issues = generateIssues()
+                val parameters = ListQueryParameters(offset = 1, limit = 1)
+
+                val paginatedIssues = issues.paginate(parameters)
+
+                paginatedIssues.size shouldBe 1
+                paginatedIssues[0] shouldBe issues[1]
+            }
+
+            "return the second and third issue when offset is 1 and limit is 2" {
+                val issues = generateIssues()
+                val parameters = ListQueryParameters(offset = 1, limit = 2)
+
+                val paginatedIssues = issues.paginate(parameters)
+
+                paginatedIssues.size shouldBe 2
+                paginatedIssues[0] shouldBe issues[1]
+                paginatedIssues[1] shouldBe issues[2]
+            }
+
+            "return an empty list when offset is equal to the size of the list" {
+                val issues = generateIssues()
+                val parameters = ListQueryParameters(offset = issues.size.toLong(), limit = 1)
+
+                val paginatedIssues = issues.paginate(parameters)
+
+                paginatedIssues shouldBe emptyList()
+            }
+        }
     }
 
     private fun generateIssues(): List<Issue> =
@@ -181,20 +294,27 @@ class IssueServiceTest : WordSpec() {
                 affectedPath = "path"
             ),
             Issue(
-                timestamp = Clock.System.now(),
+                timestamp = Clock.System.now().plus(1.seconds),
                 source = "Advisor",
-                message = "Issue 1",
+                message = "Issue 2",
                 severity = Severity.ERROR,
                 affectedPath = "path",
                 identifier = Identifier("Maven", "com.example", "example", "1.0")
             ),
             Issue(
-                timestamp = Clock.System.now(),
+                timestamp = Clock.System.now().minus(1.seconds),
                 source = "Advisor",
-                message = "Issue 2",
+                message = "Issue 3",
                 severity = Severity.WARNING,
                 affectedPath = "path",
-                identifier = Identifier("Maven", "com.example", "example", "1.0")
+                identifier = Identifier("Maven", "com.example", "example", "1.1")
+            ),
+            Issue(
+                timestamp = Clock.System.now().minus(2.seconds),
+                source = "scanner",
+                message = "Issue 4",
+                severity = Severity.ERROR,
+                affectedPath = "package/dist/somefile"
             )
         )
 


### PR DESCRIPTION
Return Scanner issues that are stored as part of Scan Summaries. Previously, these issues were not included in the API endpoints for retrieving issues, leading to discrepancies between issues in reports and those displayed in the ORT Server Web Application.

Fixes #1534.