### PR TITLE
2104 add endpoint users for entity

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
@@ -84,6 +84,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.SourceCodeOrigin as ApiSource
 import org.eclipse.apoapsis.ortserver.api.v1.model.SubmoduleFetchStrategy as ApiSubmoduleFetchStrategy
 import org.eclipse.apoapsis.ortserver.api.v1.model.User as ApiUser
 import org.eclipse.apoapsis.ortserver.api.v1.model.UserDisplayName as ApiUserDisplayName
+import org.eclipse.apoapsis.ortserver.api.v1.model.UserGroup as ApiUserGroup
 import org.eclipse.apoapsis.ortserver.api.v1.model.VcsInfo as ApiVcsInfo
 import org.eclipse.apoapsis.ortserver.api.v1.model.Vulnerability as ApiVulnerability
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityRating as ApiVulnerabilityRating
@@ -135,6 +136,7 @@ import org.eclipse.apoapsis.ortserver.model.SourceCodeOrigin
 import org.eclipse.apoapsis.ortserver.model.SubmoduleFetchStrategy
 import org.eclipse.apoapsis.ortserver.model.User
 import org.eclipse.apoapsis.ortserver.model.UserDisplayName
+import org.eclipse.apoapsis.ortserver.model.UserGroup
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityRating
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityWithAccumulatedData
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityWithIdentifier
@@ -822,6 +824,8 @@ fun ApiSourceCodeOrigin.mapToModel() =
     }
 
 fun User.mapToApi() = ApiUser(username, firstName, lastName, email)
+
+fun UserGroup.mapToApi() = ApiUserGroup.valueOf(name)
 
 fun EcosystemStats.mapToApi() = ApiEcosystemStats(name = name, count = count)
 

--- a/api/v1/model/src/commonMain/kotlin/User.kt
+++ b/api/v1/model/src/commonMain/kotlin/User.kt
@@ -39,6 +39,35 @@ data class User(
     val email: String? = null,
 )
 
