### PR TITLE
feat(api): Add name of the user that triggered a scan

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
@@ -83,6 +83,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.SortProperty as ApiSortProper
 import org.eclipse.apoapsis.ortserver.api.v1.model.SourceCodeOrigin as ApiSourceCodeOrigin
 import org.eclipse.apoapsis.ortserver.api.v1.model.SubmoduleFetchStrategy as ApiSubmoduleFetchStrategy
 import org.eclipse.apoapsis.ortserver.api.v1.model.User as ApiUser
+import org.eclipse.apoapsis.ortserver.api.v1.model.UserDisplayName as ApiUserDisplayName
 import org.eclipse.apoapsis.ortserver.api.v1.model.VcsInfo as ApiVcsInfo
 import org.eclipse.apoapsis.ortserver.api.v1.model.Vulnerability as ApiVulnerability
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityRating as ApiVulnerabilityRating
@@ -133,6 +134,7 @@ import org.eclipse.apoapsis.ortserver.model.Severity
 import org.eclipse.apoapsis.ortserver.model.SourceCodeOrigin
 import org.eclipse.apoapsis.ortserver.model.SubmoduleFetchStrategy
 import org.eclipse.apoapsis.ortserver.model.User
+import org.eclipse.apoapsis.ortserver.model.UserDisplayName
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityRating
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityWithAccumulatedData
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityWithIdentifier
@@ -372,7 +374,8 @@ fun OrtRun.mapToApi(jobs: ApiJobs) =
         jobConfigContext,
         resolvedJobConfigContext,
         environmentConfigPath,
-        traceId
+        traceId,
+        userDisplayName?.mapToApi()
     )
 
 fun OrtRun.mapToApiSummary(jobs: ApiJobSummaries) =
@@ -392,7 +395,8 @@ fun OrtRun.mapToApiSummary(jobs: ApiJobSummaries) =
         labels = labels,
         jobConfigContext = jobConfigContext,
         resolvedJobConfigContext = resolvedJobConfigContext,
-        environmentConfigPath = environmentConfigPath
+        environmentConfigPath = environmentConfigPath,
+        userDisplayName = userDisplayName?.mapToApi()
     )
 
 fun OrtRunSummary.mapToApi() =
@@ -412,7 +416,8 @@ fun OrtRunSummary.mapToApi() =
         labels = labels,
         jobConfigContext = jobConfigContext,
         resolvedJobConfigContext = resolvedJobConfigContext,
-        environmentConfigPath = environmentConfigPath
+        environmentConfigPath = environmentConfigPath,
+        userDisplayName = userDisplayName?.mapToApi()
     )
 
 fun JobSummaries.mapToApi() =
@@ -886,3 +891,5 @@ fun Project.mapToApi() = ApiProject(
     homepageUrl,
     scopeNames
 )
+
+fun UserDisplayName.mapToApi() = ApiUserDisplayName(username, fullName)

--- a/api/v1/model/src/commonMain/kotlin/OrtRun.kt
+++ b/api/v1/model/src/commonMain/kotlin/OrtRun.kt
@@ -131,7 +131,12 @@ data class OrtRun(
      * The trace ID that is assigned to this run. This is generated when the run is created. It can be used to
      * correlate the logs from different components that are taking part in processing of the run.
      */
-    val traceId: String?
+    val traceId: String?,
+
+    /**
+     * Display name of the user that triggered the scan.
+     */
+    val userDisplayName: UserDisplayName? = null
 )
 
 /**

--- a/api/v1/model/src/commonMain/kotlin/OrtRunSummary.kt
+++ b/api/v1/model/src/commonMain/kotlin/OrtRunSummary.kt
@@ -111,7 +111,12 @@ data class OrtRunSummary(
      * The optional path to an environment configuration file. If this is not defined, the environment configuration is
      * read from the default location `.ort.env.yml`.
      */
-    val environmentConfigPath: String? = null
+    val environmentConfigPath: String? = null,
+
+    /**
+     * Display name of the user that triggered this run.
+     */
+    val userDisplayName: UserDisplayName? = null
 )
 
 @Serializable

--- a/api/v1/model/src/commonMain/kotlin/UserDisplayName.kt
+++ b/api/v1/model/src/commonMain/kotlin/UserDisplayName.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.api.v1.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * User information to be displayed in the UI.
+ */
+@Serializable
+data class UserDisplayName(
+    /**
+     * Unique, human-readable identifier chosen by the user or administrator, used for authentication and login.
+     * This can change over time.
+     */
+    val username: String,
+
+    /**
+     * Full name of the user: A derived attribute that typically combines a user's first name and last name,
+     * providing a readable display name but not serving as a unique identifier. This can change over time.
+     */
+    val fullName: String? = null
+)

