### PR TITLE
fix: Return proper HTTP error code when calling non existing repo

### DIFF
--- a/core/src/main/kotlin/api/RepositoriesRoute.kt
+++ b/core/src/main/kotlin/api/RepositoriesRoute.kt
@@ -125,20 +125,22 @@ fun Route.repositories() = route("repositories/{repositoryId}") {
             requirePermission(RepositoryPermission.TRIGGER_ORT_RUN)
 
             val repositoryId = call.requireIdParameter("repositoryId")
-            val createOrtRun = call.receive<CreateOrtRun>()
 
-            call.respond(
-                HttpStatusCode.Created,
-                orchestratorService.createOrtRun(
-                    repositoryId,
-                    createOrtRun.revision,
-                    createOrtRun.path,
-                    createOrtRun.jobConfigs.mapToModel(),
-                    createOrtRun.jobConfigContext,
-                    createOrtRun.labels,
-                    createOrtRun.environmentConfigPath
-                ).mapToApi(Jobs())
-            )
+            repositoryService.getRepository(repositoryId)?.let {
+                val createOrtRun = call.receive<CreateOrtRun>()
+                call.respond(
+                    HttpStatusCode.Created,
+                    orchestratorService.createOrtRun(
+                        repositoryId,
+                        createOrtRun.revision,
+                        createOrtRun.path,
+                        createOrtRun.jobConfigs.mapToModel(),
+                        createOrtRun.jobConfigContext,
+                        createOrtRun.labels,
+                        createOrtRun.environmentConfigPath
+                    ).mapToApi(Jobs())
+                )
+            } ?: call.respond(HttpStatusCode.NotFound)
         }
 
         route("{ortRunIndex}") {

--- a/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
@@ -715,6 +715,24 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                 responses.forAll { it shouldHaveStatus HttpStatusCode.Created }
             }
         }
+
+        "respond with \"Not Found\" if repository doesn't exist" {
+            integrationTestApplication {
+                val nonExistingRepositoryId = 999
+                val createRun = CreateOrtRun(
+                    "main",
+                    null,
+                    ApiJobConfigurations(),
+                    emptyMap()
+                )
+
+                val response = superuserClient.post("/api/v1/repositories/$nonExistingRepositoryId/runs") {
+                    setBody(createRun)
+                }
+
+                response.status shouldBe HttpStatusCode.NotFound
+            }
+        }
     }
 
     "GET /repositories/{repositoryId}/secrets" should {


### PR DESCRIPTION
Return 404 HTTP error code instead of 500 when triggering ORT run on non existing repository.