### PR TITLE
chore: Remove vulnerability resolutions

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -65,24 +65,3 @@ resolutions:
   - message: "ERROR: Timeout after .+ seconds while scanning file 'rules/matrixseqexpl.json'."
     reason: SCANNER_ISSUE
     comment: "This file does not contain any license declarations."
-  vulnerabilities:
-  - id: "CVE-2022-40150"
-    reason: "INEFFECTIVE_VULNERABILITY"
-    comment: |
-      This vulnerability is reported for the jettison package which is a transitive dependency of the SW360 client used
-      by the ORT scanner. The component is vulnerable to Denial of Service attacks causing out of memory errors for
-      specially crafted parser inputs. Since it is used here only to parse responses of valid SW360 servers, this is not
-      an issue.
-  - id: "CVE-2022-45685"
-    reason: "INEFFECTIVE_VULNERABILITY"
-    comment: |
-      This vulnerability is reported for the jettison package which is a transitive dependency of the SW360 client used
-      by the ORT scanner. The component is vulnerable to Denial of Service attacks due to uncontrolled recursion for
-      specially crafted parser input. Since it is used only to parse responses of valid SW360 servers, this is not an
-      issue.
-  - id: "CVE-2022-45693"
-    reason: "INEFFECTIVE_VULNERABILITY"
-    comment: |
-      This vulnerability is reported for the jettison package which is a transitive dependency of the SW360 client used
-      by the ORT scanner. The component is vulnerable to Denial of Service attacks causing stack overflow for specially
-      crafted parser input. Since it is used here only to parse responses of valid SW360 servers, this is not an issue.


### PR DESCRIPTION
The vulnerable packages are no longer part of the dependency tree. Therefore, the vulnerability resolutions can be removed.