### PR TITLE
Disable Kotest's auto-scan also for multi-platform projects

### DIFF
--- a/api/v1/mapping/build.gradle.kts
+++ b/api/v1/mapping/build.gradle.kts
@@ -33,11 +33,5 @@ kotlin {
                 api(projects.model)
             }
         }
-
-        commonTest {
-            dependencies {
-                implementation(projects.utils.test)
-            }
-        }
     }
 }

--- a/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-conventions.gradle.kts
@@ -36,6 +36,10 @@ plugins {
     id("org.jetbrains.kotlin.jvm")
 }
 
+dependencies {
+    testImplementation(project(":utils:test"))
+}
+
 java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(javaLanguageVersion)

--- a/buildSrc/src/main/kotlin/ort-server-kotlin-multiplatform-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-kotlin-multiplatform-conventions.gradle.kts
@@ -29,6 +29,14 @@ plugins {
 
 kotlin {
     jvm()
+
+    sourceSets {
+        jvmTest {
+            dependencies {
+                implementation(project(":utils:test"))
+            }
+        }
+    }
 }
 
 tasks.named<Detekt>("detekt") {

--- a/clients/keycloak/build.gradle.kts
+++ b/clients/keycloak/build.gradle.kts
@@ -39,8 +39,6 @@ dependencies {
     implementation(libs.ktorClientOkHttp)
     implementation(libs.ktorKotlinxSerialization)
 
-    testImplementation(projects.utils.test)
-
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestExtensionsTestContainer)
     testImplementation(libs.kotestRunnerJunit5)

--- a/config/git/build.gradle.kts
+++ b/config/git/build.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
     implementation(projects.utils.config)
 
     testImplementation(testFixtures(projects.config.configSpi))
-    testImplementation(projects.utils.test)
 
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestRunnerJunit5)

--- a/config/github/build.gradle.kts
+++ b/config/github/build.gradle.kts
@@ -38,7 +38,6 @@ dependencies {
     implementation(libs.ktorKotlinxSerialization)
 
     testImplementation(testFixtures(projects.config.configSpi))
-    testImplementation(projects.utils.test)
 
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestRunnerJunit5)

--- a/config/local/build.gradle.kts
+++ b/config/local/build.gradle.kts
@@ -32,7 +32,6 @@ dependencies {
     implementation(projects.utils.config)
 
     testImplementation(testFixtures(projects.config.configSpi))
-    testImplementation(projects.utils.test)
 
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestRunnerJunit5)

--- a/config/secret-file/build.gradle.kts
+++ b/config/secret-file/build.gradle.kts
@@ -32,7 +32,6 @@ dependencies {
     implementation(libs.slf4j)
 
     testImplementation(testFixtures(projects.config.configSpi))
-    testImplementation(projects.utils.test)
 
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestRunnerJunit5)

--- a/config/spi/build.gradle.kts
+++ b/config/spi/build.gradle.kts
@@ -33,8 +33,6 @@ dependencies {
 
     implementation(projects.utils.config)
 
-    testImplementation(projects.utils.test)
-
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestExtensionsTestContainer)
     testImplementation(libs.kotestRunnerJunit5)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -100,7 +100,6 @@ dependencies {
     testImplementation(testFixtures(projects.logaccess.logaccessSpi))
     testImplementation(testFixtures(projects.secrets.secretsSpi))
     testImplementation(testFixtures(projects.transport.transportSpi))
-    testImplementation(projects.utils.test)
 
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestAssertionsKtor)

--- a/dao/build.gradle.kts
+++ b/dao/build.gradle.kts
@@ -54,7 +54,6 @@ dependencies {
     runtimeOnly(libs.logback)
 
     testImplementation(testFixtures(projects.config.configSpi))
-    testImplementation(projects.utils.test)
 
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestAssertionsKtor)

--- a/kubernetes/jobmonitor/build.gradle.kts
+++ b/kubernetes/jobmonitor/build.gradle.kts
@@ -32,7 +32,6 @@ plugins {
 
     // Apply third-party plugins.
     alias(libs.plugins.jib)
-    alias(libs.plugins.kotlinSerialization)
 }
 
 group = "org.eclipse.apoapsis.ortserver.kubernetes"
@@ -45,15 +44,12 @@ dependencies {
     implementation(projects.dao)
     implementation(projects.model)
     implementation(projects.transport.transportSpi)
-    implementation(projects.utils.config)
     implementation(projects.utils.logging)
 
     implementation(libs.koinCore)
     implementation(libs.kotlinxCoroutines)
     implementation(libs.kotlinxCoroutinesSlf4j)
-    implementation(libs.kotlinxSerializationJson)
     implementation(libs.kubernetesClient)
-    implementation(libs.kubernetesClientExtended)
     implementation(libs.typesafeConfig)
 
     runtimeOnly(projects.config.secretFile)
@@ -67,7 +63,6 @@ dependencies {
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
-    testImplementation(libs.ortTestUtils)
 }
 
 jib {

--- a/logaccess/loki/build.gradle.kts
+++ b/logaccess/loki/build.gradle.kts
@@ -42,7 +42,6 @@ dependencies {
     implementation(libs.ktorKotlinxSerialization)
 
     testImplementation(testFixtures(projects.logaccess.logaccessSpi))
-    testImplementation(projects.utils.test)
 
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestRunnerJunit5)

--- a/logaccess/spi/build.gradle.kts
+++ b/logaccess/spi/build.gradle.kts
@@ -41,8 +41,6 @@ dependencies {
     implementation(libs.ortCommonUtils)
     implementation(libs.slf4j)
 
-    testImplementation(projects.utils.test)
-
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestExtensionsTestContainer)
     testImplementation(libs.kotestRunnerJunit5)

--- a/orchestrator/build.gradle.kts
+++ b/orchestrator/build.gradle.kts
@@ -50,7 +50,6 @@ dependencies {
     testImplementation(testFixtures(projects.config.configSpi))
     testImplementation(testFixtures(projects.dao))
     testImplementation(testFixtures(projects.transport.transportSpi))
-    testImplementation(projects.utils.test)
 
     testImplementation(libs.koinTest)
     testImplementation(libs.kotestAssertionsCore)

--- a/secrets/azure-keyvault/build.gradle.kts
+++ b/secrets/azure-keyvault/build.gradle.kts
@@ -39,8 +39,6 @@ dependencies {
 
     testImplementation(testFixtures(projects.config.configSpi))
 
-    testImplementation(projects.utils.test)
-
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestRunnerJunit5)
 }

--- a/secrets/file/build.gradle.kts
+++ b/secrets/file/build.gradle.kts
@@ -34,8 +34,6 @@ dependencies {
 
     implementation(libs.ktorKotlinxSerialization)
 
-    testImplementation(projects.utils.test)
-
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestRunnerJunit5)
 }

--- a/secrets/scaleway/build.gradle.kts
+++ b/secrets/scaleway/build.gradle.kts
@@ -40,8 +40,6 @@ dependencies {
 
     testImplementation(testFixtures(projects.config.configSpi))
 
-    testImplementation(projects.utils.test)
-
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestRunnerJunit5)
 }

--- a/secrets/spi/build.gradle.kts
+++ b/secrets/spi/build.gradle.kts
@@ -31,8 +31,6 @@ group = "org.eclipse.apoapsis.ortserver.secrets"
 dependencies {
     api(projects.config.configSpi)
 
-    testImplementation(projects.utils.test)
-
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestExtensionsTestContainer)
     testImplementation(libs.kotestRunnerJunit5)

--- a/secrets/vault/build.gradle.kts
+++ b/secrets/vault/build.gradle.kts
@@ -39,7 +39,6 @@ dependencies {
     implementation(libs.ktorKotlinxSerialization)
 
     testImplementation(testFixtures(projects.config.configSpi))
-    testImplementation(projects.utils.test)
 
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestExtensionsTestContainer)

--- a/services/authorization/build.gradle.kts
+++ b/services/authorization/build.gradle.kts
@@ -37,7 +37,6 @@ dependencies {
 
     testImplementation(testFixtures(projects.clients.keycloak))
     testImplementation(testFixtures(projects.dao))
-    testImplementation(projects.utils.test)
 
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestRunnerJunit5)

--- a/services/hierarchy/build.gradle.kts
+++ b/services/hierarchy/build.gradle.kts
@@ -37,7 +37,6 @@ dependencies {
     runtimeOnly(libs.logback)
 
     testImplementation(testFixtures(projects.dao))
-    testImplementation(projects.utils.test)
 
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)

--- a/services/infrastructure/build.gradle.kts
+++ b/services/infrastructure/build.gradle.kts
@@ -36,7 +36,6 @@ dependencies {
     runtimeOnly(libs.logback)
 
     testImplementation(testFixtures(projects.dao))
-    testImplementation(projects.utils.test)
 
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestRunnerJunit5)

--- a/services/report-storage/build.gradle.kts
+++ b/services/report-storage/build.gradle.kts
@@ -34,8 +34,6 @@ dependencies {
 
     runtimeOnly(libs.logback)
 
-    testImplementation(projects.utils.test)
-
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)

--- a/services/secret/build.gradle.kts
+++ b/services/secret/build.gradle.kts
@@ -35,8 +35,6 @@ dependencies {
 
     runtimeOnly(libs.logback)
 
-    testImplementation(projects.utils.test)
-
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
 }

--- a/transport/kubernetes/build.gradle.kts
+++ b/transport/kubernetes/build.gradle.kts
@@ -21,9 +21,6 @@ plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
     id("ort-server-publication-conventions")
-
-    // Apply third-party plugins.
-    alias(libs.plugins.kotlinSerialization)
 }
 
 group = "org.eclipse.apoapsis.ortserver.transport"
