### PR TITLE
ci(github): Improve the check for issue links

### DIFF
--- a/.github/workflows/check-issue-links.yml
+++ b/.github/workflows/check-issue-links.yml
@@ -62,7 +62,7 @@ jobs:
         response=$(gh api graphql -f query="$query")
 
         # Extract linked issues.
-        linked_issues=$(echo $response | jq -r '.data.repository.pullRequest.closingIssuesReferences.edges[].node.number' | sort | uniq | tr '\n' ',')
+        linked_issues=$(echo $response | jq -r '.data.repository.pullRequest.closingIssuesReferences.edges | map(.node.number) | unique | join(",")')
         echo "Found currently linked issues: $linked_issues"
 
         # Export linked issues as an environment variable.


### PR DESCRIPTION
Let `jq` itself remove duplicates (and sort) [1], and also the conversion to a comma-separated list [2]. This fixes the issue with a trailing comma in the list.

[1]: https://jqlang.org/manual/#unique-unique_by
[2]: https://jqlang.org/manual/#join