### PR TITLE
ui: Display configured Package ID in Packages table

### DIFF
--- a/ui/src/components/dependency-paths.tsx
+++ b/ui/src/components/dependency-paths.tsx
@@ -19,23 +19,30 @@
 
 import { MoveRight } from 'lucide-react';
 
-import { Identifier, Package, ShortestDependencyPath } from '@/api/requests';
+import { Package, ShortestDependencyPath } from '@/api/requests';
 import { identifierToString } from '@/helpers/identifier-to-string';
 import { cn } from '@/lib/utils';
+import { PackageIdType } from '@/schemas';
 
 type DependencyPathsProps = {
   pkg: Package;
+  pkgIdType?: PackageIdType;
   className?: string;
 };
 
-export const DependencyPaths = ({ pkg, className }: DependencyPathsProps) => {
+export const DependencyPaths = ({
+  pkg,
+  pkgIdType,
+  className,
+}: DependencyPathsProps) => {
   return (
     <div className={className}>
       {pkg.shortestDependencyPaths.map((path, index) => (
         <div key={index}>
           <DependencyPath
             shortestPath={path}
-            pkgId={pkg.identifier}
+            pkg={pkg}
+            pkgIdType={pkgIdType}
             className='ml-2'
           />
         </div>
@@ -46,11 +53,13 @@ export const DependencyPaths = ({ pkg, className }: DependencyPathsProps) => {
 
 const DependencyPath = ({
   shortestPath,
-  pkgId,
+  pkg,
+  pkgIdType,
   className,
 }: {
   shortestPath: ShortestDependencyPath;
-  pkgId: Identifier;
+  pkg: Package;
+  pkgIdType?: PackageIdType;
   className: string;
 }) => {
   return (
@@ -62,12 +71,18 @@ const DependencyPath = ({
       {shortestPath.path.map((path, index) => (
         <div className='flex flex-wrap gap-x-2 align-middle' key={index}>
           <MoveRight size={20} />
-          <div>{identifierToString(path)}</div>
+          <div>
+            {pkgIdType === 'ORT_ID' ? identifierToString(path) : pkg.purl}
+          </div>
         </div>
       ))}
       <div className='flex flex-wrap gap-x-2 align-middle'>
         <MoveRight size={20} />
-        <div>{identifierToString(pkgId)}</div>
+        <div>
+          {pkgIdType === 'ORT_ID'
+            ? identifierToString(pkg.identifier)
+            : pkg.purl}
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
PR #2309 laid the groundwork for setting and saving user preferences, so in this PR, either the ORT ID or PURL will be shown as the package ID in the Packages table. 

The default is ORT ID so there are no changes to the UI by default - the user needs to specifically go to the Settings page (accessible from the top-right menu) and choose the "PURL" option to see PURLs being used in the table.

There are several other tables where we want to show PURL instead of ORT ID in the "Package ID" column, but the corresponding endpoints do not return the purl, so they will need to be extended. Such endpoints are:
- all endpoints returning vulnerabilities
- issues endpoint
- rule violations endpoint

![Screenshot from 2025-03-21 09-20-13](https://github.com/user-attachments/assets/facc8549-8b55-443a-a470-95c4dd6a873c)

![Screenshot from 2025-03-21 12-25-16](https://github.com/user-attachments/assets/b227d72c-e479-4697-9c7e-38a7dfa50858)

Please see the commits for details.