@@ -33,7 +30,6 @@ dependencies {
     implementation(projects.utils.config)
     implementation(projects.utils.logging)
 
-    implementation(libs.kotlinxSerializationJson)
     implementation(libs.kubernetesClient)
     implementation(libs.kubernetesClientExtended)
 
@@ -42,5 +38,4 @@ dependencies {
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
-    testImplementation(libs.ortTestUtils)
 }

--- a/workers/advisor/build.gradle.kts
+++ b/workers/advisor/build.gradle.kts
@@ -64,7 +64,6 @@ dependencies {
     testImplementation(testFixtures(projects.dao))
     testImplementation(testFixtures(projects.transport.transportSpi))
     testImplementation(testFixtures(projects.workers.common))
-    testImplementation(projects.utils.test)
 
     testImplementation(libs.koinTest)
     testImplementation(libs.kotestAssertionsCore)

--- a/workers/analyzer/build.gradle.kts
+++ b/workers/analyzer/build.gradle.kts
@@ -91,7 +91,6 @@ dependencies {
     testImplementation(testFixtures(projects.dao))
     testImplementation(testFixtures(projects.transport.transportSpi))
     testImplementation(testFixtures(projects.workers.common))
-    testImplementation(projects.utils.test)
 
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.koinTest)

--- a/workers/common/build.gradle.kts
+++ b/workers/common/build.gradle.kts
@@ -60,7 +60,6 @@ dependencies {
     testImplementation(testFixtures(projects.dao))
     testImplementation(testFixtures(projects.secrets.secretsSpi))
     testImplementation(testFixtures(projects.storage.storageSpi))
-    testImplementation(projects.utils.test)
 
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestRunnerJunit5)

--- a/workers/config/build.gradle.kts
+++ b/workers/config/build.gradle.kts
@@ -65,7 +65,6 @@ dependencies {
     testImplementation(testFixtures(projects.config.configSpi))
     testImplementation(testFixtures(projects.dao))
     testImplementation(testFixtures(projects.transport.transportSpi))
-    testImplementation(projects.utils.test)
     testImplementation(testFixtures(projects.workers.common))
 
     testImplementation(libs.koinTest)

--- a/workers/evaluator/build.gradle.kts
+++ b/workers/evaluator/build.gradle.kts
@@ -65,7 +65,6 @@ dependencies {
     testImplementation(testFixtures(projects.config.configSpi))
     testImplementation(testFixtures(projects.dao))
     testImplementation(testFixtures(projects.transport.transportSpi))
-    testImplementation(projects.utils.test)
     testImplementation(testFixtures(projects.workers.common))
 
     testImplementation(libs.koinTest)

--- a/workers/reporter/build.gradle.kts
+++ b/workers/reporter/build.gradle.kts
@@ -75,7 +75,6 @@ dependencies {
     testImplementation(testFixtures(projects.dao))
     testImplementation(testFixtures(projects.storage.storageSpi))
     testImplementation(testFixtures(projects.transport.transportSpi))
-    testImplementation(projects.utils.test)
     testImplementation(testFixtures(projects.workers.common))
 
     testImplementation(libs.koinTest)

--- a/workers/scanner/build.gradle.kts
+++ b/workers/scanner/build.gradle.kts
@@ -71,7 +71,6 @@ dependencies {
     testImplementation(testFixtures(projects.storage.storageSpi))
     testImplementation(testFixtures(projects.transport.transportSpi))
     testImplementation(testFixtures(projects.workers.common))
-    testImplementation(projects.utils.test)
 
     testImplementation(libs.jacksonModuleKotlin)
     testImplementation(libs.koinTest)


### PR DESCRIPTION
Please have a look at the individual commit messages for the details. 