### PR TITLE
build(cli): Enable optimized builds

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -55,6 +55,7 @@ kotlin {
             executable {
                 entryPoint = "org.eclipse.apoapsis.ortserver.cli.main"
                 baseName = "osc"
+                optimized = true
             }
         }
     }


### PR DESCRIPTION
This should result in a smaller binary size and improve runtime performance.
Additionally, this works around an issue on Linux, where debug builds were blocking rebuilding the project in IntelliJ IDEA due to an issue in Clikt [1].

[1]: https://github.com/ajalt/clikt/discussions/571