### PR TITLE
Make authentication more flexible

### DIFF
--- a/api/v1/model/src/commonMain/kotlin/CredentialsType.kt
+++ b/api/v1/model/src/commonMain/kotlin/CredentialsType.kt
@@ -23,21 +23,21 @@ package org.eclipse.apoapsis.ortserver.api.v1.model
  * An enumeration class defining the supported credential types that are available for infrastructure services.
  * Depending on the type(s) set, the credentials of the service are added to different configuration files. Note that
  * infrastructure services can be assigned multiple credential types. It is also possible that they have no type;
- * then they are ignored when generating configuration files for credentials.
+ * then they are ignored when generating configuration files for credentials. They are, however, always considered by
+ * the global authenticator of the JVM.
  */
 enum class CredentialsType {
     /**
      * Credentials type indicating that the credentials of the service should be added to the _.netrc_ file. This is
-     * in most cases the desired option, since it allows access to the service from most external tools.
+     * needed if the underlying service URL needs to be accessed from external tools (except for Git) that rely on the
+     * mechanism of the _.netrc_ file.
      */
     NETRC_FILE,
 
     /**
      * Credentials type indicating that the credentials of the service should be added to the _.git-credentials_ file.
-     * For normal cases, it should not be necessary to use this type, since Git should be able to obtain the
-     * credentials from the _.netrc_ file. There are, however, rare cases when Git is not able to authenticate against
-     * a repository based on the information in the _.netrc_ file. This was observed for instance with repositories
-     * hosted on Microsoft Azure DevOps servers.
+     * This flag should typically be set for services representing Git repositories to make sure that the Git CLI can
+     * obtain their credentials.
      */
     GIT_CREDENTIALS_FILE
 }

--- a/api/v1/model/src/commonMain/kotlin/InfrastructureService.kt
+++ b/api/v1/model/src/commonMain/kotlin/InfrastructureService.kt
@@ -53,7 +53,7 @@ data class InfrastructureService(
      * The set of [CredentialsType]s for this infrastructure service. This determines in which configuration files the
      * credentials of the service are listed when generating the runtime environment for a worker.
      */
-    val credentialsTypes: Set<CredentialsType> = setOf(CredentialsType.NETRC_FILE)
+    val credentialsTypes: Set<CredentialsType> = emptySet()
 )
 
 /**

--- a/model/src/commonMain/kotlin/CredentialsType.kt
+++ b/model/src/commonMain/kotlin/CredentialsType.kt
@@ -23,21 +23,21 @@ package org.eclipse.apoapsis.ortserver.model
  * An enumeration class defining the supported credential types that are available for infrastructure services.
  * Depending on the type(s) set, the credentials of the service are added to different configuration files. Note that
  * infrastructure services can be assigned multiple credential types. It is also possible that they have no type;
- * then they are ignored when generating configuration files for credentials.
+ * then they are ignored when generating configuration files for credentials. They are, however, always considered by
+ * the global authenticator of the JVM.
  */
 enum class CredentialsType {
     /**
      * Credentials type indicating that the credentials of the service should be added to the _.netrc_ file. This is
-     * in most cases the desired option, since it allows access to the service from most external tools.
+     * needed if the underlying service URL needs to be accessed from external tools (except for Git) that rely on the
+     * mechanism of the _.netrc_ file.
      */
     NETRC_FILE,
 
     /**
      * Credentials type indicating that the credentials of the service should be added to the _.git-credentials_ file.
-     * For normal cases, it should not be necessary to use this type, since Git should be able to obtain the
-     * credentials from the _.netrc_ file. There are, however, rare cases when Git is not able to authenticate against
-     * a repository based on the information in the _.netrc_ file. This was observed for instance with repositories
-     * hosted on Microsoft Azure DevOps servers.
+     * This flag should typically be set for services representing Git repositories to make sure that the Git CLI can
+     * obtain their credentials.
      */
     GIT_CREDENTIALS_FILE
 }

