### PR TITLE
feat(core): Cache Keycloak roles for one minute

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -66,6 +66,7 @@ dependencies {
     implementation(projects.utils.logging)
     implementation(projects.utils.system)
 
+    implementation(libs.aedile)
     implementation(libs.jsonSchemaSerialization)
     implementation(libs.koinKtor)
     implementation(libs.konform)

--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -53,6 +53,8 @@ jwt {
   audience = ${?JWT_AUDIENCE}
   realm = "master"
   realm = ${?JWT_REALM}
+  roleCacheLifetimeSeconds = 60
+  roleCacheLifetimeSeconds = ${?JWT_ROLE_CACHE_LIFETIME}
 }
 
 keycloak {

--- a/core/src/test/kotlin/auth/AuthenticationTest.kt
+++ b/core/src/test/kotlin/auth/AuthenticationTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.core.auth
+
+import com.github.benmanes.caffeine.cache.Caffeine
+
+import com.sksamuel.aedile.core.asCache
+import com.sksamuel.aedile.core.expireAfterWrite
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.should
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.minutes
+
+import kotlinx.coroutines.delay
+
+import org.eclipse.apoapsis.ortserver.clients.keycloak.KeycloakClient
+import org.eclipse.apoapsis.ortserver.clients.keycloak.Role
+import org.eclipse.apoapsis.ortserver.clients.keycloak.RoleId
+import org.eclipse.apoapsis.ortserver.clients.keycloak.RoleName
+import org.eclipse.apoapsis.ortserver.clients.keycloak.UserId
+import org.eclipse.apoapsis.ortserver.core.plugins.getRoles
+
+class AuthenticationTest : WordSpec({
+    val subject = "subject"
+    val keyCloakRoles = setOf(
+        Role(RoleId("1"), RoleName("role1")),
+        Role(RoleId("2"), RoleName("role2")),
+        Role(RoleId("3"), RoleName("role3"))
+    )
+    val roles = keyCloakRoles.mapTo(mutableSetOf()) { it.name.value }
+
+    "getRoles" should {
+        "return the roles from Keycloak" {
+            val cache = Caffeine.newBuilder().expireAfterWrite(1.minutes).asCache<String, Set<String>>()
+            val keycloakClient = mockk<KeycloakClient> {
+                coEvery { getUserClientRoles(UserId(subject)) } returns keyCloakRoles
+            }
+
+            getRoles(subject, keycloakClient, cache) should containExactlyInAnyOrder(roles)
+        }
+
+        "use the cache for subsequent requests" {
+            val cache = Caffeine.newBuilder().expireAfterWrite(1.minutes).asCache<String, Set<String>>()
+            val keycloakClient = mockk<KeycloakClient> {
+                coEvery { getUserClientRoles(UserId(subject)) } returns keyCloakRoles
+            }
+
+            getRoles(subject, keycloakClient, cache) should containExactlyInAnyOrder(roles)
+            getRoles(subject, keycloakClient, cache) should containExactlyInAnyOrder(roles)
+            getRoles(subject, keycloakClient, cache) should containExactlyInAnyOrder(roles)
+
+            coVerify(exactly = 1) {
+                keycloakClient.getUserClientRoles(UserId(subject))
+            }
+        }
+
+        "request the roles from Keycloak when the cache has expired" {
+            val cache = Caffeine.newBuilder().expireAfterWrite(1.milliseconds).asCache<String, Set<String>>()
+            val keycloakClient = mockk<KeycloakClient> {
+                coEvery { getUserClientRoles(UserId(subject)) } returns keyCloakRoles
+            }
+
+            getRoles(subject, keycloakClient, cache) should containExactlyInAnyOrder(roles)
+            delay(10)
+            getRoles(subject, keycloakClient, cache) should containExactlyInAnyOrder(roles)
+
+            coVerify(exactly = 2) {
+                keycloakClient.getUserClientRoles(UserId(subject))
+            }
+        }
+    }
+})

--- a/core/src/test/resources/application-test-auth.conf
+++ b/core/src/test/resources/application-test-auth.conf
@@ -34,6 +34,10 @@ ktor {
   }
 }
 
+jwt {
+  roleCacheLifetimeSeconds = 0
+}
+
 secretsProvider {
   name = "secretsProviderForTesting"
 }

--- a/core/src/test/resources/application-test.conf
+++ b/core/src/test/resources/application-test.conf
@@ -34,6 +34,10 @@ ktor {
   }
 }
 
+jwt {
+  roleCacheLifetimeSeconds = 0
+}
+
 keycloak {}
 
 secretsProvider {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ rabbitMq = "5.25.0"
 versionsPlugin = "0.52.0"
 
 # Gradle dependencies
+aedile = "2.0.3"
 awsSdk = "1.4.46"
 azureIdentity = "1.15.4"
 azureMessagingServicebus = "7.17.10"
@@ -89,6 +90,7 @@ plugin-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", v
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinPlugin" }
 plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublishPlugin" }
 
+aedile = { module = "com.sksamuel.aedile:aedile-core", version.ref = "aedile" }
 azureIdentity = { module = "com.azure:azure-identity", version.ref = "azureIdentity" }
 azureMessagingServicebus = { module = "com.azure:azure-messaging-servicebus", version.ref = "azureMessagingServicebus" }
 azureSecurityKeyvaultSecrets = { module = "com.azure:azure-security-keyvault-secrets", version.ref = "azureSecurityKeyvaultSecrets" }


### PR DESCRIPTION
Requesting the user roles from Keycloak can take some time, slowing down endpoint which would otherwise respond very fast. For example, it was observed in a setup with Keycloak 24 that the Keycloak role requests took between 500-1000ms while the remaining request takes <50ms.

This slows down the UI, especially on pages like the repository list, where a single page makes a lot of API requests.

To mitigate the issue, cache Keycloak roles for one minute. This speeds up such UI pages while at the same time ensuring that changes in the Keycloak roles are quickly reflected by the UI.