### PR TITLE
chore(dev): Add exemplary run configuration to run and debug the CLI

### DIFF
--- a/.run/osc --version [jvm].run.xml
+++ b/.run/osc --version [jvm].run.xml
@@ -1,0 +1,25 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="osc --version [jvm]" type="GradleRunConfiguration" factoryName="Gradle">
+    <ExternalSystemSettings>
+      <option name="executionName" />
+      <option name="externalProjectPath" value="$PROJECT_DIR$/cli" />
+      <option name="externalSystemIdString" value="GRADLE" />
+      <option name="scriptParameters" value="-DmainClass=org.eclipse.apoapsis.ortserver.cli.OrtServerMainKt --quiet" />
+      <option name="taskDescriptions">
+        <list />
+      </option>
+      <option name="taskNames">
+        <list>
+          <option value="jvmRun" />
+          <option value="--args='--version'" />
+        </list>
+      </option>
+      <option name="vmOptions" />
+    </ExternalSystemSettings>
+    <ExternalSystemDebugServerProcess>false</ExternalSystemDebugServerProcess>
+    <ExternalSystemReattachDebugProcess>true</ExternalSystemReattachDebugProcess>
+    <DebugAllEnabled>false</DebugAllEnabled>
+    <RunAsTest>false</RunAsTest>
+    <method v="2" />
+  </configuration>
+</component>


### PR DESCRIPTION
To run the CLI in the IDE using the JVM target, the Gradle task `runJvm` has to be used.
Add a run configuration that sets the args to `--version` to show how arguments can be set in these Gradle run configurations.