--- a/model/src/commonMain/kotlin/InfrastructureService.kt
+++ b/model/src/commonMain/kotlin/InfrastructureService.kt
@@ -57,15 +57,13 @@ data class InfrastructureService(
 
     /**
      * The set of [CredentialsType]s for this infrastructure service. This determines in which configuration files the
-     * credentials of the service are listed when generating the runtime environment for a worker. Per default, the
-     * credentials for all the infrastructure services referenced from a repository are added to the _.netrc_ file.
-     * This is typically desired, so that all external tools invoked from a worker can access the credentials they
-     * represent. In some constellations, however, there could be conflicting services; for instance, if multiple
-     * repositories with different credentials are defined on the same repository server. Such issues can be resolved
-     * by explicitly removing the [CredentialsType.NETRC_FILE] constant from this set. It is also possible to add other
-     * constants if a special treatment of the credentials is required.
+     * credentials of the service are listed when generating the runtime environment for a worker. All services
+     * involved in an ORT run are installed in the authenticator, so that their credentials are available when
+     * accessing the corresponding URLs from within the JVM. In case, the credentials are also required from external
+     * tools (e.g. the Git CLI), this needs to be indicated by adding the corresponding constant. Per default, the set
+     * is empty, so that the services are only used by the authenticator of the JVM.
      */
-    val credentialsTypes: Set<CredentialsType> = setOf(CredentialsType.NETRC_FILE)
+    val credentialsTypes: Set<CredentialsType> = emptySet()
 ) {
     companion object {
         val NAME_PATTERN_REGEX = """^(?!\s)[A-Za-z0-9- ]*(?<!\s)$""".toRegex()

--- a/model/src/commonMain/kotlin/InfrastructureServiceDeclaration.kt
+++ b/model/src/commonMain/kotlin/InfrastructureServiceDeclaration.kt
@@ -51,5 +51,5 @@ data class InfrastructureServiceDeclaration(
     val passwordSecret: String,
 
     /** The set of [CredentialsType]s for this infrastructure service. */
-    val credentialsTypes: Set<CredentialsType> = setOf(CredentialsType.NETRC_FILE)
+    val credentialsTypes: Set<CredentialsType> = emptySet()
 )

--- a/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
@@ -36,8 +36,10 @@ import io.kotest.matchers.string.shouldNotContain
 
 import io.mockk.coEvery
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkClass
+import io.mockk.runs
 
 import java.io.File
 import java.util.Properties
@@ -355,6 +357,7 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
                     resolvedJobConfigContext = null,
                     traceId = "trace-id",
                 )
+                coEvery { setupAuthentication(any()) } just runs
             }
 
             val repositoryFolder = File("src/test/resources/mavenProject")

--- a/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
@@ -111,7 +111,9 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
             runEndpointTest {
                 val contextFactory by inject<WorkerContextFactory>()
 
-                contextFactory.createContext(42L) shouldNot beNull()
+                contextFactory.withContext(42L) {
+                    it shouldNot beNull()
+                }
             }
         }
 

--- a/workers/analyzer/src/test/resources/mavenProject/.ort.env.yml
+++ b/workers/analyzer/src/test/resources/mavenProject/.ort.env.yml
@@ -3,10 +3,14 @@ infrastructureServices:
   url: "https://repo.example.org/test/repository.git"
   usernameSecret: "repositoryUsername"
   passwordSecret: "repositoryPassword"
+  credentialsTypes:
+  - NETRC_FILE
 - name: "SpecialGitService"
   url: "https://repo2.example.org/test2/other-repository.git"
   usernameSecret: "repositoryUsername"
   passwordSecret: "repositoryPassword"
+  credentialsTypes:
+  - NETRC_FILE
 environmentDefinitions:
   conan:
   - service: "RepositoryService"

--- a/workers/common/src/main/kotlin/common/context/AuthenticatedService.kt
+++ b/workers/common/src/main/kotlin/common/context/AuthenticatedService.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.common.context
+
+/**
+ * A data class describing a service with credentials for authentication.
+ *
+ * During the execution of a worker, instances of this class are created to access the infrastructure services
+ * relevant for the current ORT run.
+ */
+data class AuthenticatedService(
+    /** The name of the corresponding infrastructure service. */
+    val name: String,
+
+    /** The URI of the service. */
+    val uri: String,
+
+    /** The username for authentication. */
+    val username: String,
+
+    /** The password for authentication. */
+    val password: String
+)

