### PR TITLE
build(Gradle): Do not call `applyDefaultHierarchyTemplate()`

### DIFF
--- a/api/v1/client/build.gradle.kts
+++ b/api/v1/client/build.gradle.kts
@@ -33,8 +33,6 @@ kotlin {
     macosArm64()
     macosX64()
 
-    applyDefaultHierarchyTemplate()
-
     sourceSets {
         commonMain {
             dependencies {

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -48,8 +48,6 @@ kotlin {
     macosArm64()
     macosX64()
 
-    applyDefaultHierarchyTemplate()
-
     targets.withType<KotlinNativeTarget> {
         binaries {
             executable {

--- a/utils/system/build.gradle.kts
+++ b/utils/system/build.gradle.kts
@@ -36,6 +36,4 @@ kotlin {
     linuxX64()
     macosArm64()
     macosX64()
-
-    applyDefaultHierarchyTemplate()
 }


### PR DESCRIPTION
As of Kotlin 1.9.20 the hierarchy template is applied by default unless

    kotlin.mpp.applyDefaultHierarchyTemplate = false

is set, and it only needs to be re-applyed manually if custom source sets were configured with `dependsOn`-calls [1].

[1]: https://kotlinlang.org/docs/multiplatform-hierarchy.html#additional-configuration