### PR TITLE
refactor(services): Combine sorting for identifier fields

### DIFF
--- a/services/hierarchy/src/main/kotlin/VulnerabilityService.kt
+++ b/services/hierarchy/src/main/kotlin/VulnerabilityService.kt
@@ -45,12 +45,14 @@ import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
 import org.jetbrains.exposed.sql.Case
 import org.jetbrains.exposed.sql.Count
 import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.Expression
 import org.jetbrains.exposed.sql.ExpressionWithColumnTypeAlias
 import org.jetbrains.exposed.sql.GroupConcat
 import org.jetbrains.exposed.sql.IntegerColumnType
 import org.jetbrains.exposed.sql.LiteralOp
 import org.jetbrains.exposed.sql.Max
 import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.TextColumnType
 import org.jetbrains.exposed.sql.UpperCase
@@ -94,16 +96,20 @@ class VulnerabilityService(private val db: Database) {
         val repositoriesCountAlias = repositoriesCountAlias()
         val ratingAlias = ratingAlias()
 
-        val orders = parameters.sortFields.map {
+        val orders = mutableListOf<Pair<Expression<*>, SortOrder>>()
+
+        parameters.sortFields.forEach {
             val sortOrder = it.direction.toSortOrder()
             when (it.name) {
-                "rating" -> ratingAlias to sortOrder
-                "repositoriesCount" -> repositoriesCountAlias to sortOrder
-                "externalId" -> VulnerabilitiesTable.externalId to sortOrder
-                "identifierType" -> IdentifiersTable.type to sortOrder
-                "identifierNamespace" -> IdentifiersTable.namespace to sortOrder
-                "identifierName" -> IdentifiersTable.name to sortOrder
-                "identifierVersion" -> IdentifiersTable.version to sortOrder
+                "rating" -> orders += ratingAlias to sortOrder
+                "repositoriesCount" -> orders += repositoriesCountAlias to sortOrder
+                "externalId" -> orders += VulnerabilitiesTable.externalId to sortOrder
+                "identifier" -> {
+                    orders += IdentifiersTable.type to sortOrder
+                    orders += IdentifiersTable.namespace to sortOrder
+                    orders += IdentifiersTable.name to sortOrder
+                    orders += IdentifiersTable.version to sortOrder
+                }
                 else -> throw QueryParametersException("Unsupported field for sorting: '${it.name}'.")
             }
         }

--- a/services/hierarchy/src/test/kotlin/VulnerabilityServiceTest.kt
+++ b/services/hierarchy/src/test/kotlin/VulnerabilityServiceTest.kt
@@ -615,7 +615,7 @@ class VulnerabilityServiceTest : WordSpec() {
                 }
             }
 
-            "allow sorting by identifier fields" {
+            "allow sorting by identifier" {
                 val service = VulnerabilityService(db)
 
                 val repoId = fixtures.createRepository().id
@@ -665,10 +665,7 @@ class VulnerabilityServiceTest : WordSpec() {
                     listOf(runId),
                     ListQueryParameters(
                         listOf(
-                            OrderField("identifierType", OrderDirection.ASCENDING),
-                            OrderField("identifierNamespace", OrderDirection.ASCENDING),
-                            OrderField("identifierName", OrderDirection.ASCENDING),
-                            OrderField("identifierVersion", OrderDirection.ASCENDING),
+                            OrderField("identifier", OrderDirection.ASCENDING)
                         )
                     )
                 )


### PR DESCRIPTION
As there is no need to sort by the identifier properties separately, combine the sorting for these fields.