### PR TITLE
No console logs in production code

### DIFF
--- a/ui/.eslintrc.cjs
+++ b/ui/.eslintrc.cjs
@@ -33,5 +33,6 @@ module.exports = {
       'warn',
       { allowConstantExport: true },
     ],
+    'no-console': ['warn'],
   },
 };

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/package-manager-field.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/package-manager-field.tsx
@@ -183,7 +183,8 @@ const FieldWithOptions = ({ form, pmIndex, pmName }: FieldWithOptionsProps) => {
   const pm = packageManagers[pmIndex];
 
   if (!pm) {
-    console.error(`No package manager found for index ${pmIndex}.`);
+    // This will never actually trigger, because in the form,
+    // we always feed a valid package manager.
     return null;
   }
 


### PR DESCRIPTION
Please see the commits for details.

Regarding the second commit, I'd like to get an opinion from @mmurto as the `console.error()` has come from you originally. Personally I've never encountered a situation where it would've been triggered, and would be willing to drop the whole line from code.