### PR TITLE
ui: Indicate a sorted column

### DIFF
--- a/ui/src/components/data-table/data-table-header.tsx
+++ b/ui/src/components/data-table/data-table-header.tsx
@@ -105,9 +105,9 @@ export function DataTableHeader<TData>({
                       onClick={column.getToggleSortingHandler()}
                     >
                       {column.getIsSorted() === 'asc' ? (
-                        <ChevronUp className='h-4 w-4' />
+                        <ChevronUp className='h-4 w-4 text-blue-500' />
                       ) : column.getIsSorted() === 'desc' ? (
-                        <ChevronDown className='h-4 w-4' />
+                        <ChevronDown className='h-4 w-4 text-blue-500' />
                       ) : (
                         <ChevronsUpDown className='h-4 w-4' />
                       )}


### PR DESCRIPTION
![Screenshot from 2025-03-26 07-55-27](https://github.com/user-attachments/assets/8ff9ae5e-0d8f-4776-b6fd-68dfaebeeaa1)

![Screenshot from 2025-03-26 07-55-57](https://github.com/user-attachments/assets/1a718894-0205-4cf6-911d-b99f48b081fc)

For discussion: the sorting and filtering "hints" might be too subtle, especially with the light theme, where the bluish color of the sorting/filtering icons is almost non-distinguishable. Should we improve this by for example providing a greyish background to the icons, when a column is sorted or filtered?

Please see the commits for details.