--- a/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
@@ -67,6 +67,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.SourceCodeOrigin
 import org.eclipse.apoapsis.ortserver.api.v1.model.SubmoduleFetchStrategy.FULLY_RECURSIVE
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateRepository
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateSecret
+import org.eclipse.apoapsis.ortserver.api.v1.model.UserDisplayName
 import org.eclipse.apoapsis.ortserver.api.v1.model.Username
 import org.eclipse.apoapsis.ortserver.api.v1.model.asPresent
 
@@ -360,7 +361,8 @@ val getOrtRunsByRepositoryId: OpenApiRoute.() -> Unit = {
                                 status = OrtRunStatus.FINISHED,
                                 labels = mapOf("label key" to "label value"),
                                 jobConfigContext = null,
-                                resolvedJobConfigContext = "c80ef3bcd2bec428da923a188dd0870b1153995c"
+                                resolvedJobConfigContext = "c80ef3bcd2bec428da923a188dd0870b1153995c",
+                                userDisplayName = UserDisplayName("john.doe", "John Doe")
                             ),
                             OrtRunSummary(
                                 id = 3,
@@ -381,7 +383,8 @@ val getOrtRunsByRepositoryId: OpenApiRoute.() -> Unit = {
                                 labels = mapOf("label key" to "label value"),
                                 jobConfigContext = null,
                                 resolvedJobConfigContext = "32f955941e94d0a318e1c985903f42af924e9050",
-                                environmentConfigPath = null
+                                environmentConfigPath = null,
+                                userDisplayName = UserDisplayName("john.doe", "John Doe")
                             )
                         ),
                         PagingData(

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -52,6 +52,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.Severity
 import org.eclipse.apoapsis.ortserver.api.v1.model.ShortestDependencyPath
 import org.eclipse.apoapsis.ortserver.api.v1.model.SortDirection
 import org.eclipse.apoapsis.ortserver.api.v1.model.SortProperty
+import org.eclipse.apoapsis.ortserver.api.v1.model.UserDisplayName
 import org.eclipse.apoapsis.ortserver.api.v1.model.VcsInfo
 import org.eclipse.apoapsis.ortserver.api.v1.model.Vulnerability
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityRating
@@ -94,7 +95,8 @@ val getOrtRunById: OpenApiRoute.() -> Unit = {
                         jobConfigContext = null,
                         resolvedJobConfigContext = "32f955941e94d0a318e1c985903f42af924e9050",
                         traceId = "35b67724-a85a-4cc4-b2a4-60fd914634e7",
-                        environmentConfigPath = null
+                        environmentConfigPath = null,
+                        userDisplayName = UserDisplayName("john.doe", "John Doe")
                     )
                 }
             }

--- a/core/src/main/kotlin/authorization/OrtPrincipal.kt
+++ b/core/src/main/kotlin/authorization/OrtPrincipal.kt
@@ -49,3 +49,9 @@ fun OrtPrincipal?.hasRole(role: String) = this != null && role in roles
  * Return true if this [OrtPrincipal] is not `null` and has the [superuser role][Superuser.ROLE_NAME].
  */
 fun OrtPrincipal?.isSuperuser() = hasRole(Superuser.ROLE_NAME)
+
+fun OrtPrincipal.getUserId(): String = payload.subject
+
+fun OrtPrincipal.getUsername(): String = payload.getClaim("preferred_username").asString()
+
+fun OrtPrincipal.getFullName(): String? = payload.getClaim("name").asString()

--- a/core/src/main/kotlin/services/OrchestratorService.kt
+++ b/core/src/main/kotlin/services/OrchestratorService.kt
@@ -25,6 +25,7 @@ import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
 import org.eclipse.apoapsis.ortserver.model.JobConfigurations
 import org.eclipse.apoapsis.ortserver.model.OrtRun
+import org.eclipse.apoapsis.ortserver.model.UserDisplayName
 import org.eclipse.apoapsis.ortserver.model.orchestrator.CreateOrtRun
 import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
 import org.eclipse.apoapsis.ortserver.transport.Message
