### PR TITLE
ui: Fix statistics cards in the run overview page

### DIFF
--- a/ui/src/helpers/job-helpers.ts
+++ b/ui/src/helpers/job-helpers.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { JobStatus } from '@/api/requests';
+
+/**
+ * Check if a job is finished, based on its status. The finished states are
+ * 'FINISHED', 'FINISHED_WITH_ISSUES', and 'FAILED'.
+ * @param status The job status.
+ * @returns Whether the job is finished.
+ */
+export const isJobFinished = (status: JobStatus | undefined) => {
+  return (
+    status && ['FINISHED', 'FINISHED_WITH_ISSUES', 'FAILED'].includes(status)
+  );
+};
+
+/**
+ * A helper function to determine the contents of the statistics cards for the run.
+ * @param status The job status.
+ * @param jobIncluded Is the job included in the run?
+ * @param total Total number of items (issues, vulnerabilities etc.) found by the job.
+ * @returns A value and description for the value, to be consumed by the statistics cards.
+ */
+export const jobStatusTexts = (
+  status: JobStatus | undefined,
+  jobIncluded: boolean | undefined,
+  total: number | null | undefined
+): { value: string | number | null | undefined; description: string } => {
+  const finished = isJobFinished(status);
+
+  const { value, description } = jobIncluded
+    ? status !== undefined
+      ? finished
+        ? { value: total, description: '' }
+        : { value: '...', description: 'Running' }
+      : { value: '-', description: 'Not started' }
+    : { value: 'Skipped', description: 'Enable the job for results' };
+  return { value, description };
+};

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/issues-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/issues-statistics-card.tsx
@@ -28,6 +28,7 @@ import {
   getIssueSeverityBackgroundColor,
   getStatusFontColor,
 } from '@/helpers/get-status-class';
