### PR TITLE
feat(tasks): Add logging configuration

### DIFF
--- a/tasks/src/main/resources/logback.xml
+++ b/tasks/src/main/resources/logback.xml
@@ -1,0 +1,34 @@
+<!--
+  ~ Copyright (C) 2023 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ License-Filename: LICENSE
+  -->
+
+<configuration>
+    <conversionRule conversionWord="customMdc" converterClass="org.eclipse.apoapsis.ortserver.utils.logging.MdcConverter" />
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>time=%d{YYYY-MM-dd'T'HH:mm:ss.SSS} thread=%thread %customMdc level=%-5level logger=%logger{36} message="%replace(%msg){'\"','\\\"'}"%n</pattern>
+        </encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+    <logger name="org.apache.http" level="WARN"/>
+    <logger name="org.eclipse.apoapsis" level="DEBUG"/>
+    <logger name="org.ossreviewtoolkit" level="DEBUG"/>
+    <logger name="Exposed" level="TRACE"/> <!-- Log SQL statements executed by Exposed -->
+</configuration>


### PR DESCRIPTION
Copy `logback.xml` from the Kubernetes Job Monitor deployment to align the logging output and configuration with other ORT Server components.