+/**
+ * User group (privilege level) for repositories, products or organizations.
+ */
+@Serializable
+enum class UserGroup(private val rank: Int) {
+    /** READER privilege */
+    READERS(1),
+
+    /** WRITER privilege */
+    WRITERS(2),
+
+    /** ADMIN privilege */
+    ADMINS(3);
+
+    fun getRank() = rank
+}
+
+/**
+ * Response object for a user containing groups that user belongs to.
+ */
+@Serializable
+data class UserWithGroups(
+    /** User object */
+    val user: User,
+
+    /** List of groups user belongs to */
+    val groups: List<UserGroup>
+)
+
 @Serializable
 data class CreateUser(
     val username: String,

--- a/clients/keycloak/src/main/kotlin/KeycloakClient.kt
+++ b/clients/keycloak/src/main/kotlin/KeycloakClient.kt
@@ -41,6 +41,11 @@ interface KeycloakClient {
     suspend fun getGroup(name: GroupName): Group
 
     /**
+     * Searches the [group][Group] that group name contains [name].
+     */
+    suspend fun searchGroups(name: GroupName): Set<Group>
+
+    /**
      * Add a new [group][Group] to the Keycloak realm with the given [name].
      */
     suspend fun createGroup(name: GroupName)
@@ -180,4 +185,9 @@ interface KeycloakClient {
      * Return a set of all [users][User] of a group [GroupName].
      */
     suspend fun getGroupMembers(groupName: GroupName): Set<User>
+
+    /**
+     * Return a set of all [users][User] of a group [GroupId].
+     */
+    suspend fun getGroupMembers(groupId: GroupId): Set<User>
 }

--- a/core/src/main/kotlin/api/UserWithGroupsHelper.kt
+++ b/core/src/main/kotlin/api/UserWithGroupsHelper.kt
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.core.api
+
+import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToApi
+import org.eclipse.apoapsis.ortserver.api.v1.model.PagingOptions
+import org.eclipse.apoapsis.ortserver.api.v1.model.SortDirection
+import org.eclipse.apoapsis.ortserver.api.v1.model.UserWithGroups
+import org.eclipse.apoapsis.ortserver.core.utils.paginate
+import org.eclipse.apoapsis.ortserver.dao.QueryParametersException
+import org.eclipse.apoapsis.ortserver.model.User
+import org.eclipse.apoapsis.ortserver.model.UserGroup
+
+/**
+ * Sort and paginate the list of [UserWithGroups] by the given [PagingOptions].
+ * As records returned from Keycloak have no sort and paging capabilities, this class is used to do so.
+ * Although the API supports to have more than one sort order field, this implementation only supports a single
+ * sort field.
+ */
+internal object UserWithGroupsHelper {
+    internal fun List<UserWithGroups>.sortAndPage(paging: PagingOptions): List<UserWithGroups> {
+        if (paging.sortProperties?.size != 1) {
+            throw QueryParametersException("Exactly one sort field must be defined.")
+        }
+
+        val sortField = paging.sortProperties?.first()
+        requireNotNull(sortField) {
+            "Exactly one sort field must be defined."
+        }
+
+        return when (sortField.name) {
+            "username" -> compareBy<UserWithGroups> { it.user.username }
+            "firstName" -> compareBy<UserWithGroups> { it.user.firstName }
+            "lastName" -> compareBy<UserWithGroups> { it.user.lastName }
+            "email" -> compareBy<UserWithGroups> { it.user.email }
+            "group" -> compareBy<UserWithGroups> { it.groups.minBy { group -> group.getRank() } }
+            "" -> throw QueryParametersException("Empty sort field.")
+            else -> throw QueryParametersException("Unknown sort field '${sortField.name}'.")
+        }.let {
+            sortedWith(it)
+        }.let {
+            if (sortField.direction == SortDirection.DESCENDING) it.reversed() else it
+        }.paginate(paging)
+    }
+
+    internal fun Map<User, Set<UserGroup>>.mapToApi(): List<UserWithGroups> = map { user ->
+        UserWithGroups(
+            user.key.mapToApi(),
+            user.value.map { it.mapToApi() }.toList().sortedBy { it.getRank() }.reversed()
+        )
+    }
+}

--- a/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
@@ -43,6 +43,9 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.SortProperty
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateInfrastructureService
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateOrganization
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateSecret
+import org.eclipse.apoapsis.ortserver.api.v1.model.User
+import org.eclipse.apoapsis.ortserver.api.v1.model.UserGroup
+import org.eclipse.apoapsis.ortserver.api.v1.model.UserWithGroups
 import org.eclipse.apoapsis.ortserver.api.v1.model.Username
 import org.eclipse.apoapsis.ortserver.api.v1.model.Vulnerability
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityRating
@@ -700,6 +703,54 @@ val getOrtRunStatisticsByOrganizationId: OpenApiRoute.() -> Unit = {
                             Severity.HINT to 3,
                             Severity.WARNING to 1,
                             Severity.ERROR to 0
+                        )
+                    )
+                }
+            }
+        }
+    }
+}
+
+val getUsersForOrganization: OpenApiRoute.() -> Unit = {
+    operationId = "GetUsersForOrganization"
+    summary = "Get all users that have rights for a organization, including user privileges (groups) that user have " +
+        "within organization."
+    description = "Fields available for sorting: 'username', 'firstName', 'lastName', 'email', 'group'. " +
+        "NOTE: This endpoint supports only one sort field. All fields other than first one are ignored."
+
+    request {
+        pathParameter<Long>("organizationId") {
+            description = "The ID of an organization."
+        }
+
+        standardListQueryParameters()
+    }
+
+    response {
+        HttpStatusCode.OK to {
+            description = "Success"
+            jsonBody<PagedResponse<UserWithGroups>> {
+                example("Get users for organization") {
+                    value = PagedResponse(
+                        listOf(
+                            UserWithGroups(
+                                User(
+                                    username = "jdoe",
+                                    firstName = "John",
+                                    lastName = "Doe",
+                                    email = "johndoe@example.com"
+                                ),
+                                listOf(
+                                    UserGroup.READERS,
+                                    UserGroup.WRITERS
+                                )
+                            )
+                        ),
+                        PagingData(
+                            limit = 20,
+                            offset = 0,
+                            totalCount = 1,
+                            sortProperties = listOf(SortProperty("username", SortDirection.ASCENDING))
                         )
                     )
                 }

--- a/core/src/main/kotlin/apiDocs/ProductsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/ProductsDocs.kt
@@ -40,6 +40,9 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.SortDirection
 import org.eclipse.apoapsis.ortserver.api.v1.model.SortProperty
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateProduct
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateSecret
+import org.eclipse.apoapsis.ortserver.api.v1.model.User
+import org.eclipse.apoapsis.ortserver.api.v1.model.UserGroup
+import org.eclipse.apoapsis.ortserver.api.v1.model.UserWithGroups
 import org.eclipse.apoapsis.ortserver.api.v1.model.Username
 import org.eclipse.apoapsis.ortserver.api.v1.model.Vulnerability
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityRating
@@ -513,6 +516,54 @@ val getOrtRunStatisticsByProductId: OpenApiRoute.() -> Unit = {
                             Severity.HINT to 0,
                             Severity.WARNING to 6,
                             Severity.ERROR to 98
+                        )
+                    )
+                }
+            }
+        }
+    }
+}
+
+val getUsersForProduct: OpenApiRoute.() -> Unit = {
+    operationId = "GetUsersForProduct"
+    summary = "Get all users that have rights for a product, including user privileges (groups) that user have " +
+        "within product."
+    description = "Fields available for sorting: 'username', 'firstName', 'lastName', 'email', 'group'. " +
+        "NOTE: This endpoint supports only one sort field. All fields other than first one are ignored."
+
+    request {
+        pathParameter<Long>("productId") {
+            description = "The product's ID."
+        }
+
+        standardListQueryParameters()
+    }
+
+    response {
+        HttpStatusCode.OK to {
+            description = "Success"
+            jsonBody<PagedResponse<UserWithGroups>> {
+                example("Get users for product") {
+                    value = PagedResponse(
+                        listOf(
+                            UserWithGroups(
+                                User(
+                                    username = "jdoe",
+                                    firstName = "John",
+                                    lastName = "Doe",
+                                    email = "johndoe@example.com"
+                                ),
+                                listOf(
+                                    UserGroup.READERS,
+                                    UserGroup.WRITERS
+                                )
+                            )
+                        ),
+                        PagingData(
+                            limit = 20,
+                            offset = 0,
+                            totalCount = 1,
+                            sortProperties = listOf(SortProperty("username", SortDirection.ASCENDING))
                         )
                     )
                 }

--- a/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
@@ -67,7 +67,10 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.SourceCodeOrigin
 import org.eclipse.apoapsis.ortserver.api.v1.model.SubmoduleFetchStrategy.FULLY_RECURSIVE
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateRepository
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateSecret
+import org.eclipse.apoapsis.ortserver.api.v1.model.User
 import org.eclipse.apoapsis.ortserver.api.v1.model.UserDisplayName
+import org.eclipse.apoapsis.ortserver.api.v1.model.UserGroup
+import org.eclipse.apoapsis.ortserver.api.v1.model.UserWithGroups
 import org.eclipse.apoapsis.ortserver.api.v1.model.Username
 import org.eclipse.apoapsis.ortserver.api.v1.model.asPresent
 
@@ -742,6 +745,54 @@ val deleteUserFromRepositoryGroup: OpenApiRoute.() -> Unit = {
 
         HttpStatusCode.NotFound to {
             description = "Repository or group not found."
+        }
+    }
+}
+
+val getUsersForRepository: OpenApiRoute.() -> Unit = {
+    operationId = "GetUsersForRepository"
+    summary = "Get all users that have rights for a repository, including privileges (groups) that user have within " +
+        "repository."
+    description = "Fields available for sorting: 'username', 'firstName', 'lastName', 'email', 'group'. " +
+        "NOTE: This endpoint supports only one sort field. All fields other than first one are ignored."
+
+    request {
+        pathParameter<Long>("repositoryId") {
+            description = "The repository's ID."
+        }
+
+        standardListQueryParameters()
+    }
+
+    response {
+        HttpStatusCode.OK to {
+            description = "Success"
+            jsonBody<PagedResponse<UserWithGroups>> {
+                example("Get users for repository") {
+                    value = PagedResponse(
+                        listOf(
+                            UserWithGroups(
+                                User(
+                                    username = "jdoe",
+                                    firstName = "John",
+                                    lastName = "Doe",
+                                    email = "johndoe@example.com"
+                                ),
+                                listOf(
+                                    UserGroup.READERS,
+                                    UserGroup.WRITERS
+                                )
+                            )
+                        ),
+                        PagingData(
+                            limit = 20,
+                            offset = 0,
+                            totalCount = 1,
+                            sortProperties = listOf(SortProperty("username", SortDirection.ASCENDING))
+                        )
+                    )
+                }
+            }
         }
     }
 }

--- a/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
@@ -76,11 +76,15 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.SortProperty
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateInfrastructureService
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateOrganization
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateSecret
+import org.eclipse.apoapsis.ortserver.api.v1.model.User as ApiUser
+import org.eclipse.apoapsis.ortserver.api.v1.model.UserGroup as ApiUserGroup
+import org.eclipse.apoapsis.ortserver.api.v1.model.UserWithGroups as ApiUserWithGroups
 import org.eclipse.apoapsis.ortserver.api.v1.model.Username
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityRating
 import org.eclipse.apoapsis.ortserver.api.v1.model.asPresent
 import org.eclipse.apoapsis.ortserver.api.v1.model.valueOrThrow
 import org.eclipse.apoapsis.ortserver.clients.keycloak.GroupName
+import org.eclipse.apoapsis.ortserver.core.SUPERUSER
 import org.eclipse.apoapsis.ortserver.core.TEST_USER
 import org.eclipse.apoapsis.ortserver.core.addUserRole
 import org.eclipse.apoapsis.ortserver.core.shouldHaveBody
@@ -1935,6 +1939,96 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
             val createdOrganization = createOrganization()
             requestShouldRequireRole(OrganizationPermission.READ.roleName(createdOrganization.id)) {
                 get("/api/v1/organizations/${createdOrganization.id}/statistics/runs")
+            }
+        }
+    }
+
+    "GET /organizations/{productId}/users" should {
+        "return list of users that have rights for organization" {
+            integrationTestApplication {
+                val orgId = createOrganization().id
+
+                // Using two users that are prepared for test, just to have their user names
+                addUserToGroup(TEST_USER.username.value, orgId, "READERS")
+                addUserToGroup(SUPERUSER.username.value, orgId, "WRITERS")
+                addUserToGroup(SUPERUSER.username.value, orgId, "ADMINS")
+
+                val response = superuserClient.get("/api/v1/organizations/$orgId/users")
+
+                response shouldHaveStatus HttpStatusCode.OK
+                response shouldHaveBody PagedResponse<ApiUserWithGroups>(
+                    listOf(
+                        ApiUserWithGroups(
+                            ApiUser(SUPERUSER.username.value, SUPERUSER.firstName, SUPERUSER.lastName, SUPERUSER.email),
+                            listOf(ApiUserGroup.ADMINS, ApiUserGroup.WRITERS)
+                        ),
+                        ApiUserWithGroups(
+                            ApiUser(TEST_USER.username.value, TEST_USER.firstName, TEST_USER.lastName, TEST_USER.email),
+                            listOf(ApiUserGroup.READERS)
+                        )
+                    ),
+                    PagingData(
+                        limit = DEFAULT_LIMIT,
+                        offset = 0,
+                        totalCount = 2,
+                        sortProperties = listOf(SortProperty("username", SortDirection.ASCENDING))
+                    )
+                )
+            }
+        }
+
+        "return empty list if no user has rights for organizations" {
+            integrationTestApplication {
+                val orgId = createOrganization().id
+
+                val response = superuserClient.get("/api/v1/organizations/$orgId/users")
+
+                response shouldHaveStatus HttpStatusCode.OK
+                response shouldHaveBody PagedResponse<ApiUserWithGroups>(
+                    emptyList(),
+                    PagingData(
+                        limit = DEFAULT_LIMIT,
+                        offset = 0,
+                        totalCount = 0,
+                        sortProperties = listOf(SortProperty("username", SortDirection.ASCENDING))
+                    )
+                )
+            }
+        }
+
+        "respond with 'Bad Request' if there is more than one sort field" {
+            integrationTestApplication {
+                val orgId = createOrganization().id
+
+                val response = superuserClient.get("/api/v1/organizations/$orgId/users?sort=username,firstName")
+
+                response shouldHaveStatus HttpStatusCode.BadRequest
+
+                val body = response.body<ErrorResponse>()
+                body.message shouldBe "Invalid query parameters."
+                body.cause shouldBe "Exactly one sort field must be defined."
+            }
+        }
+
+        "respond with 'Bad Request' if there is no sort field" {
+            integrationTestApplication {
+                val orgId = createOrganization().id
+
+                val response = superuserClient.get("/api/v1/organizations/$orgId/users?sort=")
+
+                response shouldHaveStatus HttpStatusCode.BadRequest
+
+                val body = response.body<ErrorResponse>()
+                body.message shouldBe "Invalid query parameters."
+                body.cause shouldBe "Empty sort field."
+            }
+        }
+
+        "require OrganizationPermission.READ" {
+            val orgId = createOrganization().id
+
+            requestShouldRequireRole(OrganizationPermission.READ.roleName(orgId)) {
+                get("/api/v1/organizations/$orgId/users")
             }
         }
     }

--- a/core/src/test/kotlin/api/UserWithGroupsHelperTest.kt
+++ b/core/src/test/kotlin/api/UserWithGroupsHelperTest.kt
@@ -1,0 +1,259 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.core.api
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.ints.shouldBeExactly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+
+import org.eclipse.apoapsis.ortserver.api.v1.model.PagingOptions
+import org.eclipse.apoapsis.ortserver.api.v1.model.SortDirection
+import org.eclipse.apoapsis.ortserver.api.v1.model.SortProperty
+import org.eclipse.apoapsis.ortserver.api.v1.model.User as ApiUser
+import org.eclipse.apoapsis.ortserver.api.v1.model.UserGroup as ApiUserGroup
+import org.eclipse.apoapsis.ortserver.api.v1.model.UserWithGroups as ApiUserWithGroups
+import org.eclipse.apoapsis.ortserver.core.api.UserWithGroupsHelper.mapToApi
+import org.eclipse.apoapsis.ortserver.core.api.UserWithGroupsHelper.sortAndPage
+import org.eclipse.apoapsis.ortserver.dao.QueryParametersException
+import org.eclipse.apoapsis.ortserver.model.User as ModelUser
+import org.eclipse.apoapsis.ortserver.model.UserGroup as ModelUserGroup
+
+class UserWithGroupsHelperTest : WordSpec({
+    "sortAndPage" should {
+        "be paged" {
+            // Given
+            val users = listOf(
+                ApiUserWithGroups(ApiUser("john1hh", "John", "Doe", "j.d1@example.com"), listOf(ApiUserGroup.ADMINS)),
+                ApiUserWithGroups(ApiUser("john2hh", "John", "Doe", "j.d2@example.com"), listOf(ApiUserGroup.ADMINS)),
+                ApiUserWithGroups(ApiUser("john3hh", "John", "Doe", "j.d3@example.com"), listOf(ApiUserGroup.ADMINS)),
+                ApiUserWithGroups(ApiUser("john4hh", "John", "Doe", "j.d4@example.com"), listOf(ApiUserGroup.ADMINS)),
+                ApiUserWithGroups(ApiUser("john5hh", "John", "Doe", "j.d5@example.com"), listOf(ApiUserGroup.ADMINS)),
+                ApiUserWithGroups(ApiUser("john6hh", "John", "Doe", "j.d6@example.com"), listOf(ApiUserGroup.ADMINS))
+            )
+
+            val pagingOptions = PagingOptions(2, 2, listOf(SortProperty("username", SortDirection.ASCENDING)))
+
+            // When
+            val pagedUsers = users.sortAndPage(pagingOptions)
+
+            // Then
+            pagedUsers.size shouldBe 2
+            pagedUsers[0].user.username shouldBe "john3hh"
+            pagedUsers[1].user.username shouldBe "john4hh"
+        }
+
+        "sort list by given user field" {
+            // Given
+            val users = listOf(
+                ApiUserWithGroups(ApiUser("john6hh", "John", "Doe", "j.d6@example.com"), listOf(ApiUserGroup.ADMINS)),
+                ApiUserWithGroups(ApiUser("john2hh", "John", "Doe", "j.d2@example.com"), listOf(ApiUserGroup.ADMINS)),
+                ApiUserWithGroups(ApiUser("john1hh", "John", "Doe", "j.d1@example.com"), listOf(ApiUserGroup.ADMINS)),
+                ApiUserWithGroups(ApiUser("john5hh", "John", "Doe", "j.d5@example.com"), listOf(ApiUserGroup.ADMINS)),
+                ApiUserWithGroups(ApiUser("john4hh", "John", "Doe", "j.d4@example.com"), listOf(ApiUserGroup.ADMINS)),
+                ApiUserWithGroups(ApiUser("john3hh", "John", "Doe", "j.d3@example.com"), listOf(ApiUserGroup.ADMINS))
+            )
+
+            val pagingOptions = PagingOptions(999, 0, listOf(SortProperty("username", SortDirection.ASCENDING)))
+
+            // When
+            val pagedUsers = users.sortAndPage(pagingOptions)
+
+            // Then
+            pagedUsers.size shouldBe 6
+            pagedUsers[0].user.username shouldBe "john1hh"
+            pagedUsers[1].user.username shouldBe "john2hh"
+            pagedUsers[2].user.username shouldBe "john3hh"
+            pagedUsers[3].user.username shouldBe "john4hh"
+            pagedUsers[4].user.username shouldBe "john5hh"
+            pagedUsers[5].user.username shouldBe "john6hh"
+        }
+
+        "sort list by group field" {
+            // Given
+            val users = listOf(
+                ApiUserWithGroups(ApiUser("john6hh", "John", "Doe", "j.d6@example.com"), listOf(ApiUserGroup.ADMINS)),
+                ApiUserWithGroups(ApiUser("john2hh", "John", "Doe", "j.d2@example.com"), listOf(ApiUserGroup.WRITERS)),
+                ApiUserWithGroups(ApiUser("john1hh", "John", "Doe", "j.d1@example.com"), listOf(ApiUserGroup.ADMINS)),
+                ApiUserWithGroups(ApiUser("john5hh", "John", "Doe", "j.d5@example.com"), listOf(ApiUserGroup.READERS)),
+                ApiUserWithGroups(ApiUser("john4hh", "John", "Doe", "j.d4@example.com"), listOf(ApiUserGroup.READERS)),
+                ApiUserWithGroups(ApiUser("john3hh", "John", "Doe", "j.d3@example.com"), listOf(ApiUserGroup.WRITERS))
+            )
+
+            val pagingOptions = PagingOptions(999, 0, listOf(SortProperty("group", SortDirection.DESCENDING)))
+
+            // When
+            val pagedUsers = users.sortAndPage(pagingOptions)
+
+            // Then
+            pagedUsers.size shouldBe 6
+            pagedUsers[4].groups[0] shouldBe ApiUserGroup.READERS
+            pagedUsers[5].groups[0] shouldBe ApiUserGroup.READERS
+            pagedUsers[2].groups[0] shouldBe ApiUserGroup.WRITERS
+            pagedUsers[3].groups[0] shouldBe ApiUserGroup.WRITERS
+            pagedUsers[1].groups[0] shouldBe ApiUserGroup.ADMINS
+            pagedUsers[0].groups[0] shouldBe ApiUserGroup.ADMINS
+        }
+
+        "sort list by highest ranked group for user with multiple groups" {
+            // Given
+            val users = listOf(
+                ApiUserWithGroups(
+                    ApiUser("john6hh", "John", "Doe", "j.d6@example.com"),
+                    listOf(ApiUserGroup.ADMINS, ApiUserGroup.READERS)
+                ),
+                ApiUserWithGroups(
+                    ApiUser("john2hh", "John", "Doe", "j.d2@example.com"),
+                    listOf(ApiUserGroup.WRITERS, ApiUserGroup.READERS)
+                ),
+                ApiUserWithGroups(
+                    ApiUser("john1hh", "John", "Doe", "j.d1@example.com"),
+                    listOf(ApiUserGroup.READERS)
+                )
+            )
+
+            val pagingOptions = PagingOptions(999, 0, listOf(SortProperty("group", SortDirection.ASCENDING)))
+
+            // When
+            val pagedUsers = users.sortAndPage(pagingOptions)
+
+            // Then
+            pagedUsers.size shouldBe 3
+            pagedUsers[0].groups[0] shouldBe ApiUserGroup.ADMINS
+            pagedUsers[0].user.username shouldBe "john6hh"
+            pagedUsers[1].groups[0] shouldBe ApiUserGroup.WRITERS
+            pagedUsers[1].user.username shouldBe "john2hh"
+            pagedUsers[2].groups[0] shouldBe ApiUserGroup.READERS
+            pagedUsers[2].user.username shouldBe "john1hh"
+        }
+
+        "throw an exception if sort field is empty" {
+            // Given
+            val users = listOf(
+                ApiUserWithGroups(
+                    ApiUser("john6hh", "John", "Doe", "j.d6@example.com"),
+                    listOf(ApiUserGroup.ADMINS, ApiUserGroup.READERS)
+                )
+            )
+
+            val pagingOptions = PagingOptions(999, 0, listOf(SortProperty("", SortDirection.ASCENDING)))
+
+            // Then
+            val exception = shouldThrow<QueryParametersException> { users.sortAndPage(pagingOptions) }
+            exception.message shouldBe "Empty sort field."
+        }
+
+        "throw an exception if sort field has wrong name" {
+            // Given
+            val users = listOf(
+                ApiUserWithGroups(
+                    ApiUser("john6hh", "John", "Doe", "j.d6@example.com"),
+                    listOf(ApiUserGroup.ADMINS, ApiUserGroup.READERS)
+                )
+            )
+
+            val pagingOptions = PagingOptions(999, 0, listOf(SortProperty("blobby", SortDirection.ASCENDING)))
+
+            // Then
+            val exception = shouldThrow<QueryParametersException> { users.sortAndPage(pagingOptions) }
+            exception.message shouldBe "Unknown sort field 'blobby'."
+        }
+
+        "throw an exception if number of sort fields is higher than 1" {
+            // Given
+            val users = listOf(
+                ApiUserWithGroups(
+                    ApiUser("john6hh", "John", "Doe", "j.d6@example.com"),
+                    listOf(ApiUserGroup.ADMINS, ApiUserGroup.READERS)
+                )
+            )
+
+            val pagingOptions = PagingOptions(
+                999,
+                0,
+                listOf(
+                    SortProperty("group", SortDirection.ASCENDING),
+                    SortProperty("username", SortDirection.ASCENDING),
+                )
+            )
+
+            // Then
+            val exception = shouldThrow<QueryParametersException> { users.sortAndPage(pagingOptions) }
+            exception.message shouldBe "Exactly one sort field must be defined."
+        }
+    }
+
+    "mapToApi" should {
+        "map service output model to API model" {
+            // Given
+            val modelUsers = mapOf(
+                Pair(
+                    ModelUser("john2hh", "John", "Doe", "john.doe@example.com"),
+                    setOf(ModelUserGroup.ADMINS, ModelUserGroup.WRITERS)
+                ),
+                Pair(
+                    ModelUser("ron5ff", "Ron", "Boo", "ron.boo@example.com"),
+                    setOf(ModelUserGroup.WRITERS, ModelUserGroup.ADMINS, ModelUserGroup.READERS)
+                )
+            )
+
+            // When
+            val apiUsers = modelUsers.mapToApi()
+
+            // Then
+            apiUsers.size shouldBeExactly 2
+            val user1 = apiUsers.find { it.user.username == "john2hh" }
+            user1 shouldNotBe null
+            user1?.user?.firstName shouldBe "John"
+            user1?.user?.lastName shouldBe "Doe"
+            user1?.user?.email shouldBe "john.doe@example.com"
+            user1?.groups?.size shouldBe 2
+            user1?.groups shouldContainExactly listOf(ApiUserGroup.ADMINS, ApiUserGroup.WRITERS)
+
+            val user2 = apiUsers.find { it.user.username == "ron5ff" }
+            user2 shouldNotBe null
+            user2?.user?.firstName shouldBe "Ron"
+            user2?.user?.lastName shouldBe "Boo"
+            user2?.user?.email shouldBe "ron.boo@example.com"
+            user2?.groups?.size shouldBe 3
+            user2?.groups shouldContainExactly listOf(ApiUserGroup.ADMINS, ApiUserGroup.WRITERS, ApiUserGroup.READERS)
+        }
+
+        "sort groups by rank" {
+            // Given
+            val modelUsers = mapOf(
+                Pair(
+                    ModelUser("john2hh", "John", "Doe", "j.doe@example.com"),
+                    setOf(ModelUserGroup.WRITERS, ModelUserGroup.ADMINS, ModelUserGroup.READERS)
+                )
+            )
+
+            // When
+            val apiUsers = modelUsers.mapToApi()
+
+            // Then
+            apiUsers.first().groups[0] shouldBe ApiUserGroup.ADMINS
+            apiUsers.first().groups[1] shouldBe ApiUserGroup.WRITERS
+            apiUsers.first().groups[2] shouldBe ApiUserGroup.READERS
+        }
+    }
+})

--- a/model/src/commonMain/kotlin/User.kt
+++ b/model/src/commonMain/kotlin/User.kt
@@ -33,5 +33,14 @@ data class User(
     val lastName: String? = null,
 
     /** The mail address of the user. */
-    val email: String? = null,
+    val email: String? = null
 )
+
+/**
+ * Enum class representing user group (privilege level)
+ */
+enum class UserGroup {
+    READERS,
+    WRITERS,
+    ADMINS
+}

--- a/services/authorization/src/main/kotlin/UserService.kt
+++ b/services/authorization/src/main/kotlin/UserService.kt
@@ -19,9 +19,15 @@
 
 package org.eclipse.apoapsis.ortserver.services
 
+import org.eclipse.apoapsis.ortserver.clients.keycloak.Group
+import org.eclipse.apoapsis.ortserver.clients.keycloak.GroupName
 import org.eclipse.apoapsis.ortserver.clients.keycloak.KeycloakClient
 import org.eclipse.apoapsis.ortserver.clients.keycloak.UserName
 import org.eclipse.apoapsis.ortserver.model.User
+import org.eclipse.apoapsis.ortserver.model.UserGroup
+import org.eclipse.apoapsis.ortserver.model.authorization.OrganizationRole
+import org.eclipse.apoapsis.ortserver.model.authorization.ProductRole
+import org.eclipse.apoapsis.ortserver.model.authorization.RepositoryRole
 
 /**
  * A service providing functions for working with [users][User].
@@ -32,6 +38,7 @@ class UserService(
     /**
      * Create a user. If "password" is null, then "temporary" is ignored.
      */
+    @Suppress("LongParameterList")
     suspend fun createUser(
         username: String,
         firstName: String?,
@@ -72,4 +79,57 @@ class UserService(
         val user = keycloakClient.getUser(username = UserName(username))
         keycloakClient.deleteUser(id = user.id)
     }
+
+    /**
+     * Get [User]s with all the [UserGroup]s assigned to them (ADMINS, WRITERS, READERS), that have access to the
+     * organization with this [organizationId].
+     */
+    suspend fun getUsersHavingRightsForOrganization(organizationId: Long): Map<User, Set<UserGroup>> =
+        getUsersForGroups(keycloakClient.searchGroups(GroupName(OrganizationRole.groupPrefix(organizationId))))
+
+    /**
+     * Get [User]s with all the [UserGroup]s assigned to them (ADMINS, WRITERS, READERS), that have access to the
+     * product with this [productId].
+     */
+    suspend fun getUsersHavingRightForProduct(productId: Long): Map<User, Set<UserGroup>> =
+        getUsersForGroups(keycloakClient.searchGroups(GroupName(ProductRole.groupPrefix(productId))))
+
+    /**
+     * Get [User]s with all  the [UserGroup]s assigned to them (ADMINS, WRITERS, READERS), that have rights to the
+     * repository with this [repositoryId].
+     */
+    suspend fun getUsersHavingRightsForRepository(repositoryId: Long): Map<User, Set<UserGroup>> =
+        getUsersForGroups(keycloakClient.searchGroups(GroupName(RepositoryRole.groupPrefix(repositoryId))))
+
+    private suspend fun getUsersForGroups(groups: Set<Group>): Map<User, Set<UserGroup>> {
+        val users = mutableMapOf<User, Set<UserGroup>>()
+        groups.forEach { group ->
+            keycloakClient.getGroupMembers(group.id).map {
+                val user = User(
+                    username = it.username.value,
+                    firstName = it.firstName,
+                    lastName = it.lastName,
+                    email = it.email
+                )
+
+                users[user]?.let { groupSet ->
+                    users[user] = groupSet + calculateUserGroupName(group)
+                } ?: run {
+                    users[user] = mutableSetOf(calculateUserGroupName(group))
+                }
+            }
+        }
+        return users
+    }
+
+    /**
+     * Keycloak group name format is: "<ENTITY_TYPE>_<ENTITY_ID>_<ROLE>".
+     * By extracting the "ROLE" part from group name, we can map it to [UserGroup].
+     * In example, group name "ORGANIZATION_99_ADMINS" will be mapped to [UserGroup.ADMINS].
+     * @see: [ProductRole.groupName], [OrganizationRole.groupName], [RepositoryRole.groupName].
+     */
+    private fun calculateUserGroupName(group: Group): UserGroup =
+        group.name.value.split("_").last().let {
+            UserGroup.valueOf(it)
+        }
 }

--- a/services/authorization/src/test/kotlin/UserServiceTest.kt
+++ b/services/authorization/src/test/kotlin/UserServiceTest.kt
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.services
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import io.mockk.coEvery
+import io.mockk.mockk
+
+import org.eclipse.apoapsis.ortserver.clients.keycloak.Group
+import org.eclipse.apoapsis.ortserver.clients.keycloak.GroupId
+import org.eclipse.apoapsis.ortserver.clients.keycloak.GroupName
+import org.eclipse.apoapsis.ortserver.clients.keycloak.KeycloakClient
+import org.eclipse.apoapsis.ortserver.clients.keycloak.User
+import org.eclipse.apoapsis.ortserver.clients.keycloak.UserId
+import org.eclipse.apoapsis.ortserver.clients.keycloak.UserName
+import org.eclipse.apoapsis.ortserver.model.UserGroup
+
+class UserServiceTest : WordSpec({
+    val keycloakClient = mockk<KeycloakClient>()
+    val service = UserService(keycloakClient)
+
+    fun mockGroupsListForEntity(entityName: String, entityId: Long) {
+        coEvery {
+            keycloakClient.getGroupMembers(GroupId("gr1-wri"))
+        } returns setOf(
+            User(UserId("usr-1"), UserName("user1"), "Boo", "Zoo", "boo.zoo@example.com"),
+            User(UserId("usr-2"), UserName("user2"), "Woo", "Goo", "woo.goo@example.com"),
+            User(UserId("usr-3"), UserName("user3"), "Wee", "Moo", "wee.moo@example.com")
+        )
+
+        coEvery {
+            keycloakClient.getGroupMembers(GroupId("gr2-adm"))
+        } returns setOf(
+            User(UserId("usr-1"), UserName("user1"), "Boo", "Zoo", "boo.zoo@example.com")
+        )
+
+        coEvery {
+            keycloakClient.getGroupMembers(GroupId("gr3-rea"))
+        } returns emptySet()
+
+        coEvery {
+            keycloakClient.searchGroups(GroupName("${entityName}_${entityId}_"))
+        } returns setOf(
+            Group(GroupId("gr1-wri"), GroupName("${entityName}_${entityId}_WRITERS")),
+            Group(GroupId("gr2-adm"), GroupName("${entityName}_${entityId}_ADMINS")),
+            Group(GroupId("gr3-rea"), GroupName("${entityName}_${entityId}_READERS"))
+        )
+    }
+
+    "getUsersForOrganization" should {
+        "return empty list when no users are found for organization" {
+            // Given
+            val orgId = 7L
+
+            coEvery {
+                keycloakClient.searchGroups(GroupName("ORGANIZATION_${orgId}_"))
+            } returns emptySet()
+
+            // When
+            val result = service.getUsersHavingRightsForOrganization(orgId)
+
+            // Then
+            result shouldBe emptyMap()
+        }
+
+        "return map of users with corresponding set of roles within organization" {
+            // Given
+            val orgId = 7L
+            mockGroupsListForEntity("ORGANIZATION", orgId)
+
+            // When
+            val result = service.getUsersHavingRightsForOrganization(orgId)
+
+            // Then
+            result.size shouldBe 3
+            result.keys.map { it.username } shouldBe listOf("user1", "user2", "user3")
+            result[result.keys.find { it.username == "user1" }] shouldBe setOf(UserGroup.WRITERS, UserGroup.ADMINS)
+            result[result.keys.find { it.username == "user2" }] shouldBe setOf(UserGroup.WRITERS)
+            result[result.keys.find { it.username == "user3" }] shouldBe setOf(UserGroup.WRITERS)
+        }
+    }
+
+    "getUsersForProduct" should {
+        "return empty list when no users are found for product" {
+            // Given
+            val prodId = 4L
+
+            coEvery {
+                keycloakClient.searchGroups(GroupName("PRODUCT_${prodId}_"))
+            } returns emptySet()
+
+            // When
+            val result = service.getUsersHavingRightForProduct(prodId)
+
+            // Then
+            result shouldBe emptyMap()
+        }
+
+        "return map of users with corresponding set of roles within organization" {
+            // Given
+            val prodId = 4L
+            mockGroupsListForEntity("PRODUCT", prodId)
+
+            // When
+            val result = service.getUsersHavingRightForProduct(prodId)
+
+            // Then
+            result.size shouldBe 3
+            result.keys.map { it.username } shouldBe listOf("user1", "user2", "user3")
+            result[result.keys.find { it.username == "user1" }] shouldBe setOf(UserGroup.WRITERS, UserGroup.ADMINS)
+            result[result.keys.find { it.username == "user2" }] shouldBe setOf(UserGroup.WRITERS)
+            result[result.keys.find { it.username == "user3" }] shouldBe setOf(UserGroup.WRITERS)
+        }
+    }
+
+    "getUsersForRepository" should {
+        "return empty list when no users are found for repository" {
+            // Given
+            val repoId = 2L
+
+            coEvery {
+                keycloakClient.searchGroups(GroupName("REPOSITORY_${repoId}_"))
+            } returns emptySet()
+
+            // When
+            val result = service.getUsersHavingRightsForRepository(repoId)
+
+            // Then
+            result shouldBe emptyMap()
+        }
+
+        "return map of users with corresponding set of roles within repository" {
+            // Given
+            val prodId = 4L
+            mockGroupsListForEntity("REPOSITORY", prodId)
+
+            // When
+            val result = service.getUsersHavingRightsForRepository(prodId)
+
+            // Then
+            result.size shouldBe 3
+            result.keys.map { it.username } shouldBe listOf("user1", "user2", "user3")
+            result[result.keys.find { it.username == "user1" }] shouldBe setOf(UserGroup.ADMINS, UserGroup.WRITERS)
+            result[result.keys.find { it.username == "user2" }] shouldBe setOf(UserGroup.WRITERS)
+            result[result.keys.find { it.username == "user3" }] shouldBe setOf(UserGroup.WRITERS)
+        }
+    }
+})


### PR DESCRIPTION
Implements: https://github.com/eclipse-apoapsis/ort-server/issues/2104
For the improved Users page as described in https://github.com/eclipse-apoapsis/ort-server/issues/2053, the ORT Server needs a new endpoint to return the list of users within an entity (organization, product, or repository). The endpoint should also clearly indicate which group (readers, writers, admins) each user belongs to.