### PR TITLE
feat(ui): Style `errorComponent` for global run search

### DIFF
--- a/ui/src/routes/runs/$runId/index.tsx
+++ b/ui/src/routes/runs/$runId/index.tsx
@@ -18,9 +18,12 @@
  */
 
 import { createFileRoute, redirect } from '@tanstack/react-router';
+import { AlertCircle } from 'lucide-react';
 
 import { ApiError, RunsService } from '@/api/requests';
 import { NotFoundError } from '@/components/not-found-error';
+import { Card, CardContent, CardHeader } from '@/components/ui/card.tsx';
+import { Separator } from '@/components/ui/separator.tsx';
 
 export const Route = createFileRoute('/runs/$runId/')({
   beforeLoad: async ({ params }) => {
@@ -52,7 +55,22 @@ export const Route = createFileRoute('/runs/$runId/')({
   },
   errorComponent: ({ error }) => {
     if (error instanceof NotFoundError) {
-      return <>There is no run with ID {error.message}.</>;
+      return (
+        <Card className='mx-auto w-full max-w-4xl'>
+          <CardHeader className='flex flex-row justify-items-center p-4'>
+            <div className='flex gap-2'>
+              <AlertCircle className='size-12' />
+              <h2 className='place-content-center text-3xl font-bold'>
+                Resource not found
+              </h2>
+            </div>
+          </CardHeader>
+          <Separator />
+          <CardContent className='p-4'>
+            <p>There is no run with ID {error.message}.</p>
+          </CardContent>
+        </Card>
+      );
     }
 
     throw error;


### PR DESCRIPTION
Add a styled `errorComponent` to display a more user-friendly message when a `NotFoundError` occurs, aligning with the consistent use of the custom `Card` compoent across other routes.

New look:
![Bildschirmfoto 2025-02-27 um 15 01 41](https://github.com/user-attachments/assets/e637b06c-e2cd-4a2e-b8fc-0de5079c23e1)
