### PR TITLE
feat: Add initial endpoint for the licenses for packages

### DIFF
--- a/api/v1/model/src/commonMain/kotlin/Licenses.kt
+++ b/api/v1/model/src/commonMain/kotlin/Licenses.kt
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.api.v1.model
+
+import kotlinx.serialization.Serializable
+
+/**
+ * A response object for licenses.
+ */
+@Serializable
+data class Licenses(
+    /** The distinct processed declared license expressions. */
+    val processedDeclaredLicenses: List<String>
+)

--- a/core/src/main/kotlin/api/RunsRoute.kt
+++ b/core/src/main/kotlin/api/RunsRoute.kt
@@ -41,6 +41,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToModel
 import org.eclipse.apoapsis.ortserver.api.v1.model.ComparisonOperator
 import org.eclipse.apoapsis.ortserver.api.v1.model.FilterOperatorAndValue
 import org.eclipse.apoapsis.ortserver.api.v1.model.JobSummaries
+import org.eclipse.apoapsis.ortserver.api.v1.model.Licenses
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunFilters
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatistics
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatus
@@ -49,6 +50,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.SortDirection
 import org.eclipse.apoapsis.ortserver.api.v1.model.SortProperty
 import org.eclipse.apoapsis.ortserver.core.apiDocs.deleteOrtRunById
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getIssuesByRunId
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getLicensesForPackagesByRunId
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getLogsByRunId
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getOrtRunById
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getOrtRunStatistics
@@ -247,6 +249,20 @@ fun Route.runs() = route("runs") {
                         .toSearchResponse(filters)
 
                     call.respond(HttpStatusCode.OK, pagedResponse)
+                }
+            }
+
+            route("licenses") {
+                get(getLicensesForPackagesByRunId) {
+                    call.forRun(ortRunRepository) { ortRun ->
+                        requirePermission(RepositoryPermission.READ_ORT_RUNS.roleName(ortRun.repositoryId))
+
+                        val licenses = Licenses(
+                            packageService.getProcessedDeclaredLicenses(ortRun.id)
+                        )
+
+                        call.respond(HttpStatusCode.OK, licenses)
+                    }
                 }
             }
         }

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -33,6 +33,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.FilterOperatorAndValue
 import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
 import org.eclipse.apoapsis.ortserver.api.v1.model.Issue
 import org.eclipse.apoapsis.ortserver.api.v1.model.JobSummaries
+import org.eclipse.apoapsis.ortserver.api.v1.model.Licenses
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunFilters
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatistics
@@ -623,6 +624,30 @@ val getOrtRunStatistics: OpenApiRoute.() -> Unit = {
                             Severity.WARNING to 1,
                             Severity.ERROR to 4
                         )
+                    )
+                }
+            }
+        }
+    }
+}
+
+val getLicensesForPackagesByRunId: OpenApiRoute.() -> Unit = {
+    operationId = "GetLicensesForPackagesByRunId"
+    summary = "Get the licenses for packages found in an ORT run."
+    tags = listOf("Runs")
+
+    request {
+        pathParameter<Long>("runId") {
+            description = "The ID of the ORT run."
+        }
+    }
+
+    response {
+        HttpStatusCode.OK to {
+            jsonBody<Licenses> {
+                example("Get licenses for packages") {
+                    value = Licenses(
+                        processedDeclaredLicenses = listOf("Apache-2.0", "MIT")
                     )
                 }
             }

--- a/services/hierarchy/src/main/kotlin/PackageService.kt
+++ b/services/hierarchy/src/main/kotlin/PackageService.kt
@@ -161,6 +161,18 @@ class PackageService(private val db: Database) {
                     )
                 }
         }
+
+    /** Get all distinct processed declared license expressions found in packages in an ORT run. */
+    suspend fun getProcessedDeclaredLicenses(ortRunId: Long): List<String> =
+        db.dbQuery {
+            PackagesTable.joinAnalyzerTables()
+                .innerJoin(ProcessedDeclaredLicensesTable)
+                .select(ProcessedDeclaredLicensesTable.spdxExpression)
+                .withDistinct()
+                .where { AnalyzerJobsTable.ortRunId eq ortRunId }
+                .orderBy(ProcessedDeclaredLicensesTable.spdxExpression)
+                .mapNotNull { it[ProcessedDeclaredLicensesTable.spdxExpression] }
+        }
 }
 
 private fun ResultRow.toPackageWithShortestDependencyPaths(): PackageWithShortestDependencyPaths =

--- a/services/hierarchy/src/test/kotlin/PackageServiceTest.kt
+++ b/services/hierarchy/src/test/kotlin/PackageServiceTest.kt
@@ -578,6 +578,54 @@ class PackageServiceTest : WordSpec() {
                 ecosystems.last().count shouldBe 1
             }
         }
+
+        "getProcessedDeclaredLicenses" should {
+            "return the distinct processed declared SPDX licenses found in packages in the ORT run" {
+                val service = PackageService(db)
+
+                val ortRunId = createAnalyzerRunWithPackages(
+                    setOf(
+                        fixtures.generatePackage(
+                            Identifier("Maven", "com.example", "example", "1.0"),
+                            processedDeclaredLicense = ProcessedDeclaredLicense(
+                                "Apache-2.0 OR LGPL-2.1-or-later",
+                                emptyMap(),
+                                emptySet()
+                            )
+                        ),
+                        fixtures.generatePackage(
+                            Identifier("Maven", "com.example", "example2", "1.0"),
+                            processedDeclaredLicense = ProcessedDeclaredLicense(
+                                "Apache-2.0",
+                                emptyMap(),
+                                emptySet()
+                            )
+                        ),
+                        fixtures.generatePackage(
+                            Identifier("NPM", "com.example", "example3", "1.0"),
+                            processedDeclaredLicense = ProcessedDeclaredLicense(
+                                "MIT",
+                                emptyMap(),
+                                emptySet()
+                            )
+                        ),
+                        fixtures.generatePackage(
+                            Identifier("NPM", "com.example", "example4", "1.0"),
+                            processedDeclaredLicense = ProcessedDeclaredLicense(
+                                "MIT",
+                                emptyMap(),
+                                emptySet()
+                            )
+                        )
+                    )
+                ).id
+
+                val licenses = service.getProcessedDeclaredLicenses(ortRunId)
+
+                licenses.size shouldBe 3
+                licenses shouldBe listOf("Apache-2.0", "Apache-2.0 OR LGPL-2.1-or-later", "MIT")
+            }
+        }
     }
 
     private fun createAnalyzerRunWithPackages(


### PR DESCRIPTION
The endpoint now returns the distinct processed declared licenses for packages found in a run.

These will be used to provide select filter options in the packages table in the UI.