@@ -56,7 +57,8 @@ class OrchestratorService(
         jobConfig: JobConfigurations,
         jobConfigContext: String?,
         labels: Map<String, String>?,
-        environmentConfigPath: String?
+        environmentConfigPath: String?,
+        userDisplayName: UserDisplayName?
     ): OrtRun {
         val traceId = MDC.get("traceId")
 
@@ -70,7 +72,8 @@ class OrchestratorService(
                 jobConfigContext,
                 labels.orEmpty(),
                 traceId = traceId,
-                environmentConfigPath = environmentConfigPath
+                environmentConfigPath = environmentConfigPath,
+                userDisplayName = userDisplayName
             )
         }
 

--- a/dao/src/main/kotlin/repositories/ortrun/DaoOrtRunRepository.kt
+++ b/dao/src/main/kotlin/repositories/ortrun/DaoOrtRunRepository.kt
@@ -28,6 +28,7 @@ import org.eclipse.apoapsis.ortserver.dao.entityQuery
 import org.eclipse.apoapsis.ortserver.dao.mapAndDeduplicate
 import org.eclipse.apoapsis.ortserver.dao.repositories.product.ProductsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.repository.RepositoriesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.userDisplayName.UserDisplayNameDAO
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.OrtRunIssueDao
 import org.eclipse.apoapsis.ortserver.dao.utils.applyFilter
 import org.eclipse.apoapsis.ortserver.dao.utils.listQuery
@@ -38,6 +39,7 @@ import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.OrtRunFilters
 import org.eclipse.apoapsis.ortserver.model.OrtRunStatus
 import org.eclipse.apoapsis.ortserver.model.OrtRunSummary
+import org.eclipse.apoapsis.ortserver.model.UserDisplayName
 import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
@@ -67,7 +69,8 @@ class DaoOrtRunRepository(private val db: Database) : OrtRunRepository {
         jobConfigContext: String?,
         labels: Map<String, String>,
         traceId: String?,
-        environmentConfigPath: String?
+        environmentConfigPath: String?,
+        userDisplayName: UserDisplayName?
     ): OrtRun = db.blockingQuery {
         val maxIndex = OrtRunsTable.index.max()
         val lastIndex = OrtRunsTable
@@ -90,6 +93,7 @@ class DaoOrtRunRepository(private val db: Database) : OrtRunRepository {
             this.labels = mapAndDeduplicate(labels.entries, ::getLabelDao)
             this.traceId = traceId
             this.environmentConfigPath = environmentConfigPath
+            this.userDisplayName = UserDisplayNameDAO.insertOrUpdate(userDisplayName)
         }.mapToModel()
     }
 

--- a/dao/src/main/kotlin/repositories/ortrun/OrtRunsTable.kt
+++ b/dao/src/main/kotlin/repositories/ortrun/OrtRunsTable.kt
@@ -35,6 +35,8 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.R
 import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.RepositoryConfigurationsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.scannerjob.ScannerJobDao
 import org.eclipse.apoapsis.ortserver.dao.repositories.scannerjob.ScannerJobsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.userDisplayName.UserDisplayNameDAO
