### PR TITLE
feat(git-config): Add support for private repositories

### DIFF
--- a/config/git/README.md
+++ b/config/git/README.md
@@ -43,6 +43,12 @@ configManager {
 }
 ```
 
+The provider supports password authentication for private repositories using these configuration options:
+
+| Option                     | Secret | Description                                      |
+|----------------------------|--------|--------------------------------------------------|
+| gitConfigFileProviderUser  | yes    | The username to use for authentication.          |
+| gitConfigFileProviderToken | yes    | The token or password to use for authentication. |
 
 ### Runtime configuration
 

--- a/config/git/src/main/kotlin/GitConfigFileProvider.kt
+++ b/config/git/src/main/kotlin/GitConfigFileProvider.kt
@@ -81,7 +81,7 @@ class GitConfigFileProvider internal constructor(
         }
     }
 
-    private val git = GitFactory.create()
+    private val git = GitFactory.create(historyDepth = 1)
 
     override fun resolveContext(context: Context): Context {
         val resolvedRevision = updateWorkingTree(context.name)

--- a/config/git/src/main/kotlin/GitConfigFileProviderAuthenticator.kt
+++ b/config/git/src/main/kotlin/GitConfigFileProviderAuthenticator.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.config.git
+
+import java.net.Authenticator
+import java.net.PasswordAuthentication
+
+import org.slf4j.LoggerFactory
+
+private val logger = LoggerFactory.getLogger(GitConfigFileProviderAuthenticator::class.java)
+
+internal class GitConfigFileProviderAuthenticator(val username: String, val password: String) : Authenticator() {
+    companion object {
+        var original: Authenticator? = null
+
+        @Synchronized
+        fun install(username: String, password: String): GitConfigFileProviderAuthenticator {
+            val active = getDefault()
+
+            if (active is GitConfigFileProviderAuthenticator) return active
+
+            original = active
+
+            return GitConfigFileProviderAuthenticator(username, password).also {
+                setDefault(it)
+                logger.info("GitConfigFileProviderAuthenticator was successfully installed.")
+            }
+        }
+
+        @Synchronized
+        fun uninstall(): Authenticator? {
+            val active = getDefault()
+
+            return if (active is GitConfigFileProviderAuthenticator) {
+                original.also {
+                    setDefault(it)
+                    logger.info("GitConfigFileProviderAuthenticator was successfully uninstalled.")
+                }
+            } else {
+                logger.info("GitConfigFileProviderAuthenticator is not installed.")
+                active
+            }
+        }
+    }
+
+    override fun getPasswordAuthentication() = PasswordAuthentication(username, password.toCharArray())
+}
+
+/**
+ * Install an [GitConfigFileProviderAuthenticator] with the given [username] and [password] and execute the [block]. If
+ * [username] or [password] is `null`, the [block] is executed without installing an authenticator.
+ */
+internal fun <T> withAuthenticator(username: String?, password: String?, block: () -> T): T {
+    if (username == null || password == null) {
+        return block()
+    }
+
+    try {
+        GitConfigFileProviderAuthenticator.install(username, password)
+        return block()
+    } finally {
+        GitConfigFileProviderAuthenticator.uninstall()
+    }
+}

--- a/config/git/src/main/kotlin/GitConfigFileProviderFactory.kt
+++ b/config/git/src/main/kotlin/GitConfigFileProviderFactory.kt
@@ -37,5 +37,5 @@ class GitConfigFileProviderFactory : ConfigFileProviderFactory {
     override val name: String = NAME
 
     override fun createProvider(config: Config, secretProvider: ConfigSecretProvider): ConfigFileProvider =
-        GitConfigFileProvider.create(config)
+        GitConfigFileProvider.create(config, secretProvider)
 }

--- a/config/git/src/test/kotlin/GitConfigFileProviderAuthenticatorTest.kt
+++ b/config/git/src/test/kotlin/GitConfigFileProviderAuthenticatorTest.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.config.git
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.shouldBeSameInstanceAs
+
+import io.mockk.mockk
+
+import java.net.Authenticator
+
+class GitConfigFileProviderAuthenticatorTest : WordSpec({
+    var originalAuthenticator: Authenticator? = null
+
+    beforeEach {
+        originalAuthenticator = Authenticator.getDefault()
+    }
+
+    afterEach {
+        Authenticator.setDefault(originalAuthenticator)
+    }
+
+    "install()" should {
+        "check whether the authenticator is already installed" {
+            val authenticator = GitConfigFileProviderAuthenticator.install("username", "password")
+
+            GitConfigFileProviderAuthenticator.install("username", "password") shouldBeSameInstanceAs authenticator
+        }
+    }
+
+    "uninstall()" should {
+        "restore the previous authenticator" {
+            val orgAuthenticator = mockk<Authenticator>()
+            Authenticator.setDefault(orgAuthenticator)
+
+            GitConfigFileProviderAuthenticator.install("username", "password")
+            GitConfigFileProviderAuthenticator.uninstall() shouldBe orgAuthenticator
+
+            Authenticator.getDefault() shouldBe orgAuthenticator
+        }
+
+        "not change anything if the authenticator is not installed" {
+            val orgAuthenticator = mockk<Authenticator>()
+            Authenticator.setDefault(orgAuthenticator)
+
+            GitConfigFileProviderAuthenticator.uninstall() shouldBe orgAuthenticator
+
+            Authenticator.getDefault() shouldBe orgAuthenticator
+        }
+    }
+
+    "getPasswordAuthentication()" should {
+        "return the provided credentials" {
+            GitConfigFileProviderAuthenticator.install("username", "password")
+
+            val credentials = Authenticator.requestPasswordAuthentication("", null, 443, "", "", "")
+
+            credentials.userName shouldBe "username"
+            credentials.password shouldBe "password".toCharArray()
+        }
+    }
+})


### PR DESCRIPTION
Add support for password authentication to the `GitConfigFileProvider`.
This is implemented using a custom `Authenticator` which is temporarily
installed when cloning the config repository.