--- a/workers/common/src/main/kotlin/common/context/OrtServerAuthenticator.kt
+++ b/workers/common/src/main/kotlin/common/context/OrtServerAuthenticator.kt
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.common.context
+
+import java.net.Authenticator
+import java.net.PasswordAuthentication
+import java.net.URI
+import java.net.URL
+import java.util.concurrent.atomic.AtomicReference
+
+import org.slf4j.LoggerFactory
+
+/**
+ * Implementation of an [Authenticator] which uses the current set of infrastructure services to authenticate requests.
+ *
+ * This implementation extends ORT's authenticator implementation which is unable to handle multiple credentials for
+ * the same host.
+ *
+ * When setting up a new [WorkerContext], this authenticator is installed as the default authenticator. It is
+ * uninstalled when the context is closed. Since the set of infrastructure services can change during the execution
+ * time of a worker (for instance after parsing the `.env.ort.yml` file), this implementation can be modified
+ * dynamically. Workers do not interact with this class directly, but use functionality provided by the
+ * [WorkerContext] interface instead.
+ */
+internal class OrtServerAuthenticator(
+    /** The original authenticator that was active when this instance was installed. */
+    private val original: Authenticator? = null
+) : Authenticator() {
+    companion object {
+        private val logger = LoggerFactory.getLogger(OrtServerAuthenticator::class.java)
+
+        /**
+         * Install this authenticator as the global default if it is not already installed.
+         */
+        @Synchronized
+        fun install(): OrtServerAuthenticator {
+            val active = getDefault()
+            return active as? OrtServerAuthenticator
+                ?: OrtServerAuthenticator(active).also {
+                    setDefault(it)
+                    logger.info("OrtServerAuthenticator was successfully installed.")
+                }
+        }
+
+        /**
+         * Uninstall the [OrtServerAuthenticator] if it is currently installed and restore the previous
+         * [Authenticator]. Return the new default [Authenticator], which may be *null*.
+         */
+        @Synchronized
+        fun uninstall(): Authenticator? {
+            val active = getDefault()
+            return if (active is OrtServerAuthenticator) {
+                active.original.also {
+                    setDefault(it)
+                    logger.info("OrtServerAuthenticator was successfully uninstalled.")
+                }
+            } else {
+                logger.info("OrtServerAuthenticator is not installed.")
+                active
+            }
+        }
+    }
+
+    /**
+     * A reference to the current set of services for which authentication information is available. It is not
+     * expected that the services are updated concurrently, but they may be accessed from different threads.
+     * Therefore, an atomic reference is used to ensure safe publishing of changes.
+     */
+    private val refServices = AtomicReference<ServiceData>(ServiceData(emptyMap()))
+
+    override fun getPasswordAuthentication(): PasswordAuthentication? {
+        if (requestorType != RequestorType.SERVER) return null
+
+        logger.info("Request for password authentication for '${requestingURL ?: requestingHost}'.")
+
+        return refServices.get().getAuthenticatedService(requestingHost, requestingURL)?.let { service ->
+            logger.info("Using credentials from service '${service.name}'.")
+            PasswordAuthentication(service.username, service.password.toCharArray())
+        }
+    }
+
+    /**
+     * Update the list of [services] for which authentication information is available. The authenticator is able to
+     * handle password requests for these services.
+     */
+    fun updateAuthenticatedServices(services: Collection<AuthenticatedService>) {
+        logger.info("Updating the list of authenticated services. Setting ${services.size} services.")
+
+        val validatedServices = services.mapNotNull { service ->
+            runCatching {
+                URI.create(service.uri) to service
+            }.onFailure {
+                logger.error("Invalid URI for service '${service.name}': '${service.uri}'. Ignoring service.", it)
+            }.getOrNull()
+        }.groupBy { it.first.host }
+            .mapValues { e -> e.value.map { it.second.withTrailingSlash() } }
+
+        refServices.set(ServiceData(validatedServices))
+    }
+}
+
+/**
+ * An internally used data class to store information about the services that can be authenticated.
+ */
+private data class ServiceData(
+    /** A [Map] storing the known services grouped by their host name. */
+    private val servicesByHost: Map<String, Collection<AuthenticatedService>>
+) {
+    /**
+     * Find the best-matching [AuthenticatedService] for the given [host] and optional [url]. If there are multiple
+     * services for the same host, the one with the longest matching URL is returned. Result is *null* if no
+     * matching service is found.
+     */
+    fun getAuthenticatedService(host: String, url: URL?): AuthenticatedService? {
+        val services = servicesByHost[url?.host ?: host].orEmpty()
+
+        val matchingServices = url?.let { requestUrl ->
+            val strUrl = "${requestUrl.toString().removeSuffix("/")}/"
+            services.filter { strUrl.startsWith(it.uri) || it.uri == strUrl }
+        } ?: services
+
+        return matchingServices.maxByOrNull { it.uri.length }
+    }
+}
+
+/**
+ * Return an [AuthenticatedService] instance whose URI is guaranteed to end on a slash. This is needed for correct
+ * prefix matching.
+ */
+private fun AuthenticatedService.withTrailingSlash(): AuthenticatedService =
+    this.takeIf { uri.endsWith('/') } ?: copy(uri = "$uri/")

