### PR TITLE
Add a mode to let workers handle only a single message

### DIFF
--- a/orchestrator/src/main/kotlin/Entrypoint.kt
+++ b/orchestrator/src/main/kotlin/Entrypoint.kt
@@ -59,6 +59,7 @@ import org.eclipse.apoapsis.ortserver.model.repositories.RepositoryRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.ScannerJobRepository
 import org.eclipse.apoapsis.ortserver.transport.EndpointComponent
 import org.eclipse.apoapsis.ortserver.transport.EndpointHandler
+import org.eclipse.apoapsis.ortserver.transport.EndpointHandlerResult
 import org.eclipse.apoapsis.ortserver.transport.OrchestratorEndpoint
 import org.eclipse.apoapsis.ortserver.utils.logging.withMdcContext
 
@@ -104,6 +105,8 @@ class OrchestratorComponent : EndpointComponent<OrchestratorMessage>(Orchestrato
             is WorkerError -> orchestrator.handleWorkerError(message.header, payload)
             is LostSchedule -> orchestrator.handleLostSchedule(message.header, payload)
         }
+
+        EndpointHandlerResult.CONTINUE
     }
 
     override fun customModules(): List<Module> {

--- a/transport/kubernetes/src/test/kotlin/KubernetesMessageReceiverFactoryTest.kt
+++ b/transport/kubernetes/src/test/kotlin/KubernetesMessageReceiverFactoryTest.kt
@@ -36,6 +36,7 @@ import io.mockk.verify
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.model.orchestrator.AnalyzerRequest
 import org.eclipse.apoapsis.ortserver.transport.AnalyzerEndpoint
+import org.eclipse.apoapsis.ortserver.transport.EndpointHandlerResult
 import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessageHeader
 import org.eclipse.apoapsis.ortserver.transport.RUN_ID_PROPERTY
@@ -73,6 +74,7 @@ class KubernetesMessageReceiverFactoryTest : StringSpec({
             var receivedMessage: Message<AnalyzerRequest>? = null
             KubernetesMessageReceiverFactory().createReceiver(AnalyzerEndpoint, configManager) { message ->
                 receivedMessage = message
+                EndpointHandlerResult.CONTINUE
             }
 
             receivedMessage.shouldNotBeNull {

--- a/transport/rabbitmq/src/main/kotlin/RabbitMqMessageReceiverFactory.kt
+++ b/transport/rabbitmq/src/main/kotlin/RabbitMqMessageReceiverFactory.kt
@@ -30,15 +30,19 @@ import com.rabbitmq.client.Envelope
 import java.util.concurrent.Executors
 import java.util.concurrent.ThreadFactory
 
+import kotlin.coroutines.coroutineContext
+
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.channels.ProducerScope
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.job
 
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.transport.Endpoint
 import org.eclipse.apoapsis.ortserver.transport.EndpointHandler
+import org.eclipse.apoapsis.ortserver.transport.EndpointHandlerResult
 import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessageReceiverFactory
 import org.eclipse.apoapsis.ortserver.transport.json.JsonSerializer
@@ -62,7 +66,7 @@ class RabbitMqMessageReceiverFactory : MessageReceiverFactory {
         configManager: ConfigManager,
         handler: EndpointHandler<T>
     ) {
-        createMessageFlow(from, configManager).collect(handler)
+        createMessageFlow(from, configManager).collect { handler(it) }
     }
 
     /**

--- a/transport/spi/src/main/kotlin/MessageReceiverFactory.kt
+++ b/transport/spi/src/main/kotlin/MessageReceiverFactory.kt
@@ -27,9 +27,21 @@ import org.eclipse.apoapsis.ortserver.config.Path
 import org.slf4j.LoggerFactory
 
 /**
- * Definition of a message handler function of an endpoint. The function is passed the message it should handle.
+ * Definition of a message handler function for an endpoint. The function is passed the message it should handle and
+ * returns whether the handler shall receive further messages.
  */
-typealias EndpointHandler<T> = suspend (Message<T>) -> Unit
+typealias EndpointHandler<T> = suspend (Message<T>) -> EndpointHandlerResult
+
+/**
+ * The result of handling a message by an [EndpointHandler].
+ */
+enum class EndpointHandlerResult {
+    /** The handler shall receive further messages. */
+    CONTINUE,
+
+    /** The handler shall not receive further messages. */
+    STOP
+}
 
 /**
  * Factory interface for setting up a receiver for an [Endpoint].

--- a/transport/spi/src/test/kotlin/EndpointComponentTest.kt
+++ b/transport/spi/src/test/kotlin/EndpointComponentTest.kt
@@ -109,6 +109,8 @@ private class EndpointForTesting : EndpointComponent<OrchestratorMessage>(Orches
         publisher.publish(AnalyzerEndpoint, response)
 
         service.process()
+
+        EndpointHandlerResult.CONTINUE
     }
 
     override fun customModules(): List<Module> {

--- a/transport/spi/src/testFixtures/kotlin/Utils.kt
+++ b/transport/spi/src/testFixtures/kotlin/Utils.kt
@@ -67,12 +67,15 @@ fun createConfigManager(
  * Start a receiver that is initialized from the given [configManager]. Since the receiver blocks, this has to be done
  * in a separate thread. Return a queue that can be polled to obtain the received messages.
  */
-fun startReceiver(configManager: ConfigManager): LinkedBlockingQueue<Message<OrchestratorMessage>> {
+fun startReceiver(
+    configManager: ConfigManager,
+    result: EndpointHandlerResult = EndpointHandlerResult.CONTINUE
+): LinkedBlockingQueue<Message<OrchestratorMessage>> {
     val queue = LinkedBlockingQueue<Message<OrchestratorMessage>>()
 
     fun handler(message: Message<OrchestratorMessage>): EndpointHandlerResult {
         queue.offer(message)
-        return EndpointHandlerResult.CONTINUE
+        return result
     }
 
     thread {

--- a/transport/spi/src/testFixtures/kotlin/Utils.kt
+++ b/transport/spi/src/testFixtures/kotlin/Utils.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.runBlocking
 
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.model.orchestrator.OrchestratorMessage
+import org.eclipse.apoapsis.ortserver.transport.EndpointHandlerResult
 import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessageReceiverFactory
 import org.eclipse.apoapsis.ortserver.transport.OrchestratorEndpoint
@@ -69,8 +70,9 @@ fun createConfigManager(
 fun startReceiver(configManager: ConfigManager): LinkedBlockingQueue<Message<OrchestratorMessage>> {
     val queue = LinkedBlockingQueue<Message<OrchestratorMessage>>()
 
-    fun handler(message: Message<OrchestratorMessage>) {
+    fun handler(message: Message<OrchestratorMessage>): EndpointHandlerResult {
         queue.offer(message)
+        return EndpointHandlerResult.CONTINUE
     }
 
     thread {

--- a/workers/advisor/src/main/kotlin/advisor/AdvisorComponent.kt
+++ b/workers/advisor/src/main/kotlin/advisor/AdvisorComponent.kt
@@ -84,7 +84,8 @@ class AdvisorComponent : EndpointComponent<AdvisorRequest>(AdvisorEndpoint) {
             if (response != null) publisher.publish(OrchestratorEndpoint, response)
         }
 
-        EndpointHandlerResult.CONTINUE
+        val handleSingleJobOnly = configManager.config.getBoolean("advisor.handleSingleJobOnly")
+        if (handleSingleJobOnly) EndpointHandlerResult.STOP else EndpointHandlerResult.CONTINUE
     }
 
     override fun customModules(): List<Module> =

--- a/workers/advisor/src/main/kotlin/advisor/AdvisorComponent.kt
+++ b/workers/advisor/src/main/kotlin/advisor/AdvisorComponent.kt
@@ -37,6 +37,7 @@ import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
 import org.eclipse.apoapsis.ortserver.transport.AdvisorEndpoint
 import org.eclipse.apoapsis.ortserver.transport.EndpointComponent
 import org.eclipse.apoapsis.ortserver.transport.EndpointHandler
+import org.eclipse.apoapsis.ortserver.transport.EndpointHandlerResult
 import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessagePublisher
 import org.eclipse.apoapsis.ortserver.transport.OrchestratorEndpoint
@@ -82,6 +83,8 @@ class AdvisorComponent : EndpointComponent<AdvisorRequest>(AdvisorEndpoint) {
 
             if (response != null) publisher.publish(OrchestratorEndpoint, response)
         }
+
+        EndpointHandlerResult.CONTINUE
     }
 
     override fun customModules(): List<Module> =

--- a/workers/advisor/src/main/resources/application.conf
+++ b/workers/advisor/src/main/resources/application.conf
@@ -35,6 +35,9 @@ configManager {
 }
 
 advisor {
+  handleSingleJobOnly = false
+  handleSingleJobOnly = ${?ADVISOR_HANDLE_SINGLE_JOB_ONLY}
+
   receiver {
     type = "kubernetes"
     type = ${?ADVISOR_RECEIVER_TRANSPORT_TYPE}

--- a/workers/analyzer/src/main/kotlin/analyzer/AnalyzerComponent.kt
+++ b/workers/analyzer/src/main/kotlin/analyzer/AnalyzerComponent.kt
@@ -26,6 +26,7 @@ import org.eclipse.apoapsis.ortserver.model.orchestrator.AnalyzerWorkerResult
 import org.eclipse.apoapsis.ortserver.transport.AnalyzerEndpoint
 import org.eclipse.apoapsis.ortserver.transport.EndpointComponent
 import org.eclipse.apoapsis.ortserver.transport.EndpointHandler
+import org.eclipse.apoapsis.ortserver.transport.EndpointHandlerResult
 import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessagePublisher
 import org.eclipse.apoapsis.ortserver.transport.OrchestratorEndpoint
@@ -75,6 +76,8 @@ class AnalyzerComponent : EndpointComponent<AnalyzerRequest>(AnalyzerEndpoint) {
 
             if (response != null) publisher.publish(OrchestratorEndpoint, response)
         }
+
+        EndpointHandlerResult.CONTINUE
     }
 
     override fun customModules(): List<Module> = listOf(

--- a/workers/analyzer/src/main/kotlin/analyzer/AnalyzerComponent.kt
+++ b/workers/analyzer/src/main/kotlin/analyzer/AnalyzerComponent.kt
@@ -77,7 +77,8 @@ class AnalyzerComponent : EndpointComponent<AnalyzerRequest>(AnalyzerEndpoint) {
             if (response != null) publisher.publish(OrchestratorEndpoint, response)
         }
 
-        EndpointHandlerResult.CONTINUE
+        val handleSingleJobOnly = configManager.config.getBoolean("analyzer.handleSingleJobOnly")
+        if (handleSingleJobOnly) EndpointHandlerResult.STOP else EndpointHandlerResult.CONTINUE
     }
 
     override fun customModules(): List<Module> = listOf(

--- a/workers/analyzer/src/main/resources/application.conf
+++ b/workers/analyzer/src/main/resources/application.conf
@@ -35,6 +35,9 @@ configManager {
 }
 
 analyzer {
+  handleSingleJobOnly = false
+  handleSingleJobOnly = ${?ANALYZER_HANDLE_SINGLE_JOB_ONLY}
+
   receiver {
     type = "kubernetes"
     type = ${?ANALYZER_RECEIVER_TRANSPORT_TYPE}

--- a/workers/config/src/main/kotlin/ConfigComponent.kt
+++ b/workers/config/src/main/kotlin/ConfigComponent.kt
@@ -26,6 +26,7 @@ import org.eclipse.apoapsis.ortserver.model.orchestrator.ConfigWorkerResult
 import org.eclipse.apoapsis.ortserver.transport.ConfigEndpoint
 import org.eclipse.apoapsis.ortserver.transport.EndpointComponent
 import org.eclipse.apoapsis.ortserver.transport.EndpointHandler
+import org.eclipse.apoapsis.ortserver.transport.EndpointHandlerResult
 import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessagePublisher
 import org.eclipse.apoapsis.ortserver.transport.OrchestratorEndpoint
@@ -65,6 +66,8 @@ class ConfigComponent : EndpointComponent<ConfigRequest>(ConfigEndpoint) {
         }
 
         publisher.publish(OrchestratorEndpoint, Message(message.header, responsePayload))
+
+        EndpointHandlerResult.CONTINUE
     }
 
     override fun customModules(): List<Module> = listOf(configModule(), databaseModule(), workerContextModule())

--- a/workers/config/src/main/kotlin/ConfigComponent.kt
+++ b/workers/config/src/main/kotlin/ConfigComponent.kt
@@ -67,7 +67,8 @@ class ConfigComponent : EndpointComponent<ConfigRequest>(ConfigEndpoint) {
 
         publisher.publish(OrchestratorEndpoint, Message(message.header, responsePayload))
 
-        EndpointHandlerResult.CONTINUE
+        val handleSingleJobOnly = configManager.config.getBoolean("config.handleSingleJobOnly")
+        if (handleSingleJobOnly) EndpointHandlerResult.STOP else EndpointHandlerResult.CONTINUE
     }
 
     override fun customModules(): List<Module> = listOf(configModule(), databaseModule(), workerContextModule())

--- a/workers/config/src/main/resources/application.conf
+++ b/workers/config/src/main/resources/application.conf
@@ -35,6 +35,9 @@ configManager {
 }
 
 config {
+  handleSingleJobOnly = false
+  handleSingleJobOnly = ${?CONFIG_HANDLE_SINGLE_JOB_ONLY}
+
   receiver {
     type = "kubernetes"
     type = ${?CONFIG_RECEIVER_TRANSPORT_TYPE}

--- a/workers/evaluator/src/main/kotlin/evaluator/EvaluatorComponent.kt
+++ b/workers/evaluator/src/main/kotlin/evaluator/EvaluatorComponent.kt
@@ -26,6 +26,7 @@ import org.eclipse.apoapsis.ortserver.model.orchestrator.EvaluatorWorkerResult
 import org.eclipse.apoapsis.ortserver.storage.Storage
 import org.eclipse.apoapsis.ortserver.transport.EndpointComponent
 import org.eclipse.apoapsis.ortserver.transport.EndpointHandler
+import org.eclipse.apoapsis.ortserver.transport.EndpointHandlerResult
 import org.eclipse.apoapsis.ortserver.transport.EvaluatorEndpoint
 import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessagePublisher
@@ -75,6 +76,8 @@ class EvaluatorComponent : EndpointComponent<EvaluatorRequest>(EvaluatorEndpoint
 
             if (response != null) publisher.publish(OrchestratorEndpoint, response)
         }
+
+        EndpointHandlerResult.CONTINUE
     }
 
     override fun customModules(): List<Module> =

--- a/workers/evaluator/src/main/kotlin/evaluator/EvaluatorComponent.kt
+++ b/workers/evaluator/src/main/kotlin/evaluator/EvaluatorComponent.kt
@@ -77,7 +77,8 @@ class EvaluatorComponent : EndpointComponent<EvaluatorRequest>(EvaluatorEndpoint
             if (response != null) publisher.publish(OrchestratorEndpoint, response)
         }
 
-        EndpointHandlerResult.CONTINUE
+        val handleSingleJobOnly = configManager.config.getBoolean("evaluator.handleSingleJobOnly")
+        if (handleSingleJobOnly) EndpointHandlerResult.STOP else EndpointHandlerResult.CONTINUE
     }
 
     override fun customModules(): List<Module> =

--- a/workers/evaluator/src/main/resources/application.conf
+++ b/workers/evaluator/src/main/resources/application.conf
@@ -36,15 +36,15 @@ configManager {
 
 evaluator {
   receiver {
-  type = "kubernetes"
-  type = ${?EVALUATOR_RECEIVER_TRANSPORT_TYPE}
-  serverUri = "amqp://localhost:61616"
-  serverUri = ${?EVALUATOR_RECEIVER_TRANSPORT_SERVER_URI}
-  queueName = "evaluator_queue"
-  queueName = ${?EVALUATOR_RECEIVER_TRANSPORT_QUEUE_NAME}
-  username = "username"
-  username = ${?EVALUATOR_RECEIVER_TRANSPORT_USERNAME}
-  password = "password"
-  password = ${?EVALUATOR_RECEIVER_TRANSPORT_PASSWORD}
+    type = "kubernetes"
+    type = ${?EVALUATOR_RECEIVER_TRANSPORT_TYPE}
+    serverUri = "amqp://localhost:61616"
+    serverUri = ${?EVALUATOR_RECEIVER_TRANSPORT_SERVER_URI}
+    queueName = "evaluator_queue"
+    queueName = ${?EVALUATOR_RECEIVER_TRANSPORT_QUEUE_NAME}
+    username = "username"
+    username = ${?EVALUATOR_RECEIVER_TRANSPORT_USERNAME}
+    password = "password"
+    password = ${?EVALUATOR_RECEIVER_TRANSPORT_PASSWORD}
   }
 }

--- a/workers/evaluator/src/main/resources/application.conf
+++ b/workers/evaluator/src/main/resources/application.conf
@@ -35,6 +35,9 @@ configManager {
 }
 
 evaluator {
+  handleSingleJobOnly = false
+  handleSingleJobOnly = ${?EVALUATOR_HANDLE_SINGLE_JOB_ONLY}
+
   receiver {
     type = "kubernetes"
     type = ${?EVALUATOR_RECEIVER_TRANSPORT_TYPE}

--- a/workers/notifier/src/main/kotlin/notifier/NotifierComponent.kt
+++ b/workers/notifier/src/main/kotlin/notifier/NotifierComponent.kt
@@ -25,6 +25,7 @@ import org.eclipse.apoapsis.ortserver.model.orchestrator.NotifierWorkerError
 import org.eclipse.apoapsis.ortserver.model.orchestrator.NotifierWorkerResult
 import org.eclipse.apoapsis.ortserver.transport.EndpointComponent
 import org.eclipse.apoapsis.ortserver.transport.EndpointHandler
+import org.eclipse.apoapsis.ortserver.transport.EndpointHandlerResult
 import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessagePublisher
 import org.eclipse.apoapsis.ortserver.transport.NotifierEndpoint
@@ -70,6 +71,8 @@ class NotifierComponent : EndpointComponent<NotifierRequest>(NotifierEndpoint) {
 
             if (response != null) publisher.publish(OrchestratorEndpoint, response)
         }
+
+        EndpointHandlerResult.CONTINUE
     }
 
     override fun customModules() =

--- a/workers/notifier/src/main/kotlin/notifier/NotifierComponent.kt
+++ b/workers/notifier/src/main/kotlin/notifier/NotifierComponent.kt
@@ -72,7 +72,8 @@ class NotifierComponent : EndpointComponent<NotifierRequest>(NotifierEndpoint) {
             if (response != null) publisher.publish(OrchestratorEndpoint, response)
         }
 
-        EndpointHandlerResult.CONTINUE
+        val handleSingleJobOnly = configManager.config.getBoolean("notifier.handleSingleJobOnly")
+        if (handleSingleJobOnly) EndpointHandlerResult.STOP else EndpointHandlerResult.CONTINUE
     }
 
     override fun customModules() =

--- a/workers/notifier/src/main/resources/application.conf
+++ b/workers/notifier/src/main/resources/application.conf
@@ -35,6 +35,9 @@ configManager {
 }
 
 notifier {
+  handleSingleJobOnly = false
+  handleSingleJobOnly = ${?NOTIFIER_HANDLE_SINGLE_JOB_ONLY}
+
   receiver {
     type = "kubernetes"
     type = ${?NOTIFIER_RECEIVER_TRANSPORT_TYPE}

--- a/workers/reporter/src/main/kotlin/reporter/ReporterComponent.kt
+++ b/workers/reporter/src/main/kotlin/reporter/ReporterComponent.kt
@@ -29,6 +29,7 @@ import org.eclipse.apoapsis.ortserver.model.orchestrator.ReporterWorkerResult
 import org.eclipse.apoapsis.ortserver.storage.Storage
 import org.eclipse.apoapsis.ortserver.transport.EndpointComponent
 import org.eclipse.apoapsis.ortserver.transport.EndpointHandler
+import org.eclipse.apoapsis.ortserver.transport.EndpointHandlerResult
 import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessagePublisher
 import org.eclipse.apoapsis.ortserver.transport.OrchestratorEndpoint
@@ -120,6 +121,8 @@ class ReporterComponent : EndpointComponent<ReporterRequest>(ReporterEndpoint) {
 
             if (response != null) publisher.publish(OrchestratorEndpoint, response)
         }
+
+        EndpointHandlerResult.CONTINUE
     }
 
     override fun customModules(): List<Module> =

--- a/workers/reporter/src/main/kotlin/reporter/ReporterComponent.kt
+++ b/workers/reporter/src/main/kotlin/reporter/ReporterComponent.kt
@@ -122,7 +122,8 @@ class ReporterComponent : EndpointComponent<ReporterRequest>(ReporterEndpoint) {
             if (response != null) publisher.publish(OrchestratorEndpoint, response)
         }
 
-        EndpointHandlerResult.CONTINUE
+        val handleSingleJobOnly = configManager.config.getBoolean("reporter.handleSingleJobOnly")
+        if (handleSingleJobOnly) EndpointHandlerResult.STOP else EndpointHandlerResult.CONTINUE
     }
 
     override fun customModules(): List<Module> =

--- a/workers/reporter/src/main/resources/application.conf
+++ b/workers/reporter/src/main/resources/application.conf
@@ -35,6 +35,9 @@ configManager {
 }
 
 reporter {
+  handleSingleJobOnly = false
+  handleSingleJobOnly = ${?REPORTER_HANDLE_SINGLE_JOB_ONLY}
+
   receiver {
     type = "kubernetes"
     type = ${?REPORTER_RECEIVER_TRANSPORT_TYPE}

--- a/workers/scanner/src/main/kotlin/scanner/ScannerComponent.kt
+++ b/workers/scanner/src/main/kotlin/scanner/ScannerComponent.kt
@@ -79,7 +79,8 @@ class ScannerComponent : EndpointComponent<ScannerRequest>(ScannerEndpoint) {
             if (response != null) publisher.publish(OrchestratorEndpoint, response)
         }
 
-        EndpointHandlerResult.CONTINUE
+        val handleSingleJobOnly = configManager.config.getBoolean("scanner.handleSingleJobOnly")
+        if (handleSingleJobOnly) EndpointHandlerResult.STOP else EndpointHandlerResult.CONTINUE
     }
 
     override fun customModules(): List<Module> = listOf(

--- a/workers/scanner/src/main/kotlin/scanner/ScannerComponent.kt
+++ b/workers/scanner/src/main/kotlin/scanner/ScannerComponent.kt
@@ -26,6 +26,7 @@ import org.eclipse.apoapsis.ortserver.model.orchestrator.ScannerWorkerResult
 import org.eclipse.apoapsis.ortserver.storage.Storage
 import org.eclipse.apoapsis.ortserver.transport.EndpointComponent
 import org.eclipse.apoapsis.ortserver.transport.EndpointHandler
+import org.eclipse.apoapsis.ortserver.transport.EndpointHandlerResult
 import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessagePublisher
 import org.eclipse.apoapsis.ortserver.transport.OrchestratorEndpoint
@@ -77,6 +78,8 @@ class ScannerComponent : EndpointComponent<ScannerRequest>(ScannerEndpoint) {
 
             if (response != null) publisher.publish(OrchestratorEndpoint, response)
         }
+
+        EndpointHandlerResult.CONTINUE
     }
 
     override fun customModules(): List<Module> = listOf(

--- a/workers/scanner/src/main/resources/application.conf
+++ b/workers/scanner/src/main/resources/application.conf
@@ -35,6 +35,9 @@ configManager {
 }
 
 scanner {
+  handleSingleJobOnly = false
+  handleSingleJobOnly = ${?SCANNER_HANDLE_SINGLE_JOB_ONLY}
+
   receiver {
     type = "kubernetes"
     type = ${?SCANNER_RECEIVER_TRANSPORT_TYPE}


### PR DESCRIPTION
Add a way to configure workers to handle only a single message. This is useful when using Keda instead of the Kubernetes transport to create Kubernetes jobs which is used in an Azure deployment because the Kubernetes transport does not support the required configuration, and because it is more straightforward to configure the Kubernetes jobs with YAML files instead of environment variables passed to the orchestrator.