### PR TITLE
chore(vault): Extend logging

### DIFF
--- a/secrets/vault/src/main/kotlin/VaultSecretsProviderFactory.kt
+++ b/secrets/vault/src/main/kotlin/VaultSecretsProviderFactory.kt
@@ -40,8 +40,11 @@ class VaultSecretsProviderFactory : SecretsProviderFactory {
         val vaultConfig = VaultConfiguration.create(configManager)
 
         logger.info("Creating VaultSecretsProvider.")
-        logger.debug("Vault URI: '${vaultConfig.vaultUri}'.")
-        logger.debug("RoleId: '${vaultConfig.credentials.roleId}'.")
+        logger.info("Vault URI: '${vaultConfig.vaultUri}'.")
+        logger.info("RoleId: '${vaultConfig.credentials.roleId}'.")
+        logger.info("Root path: '${vaultConfig.rootPath}'.")
+        logger.info("Prefix: '${vaultConfig.prefix}'.")
+        logger.info("Namespace: '${vaultConfig.namespace ?: "<undefined>"}'.")
 
         return VaultSecretsProvider(vaultConfig)
     }


### PR DESCRIPTION
To diagnose problems with access to a HashiCorp Vault instance, it is helpful to know the exact configuration. Therefore, log it when creating a `VaultSecretProvider` instance.