### PR TITLE
ui: Improve infrastructure handling

### DIFF
--- a/ui/src/routes/organizations/$orgId/infrastructure-services/$serviceName/edit/index.tsx
+++ b/ui/src/routes/organizations/$orgId/infrastructure-services/$serviceName/edit/index.tsx
@@ -28,6 +28,7 @@ import {
   useInfrastructureServicesServiceGetApiV1OrganizationsByOrganizationIdInfrastructureServicesKey,
   useInfrastructureServicesServicePatchApiV1OrganizationsByOrganizationIdInfrastructureServicesByServiceName,
 } from '@/api/queries';
+import { useSecretsServiceGetApiV1OrganizationsByOrganizationIdSecretsSuspense } from '@/api/queries/suspense';
 import { ApiError, InfrastructureServicesService } from '@/api/requests';
 import { MultiSelectField } from '@/components/form/multi-select-field';
 import { LoadingIndicator } from '@/components/loading-indicator';
@@ -49,6 +50,13 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { ALL_ITEMS } from '@/lib/constants';
 import { toast } from '@/lib/toast';
 
@@ -66,6 +74,12 @@ type FormSchema = z.infer<typeof formSchema>;
 const EditInfrastructureServicePage = () => {
   const navigate = useNavigate();
   const params = Route.useParams();
+
+  const { data: secrets } =
+    useSecretsServiceGetApiV1OrganizationsByOrganizationIdSecretsSuspense({
+      organizationId: Number.parseInt(params.orgId),
+      limit: ALL_ITEMS,
+    });
 
   /* Search service details from all infrastructure services of the organization
    * TODO: Edit this to fetch the details from:
@@ -202,9 +216,23 @@ const EditInfrastructureServicePage = () => {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Username Secret</FormLabel>
-                  <FormControl>
-                    <Input {...field} />
-                  </FormControl>
+                  <Select
+                    onValueChange={field.onChange}
+                    defaultValue={field.value}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder='Select an existing username secret from the list' />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {secrets?.data.map((secret) => (
+                        <SelectItem key={secret.name} value={secret.name}>
+                          {secret.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                   <FormDescription>
                     The name of the organization secret that contains the
                     username of the credentials for the infrastructure service.
@@ -221,9 +249,23 @@ const EditInfrastructureServicePage = () => {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Password Secret</FormLabel>
-                  <FormControl>
-                    <Input {...field} />
-                  </FormControl>
+                  <Select
+                    onValueChange={field.onChange}
+                    defaultValue={field.value}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder='Select an existing password secret from the list' />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {secrets?.data.map((secret) => (
+                        <SelectItem key={secret.name} value={secret.name}>
+                          {secret.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                   <FormDescription>
                     The name of the organization secret that contains the
                     password of the credentials for the infrastructure service.

--- a/ui/src/routes/organizations/$orgId/infrastructure-services/create/index.tsx
+++ b/ui/src/routes/organizations/$orgId/infrastructure-services/create/index.tsx
@@ -24,6 +24,7 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import { useInfrastructureServicesServicePostApiV1OrganizationsByOrganizationIdInfrastructureServices } from '@/api/queries';
+import { useSecretsServiceGetApiV1OrganizationsByOrganizationIdSecretsSuspense } from '@/api/queries/suspense';
 import { ApiError } from '@/api/requests';
 import { MultiSelectField } from '@/components/form/multi-select-field';
 import { ToastError } from '@/components/toast-error';
@@ -46,6 +47,14 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { ALL_ITEMS } from '@/lib/constants';
 import { toast } from '@/lib/toast';
 
 const formSchema = z.object({
@@ -62,6 +71,12 @@ type FormSchema = z.infer<typeof formSchema>;
 const CreateInfrastructureServicePage = () => {
   const navigate = useNavigate();
   const params = Route.useParams();
+
+  const { data: secrets } =
+    useSecretsServiceGetApiV1OrganizationsByOrganizationIdSecretsSuspense({
+      organizationId: Number.parseInt(params.orgId),
+      limit: ALL_ITEMS,
+    });
 
   const { mutateAsync, isPending } =
     useInfrastructureServicesServicePostApiV1OrganizationsByOrganizationIdInfrastructureServices(
@@ -189,9 +204,23 @@ const CreateInfrastructureServicePage = () => {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Username Secret</FormLabel>
-                  <FormControl>
-                    <Input {...field} />
-                  </FormControl>
+                  <Select
+                    onValueChange={field.onChange}
+                    defaultValue={field.value}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder='Select an existing username secret from the list' />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {secrets?.data.map((secret) => (
+                        <SelectItem key={secret.name} value={secret.name}>
+                          {secret.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                   <FormDescription>
                     The name of the organization secret that contains the
                     username of the credentials for the infrastructure service.
@@ -208,9 +237,23 @@ const CreateInfrastructureServicePage = () => {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Password Secret</FormLabel>
-                  <FormControl>
-                    <Input {...field} />
-                  </FormControl>
+                  <Select
+                    onValueChange={field.onChange}
+                    defaultValue={field.value}
+                  >
+                    <FormControl>
+                      <SelectTrigger>
+                        <SelectValue placeholder='Select an existing password secret from the list' />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {secrets?.data.map((secret) => (
+                        <SelectItem key={secret.name} value={secret.name}>
+                          {secret.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
                   <FormDescription>
                     The name of the organization secret that contains the
                     password of the credentials for the infrastructure service.

--- a/ui/src/routes/organizations/$orgId/infrastructure-services/index.tsx
+++ b/ui/src/routes/organizations/$orgId/infrastructure-services/index.tsx
@@ -25,7 +25,7 @@ import {
   getCoreRowModel,
   useReactTable,
 } from '@tanstack/react-table';
-import { EditIcon, Pencil, PlusIcon } from 'lucide-react';
+import { EditIcon, PlusIcon } from 'lucide-react';
 
 import {
   useInfrastructureServicesServiceDeleteApiV1OrganizationsByOrganizationIdInfrastructureServicesByServiceName,
@@ -171,28 +171,7 @@ const InfrastructureServices = () => {
       header: 'Username Secret',
       cell: ({ row }) => (
         <div className='flex items-baseline'>
-          {row.original.usernameSecretRef}{' '}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Link
-                to='/organizations/$orgId/secrets/$secretName/edit'
-                params={{
-                  orgId: params.orgId,
-                  secretName: row.original.usernameSecretRef,
-                }}
-                search={{
-                  returnTo: '/organizations/$orgId/infrastructure-services',
-                }}
-                className='px-2'
-              >
-                <span className='sr-only'>Edit</span>
-                <Pencil size={16} className='inline' />
-              </Link>
-            </TooltipTrigger>
-            <TooltipContent>
-              Edit the secret "{row.original.usernameSecretRef}"
-            </TooltipContent>
-          </Tooltip>
+          {row.original.usernameSecretRef}
         </div>
       ),
       enableColumnFilter: false,
@@ -202,28 +181,7 @@ const InfrastructureServices = () => {
       header: 'Password Secret',
       cell: ({ row }) => (
         <div className='flex items-baseline'>
-          {row.original.passwordSecretRef}{' '}
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Link
-                to='/organizations/$orgId/secrets/$secretName/edit'
-                params={{
-                  orgId: params.orgId,
-                  secretName: row.original.passwordSecretRef,
-                }}
-                search={{
-                  returnTo: '/organizations/$orgId/infrastructure-services',
-                }}
-                className='px-2'
-              >
-                <span className='sr-only'>Edit</span>
-                <Pencil size={16} className='inline' />
-              </Link>
-            </TooltipTrigger>
-            <TooltipContent>
-              Edit the secret "{row.original.passwordSecretRef}"
-            </TooltipContent>
-          </Tooltip>
+          {row.original.passwordSecretRef}
         </div>
       ),
       enableColumnFilter: false,

--- a/ui/src/routes/organizations/$orgId/infrastructure-services/index.tsx
+++ b/ui/src/routes/organizations/$orgId/infrastructure-services/index.tsx
@@ -100,7 +100,7 @@ const ActionCell = ({ row }: CellContext<InfrastructureService, unknown>) => {
           <Link
             to='/organizations/$orgId/infrastructure-services/$serviceName/edit'
             params={{ orgId: params.orgId, serviceName: row.original.name }}
-            className={cn(buttonVariants({ variant: 'outline' }), 'h-9 px-2')}
+            className={cn(buttonVariants({ variant: 'outline' }), 'h-8 px-2')}
           >
             <span className='sr-only'>Edit</span>
             <EditIcon size={16} />

--- a/ui/src/routes/organizations/$orgId/infrastructure-services/index.tsx
+++ b/ui/src/routes/organizations/$orgId/infrastructure-services/index.tsx
@@ -153,18 +153,17 @@ const InfrastructureServices = () => {
 
   const columns: ColumnDef<InfrastructureService>[] = [
     {
-      accessorKey: 'name',
-      header: 'Name',
-      enableColumnFilter: false,
-    },
-    {
-      accessorKey: 'description',
-      header: 'Description',
-      enableColumnFilter: false,
-    },
-    {
-      accessorKey: 'url',
-      header: 'URL',
+      accessorKey: 'details',
+      header: undefined,
+      cell: ({ row }) => (
+        <div className='flex flex-col'>
+          <div>{row.original.name}</div>
+          <div className='text-muted-foreground text-sm'>
+            {row.original.description}
+          </div>
+          <div>{row.original.url}</div>
+        </div>
+      ),
       enableColumnFilter: false,
     },
     {


### PR DESCRIPTION
This PR addresses two issues:

1. Infrastructure service table's overflow off-screen to the right: 
![Screenshot from 2025-03-10 12-44-22](https://github.com/user-attachments/assets/842f4f81-9904-4c5d-b059-60b43efe853e)

2. Simplification of creation and editing of the infrastructure services with usage of dropdown lists for the secrets:
![Screenshot from 2025-03-10 12-45-20](https://github.com/user-attachments/assets/98b380f3-6592-4661-ad41-d065fbc521a6)

Please see the commits for details.