### PR TITLE
ui: Start refactoring the configuration page

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/advisor-job-details.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/advisor-job-details.tsx
@@ -38,29 +38,22 @@ export const AdvisorJobDetails = ({ run }: AdvisorJobDetailsProps) => {
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <div className='space-y-2 text-sm'>
-          {jobConfigs && (
-            <div className='space-y-2'>
-              <Label className='font-semibold'>
-                Resolved job configuration:
-              </Label>
-              <div className='ml-2 space-y-2'>
-                {jobConfigs?.skipExcluded && (
-                  <div>
-                    <Label className='font-semibold'>Skip excluded: </Label>
-                    {jobConfigs.skipExcluded.toString()}
-                  </div>
-                )}
-                {jobConfigs?.advisors && (
-                  <div>
-                    <Label className='font-semibold'>Advisors:</Label>{' '}
-                    {jobConfigs.advisors.join(', ')}
-                  </div>
-                )}
+        {jobConfigs && (
+          <div className='space-y-2 text-sm'>
+            {jobConfigs?.skipExcluded && (
+              <div>
+                <Label className='font-semibold'>Skip excluded: </Label>
+                {jobConfigs.skipExcluded.toString()}
               </div>
-            </div>
-          )}
-        </div>
+            )}
+            {jobConfigs?.advisors && (
+              <div>
+                <Label className='font-semibold'>Advisors:</Label>{' '}
+                {jobConfigs.advisors.join(', ')}
+              </div>
+            )}
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/advisor-job-details.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/advisor-job-details.tsx
@@ -18,11 +18,9 @@
  */
 
 import { OrtRun } from '@/api/requests';
-import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
-import { calculateDuration } from '@/helpers/get-run-duration';
-import { getStatusBackgroundColor } from '@/helpers/get-status-class';
+import { JobTitle } from './job-title';
 
 type AdvisorJobDetailsProps = {
   run: OrtRun;
@@ -35,21 +33,12 @@ export const AdvisorJobDetails = ({ run }: AdvisorJobDetailsProps) => {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className='flex gap-2'>
-          Advisor
-          <Badge className={`border ${getStatusBackgroundColor(job?.status)}`}>
-            {job?.status || 'NOT RUN'}
-          </Badge>
+        <CardTitle>
+          <JobTitle title='Advisor' job={job} />
         </CardTitle>
       </CardHeader>
       <CardContent>
         <div className='space-y-2 text-sm'>
-          <div>
-            <Label className='font-semibold'>Duration: </Label>
-            {job?.startedAt && job?.finishedAt
-              ? calculateDuration(job.startedAt, job.finishedAt)
-              : 'N/A'}
-          </div>
           {jobConfigs && (
             <div className='space-y-2'>
               <Label className='font-semibold'>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/analyzer-job-details.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/analyzer-job-details.tsx
@@ -38,100 +38,86 @@ export const AnalyzerJobDetails = ({ run }: AnalyzerJobDetailsProps) => {
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <div className='space-y-2 text-sm'>
-          {jobConfigs && (
-            <div className='space-y-2'>
-              <Label className='font-semibold'>
-                Resolved job configuration:
-              </Label>
-              <div className='ml-2 space-y-2'>
-                {jobConfigs.repositoryConfigPath && (
-                  <div>
-                    <Label className='font-semibold'>
-                      Repository configuration path:
-                    </Label>{' '}
-                    {jobConfigs.repositoryConfigPath}
-                  </div>
-                )}
-                {jobConfigs.allowDynamicVersions && (
-                  <div>
-                    <Label className='font-semibold'>
-                      Allow dynamic versions:
-                    </Label>{' '}
-                    {jobConfigs.allowDynamicVersions.toString()}
-                  </div>
-                )}
-                {jobConfigs.skipExcluded && (
-                  <div>
-                    <Label className='font-semibold'>Skip excluded: </Label>
-                    {jobConfigs.skipExcluded.toString()}
-                  </div>
-                )}
-                {jobConfigs.enabledPackageManagers && (
-                  <div>
-                    <Label className='font-semibold'>
-                      Enabled package managers:
-                    </Label>{' '}
-                    {jobConfigs.enabledPackageManagers.join(', ')}
-                  </div>
-                )}
-                {jobConfigs.environmentConfig?.environmentVariables && (
-                  <div>
-                    <Label className='font-semibold'>
-                      Environment variables:
-                    </Label>{' '}
-                    {jobConfigs.environmentConfig.environmentVariables.map(
-                      (env) => (
-                        <div className='ml-2 flex gap-1' key={env.name}>
-                          <div>{env.name}</div>
-                          <div>=</div>
-                          <div>{env.value}</div>
-                        </div>
-                      )
-                    )}
-                  </div>
-                )}
-                {jobConfigs.packageManagerOptions && (
-                  <div className='space-y-2'>
-                    <Label className='font-semibold'>
-                      Package manager options:
-                    </Label>{' '}
-                    {Object.keys(jobConfigs.packageManagerOptions).map((pm) => (
-                      <div className='ml-2' key={pm}>
-                        <Label className='font-semibold'>{pm}:</Label>
-                        {jobConfigs.packageManagerOptions?.[pm]
-                          ?.mustRunAfter && (
-                          <div className='ml-2'>
-                            <Label>Must run after:</Label>{' '}
-                            {jobConfigs.packageManagerOptions?.[
-                              pm
-                            ].mustRunAfter.join(', ')}
-                          </div>
-                        )}
-                        {jobConfigs.packageManagerOptions?.[pm]?.options && (
-                          <div className='ml-2'>
-                            <div className='ml-2'>
-                              {Object.entries(
-                                jobConfigs.packageManagerOptions[pm].options
-                              ).map(([key, value]) => (
-                                <div key={key}>
-                                  <Label className='font-semibold'>
-                                    {key}:
-                                  </Label>{' '}
-                                  {value}
-                                </div>
-                              ))}
-                            </div>
-                          </div>
-                        )}
-                      </div>
-                    ))}
-                  </div>
+        {jobConfigs && (
+          <div className='space-y-2 text-sm'>
+            {jobConfigs.repositoryConfigPath && (
+              <div>
+                <Label className='font-semibold'>
+                  Repository configuration path:
+                </Label>{' '}
+                {jobConfigs.repositoryConfigPath}
+              </div>
+            )}
+            {jobConfigs.allowDynamicVersions && (
+              <div>
+                <Label className='font-semibold'>Allow dynamic versions:</Label>{' '}
+                {jobConfigs.allowDynamicVersions.toString()}
+              </div>
+            )}
+            {jobConfigs.skipExcluded && (
+              <div>
+                <Label className='font-semibold'>Skip excluded: </Label>
+                {jobConfigs.skipExcluded.toString()}
+              </div>
+            )}
+            {jobConfigs.enabledPackageManagers && (
+              <div>
+                <Label className='font-semibold'>
+                  Enabled package managers:
+                </Label>{' '}
+                {jobConfigs.enabledPackageManagers.join(', ')}
+              </div>
+            )}
+            {jobConfigs.environmentConfig?.environmentVariables && (
+              <div>
+                <Label className='font-semibold'>Environment variables:</Label>{' '}
+                {jobConfigs.environmentConfig.environmentVariables.map(
+                  (env) => (
+                    <div className='ml-2 flex gap-1' key={env.name}>
+                      <div>{env.name}</div>
+                      <div>=</div>
+                      <div>{env.value}</div>
+                    </div>
+                  )
                 )}
               </div>
-            </div>
-          )}
-        </div>
+            )}
+            {jobConfigs.packageManagerOptions && (
+              <div className='space-y-2'>
+                <Label className='font-semibold'>
+                  Package manager options:
+                </Label>{' '}
+                {Object.keys(jobConfigs.packageManagerOptions).map((pm) => (
+                  <div className='ml-2' key={pm}>
+                    <Label className='font-semibold'>{pm}:</Label>
+                    {jobConfigs.packageManagerOptions?.[pm]?.mustRunAfter && (
+                      <div className='ml-2'>
+                        <Label>Must run after:</Label>{' '}
+                        {jobConfigs.packageManagerOptions?.[
+                          pm
+                        ].mustRunAfter.join(', ')}
+                      </div>
+                    )}
+                    {jobConfigs.packageManagerOptions?.[pm]?.options && (
+                      <div className='ml-2'>
+                        <div className='ml-2'>
+                          {Object.entries(
+                            jobConfigs.packageManagerOptions[pm].options
+                          ).map(([key, value]) => (
+                            <div key={key}>
+                              <Label className='font-semibold'>{key}:</Label>{' '}
+                              {value}
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/analyzer-job-details.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/analyzer-job-details.tsx
@@ -93,7 +93,7 @@ export const AnalyzerJobDetails = ({ run }: AnalyzerJobDetailsProps) => {
                     </Label>{' '}
                     {jobConfigs.environmentConfig.environmentVariables.map(
                       (env) => (
-                        <div className='ml-2 flex gap-1'>
+                        <div className='ml-2 flex gap-1' key={env.name}>
                           <div>{env.name}</div>
                           <div>=</div>
                           <div>{env.value}</div>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/analyzer-job-details.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/analyzer-job-details.tsx
@@ -18,11 +18,9 @@
  */
 
 import { OrtRun } from '@/api/requests';
-import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
-import { calculateDuration } from '@/helpers/get-run-duration';
-import { getStatusBackgroundColor } from '@/helpers/get-status-class';
+import { JobTitle } from './job-title';
 
 type AnalyzerJobDetailsProps = {
   run: OrtRun;
@@ -35,21 +33,12 @@ export const AnalyzerJobDetails = ({ run }: AnalyzerJobDetailsProps) => {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className='flex gap-2'>
-          Analyzer
-          <Badge className={`border ${getStatusBackgroundColor(job?.status)}`}>
-            {job?.status || 'NOT RUN'}
-          </Badge>
+        <CardTitle>
+          <JobTitle title='Analyzer' job={job} />
         </CardTitle>
       </CardHeader>
       <CardContent>
         <div className='space-y-2 text-sm'>
-          <div>
-            <Label className='font-semibold'>Duration: </Label>
-            {job?.startedAt && job?.finishedAt
-              ? calculateDuration(job.startedAt, job.finishedAt)
-              : 'N/A'}
-          </div>
           {jobConfigs && (
             <div className='space-y-2'>
               <Label className='font-semibold'>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/evaluator-job-details.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/evaluator-job-details.tsx
@@ -18,11 +18,9 @@
  */
 
 import { OrtRun } from '@/api/requests';
-import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
-import { calculateDuration } from '@/helpers/get-run-duration';
-import { getStatusBackgroundColor } from '@/helpers/get-status-class';
+import { JobTitle } from './job-title';
 
 type EvaluatorJobDetailsProps = {
   run: OrtRun;
@@ -35,21 +33,12 @@ export const EvaluatorJobDetails = ({ run }: EvaluatorJobDetailsProps) => {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className='flex gap-2'>
-          Evaluator
-          <Badge className={`border ${getStatusBackgroundColor(job?.status)}`}>
-            {job?.status || 'NOT RUN'}
-          </Badge>
+        <CardTitle>
+          <JobTitle title='Evaluator' job={job} />
         </CardTitle>
       </CardHeader>
       <CardContent>
         <div className='space-y-2 text-sm'>
-          <div>
-            <Label className='font-semibold'>Duration: </Label>
-            {job?.startedAt && job?.finishedAt
-              ? calculateDuration(job.startedAt, job.finishedAt)
-              : 'N/A'}
-          </div>
           {jobConfigs && (
             <div className='space-y-2'>
               <Label className='font-semibold'>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/evaluator-job-details.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/evaluator-job-details.tsx
@@ -38,105 +38,90 @@ export const EvaluatorJobDetails = ({ run }: EvaluatorJobDetailsProps) => {
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <div className='space-y-2 text-sm'>
-          {jobConfigs && (
-            <div className='space-y-2'>
-              <Label className='font-semibold'>
-                Resolved job configuration:
-              </Label>
-              <div className='ml-2 space-y-2'>
-                {jobConfigs?.ruleSet && (
-                  <div>
-                    <Label className='font-semibold'>Ruleset:</Label>{' '}
-                    {jobConfigs.ruleSet}
-                  </div>
-                )}
-                {jobConfigs?.licenseClassificationsFile && (
-                  <div>
-                    <Label className='font-semibold'>
-                      License classifications:
-                    </Label>{' '}
-                    {jobConfigs.licenseClassificationsFile}
-                  </div>
-                )}
-                {jobConfigs?.copyrightGarbageFile && (
-                  <div>
-                    <Label className='font-semibold'>Copyright garbage:</Label>{' '}
-                    {jobConfigs.copyrightGarbageFile}
-                  </div>
-                )}
-                {jobConfigs?.resolutionsFile && (
-                  <div>
-                    <Label className='font-semibold'>Resolutions:</Label>{' '}
-                    {jobConfigs.resolutionsFile}
-                  </div>
-                )}
-                {jobConfigs?.packageConfigurationProviders && (
-                  <div className='space-y-2'>
-                    <Label className='font-semibold'>
-                      Package configuration providers:
-                    </Label>{' '}
-                    {jobConfigs.packageConfigurationProviders.map(
-                      (provider) => (
-                        <div className='ml-2' key={provider.id}>
-                          <Label className='font-semibold'>
-                            {provider.type}
-                          </Label>
-                          {provider.id && (
-                            <div className='ml-2'>
-                              <Label className='font-semibold'>Id:</Label>{' '}
-                              {provider.id.toString()}
-                            </div>
-                          )}
-                          {provider.enabled && (
-                            <div className='ml-2'>
-                              <Label className='font-semibold'>Enabled:</Label>{' '}
-                              {provider.enabled.toString()}
-                            </div>
-                          )}
-                          {provider.options && (
-                            <div className='ml-2'>
-                              <Label className='font-semibold'>Options:</Label>{' '}
-                              <div className='ml-2'>
-                                {Object.entries(provider.options).map(
-                                  ([key, value]) => (
-                                    <div key={key}>
-                                      <Label className='font-semibold'>
-                                        {key}:
-                                      </Label>{' '}
-                                      {value.toString()}
-                                    </div>
-                                  )
-                                )}
+        {jobConfigs && (
+          <div className='space-y-2 text-sm'>
+            {jobConfigs?.ruleSet && (
+              <div>
+                <Label className='font-semibold'>Ruleset:</Label>{' '}
+                {jobConfigs.ruleSet}
+              </div>
+            )}
+            {jobConfigs?.licenseClassificationsFile && (
+              <div>
+                <Label className='font-semibold'>
+                  License classifications:
+                </Label>{' '}
+                {jobConfigs.licenseClassificationsFile}
+              </div>
+            )}
+            {jobConfigs?.copyrightGarbageFile && (
+              <div>
+                <Label className='font-semibold'>Copyright garbage:</Label>{' '}
+                {jobConfigs.copyrightGarbageFile}
+              </div>
+            )}
+            {jobConfigs?.resolutionsFile && (
+              <div>
+                <Label className='font-semibold'>Resolutions:</Label>{' '}
+                {jobConfigs.resolutionsFile}
+              </div>
+            )}
+            {jobConfigs?.packageConfigurationProviders && (
+              <div className='space-y-2'>
+                <Label className='font-semibold'>
+                  Package configuration providers:
+                </Label>{' '}
+                {jobConfigs.packageConfigurationProviders.map((provider) => (
+                  <div className='ml-2' key={provider.id}>
+                    <Label className='font-semibold'>{provider.type}</Label>
+                    {provider.id && (
+                      <div className='ml-2'>
+                        <Label className='font-semibold'>Id:</Label>{' '}
+                        {provider.id.toString()}
+                      </div>
+                    )}
+                    {provider.enabled && (
+                      <div className='ml-2'>
+                        <Label className='font-semibold'>Enabled:</Label>{' '}
+                        {provider.enabled.toString()}
+                      </div>
+                    )}
+                    {provider.options && (
+                      <div className='ml-2'>
+                        <Label className='font-semibold'>Options:</Label>{' '}
+                        <div className='ml-2'>
+                          {Object.entries(provider.options).map(
+                            ([key, value]) => (
+                              <div key={key}>
+                                <Label className='font-semibold'>{key}:</Label>{' '}
+                                {value.toString()}
                               </div>
-                            </div>
-                          )}
-                          {provider.secrets && (
-                            <div className='ml-2'>
-                              <Label className='font-semibold'>Secrets:</Label>{' '}
-                              <div className='ml-2'>
-                                {Object.entries(provider.secrets).map(
-                                  ([key, value]) => (
-                                    <div key={key}>
-                                      <Label className='font-semibold'>
-                                        {key}:
-                                      </Label>{' '}
-                                      {value.toString()}
-                                    </div>
-                                  )
-                                )}
-                              </div>
-                            </div>
+                            )
                           )}
                         </div>
-                      )
+                      </div>
+                    )}
+                    {provider.secrets && (
+                      <div className='ml-2'>
+                        <Label className='font-semibold'>Secrets:</Label>{' '}
+                        <div className='ml-2'>
+                          {Object.entries(provider.secrets).map(
+                            ([key, value]) => (
+                              <div key={key}>
+                                <Label className='font-semibold'>{key}:</Label>{' '}
+                                {value.toString()}
+                              </div>
+                            )
+                          )}
+                        </div>
+                      </div>
                     )}
                   </div>
-                )}
+                ))}
               </div>
-            </div>
-          )}
-        </div>
+            )}
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/job-title.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/job-title.tsx
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import {
+  AdvisorJob,
+  AnalyzerJob,
+  EvaluatorJob,
+  NotifierJob,
+  ReporterJob,
+  ScannerJob,
+} from '@/api/requests/types.gen';
+import { RunDuration } from '@/components/run-duration';
+import { Badge } from '@/components/ui/badge';
+import { getStatusBackgroundColor } from '@/helpers/get-status-class';
+
+type JobTitleProps = {
+  title: string;
+  job:
+    | AnalyzerJob
+    | AdvisorJob
+    | ScannerJob
+    | EvaluatorJob
+    | ReporterJob
+    | NotifierJob
+    | null
+    | undefined;
+};
+
+export const JobTitle = ({ title, job }: JobTitleProps) => {
+  return (
+    <div className='flex items-center gap-2'>
+      {title}
+      <Badge className={`border ${getStatusBackgroundColor(job?.status)}`}>
+        {job?.status || 'NOT RUN'}
+      </Badge>
+      {job?.startedAt && (
+        <>
+          {job.finishedAt ? (
+            <div className='text-muted-foreground flex items-center gap-1'>
+              in
+              <RunDuration
+                createdAt={job.startedAt}
+                finishedAt={job.finishedAt}
+              />
+            </div>
+          ) : (
+            <div className='text-muted-foreground flex items-center'>
+              (<RunDuration createdAt={job.startedAt} finishedAt={undefined} />)
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/notifier-job-details.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/notifier-job-details.tsx
@@ -18,11 +18,9 @@
  */
 
 import { OrtRun } from '@/api/requests';
-import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
-import { calculateDuration } from '@/helpers/get-run-duration';
-import { getStatusBackgroundColor } from '@/helpers/get-status-class';
+import { JobTitle } from './job-title';
 
 type NotifierJobDetailsProps = {
   run: OrtRun;
@@ -35,21 +33,12 @@ export const NotifierJobDetails = ({ run }: NotifierJobDetailsProps) => {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className='flex gap-2'>
-          Notifier
-          <Badge className={`border ${getStatusBackgroundColor(job?.status)}`}>
-            {job?.status || 'NOT RUN'}
-          </Badge>
+        <CardTitle>
+          <JobTitle title='Notifier' job={job} />
         </CardTitle>
       </CardHeader>
       <CardContent>
         <div className='space-y-2 text-sm'>
-          <div>
-            <Label className='font-semibold'>Duration: </Label>
-            {job?.startedAt && job?.finishedAt
-              ? calculateDuration(job.startedAt, job.finishedAt)
-              : 'N/A'}
-          </div>
           {jobConfigs && (
             <div className='space-y-2'>
               <Label className='font-semibold'>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/notifier-job-details.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/notifier-job-details.tsx
@@ -41,9 +41,6 @@ export const NotifierJobDetails = ({ run }: NotifierJobDetailsProps) => {
         <div className='space-y-2 text-sm'>
           {jobConfigs && (
             <div className='space-y-2'>
-              <Label className='font-semibold'>
-                Resolved job configuration:
-              </Label>
               <div className='ml-2 space-y-2'>
                 {jobConfigs?.notifierRules && (
                   <div>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/reporter-job-details.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/reporter-job-details.tsx
@@ -38,23 +38,16 @@ export const ReporterJobDetails = ({ run }: ReporterJobDetailsProps) => {
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <div className='space-y-2 text-sm'>
-          {jobConfigs && (
-            <div className='space-y-2'>
-              <Label className='font-semibold'>
-                Resolved job configuration:
-              </Label>
-              <div className='ml-2'>
-                {jobConfigs?.formats && (
-                  <div>
-                    <Label className='font-semibold'>Report formats:</Label>{' '}
-                    {jobConfigs.formats.join(', ')}
-                  </div>
-                )}
+        {jobConfigs && (
+          <div className='space-y-2 text-sm'>
+            {jobConfigs?.formats && (
+              <div>
+                <Label className='font-semibold'>Report formats:</Label>{' '}
+                {jobConfigs.formats.join(', ')}
               </div>
-            </div>
-          )}
-        </div>
+            )}
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/reporter-job-details.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/reporter-job-details.tsx
@@ -18,11 +18,9 @@
  */
 
 import { OrtRun } from '@/api/requests';
-import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
-import { calculateDuration } from '@/helpers/get-run-duration';
-import { getStatusBackgroundColor } from '@/helpers/get-status-class';
+import { JobTitle } from './job-title';
 
 type ReporterJobDetailsProps = {
   run: OrtRun;
@@ -35,21 +33,12 @@ export const ReporterJobDetails = ({ run }: ReporterJobDetailsProps) => {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className='flex gap-2'>
-          Reporter
-          <Badge className={`border ${getStatusBackgroundColor(job?.status)}`}>
-            {run.jobs.reporter?.status || 'NOT RUN'}
-          </Badge>
+        <CardTitle>
+          <JobTitle title='Reporter' job={job} />
         </CardTitle>
       </CardHeader>
       <CardContent>
         <div className='space-y-2 text-sm'>
-          <div>
-            <Label className='font-semibold'>Duration: </Label>
-            {job?.startedAt && job?.finishedAt
-              ? calculateDuration(job.startedAt, job.finishedAt)
-              : 'N/A'}
-          </div>
           {jobConfigs && (
             <div className='space-y-2'>
               <Label className='font-semibold'>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/scanner-job-details.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/scanner-job-details.tsx
@@ -18,11 +18,9 @@
  */
 
 import { OrtRun } from '@/api/requests';
-import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
-import { calculateDuration } from '@/helpers/get-run-duration';
-import { getStatusBackgroundColor } from '@/helpers/get-status-class';
+import { JobTitle } from './job-title';
 
 type ScannerJobDetailsProps = {
   run: OrtRun;
@@ -35,21 +33,12 @@ export const ScannerJobDetails = ({ run }: ScannerJobDetailsProps) => {
   return (
     <Card>
       <CardHeader>
-        <CardTitle className='flex gap-2'>
-          Scanner
-          <Badge className={`border ${getStatusBackgroundColor(job?.status)}`}>
-            {job?.status || 'NOT RUN'}
-          </Badge>
+        <CardTitle>
+          <JobTitle title='Scanner' job={job} />
         </CardTitle>
       </CardHeader>
       <CardContent>
         <div className='space-y-2 text-sm'>
-          <div>
-            <Label className='font-semibold'>Duration: </Label>
-            {job?.startedAt && job?.finishedAt
-              ? calculateDuration(job.startedAt, job.finishedAt)
-              : 'N/A'}
-          </div>
           {jobConfigs && (
             <div className='space-y-2'>
               <Label className='font-semibold'>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/scanner-job-details.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/scanner-job-details.tsx
@@ -38,84 +38,71 @@ export const ScannerJobDetails = ({ run }: ScannerJobDetailsProps) => {
         </CardTitle>
       </CardHeader>
       <CardContent>
-        <div className='space-y-2 text-sm'>
-          {jobConfigs && (
-            <div className='space-y-2'>
-              <Label className='font-semibold'>
-                Resolved job configuration:
-              </Label>
-              <div className='ml-2 space-y-2'>
-                {jobConfigs?.skipConcluded && (
-                  <div>
-                    <Label className='font-semibold'>Skip concluded: </Label>
-                    {jobConfigs.skipConcluded.toString()}
-                  </div>
-                )}
-                {jobConfigs?.skipExcluded && (
-                  <div>
-                    <Label className='font-semibold'>Skip excluded: </Label>
-                    {jobConfigs.skipExcluded.toString()}
-                  </div>
-                )}
-                {jobConfigs?.scanners && (
-                  <div className='space-y-2'>
-                    <Label className='font-semibold'>Scanners:</Label>{' '}
-                    {jobConfigs.scanners.map((scanner) => (
-                      <div className='ml-2' key={scanner}>
-                        <Label className='font-semibold'>{scanner}</Label>
-                        {jobConfigs?.config?.[scanner] && (
+        {jobConfigs && (
+          <div className='space-y-2 text-sm'>
+            {jobConfigs?.skipConcluded && (
+              <div>
+                <Label className='font-semibold'>Skip concluded: </Label>
+                {jobConfigs.skipConcluded.toString()}
+              </div>
+            )}
+            {jobConfigs?.skipExcluded && (
+              <div>
+                <Label className='font-semibold'>Skip excluded: </Label>
+                {jobConfigs.skipExcluded.toString()}
+              </div>
+            )}
+            {jobConfigs?.scanners && (
+              <div className='space-y-2'>
+                <Label className='font-semibold'>Scanners:</Label>{' '}
+                {jobConfigs.scanners.map((scanner) => (
+                  <div className='ml-2' key={scanner}>
+                    <Label className='font-semibold'>{scanner}</Label>
+                    {jobConfigs?.config?.[scanner] && (
+                      <div className='ml-2'>
+                        <Label className='font-semibold'>Configuration:</Label>
+                        {jobConfigs.config?.[scanner].options && (
                           <div className='ml-2'>
-                            <Label className='font-semibold'>
-                              Configuration:
-                            </Label>
-                            {jobConfigs.config?.[scanner].options && (
-                              <div className='ml-2'>
-                                <Label className='font-semibold'>
-                                  Options:
-                                </Label>
-                                <div className='ml-2'>
-                                  {Object.entries(
-                                    jobConfigs.config[scanner].options
-                                  ).map(([key, value]) => (
-                                    <div key={key}>
-                                      <Label className='font-semibold'>
-                                        {key}:
-                                      </Label>{' '}
-                                      {value.toString()}
-                                    </div>
-                                  ))}
+                            <Label className='font-semibold'>Options:</Label>
+                            <div className='ml-2'>
+                              {Object.entries(
+                                jobConfigs.config[scanner].options
+                              ).map(([key, value]) => (
+                                <div key={key}>
+                                  <Label className='font-semibold'>
+                                    {key}:
+                                  </Label>{' '}
+                                  {value.toString()}
                                 </div>
-                              </div>
-                            )}
-                            {jobConfigs.config?.[scanner].secrets && (
-                              <div className='ml-2'>
-                                <Label className='font-semibold'>
-                                  Secrets:
-                                </Label>
-                                <div className='ml-2'>
-                                  {Object.entries(
-                                    jobConfigs.config[scanner].secrets
-                                  ).map(([key, value]) => (
-                                    <div key={key}>
-                                      <Label className='font-semibold'>
-                                        {key}:
-                                      </Label>{' '}
-                                      {value.toString()}
-                                    </div>
-                                  ))}
+                              ))}
+                            </div>
+                          </div>
+                        )}
+                        {jobConfigs.config?.[scanner].secrets && (
+                          <div className='ml-2'>
+                            <Label className='font-semibold'>Secrets:</Label>
+                            <div className='ml-2'>
+                              {Object.entries(
+                                jobConfigs.config[scanner].secrets
+                              ).map(([key, value]) => (
+                                <div key={key}>
+                                  <Label className='font-semibold'>
+                                    {key}:
+                                  </Label>{' '}
+                                  {value.toString()}
                                 </div>
-                              </div>
-                            )}
+                              ))}
+                            </div>
                           </div>
                         )}
                       </div>
-                    ))}
+                    )}
                   </div>
-                )}
+                ))}
               </div>
-            </div>
-          )}
-        </div>
+            )}
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/index.tsx
@@ -22,6 +22,8 @@ import { createFileRoute } from '@tanstack/react-router';
 import { prefetchUseRepositoriesServiceGetApiV1RepositoriesByRepositoryIdRunsByOrtRunIndex } from '@/api/queries/prefetch';
 import { useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdRunsByOrtRunIndexSuspense } from '@/api/queries/suspense';
 import { LoadingIndicator } from '@/components/loading-indicator';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
 import { AdvisorJobDetails } from './-components/advisor-job-details';
 import { AnalyzerJobDetails } from './-components/analyzer-job-details';
 import { EvaluatorJobDetails } from './-components/evaluator-job-details';
@@ -42,6 +44,58 @@ const ConfigComponent = () => {
 
   return (
     <div className='flex flex-col gap-4'>
+      <Card>
+        <CardHeader>
+          <CardTitle>Run Configuration</CardTitle>
+        </CardHeader>
+        <CardContent>
+          {ortRun.path && (
+            <div className='text-sm'>
+              <Label className='font-semibold'>Path:</Label> {ortRun.path}
+            </div>
+          )}
+          {(ortRun.jobConfigContext || ortRun.resolvedJobConfigContext) && (
+            <div className='flex items-center gap-1 text-sm'>
+              <Label className='font-semibold'>Configuration context:</Label>
+              {ortRun.jobConfigContext && <div>{ortRun.jobConfigContext}</div>}
+              {ortRun.resolvedJobConfigContext && (
+                <div>({ortRun.resolvedJobConfigContext})</div>
+              )}
+            </div>
+          )}
+          {Object.keys(ortRun.labels).length > 0 && (
+            <div className='text-sm'>
+              <Label className='font-semibold'>Labels:</Label>{' '}
+              {Object.entries(ortRun.labels).map(([key, value]) => (
+                <div key={key} className='ml-4 grid grid-cols-12 text-xs'>
+                  <div className='col-span-3 text-left break-all'>{key}</div>
+                  <div className='col-span-1 text-center'>=</div>
+                  <div className='col-span-8 text-left break-all'>{value}</div>
+                </div>
+              ))}
+            </div>
+          )}
+          {ortRun.jobConfigs.parameters &&
+            Object.keys(ortRun.jobConfigs.parameters).length > 0 && (
+              <div className='text-sm'>
+                <Label className='font-semibold'>Parameters:</Label>{' '}
+                {Object.entries(ortRun.jobConfigs.parameters).map(
+                  ([key, value]) => (
+                    <div key={key} className='ml-4 grid grid-cols-12 text-xs'>
+                      <div className='col-span-3 text-left break-all'>
+                        {key}
+                      </div>
+                      <div className='col-span-1 text-center'>=</div>
+                      <div className='col-span-8 text-left break-all'>
+                        {value}
+                      </div>
+                    </div>
+                  )
+                )}
+              </div>
+            )}
+        </CardContent>
+      </Card>
       <div id='analyzer' className='scroll-mt-16'>
         <AnalyzerJobDetails run={ortRun} />
       </div>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/route.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/route.tsx
@@ -135,7 +135,7 @@ const Layout = () => {
           icon: () => <Logs className='h-4 w-4' />,
         },
         {
-          title: 'Job Configurations',
+          title: 'Configuration',
           to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config',
           params,
           icon: () => <CalendarCheck className='h-4 w-4' />,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/route.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/route.tsx
@@ -21,6 +21,7 @@ import { createFileRoute, Outlet } from '@tanstack/react-router';
 import {
   Boxes,
   Bug,
+  CalendarCheck,
   Eye,
   Files,
   FileText,
@@ -137,6 +138,7 @@ const Layout = () => {
           title: 'Job Configurations',
           to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config',
           params,
+          icon: () => <CalendarCheck className='h-4 w-4' />,
         },
       ],
     },


### PR DESCRIPTION
This PR starts the refactoring of the (run) configuration page by simplifying the looks of it, adding the general run info which is missing from the top bar to the page, plus simplifying the code.

![Screenshot from 2025-03-18 13-01-21](https://github.com/user-attachments/assets/4a8163b5-f805-456d-b914-686636e5b8ba)

Note for the reviewers: the actual code changes to the page (especially in [this commit](https://github.com/eclipse-apoapsis/ort-server/pull/2286/commits/06f43d669c52be945df34d3d84064776ea66f62f)) are relatively small, even if the git hunks look big.