### PR TITLE
feat(ui): Add user's full name in user account menu

### DIFF
--- a/scripts/docker/keycloak/master-realm.json
+++ b/scripts/docker/keycloak/master-realm.json
@@ -430,8 +430,8 @@
   }, {
     "id" : "dc908d80-5155-4b92-a34f-3c6bbed31893",
     "username" : "ort-admin",
-    "firstName" : "",
-    "lastName" : "",
+    "firstName" : "ORT",
+    "lastName" : "Administrator User",
     "emailVerified" : false,
     "createdTimestamp" : 1660817443238,
     "enabled" : true,

--- a/ui/src/components/header.tsx
+++ b/ui/src/components/header.tsx
@@ -246,7 +246,11 @@ export const Header = () => {
                   {user.username?.slice(0, 2).toUpperCase()}
                 </AvatarFallback>
               </Avatar>
-              <span className='font-semibold'>{user.username}</span>
+              <div>
+                <span className='font-semibold'>{user.username}</span>
+                <br />
+                <span>{user.fullName}</span>
+              </div>
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             <Link to='/about'>

--- a/ui/src/hooks/use-user.ts
+++ b/ui/src/hooks/use-user.ts
@@ -35,9 +35,13 @@ export const useUser = () => {
   // Return the logged-in username.
   const username = auth?.user?.profile?.preferred_username;
 
+  // Return end-user's full name, including all name parts.
+  const fullName = auth?.user?.profile?.name;
+
   return {
     hasRole,
     username,
+    fullName,
     ...auth,
   };
 };


### PR DESCRIPTION
Below the logged-in users username in the user account menu in the top right corner, additionally display the user's full name.

![image](https://github.com/user-attachments/assets/6a8e2928-e31f-43fd-9b74-3a3ae271d39a)