--- a/workers/common/src/main/kotlin/common/context/WorkerContext.kt
+++ b/workers/common/src/main/kotlin/common/context/WorkerContext.kt
@@ -24,6 +24,7 @@ import java.io.File
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.config.Path
 import org.eclipse.apoapsis.ortserver.model.Hierarchy
+import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.PluginConfig
 import org.eclipse.apoapsis.ortserver.model.ProviderPluginConfiguration
@@ -104,4 +105,10 @@ interface WorkerContext : AutoCloseable {
      * downloaded.
      */
     suspend fun downloadConfigurationDirectory(path: Path, targetDirectory: File): Map<Path, File>
+
+    /**
+     * Install the given list of [services] in ORT Server's authenticator, so that their credentials can be used to
+     * access the corresponding URLs.
+     */
+    suspend fun setupAuthentication(services: Collection<InfrastructureService>)
 }

--- a/workers/common/src/main/kotlin/common/env/GitCredentialsGenerator.kt
+++ b/workers/common/src/main/kotlin/common/env/GitCredentialsGenerator.kt
@@ -55,8 +55,8 @@ class GitCredentialsGenerator : EnvironmentConfigGenerator<EnvironmentServiceDef
                 val serviceUrl = URI.create(url).toURL()
                 append(serviceUrl.protocol)
                 append("://")
-                append(builder.secretRef(usernameSecret)).append(':')
-                append(builder.secretRef(passwordSecret)).append('@')
+                append(builder.secretRef(usernameSecret, ConfigFileBuilder.urlEncoding)).append(':')
+                append(builder.secretRef(passwordSecret, ConfigFileBuilder.urlEncoding)).append('@')
                 append(serviceUrl.authority)
                 append(serviceUrl.path)
             }

--- a/workers/common/src/main/kotlin/common/env/config/RepositoryInfrastructureService.kt
+++ b/workers/common/src/main/kotlin/common/env/config/RepositoryInfrastructureService.kt
@@ -19,8 +19,6 @@
 
 package org.eclipse.apoapsis.ortserver.workers.common.env.config
 
-import java.util.EnumSet
-
 import kotlinx.serialization.Serializable
 
 import org.eclipse.apoapsis.ortserver.model.CredentialsType
@@ -51,6 +49,6 @@ internal data class RepositoryInfrastructureService(
     /** The reference to the secret that contains the password of the credentials for this infrastructure service. */
     val passwordSecret: String,
 
-    /** A flag whether this service should be ignored when generating the _.netrc_ file. */
-    val credentialsTypes: Set<CredentialsType> = EnumSet.of(CredentialsType.NETRC_FILE)
+    /** The set of [CredentialsType]s for this infrastructure service. */
+    val credentialsTypes: Set<CredentialsType> = emptySet()
 )

