### PR TITLE
fix(ui): Correct UI behaviour when searching for a non-existing run

### DIFF
--- a/ui/src/components/not-found-error.ts
+++ b/ui/src/components/not-found-error.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+// This custom error class is needed to circumvent a bug in TanStack Router,
+// see https://github.com/TanStack/router/issues/2139.
+export class NotFoundError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = 'NotFoundError';
+    Object.setPrototypeOf(this, NotFoundError.prototype);
+  }
+}

--- a/ui/src/routes/runs/$runId/index.tsx
+++ b/ui/src/routes/runs/$runId/index.tsx
@@ -17,9 +17,10 @@
  * License-Filename: LICENSE
  */
 
-import { createFileRoute, notFound, redirect } from '@tanstack/react-router';
+import { createFileRoute, redirect } from '@tanstack/react-router';
 
 import { ApiError, RunsService } from '@/api/requests';
+import { NotFoundError } from '@/components/not-found-error';
 
 export const Route = createFileRoute('/runs/$runId/')({
   beforeLoad: async ({ params }) => {
@@ -34,7 +35,7 @@ export const Route = createFileRoute('/runs/$runId/')({
       index = ortRun.index.toString();
     } catch (error) {
       if (error instanceof ApiError) {
-        throw notFound();
+        throw new NotFoundError(params.runId);
       }
     }
     if (organizationId && productId && repositoryId && index) {
@@ -49,7 +50,11 @@ export const Route = createFileRoute('/runs/$runId/')({
       });
     }
   },
-  notFoundComponent: () => {
-    return <div>ORT run not found!</div>;
+  errorComponent: ({ error }) => {
+    if (error instanceof NotFoundError) {
+      return <>There is no run with ID {error.message}.</>;
+    }
+
+    throw error;
   },
 });


### PR DESCRIPTION
![Screenshot from 2025-02-27 11-41-36](https://github.com/user-attachments/assets/0a569daa-bba0-44e2-acf4-44397215af50)

Please see the commits for details.