### PR TITLE
docs(ui): Clarify that the `path` is relative to the repository root

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -222,7 +222,8 @@ const CreateRunPage = () => {
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>
                   <FormDescription>
-                    The path to limit the analysis to, for example{' '}
+                    The path (relative to the repository root) to limit the
+                    analysis to, for example{' '}
                     <InlineCode>path/to/source</InlineCode>.
                   </FormDescription>
                   <FormMessage />


### PR DESCRIPTION
Avoid confusion to instead use e.g. the URL with the path to a GitHub repository.