+import { isJobFinished, jobStatusTexts } from '@/helpers/job-helpers';
 import { toast } from '@/lib/toast';
 
 type IssuesStatisticsCardProps = {
@@ -42,9 +43,13 @@ export const IssuesStatisticsCard = ({
   runId,
 }: IssuesStatisticsCardProps) => {
   const { data, isPending, isError, error } =
-    useRunsServiceGetApiV1RunsByRunIdStatistics({
-      runId: runId,
-    });
+    useRunsServiceGetApiV1RunsByRunIdStatistics(
+      {
+        runId: runId,
+      },
+      undefined,
+      { enabled: isJobFinished(status) }
+    );
 
   if (isPending) {
     return (
@@ -71,18 +76,7 @@ export const IssuesStatisticsCard = ({
 
   const total = data.issuesCount;
   const counts = data.issuesCountBySeverity;
-
-  const jobIsScheduled = status !== undefined;
-  const jobIsFinished =
-    jobIsScheduled &&
-    ['FINISHED', 'FINISHED_WITH_ISSUES', 'FAILED'].includes(status);
-  const { value, description } = jobIncluded
-    ? jobIsScheduled
-      ? jobIsFinished
-        ? { value: total, description: '' }
-        : { value: '...', description: 'Running' }
-      : { value: '-', description: 'Not started' }
-    : { value: 'Skipped', description: 'Enable the job for results' };
+  const { value, description } = jobStatusTexts(status, jobIncluded, total);
 
   return (
     <StatisticsCard

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/packages-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/packages-statistics-card.tsx
@@ -28,6 +28,7 @@ import {
   getEcosystemBackgroundColor,
   getStatusFontColor,
 } from '@/helpers/get-status-class';
+import { isJobFinished, jobStatusTexts } from '@/helpers/job-helpers';
 import { toast } from '@/lib/toast';
 
 type PackagesStatisticsCardProps = {
@@ -42,9 +43,13 @@ export const PackagesStatisticsCard = ({
   runId,
 }: PackagesStatisticsCardProps) => {
   const { data, isPending, isError, error } =
-    useRunsServiceGetApiV1RunsByRunIdStatistics({
-      runId: runId,
-    });
+    useRunsServiceGetApiV1RunsByRunIdStatistics(
+      {
+        runId: runId,
+      },
+      undefined,
+      { enabled: isJobFinished(status) }
+    );
 
   if (isPending) {
     return (
@@ -73,18 +78,7 @@ export const PackagesStatisticsCard = ({
 
   const total = data.packagesCount;
   const counts = data.ecosystems;
-
-  const jobIsScheduled = status !== undefined;
-  const jobIsFinished =
-    jobIsScheduled &&
-    ['FINISHED', 'FINISHED_WITH_ISSUES', 'FAILED'].includes(status);
-  const { value, description } = jobIncluded
-    ? jobIsScheduled
-      ? jobIsFinished
-        ? { value: total, description: '' }
-        : { value: '...', description: 'Running' }
-      : { value: '-', description: 'Not started' }
-    : { value: 'Skipped', description: 'Enable the job for results' };
+  const { value, description } = jobStatusTexts(status, jobIncluded, total);
 
   return (
     <StatisticsCard

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/rule-violations-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/rule-violations-statistics-card.tsx
@@ -28,6 +28,7 @@ import {
   getRuleViolationSeverityBackgroundColor,
   getStatusFontColor,
 } from '@/helpers/get-status-class';
+import { isJobFinished, jobStatusTexts } from '@/helpers/job-helpers';
 import { toast } from '@/lib/toast';
 
 type RuleViolationsStatisticsCardProps = {
@@ -42,9 +43,15 @@ export const RuleViolationsStatisticsCard = ({
   runId,
 }: RuleViolationsStatisticsCardProps) => {
   const { data, isPending, isError, error } =
-    useRunsServiceGetApiV1RunsByRunIdStatistics({
-      runId: runId,
-    });
+    useRunsServiceGetApiV1RunsByRunIdStatistics(
+      {
+        runId: runId,
+      },
+      undefined,
+      {
+        enabled: isJobFinished(status),
+      }
+    );
 
   if (isPending) {
     return (
@@ -74,17 +81,7 @@ export const RuleViolationsStatisticsCard = ({
   const total = data.ruleViolationsCount;
   const counts = data.ruleViolationsCountBySeverity;
 
-  const jobIsScheduled = status !== undefined;
-  const jobIsFinished =
-    jobIsScheduled &&
-    ['FINISHED', 'FINISHED_WITH_ISSUES', 'FAILED'].includes(status);
-  const { value, description } = jobIncluded
-    ? jobIsScheduled
-      ? jobIsFinished
-        ? { value: total, description: '' }
-        : { value: '...', description: 'Running' }
-      : { value: '-', description: 'Not started' }
-    : { value: 'Skipped', description: 'Enable the job for results' };
+  const { value, description } = jobStatusTexts(status, jobIncluded, total);
 
   return (
     <StatisticsCard

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/vulnerabilities-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/vulnerabilities-statistics-card.tsx
@@ -28,6 +28,7 @@ import {
   getStatusFontColor,
   getVulnerabilityRatingBackgroundColor,
 } from '@/helpers/get-status-class';
+import { isJobFinished, jobStatusTexts } from '@/helpers/job-helpers';
 import { toast } from '@/lib/toast';
 
 type VulnerabilitiesStatisticsCardProps = {
@@ -42,9 +43,15 @@ export const VulnerabilitiesStatisticsCard = ({
   runId,
 }: VulnerabilitiesStatisticsCardProps) => {
   const { data, isPending, isError, error } =
-    useRunsServiceGetApiV1RunsByRunIdStatistics({
-      runId: runId,
-    });
+    useRunsServiceGetApiV1RunsByRunIdStatistics(
+      {
+        runId: runId,
+      },
+      undefined,
+      {
+        enabled: isJobFinished(status),
+      }
+    );
 
   if (isPending) {
     return (
@@ -73,18 +80,7 @@ export const VulnerabilitiesStatisticsCard = ({
 
   const total = data.vulnerabilitiesCount;
   const counts = data.vulnerabilitiesCountByRating;
-
-  const jobIsScheduled = status !== undefined;
-  const jobIsFinished =
-    jobIsScheduled &&
-    ['FINISHED', 'FINISHED_WITH_ISSUES', 'FAILED'].includes(status);
-  const { value, description } = jobIncluded
-    ? jobIsScheduled
-      ? jobIsFinished
-        ? { value: total, description: '' }
-        : { value: '...', description: 'Running' }
-      : { value: '-', description: 'Not started' }
-    : { value: 'Skipped', description: 'Enable the job for results' };
+  const { value, description } = jobStatusTexts(status, jobIncluded, total);
 
   return (
     <StatisticsCard


### PR DESCRIPTION
With this PR, the statistics cards correctly indicate the number of items found, after each corresponding job is finished, instead of a "Failed" message.

![Screenshot from 2025-03-28 09-28-34](https://github.com/user-attachments/assets/2eddc25b-0593-436a-980b-074edd90b83c)

Please see the commits for details.
