### PR TITLE
ui: Improvements to bar chart

### DIFF
--- a/ui/src/components/charts/job-durations.tsx
+++ b/ui/src/components/charts/job-durations.tsx
@@ -16,6 +16,7 @@
  * SPDX-License-Identifier: Apache-2.0
  * License-Filename: LICENSE
  */
+import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
 import { Bar, BarChart, CartesianGrid, XAxis } from 'recharts';
 
@@ -80,6 +81,7 @@ export const JobDurations = ({
   const [fetchMode, setFetchMode] = useState<'VISIBLE_RUNS' | 'ALL_RUNS'>(
     'VISIBLE_RUNS'
   );
+  const navigate = useNavigate();
 
   const {
     data: runs,
@@ -170,6 +172,20 @@ export const JobDurations = ({
     return null;
   }
 
+  const handleBarClick = (runIndex: string) => {
+    const run = runs.data?.find((run) => run.index === Number(runIndex));
+    if (run)
+      navigate({
+        to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex',
+        params: {
+          orgId: run.organizationId.toString(),
+          productId: run.productId.toString(),
+          repoId: run.repositoryId.toString(),
+          runIndex: run.index.toString(),
+        },
+      });
+  };
+
   return (
     <Card>
       <CardHeader>
@@ -201,7 +217,13 @@ export const JobDurations = ({
           config={chartConfig}
           className='h-[200px] min-h-[200px] w-full'
         >
-          <BarChart accessibilityLayer data={chartData}>
+          <BarChart
+            accessibilityLayer
+            data={chartData}
+            onClick={(data) => {
+              handleBarClick(data.activeLabel as string);
+            }}
+          >
             <CartesianGrid vertical={false} />
             <XAxis
               dataKey='runId'
@@ -215,38 +237,66 @@ export const JobDurations = ({
                 <ChartTooltipContent
                   hideLabel
                   className='w-[180px]'
-                  formatter={(value, name) => (
-                    <div className='flex w-full items-baseline justify-between'>
-                      <div className='flex items-baseline gap-2'>
-                        <div
-                          className='size-2.5 shrink-0 rounded-[2px]'
-                          style={{
-                            backgroundColor: `var(--color-${name})`,
-                          }}
-                        />
-                        <div>
-                          {chartConfig[name as keyof typeof chartConfig]
-                            ?.label || name}
+                  formatter={(value, name, _item, index) => (
+                    <>
+                      <div className='flex w-full items-baseline justify-between'>
+                        <div className='flex items-baseline gap-2'>
+                          <div
+                            className='size-2.5 shrink-0 rounded-[2px]'
+                            style={{
+                              backgroundColor: `var(--color-${name})`,
+                            }}
+                          />
+                          <div>
+                            {chartConfig[name as keyof typeof chartConfig]
+                              ?.label || name}
+                          </div>
+                        </div>
+                        <div className='text-muted-foreground font-mono text-xs'>
+                          {convertDurationToHms(Number(value))}
                         </div>
                       </div>
-                      <div className='text-muted-foreground font-mono text-xs'>
-                        {convertDurationToHms(Number(value))}
-                      </div>
-                    </div>
+                      {index === 4 && (
+                        <div className='text-muted-foreground text-xs'>
+                          Click bar to go to run
+                        </div>
+                      )}
+                    </>
                   )}
                 />
               }
             />
             <ChartLegend content={<ChartLegendContent />} />
-            <Bar dataKey='analyzer' stackId='a' fill='var(--color-analyzer)' />
-            <Bar dataKey='advisor' stackId='a' fill='var(--color-advisor)' />
-            <Bar dataKey='scanner' stackId='a' fill='var(--color-scanner)' />
+            <Bar
+              dataKey='analyzer'
+              stackId='a'
+              fill='var(--color-analyzer)'
+              className='cursor-pointer'
+            />
+            <Bar
+              dataKey='advisor'
+              stackId='a'
+              fill='var(--color-advisor)'
+              className='cursor-pointer'
+            />
+            <Bar
+              dataKey='scanner'
+              stackId='a'
+              fill='var(--color-scanner)'
+              className='cursor-pointer'
+            />
             <Bar
               dataKey='evaluator'
               stackId='a'
               fill='var(--color-evaluator)'
+              className='cursor-pointer'
             />
-            <Bar dataKey='reporter' stackId='a' fill='var(--color-reporter)' />
+            <Bar
+              dataKey='reporter'
+              stackId='a'
+              fill='var(--color-reporter)'
+              className='cursor-pointer'
+            />
           </BarChart>
         </ChartContainer>
       </CardContent>

--- a/ui/src/components/charts/job-durations.tsx
+++ b/ui/src/components/charts/job-durations.tsx
@@ -45,23 +45,23 @@ import { ToastError } from '../toast-error';
 const chartConfig = {
   analyzer: {
     label: 'Analyzer',
-    color: 'hsl(var(--chart-1))',
+    color: 'hsl(var(--chart-analyzer))',
   },
   advisor: {
     label: 'Advisor',
-    color: 'hsl(var(--chart-2))',
+    color: 'hsl(var(--chart-advisor))',
   },
   scanner: {
     label: 'Scanner',
-    color: 'hsl(var(--chart-3))',
+    color: 'hsl(var(--chart-scanner))',
   },
   evaluator: {
     label: 'Evaluator',
-    color: 'hsl(var(--chart-4))',
+    color: 'hsl(var(--chart-evaluator))',
   },
   reporter: {
     label: 'Reporter',
-    color: 'hsl(var(--chart-5))',
+    color: 'hsl(var(--chart-reporter))',
   },
 } satisfies ChartConfig;
 

--- a/ui/src/globals.css
+++ b/ui/src/globals.css
@@ -76,6 +76,14 @@
     --chart-3: 197 37% 24%;
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
+
+    /* Custom chart colors, taken from ORT brand colors */
+    /* https://oss-review-toolkit.org/ort/              */
+    --chart-analyzer: 178 52% 61%;
+    --chart-advisor: 270 29% 60%;
+    --chart-scanner: 351 58% 72%;
+    --chart-evaluator: 205 66% 59%;
+    --chart-reporter: 22 86% 64%;
   }
 
   .dark {
@@ -112,6 +120,14 @@
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
+
+    /* Custom chart colors, taken from ORT brand colors */
+    /* https://oss-review-toolkit.org/ort/              */
+    --chart-analyzer: 178 52% 61%;
+    --chart-advisor: 270 29% 60%;
+    --chart-scanner: 351 58% 72%;
+    --chart-evaluator: 205 66% 59%;
+    --chart-reporter: 22 86% 64%;
   }
 }
 


### PR DESCRIPTION
Some minor improvements to the run timings bar chart:
- clicking any bar takes the user to the corresponding run's overview page
- bars use colors from the corresponding ORT icons

![Screenshot from 2025-03-26 12-50-19](https://github.com/user-attachments/assets/45b5e7f3-001b-4eca-98b7-97406f44de8a)

Please see the commits for details.