--- a/workers/common/src/test/kotlin/common/context/OrtServerAuthenticatorTest.kt
+++ b/workers/common/src/test/kotlin/common/context/OrtServerAuthenticatorTest.kt
@@ -1,0 +1,216 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.common.context
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.nulls.beNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+
+import io.mockk.mockk
+
+import java.net.Authenticator
+import java.net.URI
+
+class OrtServerAuthenticatorTest : WordSpec() {
+    /** Stores the original authenticator, so that it can be restored after the test. */
+    private var originalAuthenticator: Authenticator? = null
+
+    init {
+        beforeEach {
+            originalAuthenticator = Authenticator.getDefault()
+        }
+
+        afterEach {
+            Authenticator.setDefault(originalAuthenticator)
+        }
+
+        "install()" should {
+            "check whether the authenticator is already installed" {
+                val authenticator = OrtServerAuthenticator.install()
+
+                OrtServerAuthenticator.install() shouldBeSameInstanceAs authenticator
+            }
+        }
+
+        "uninstall()" should {
+            "restore the previous authenticator" {
+                val orgAuthenticator = mockk<Authenticator>()
+                Authenticator.setDefault(orgAuthenticator)
+
+                OrtServerAuthenticator.install()
+                OrtServerAuthenticator.uninstall() shouldBe orgAuthenticator
+
+                Authenticator.getDefault() shouldBe orgAuthenticator
+            }
+
+            "not change anything if the ORT Server authenticator is not installed" {
+                val orgAuthenticator = mockk<Authenticator>()
+                Authenticator.setDefault(orgAuthenticator)
+
+                OrtServerAuthenticator.uninstall() shouldBe orgAuthenticator
+
+                Authenticator.getDefault() shouldBe orgAuthenticator
+            }
+        }
+
+        "getPasswordAuthentication()" should {
+            "return null if no matching infrastructure service is found" {
+                OrtServerAuthenticator.install()
+
+                val pwd =
+                    Authenticator.requestPasswordAuthentication("example.com", null, 443, "tcp", "hello", "https")
+
+                pwd should beNull()
+            }
+
+            "return an authentication for a matching host name" {
+                val authenticator = OrtServerAuthenticator.install()
+                authenticator.updateAuthenticatedServices(
+                    listOf(
+                        AuthenticatedService("service", "https://example.com", USERNAME, PASSWORD)
+                    )
+                )
+
+                val pwd =
+                    Authenticator.requestPasswordAuthentication("example.com", null, 443, "tcp", "hello", "https")
+
+                pwd.userName shouldBe USERNAME
+                pwd.password shouldBe PASSWORD.toCharArray()
+            }
+
+            "return an authentication for a matching service URL" {
+                val url = "https://repo.example.com/org/repo"
+
+                val authenticator = OrtServerAuthenticator.install()
+                authenticator.updateAuthenticatedServices(
+                    listOf(
+                        AuthenticatedService("service", url, USERNAME, PASSWORD)
+                    )
+                )
+
+                val pwd = Authenticator.requestPasswordAuthentication(
+                    "host.does.not.matter",
+                    null,
+                    443,
+                    "tcp",
+                    "hello",
+                    "https",
+                    URI.create(url).toURL(),
+                    Authenticator.RequestorType.SERVER
+                )
+
+                pwd.userName shouldBe USERNAME
+                pwd.password shouldBe PASSWORD.toCharArray()
+            }
+
+            "return null for a proxy authentication" {
+                val url = "https://repo.example.com/org/repo"
+
+                val authenticator = OrtServerAuthenticator.install()
+                authenticator.updateAuthenticatedServices(
+                    listOf(
+                        AuthenticatedService("service", url, USERNAME, PASSWORD)
+                    )
+                )
+
+                val pwd = Authenticator.requestPasswordAuthentication(
+                    "repo.example.com",
+                    null,
+                    443,
+                    "tcp",
+                    "hello",
+                    "https",
+                    URI.create(url).toURL(),
+                    Authenticator.RequestorType.PROXY
+                )
+
+                pwd should beNull()
+            }
+
+            "return the credentials for the best-matching service URL" {
+                val url = "https://repo.example.com/org/repo"
+
+                val authenticator = OrtServerAuthenticator.install()
+                authenticator.updateAuthenticatedServices(
+                    listOf(
+                        AuthenticatedService("s1", "https://repo.example.com", "user1", "password1"),
+                        AuthenticatedService("s2", "https://repo2.example.org/org/repo", "user2", "password2"),
+                        AuthenticatedService("s3", "https://repo.example.com/org", "user3", "password3"),
+                        AuthenticatedService("s4", url, USERNAME, PASSWORD),
+                        AuthenticatedService("s5", "$url/sub-repo", "user5", "password5"),
+                        AuthenticatedService("s6", "${url}sitory", "user6", "password6"),
+                        AuthenticatedService("s7", "https://repo.example.com/org/repo2", "user7", "password7")
+                    )
+                )
+
+                val pwd = Authenticator.requestPasswordAuthentication(
+                    "repo.example.com",
+                    null,
+                    443,
+                    "tcp",
+                    "hello",
+                    "https",
+                    URI.create(url).toURL(),
+                    Authenticator.RequestorType.SERVER
+                )
+
+                pwd.userName shouldBe USERNAME
+                pwd.password shouldBe PASSWORD.toCharArray()
+            }
+        }
+
+        "updateAuthenticatedServices()" should {
+            "ignore services with invalid URLs" {
+                val url = "https://repo.example.com/org/repo"
+
+                val authenticator = OrtServerAuthenticator.install()
+                authenticator.updateAuthenticatedServices(
+                    listOf(
+                        AuthenticatedService("someService", "https://repo.example.com", "user1", "password1"),
+                        AuthenticatedService("matchingService", url, USERNAME, PASSWORD),
+                        AuthenticatedService("invalidService", "?! an invalid URL :-(", "user7", "password7")
+                    )
+                )
+
+                val pwd = Authenticator.requestPasswordAuthentication(
+                    "repo.example.com",
+                    null,
+                    443,
+                    "tcp",
+                    "hello",
+                    "https",
+                    URI.create(url).toURL(),
+                    Authenticator.RequestorType.SERVER
+                )
+
+                pwd.userName shouldBe USERNAME
+                pwd.password shouldBe PASSWORD.toCharArray()
+            }
+        }
+    }
+}
+
+/** A test username. */
+private const val USERNAME = "scott"
+
+/** A test password. */
+private const val PASSWORD = "tiger"