+import org.eclipse.apoapsis.ortserver.dao.repositories.userDisplayName.UserDisplayNamesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.NestedRepositoriesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.NestedRepositoryDao
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.OrtRunIssueDao
@@ -79,6 +81,7 @@ object OrtRunsTable : SortableTable("ort_runs") {
     val path = text("path").nullable()
     val traceId = text("trace_id").nullable()
     val environmentConfigPath = text("environment_config_path").nullable()
+    val userDisplayName = reference("user_id", UserDisplayNamesTable.id).nullable()
 }
 
 class OrtRunDao(id: EntityID<Long>) : LongEntity(id) {
@@ -104,6 +107,7 @@ class OrtRunDao(id: EntityID<Long>) : LongEntity(id) {
     var vcsId by OrtRunsTable.vcsId
     var vcsProcessedId by OrtRunsTable.vcsProcessedId
     var environmentConfigPath by OrtRunsTable.environmentConfigPath
+    var userDisplayName by UserDisplayNameDAO optionalReferencedOn OrtRunsTable.userDisplayName
 
     val advisorJob by AdvisorJobDao optionalBackReferencedOn AdvisorJobsTable.ortRunId
     val analyzerJob by AnalyzerJobDao optionalBackReferencedOn AnalyzerJobsTable.ortRunId
@@ -137,7 +141,8 @@ class OrtRunDao(id: EntityID<Long>) : LongEntity(id) {
         jobConfigContext = jobConfigContext,
         resolvedJobConfigContext = resolvedJobConfigContext,
         traceId = traceId,
-        environmentConfigPath = environmentConfigPath
+        environmentConfigPath = environmentConfigPath,
+        userDisplayName = userDisplayName?.mapToModel(),
     )
 
     /**
@@ -169,7 +174,8 @@ class OrtRunDao(id: EntityID<Long>) : LongEntity(id) {
             labels = labels.associate { it.mapToModel() },
             jobConfigContext = jobConfigContext,
             resolvedJobConfigContext = resolvedJobConfigContext,
-            environmentConfigPath = environmentConfigPath
+            environmentConfigPath = environmentConfigPath,
+            userDisplayName = userDisplayName?.mapToModel(),
         )
     }
 }

--- a/dao/src/main/kotlin/repositories/userDisplayName/UserDisplayNamesTable.kt
+++ b/dao/src/main/kotlin/repositories/userDisplayName/UserDisplayNamesTable.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.dao.repositories.userDisplayName
+
+import kotlinx.datetime.Clock
+
+import org.eclipse.apoapsis.ortserver.dao.utils.transformToDatabasePrecision
+import org.eclipse.apoapsis.ortserver.model.UserDisplayName
+
+import org.jetbrains.exposed.dao.Entity
+import org.jetbrains.exposed.dao.EntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.IdTable
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
+import org.jetbrains.exposed.sql.upsert
+
+/**
+ * A table to represent names to identify a user. This is **not** used for any authentication or authorization purposes,
+ * it is only used to store users' names in a central table, where it is easier to keep them up to date or remove them
+ * after a time of inactivity.
+ */
+object UserDisplayNamesTable : IdTable<String>("user_display_names") {
+
+    /**
+     * Unique user identifier, for example derived from JWT `sub` claim. This is stable over time.
+     */
+    override val id: Column<EntityID<String>> = varchar("user_id", 40).entityId()
+
+    /**
+     * Preferred username. This may change over time.
+     */
+    val username = text("username")
+
+    /**
+     * UX friendly display name. This may change over time.
+     */
+    val fullName = text("full_name").nullable()
+
+    val createdAt = timestamp("created_at")
+}
+
+class UserDisplayNameDAO(id: EntityID<String>) : Entity<String>(id) {
+    companion object : EntityClass<String, UserDisplayNameDAO>(UserDisplayNamesTable) {
+        /**
+         * Insert a new entry, if it does not already exist, else update the entry.
+         */
+        fun insertOrUpdate(userDisplayName: UserDisplayName?): UserDisplayNameDAO? {
+            // Tests may pass `null` as `userDisplayName`
+            if (userDisplayName == null) {
+                return null
+            }
+
+            UserDisplayNamesTable.upsert(UserDisplayNamesTable.id) {
+                it[this.id] = userDisplayName.userId
+                it[this.username] = userDisplayName.username
+                it[this.fullName] = userDisplayName.fullName
+                it[this.createdAt] = Clock.System.now()
+            }
+
+            return UserDisplayNameDAO[userDisplayName.userId]
+        }
+    }
+
+    var username by UserDisplayNamesTable.username
+    var fullName by UserDisplayNamesTable.fullName
+    var createdAt by UserDisplayNamesTable.createdAt.transformToDatabasePrecision()
+
+    fun mapToModel() = UserDisplayName(userId = id.value, username = username, fullName = fullName)
+}

--- a/dao/src/main/resources/db/migration/V98__userDisplayNames.sql
+++ b/dao/src/main/resources/db/migration/V98__userDisplayNames.sql
@@ -1,0 +1,9 @@
+CREATE TABLE user_display_names (
+    user_id VARCHAR(40) PRIMARY KEY, -- Unique user identifier (from JWT `sub` claim, stable over time)
+    username TEXT UNIQUE NOT NULL,   -- Preferred username (may change over time)
+    full_name TEXT,                  -- User's full name (optional, may change over time, UX friendly)
+    created_at TIMESTAMP NOT NULL
+);
+
+ALTER TABLE ort_runs
+    ADD COLUMN user_id VARCHAR(40) NULL;

--- a/model/src/commonMain/kotlin/OrtRun.kt
+++ b/model/src/commonMain/kotlin/OrtRun.kt
@@ -150,7 +150,12 @@ data class OrtRun(
      * The trace ID that is assigned to this run. This is generated when the run is created. It can be used to
      * correlate the logs from different components that are taking part in processing of the run.
      */
-    val traceId: String?
+    val traceId: String?,
+
+    /**
+     * Name of the user that triggered this run.
+     */
+    val userDisplayName: UserDisplayName? = null
 )
 
 enum class OrtRunStatus(

--- a/model/src/commonMain/kotlin/OrtRunSummary.kt
+++ b/model/src/commonMain/kotlin/OrtRunSummary.kt
@@ -111,7 +111,12 @@ data class OrtRunSummary(
      * The optional path to an environment configuration file. If this is not defined, the environment configuration is
      * read from the default location `.ort.env.yml`.
      */
-    val environmentConfigPath: String? = null
+    val environmentConfigPath: String? = null,
+
+    /**
+     * Display name of the user that triggered this run.
+     */
+    val userDisplayName: UserDisplayName? = null,
 )
 
 /**

--- a/model/src/commonMain/kotlin/UserDisplayName.kt
+++ b/model/src/commonMain/kotlin/UserDisplayName.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * User information to be displayed in the UI.
+ */
+@Serializable
+data class UserDisplayName(
+    /**
+     * Identifier assigned to each user in Keycloak, used to distinguish users across sessions and services.
+     * This identifier is stable over time and is unique to each user.
+     */
+    val userId: String,
+
+    /**
+     * Unique, human-readable identifier chosen by the user or administrator, used for authentication and login.
+     * Unlike the immutable [userId], this identifier can change over time.
+     */
+    val username: String,
+
+    /**
+     * Full name of the user: A derived attribute that typically combines a user's first name and last name,
+     * providing a readable display name but not serving as a unique identifier. This can change over time.
+     */
+    val fullName: String? = null
+)

--- a/model/src/commonMain/kotlin/repositories/OrtRunRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/OrtRunRepository.kt
@@ -27,6 +27,7 @@ import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.OrtRunFilters
 import org.eclipse.apoapsis.ortserver.model.OrtRunStatus
 import org.eclipse.apoapsis.ortserver.model.OrtRunSummary
+import org.eclipse.apoapsis.ortserver.model.UserDisplayName
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
@@ -49,6 +50,7 @@ interface OrtRunRepository {
         labels: Map<String, String>,
         traceId: String?,
         environmentConfigPath: String?,
+        userDisplayName: UserDisplayName? = null
     ): OrtRun
 
     /**

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/repository-runs-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/repository-runs-table.tsx
@@ -90,8 +90,28 @@ const columns = [
     enableColumnFilter: false,
   }),
   columnHelper.accessor('createdAt', {
-    header: 'Created At',
-    cell: ({ row }) => <TimestampWithUTC timestamp={row.original.createdAt} />,
+    header: 'Created',
+    cell: ({ row }) => (
+      <div>
+        <TimestampWithUTC timestamp={row.original.createdAt} />
+        {row.original.userDisplayName && (
+          <div>
+            {row.original.userDisplayName?.fullName ? (
+              <Tooltip>
+                <TooltipTrigger>
+                  {row.original.userDisplayName?.username}
+                </TooltipTrigger>
+                <TooltipContent>
+                  {row.original.userDisplayName?.fullName}
+                </TooltipContent>
+              </Tooltip>
+            ) : (
+              <span>{row.original.userDisplayName?.username}</span>
+            )}
+          </div>
+        )}
+      </div>
+    ),
     enableColumnFilter: false,
   }),
   columnHelper.accessor('status', {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/index.tsx
@@ -29,6 +29,11 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip.tsx';
 import { config } from '@/config';
 import { calculateDuration } from '@/helpers/get-run-duration';
 import { getStatusBackgroundColor } from '@/helpers/get-status-class';
@@ -110,6 +115,23 @@ const RunComponent = () => {
                 <Label className='font-semibold'>Created at:</Label>{' '}
                 <TimestampWithUTC timestamp={ortRun.createdAt} />
               </div>
+              {ortRun.userDisplayName && (
+                <div className='text-sm'>
+                  <Label className='font-semibold'>Created by:</Label>{' '}
+                  {ortRun.userDisplayName?.fullName ? (
+                    <Tooltip>
+                      <TooltipTrigger>
+                        {ortRun.userDisplayName?.username}
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {ortRun.userDisplayName?.fullName}
+                      </TooltipContent>
+                    </Tooltip>
+                  ) : (
+                    <span>{ortRun.userDisplayName?.username}</span>
+                  )}
+                </div>
+              )}
               {ortRun.finishedAt && (
                 <div>
                   <div className='text-sm'>


### PR DESCRIPTION
Add username and full name (if present) of the user that triggered a scan to the scan representation in the database, and also provide these names when querying scans using the REST API in order to allow to display them in the UI in a user-friendly way.

Add username and full name (as tooltip) of the user that triggered a scan to the list of scans per repository and in the detail view of the scan.

Fixes #2132.

See the respective commits for details.