### PR TITLE
ui: Sort packages table (server-side)

### DIFF
--- a/ui/src/helpers/handle-multisort.ts
+++ b/ui/src/helpers/handle-multisort.ts
@@ -68,12 +68,32 @@ export const updateColumnSorting = (
   return updatedSort.length > 0 ? updatedSort : undefined;
 };
 
+/**
+ * Convert the sorting state to a string format for the backend.
+ *
+ * @param sorting The current sorting state of the table.
+ * @returns The sorting state as a string for the backend.
+ */
+export const convertToBackendSorting = (
+  sorting: SortingState | undefined
+): string | undefined => {
+  if (!sorting || sorting.length === 0) {
+    return undefined;
+  }
+
+  return sorting
+    .map((sort) => (sort.desc ? `-${sort.id}` : `${sort.id}`))
+    .join(',');
+};
+
 //
-// Unit tests for the updateColumnSorting() function
+// Unit tests for multisorting
 //
 
 if (import.meta.vitest) {
   const { it, expect } = import.meta.vitest;
+
+  // Test the updateColumnSorting() function
 
   it('adds a new column to an empty sorting state', () => {
     const columns = undefined;
@@ -122,5 +142,22 @@ if (import.meta.vitest) {
       { id: 'column1', desc: false },
       { id: 'column3', desc: false },
     ]);
+  });
+
+  // Test the convertToBackendSorting() function
+
+  it('converts sorting state to backend format', () => {
+    const sorting: SortingState = [
+      { id: 'column1', desc: false },
+      { id: 'column2', desc: true },
+    ];
+
+    expect(convertToBackendSorting(sorting)).toEqual('column1,-column2');
+  });
+
+  it('returns undefined for empty sorting state', () => {
+    const sorting: SortingState = [];
+
+    expect(convertToBackendSorting(sorting)).toEqual(undefined);
   });
 }

--- a/ui/src/schemas/index.ts
+++ b/ui/src/schemas/index.ts
@@ -80,6 +80,10 @@ export const packageIdentifierSearchParameterSchema = z.object({
   pkgId: z.string().optional(),
 });
 
+export const declaredLicenseSearchParameterSchema = z.object({
+  declaredLicense: z.string().optional(),
+});
+
 export const issueCategorySearchParameterSchema = z.object({
   category: z.array(issueCategorySchema).optional(),
 });


### PR DESCRIPTION
![Screenshot from 2025-03-03 10-13-11](https://github.com/user-attachments/assets/c4e3087b-3e04-499e-8dec-b42dc6dfe356)

Client-side sorting (and filtering) for the packages table, which can be huge, is very time-consuming, leading to bad UX, so now that the corresponding endpoint supports sorting, sort the table with server-side sorting.

Please see the commits for details.