--- a/workers/common/src/test/kotlin/common/context/WorkerContextFactoryTest.kt
+++ b/workers/common/src/test/kotlin/common/context/WorkerContextFactoryTest.kt
@@ -417,6 +417,20 @@ class WorkerContextFactoryTest : WordSpec({
             }
         }
     }
+
+    "withContext" should {
+        "properly close the context after the block has been executed" {
+            val helper = ContextFactoryTestHelper()
+
+            val tempDir = helper.factory.withContext(RUN_ID) { context ->
+                context.createTempDir().also {
+                    it.exists() shouldBe true
+                }
+            }
+
+            tempDir.exists() shouldBe false
+        }
+    }
 })
 
 private const val RUN_ID = 20230607142948L

--- a/workers/common/src/test/kotlin/common/env/MockConfigFileBuilder.kt
+++ b/workers/common/src/test/kotlin/common/env/MockConfigFileBuilder.kt
@@ -60,8 +60,8 @@ class MockConfigFileBuilder {
          */
         fun createInfrastructureService(
             url: String = REPOSITORY_URL,
-            userSecret: Secret = mockk(),
-            passwordSecret: Secret = mockk(),
+            userSecret: Secret = mockk(relaxed = true),
+            passwordSecret: Secret = mockk(relaxed = true),
             credentialsTypes: Set<CredentialsType> = EnumSet.of(CredentialsType.NETRC_FILE)
         ): InfrastructureService =
             InfrastructureService(

--- a/workers/config/src/test/kotlin/ConfigWorkerTest.kt
+++ b/workers/config/src/test/kotlin/ConfigWorkerTest.kt
@@ -25,9 +25,11 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.beInstanceOf
 
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
 
@@ -283,8 +285,11 @@ private fun mockContext(orgConfigContext: String? = ORIGINAL_CONTEXT): Pair<Work
         every { ortRun } returns run
     }
 
+    val slot = slot<suspend (WorkerContext) -> RunResult>()
     val factory = mockk<WorkerContextFactory> {
-        every { createContext(RUN_ID) } returns context
+        coEvery { withContext(RUN_ID, capture(slot)) } coAnswers {
+            slot.captured(context)
+        }
     }
 
     return factory to context

--- a/workers/notifier/src/test/kotlin/NotifierWorkerTest.kt
+++ b/workers/notifier/src/test/kotlin/NotifierWorkerTest.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.workers.notifier
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.shouldBe
 
+import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
@@ -102,8 +103,12 @@ class NotifierWorkerTest : StringSpec({
         val context = mockk<WorkerContext> {
             every { this@mockk.ortRun } returns ortRun
         }
+
+        val slot = slot<suspend (WorkerContext) -> RunResult>()
         val contextFactory = mockk<WorkerContextFactory> {
-            every { createContext(ORT_RUN_ID) } returns context
+            coEvery { withContext(ORT_RUN_ID, capture(slot)) } coAnswers {
+                slot.captured(context)
+            }
         }
 
         val runnerResult = NotifierRunnerResult(

--- a/workers/scanner/src/test/kotlin/ScannerWorkerTest.kt
+++ b/workers/scanner/src/test/kotlin/ScannerWorkerTest.kt
@@ -115,9 +115,7 @@ class ScannerWorkerTest : StringSpec({
         }
 
         val context = mockk<WorkerContext>()
-        val contextFactory = mockk<WorkerContextFactory> {
-            every { createContext(ORT_RUN_ID) } returns context
-        }
+        val contextFactory = mockContextFactory(context)
 
         val ortIdentifier = Identifier("type", "namespace", "name", "version")
         val mappedIdentifier = org.eclipse.apoapsis.ortserver.model.runs.Identifier(
@@ -205,9 +203,7 @@ class ScannerWorkerTest : StringSpec({
         }
 
         val context = mockk<WorkerContext>()
-        val contextFactory = mockk<WorkerContextFactory> {
-            every { createContext(ORT_RUN_ID) } returns context
-        }
+        val contextFactory = mockContextFactory(context)
 
         val provenance1 = mockk<ArtifactProvenance>(relaxed = true)
         val provenance2 = mockk<RepositoryProvenance>(relaxed = true)
@@ -375,9 +371,7 @@ class ScannerWorkerTest : StringSpec({
         }
 
         val context = mockk<WorkerContext>()
-        val contextFactory = mockk<WorkerContextFactory> {
-            every { createContext(ORT_RUN_ID) } returns context
-        }
+        val contextFactory = mockContextFactory(context)
 
         val provenance: Provenance =
             OrtTestData.scannerRun.provenances.firstNotNullOf(ProvenanceResolutionResult::packageProvenance)
@@ -421,3 +415,15 @@ class ScannerWorkerTest : StringSpec({
         }
     }
 })
+
+/**
+ * Create a mock [WorkerContextFactory] and prepare it to return the given [context].
+ */
+private fun mockContextFactory(context: WorkerContext = mockk()): WorkerContextFactory {
+    val slot = slot<suspend (WorkerContext) -> RunResult>()
+    return mockk {
+        coEvery { withContext(ORT_RUN_ID, capture(slot)) } coAnswers {
+            slot.captured(context)
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces a new, ORT Server-specific `Authenticator` implementation that is based on infrastructure services. In contrast to the existing solution, this supports multiple credentials for the same host.

This PR depends on a change in ORT's `Authenticator` implemented in https://github.com/oss-review-toolkit/ort/pull/10060.