### PR TITLE
refactor: Align to use camel case for sorting field names

### DIFF
--- a/core/src/main/kotlin/api/RunsRoute.kt
+++ b/core/src/main/kotlin/api/RunsRoute.kt
@@ -198,7 +198,7 @@ fun Route.runs() = route("runs") {
                 call.forRun(ortRunRepository) { ortRun ->
                     requirePermission(RepositoryPermission.READ_ORT_RUNS.roleName(ortRun.repositoryId))
 
-                    val pagingOptions = call.pagingOptions(SortProperty("external_id", SortDirection.ASCENDING))
+                    val pagingOptions = call.pagingOptions(SortProperty("externalId", SortDirection.ASCENDING))
 
                     val vulnerabilitiesForOrtRun =
                         vulnerabilityService.listForOrtRunId(ortRun.id, pagingOptions.mapToModel())

--- a/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
@@ -1030,7 +1030,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 )
 
                 val response =
-                    superuserClient.get("/api/v1/products/$productId/vulnerabilities?sort=-rating,-repositories_count")
+                    superuserClient.get("/api/v1/products/$productId/vulnerabilities?sort=-rating,-repositoriesCount")
 
                 response.status shouldBe HttpStatusCode.OK
                 response shouldHaveBody PagedResponse(
@@ -1063,7 +1063,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                         totalCount = 3,
                         sortProperties = listOf(
                             SortProperty("rating", SortDirection.DESCENDING),
-                            SortProperty("repositories_count", SortDirection.DESCENDING)
+                            SortProperty("repositoriesCount", SortDirection.DESCENDING)
                         )
                     )
                 )

--- a/dao/src/main/kotlin/repositories/advisorrun/VulnerabilitiesTable.kt
+++ b/dao/src/main/kotlin/repositories/advisorrun/VulnerabilitiesTable.kt
@@ -31,7 +31,7 @@ import org.jetbrains.exposed.sql.and
  * A table to represent a vulnerability.
  */
 object VulnerabilitiesTable : SortableTable("vulnerabilities") {
-    val externalId = text("external_id").sortable()
+    val externalId = text("external_id").sortable("externalId")
     val summary = text("summary").nullable()
     val description = text("description").nullable()
 }

--- a/services/hierarchy/src/main/kotlin/VulnerabilityService.kt
+++ b/services/hierarchy/src/main/kotlin/VulnerabilityService.kt
@@ -98,12 +98,12 @@ class VulnerabilityService(private val db: Database) {
             val sortOrder = it.direction.toSortOrder()
             when (it.name) {
                 "rating" -> ratingAlias to sortOrder
-                "repositories_count" -> repositoriesCountAlias to sortOrder
-                "external_id" -> VulnerabilitiesTable.externalId to sortOrder
-                "identifier_type" -> IdentifiersTable.type to sortOrder
-                "identifier_namespace" -> IdentifiersTable.namespace to sortOrder
-                "identifier_name" -> IdentifiersTable.name to sortOrder
-                "identifier_version" -> IdentifiersTable.version to sortOrder
+                "repositoriesCount" -> repositoriesCountAlias to sortOrder
+                "externalId" -> VulnerabilitiesTable.externalId to sortOrder
+                "identifierType" -> IdentifiersTable.type to sortOrder
+                "identifierNamespace" -> IdentifiersTable.namespace to sortOrder
+                "identifierName" -> IdentifiersTable.name to sortOrder
+                "identifierVersion" -> IdentifiersTable.version to sortOrder
                 else -> throw QueryParametersException("Unsupported field for sorting: '${it.name}'.")
             }
         }

--- a/services/hierarchy/src/test/kotlin/VulnerabilityServiceTest.kt
+++ b/services/hierarchy/src/test/kotlin/VulnerabilityServiceTest.kt
@@ -193,7 +193,7 @@ class VulnerabilityServiceTest : WordSpec() {
 
                 val result = service.listForOrtRunId(
                     ortRun.id,
-                    ListQueryParameters(listOf(OrderField("external_id", OrderDirection.ASCENDING)), limit = 1)
+                    ListQueryParameters(listOf(OrderField("externalId", OrderDirection.ASCENDING)), limit = 1)
                 )
 
                 result.data shouldHaveSize 1
@@ -586,8 +586,8 @@ class VulnerabilityServiceTest : WordSpec() {
                     listOf(run1Id, run2Id, run3Id),
                     ListQueryParameters(
                         listOf(
-                            OrderField("repositories_count", OrderDirection.DESCENDING),
-                            OrderField("external_id", OrderDirection.DESCENDING)
+                            OrderField("repositoriesCount", OrderDirection.DESCENDING),
+                            OrderField("externalId", OrderDirection.DESCENDING)
                         )
                     )
                 )
@@ -665,10 +665,10 @@ class VulnerabilityServiceTest : WordSpec() {
                     listOf(runId),
                     ListQueryParameters(
                         listOf(
-                            OrderField("identifier_type", OrderDirection.ASCENDING),
-                            OrderField("identifier_namespace", OrderDirection.ASCENDING),
-                            OrderField("identifier_name", OrderDirection.ASCENDING),
-                            OrderField("identifier_version", OrderDirection.ASCENDING),
+                            OrderField("identifierType", OrderDirection.ASCENDING),
+                            OrderField("identifierNamespace", OrderDirection.ASCENDING),
+                            OrderField("identifierName", OrderDirection.ASCENDING),
+                            OrderField("identifierVersion", OrderDirection.ASCENDING),
                         )
                     )
                 )


### PR DESCRIPTION
Align with the convention of commit https://github.com/eclipse-apoapsis/ort-server/commit/8c1d23ff0067850069600ef5a122bf57372b924d#diff-07702ede8522e232eb239906b7cf8ef6f3b5451730aeb6b5732cca33fcef54c6R42 that predates the addition of these sorting fields.