### PR TITLE
fix(website): Make the link to ORT readable

### DIFF
--- a/website/src/pages/index.module.css
+++ b/website/src/pages/index.module.css
@@ -10,6 +10,11 @@
   overflow: hidden;
 }
 
+.heroBanner a {
+  color: var(--ifm-hero-text-color);
+  font-weight: bold;
+}
+
 .heroLogo {
   width: 300px;
   height: auto;


### PR DESCRIPTION
Do not use the same link color as for the background. This is a fixup for fe561a7. Also see [1].

[1]: https://github.com/oss-review-toolkit/ort/pull/9718