### PR TITLE
Rework deletion of orphaned entities

### DIFF
--- a/core/src/main/kotlin/di/Module.kt
+++ b/core/src/main/kotlin/di/Module.kt
@@ -67,7 +67,6 @@ import org.eclipse.apoapsis.ortserver.services.DefaultAuthorizationService
 import org.eclipse.apoapsis.ortserver.services.InfrastructureServiceService
 import org.eclipse.apoapsis.ortserver.services.IssueService
 import org.eclipse.apoapsis.ortserver.services.OrganizationService
-import org.eclipse.apoapsis.ortserver.services.OrphanRemovalService
 import org.eclipse.apoapsis.ortserver.services.OrtRunService
 import org.eclipse.apoapsis.ortserver.services.PackageService
 import org.eclipse.apoapsis.ortserver.services.ProductService
@@ -136,7 +135,6 @@ fun ortServerModule(config: ApplicationConfig) = module {
     single { ProjectService(get()) }
     single { UserService(get()) }
     single { OrtRunService(get(), get(), get(), get()) }
-    single { OrphanRemovalService(get()) }
     singleOf(::ReportStorageService)
     singleOf(::InfrastructureServiceService)
 }

--- a/dao/src/main/resources/db/migration/V99__addOrphanDeletionIndexes.sql
+++ b/dao/src/main/resources/db/migration/V99__addOrphanDeletionIndexes.sql
@@ -1,0 +1,12 @@
+-- This migration adds indexes on foreign key columns on tables that are processed by the task to delete orphaned
+-- entities. This is needed to speed up the corresponding DELETE statements.
+
+-- Foreign key indexes for the packages table.
+CREATE INDEX IF NOT EXISTS packages_declared_licenses_package_id ON packages_declared_licenses (package_id);
+CREATE INDEX IF NOT EXISTS shortest_dependency_paths_package_id ON shortest_dependency_paths (package_id);
+
+-- Foreign key indexes for the projects table.
+CREATE INDEX IF NOT EXISTS project_scopes_project_id ON project_scopes (project_id);
+CREATE INDEX IF NOT EXISTS projects_authors_project_id ON projects_authors (project_id);
+CREATE INDEX IF NOT EXISTS projects_declared_licenses_project_id ON projects_declared_licenses (project_id);
+CREATE INDEX IF NOT EXISTS shortest_dependency_paths_project_id ON shortest_dependency_paths (project_id);

--- a/services/hierarchy/src/main/kotlin/OrphanRemovalService.kt
+++ b/services/hierarchy/src/main/kotlin/OrphanRemovalService.kt
@@ -32,7 +32,6 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ProjectsDecla
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ProjectsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.evaluatorrun.RuleViolationsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.ortrun.OrtRunsTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.product.ProductsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageConfigurationsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageCurationDataAuthors
 import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageCurationDataTable
@@ -51,11 +50,20 @@ import org.eclipse.apoapsis.ortserver.dao.tables.shared.OrtRunsIssuesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.RemoteArtifactsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.VcsInfoTable
 
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.LongIdTable
+import org.jetbrains.exposed.sql.AbstractQuery
+import org.jetbrains.exposed.sql.Column
 import org.jetbrains.exposed.sql.Database
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.isNotNull
-import org.jetbrains.exposed.sql.SqlExpressionBuilder.notInSubQuery
+import org.jetbrains.exposed.sql.LongColumnType
+import org.jetbrains.exposed.sql.Query
+import org.jetbrains.exposed.sql.SqlExpressionBuilder
+import org.jetbrains.exposed.sql.SqlExpressionBuilder.inSubQuery
+import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.alias
 import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.notExists
+import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.union
 
 import org.slf4j.LoggerFactory
@@ -76,7 +84,7 @@ class OrphanRemovalService(
         logger.info("Deleting orphaned children of ORT runs.")
 
         logger.info("Deleted {} records from {}", deleteOrphanedPackages(), PackagesTable.tableName)
-        logger.info("Deleted {} records from {}", deleteOrphanedProjects(), ProductsTable.tableName)
+        logger.info("Deleted {} records from {}", deleteOrphanedProjects(), ProjectsTable.tableName)
         logger.info("Deleted {} records from {}", deleteOrphanedAuthors(), AuthorsTable.tableName)
         logger.info("Deleted {} records from {}", deleteOrphanedDeclaredLicenses(), DeclaredLicensesTable.tableName)
         logger.info("Deleted {} records from {}", deleteOrphanedIdentifiers(), IdentifiersTable.tableName)
@@ -86,220 +94,209 @@ class OrphanRemovalService(
         logger.info("Deleting orphaned children of ORT runs finished.")
     }
 
-    private suspend fun deleteOrphanedPackages() =
+    /**
+     * Delete all entries from this table for which the given [condition][cond] of a `NON EXISTS` subquery is
+     * fulfilled.
+     */
+    private suspend fun <T : LongIdTable> T.deleteWhereNotExists(
+        cond: SqlExpressionBuilder.(Column<EntityID<Long>>) -> AbstractQuery<*>
+    ): Int =
         db.dbQuery {
-            PackagesTable.deleteWhere {
-                id notInSubQuery (
-                    PackagesAnalyzerRunsTable
-                        .select(PackagesAnalyzerRunsTable.packageId.alias("id"))
-                        .where(PackagesAnalyzerRunsTable.packageId.isNotNull())
-                    )
+            deleteWhere {
+                id inSubQuery(
+                    select(id).where { notExists(cond(id)) }
+                )
             }
+        }
+
+    private suspend fun deleteOrphanedPackages() =
+        PackagesTable.deleteWhereNotExists { id ->
+            PackagesAnalyzerRunsTable.select(PackagesAnalyzerRunsTable.packageId)
+                .where(PackagesAnalyzerRunsTable.packageId eq id)
         }
 
     private suspend fun deleteOrphanedProjects() =
-        db.dbQuery {
-            ProjectsTable.deleteWhere {
-                id notInSubQuery (
-                    ProjectsAnalyzerRunsTable
-                        .select(ProjectsAnalyzerRunsTable.projectId.alias("id"))
-                        .where(ProjectsAnalyzerRunsTable.projectId.isNotNull())
-                    )
-            }
+        ProjectsTable.deleteWhereNotExists { id ->
+            ProjectsAnalyzerRunsTable.select(ProjectsAnalyzerRunsTable.projectId)
+                .where(ProjectsAnalyzerRunsTable.projectId eq id)
         }
 
     private suspend fun deleteOrphanedAuthors() =
-        db.dbQuery {
-            AuthorsTable.deleteWhere {
-                id notInSubQuery (
-                    PackagesAuthorsTable
-                        .select(PackagesAuthorsTable.authorId.alias("id"))
-                        .where(PackagesAuthorsTable.authorId.isNotNull())
-                        .union(
-                            ProjectsAuthorsTable
-                                .select(ProjectsAuthorsTable.authorId.alias("id"))
-                                .where(ProjectsAuthorsTable.authorId.isNotNull())
-                        )
-                        .union(
-                            PackageCurationDataAuthors
-                                .select(PackageCurationDataAuthors.authorId.alias("id"))
-                                .where(PackageCurationDataAuthors.authorId.isNotNull())
-                        )
-                    )
-            }
+        AuthorsTable.deleteWhereNotExists { id ->
+            PackagesAuthorsTable
+                .select(PackagesAuthorsTable.authorId.alias("id"))
+                .where { PackagesAuthorsTable.authorId eq id }
+                .union(
+                    ProjectsAuthorsTable
+                        .select(ProjectsAuthorsTable.authorId.alias("id"))
+                        .where { ProjectsAuthorsTable.authorId eq id }
+                )
+                .union(
+                    PackageCurationDataAuthors
+                        .select(PackageCurationDataAuthors.authorId.alias("id"))
+                        .where { PackageCurationDataAuthors.authorId eq id }
+                )
         }
 
     private suspend fun deleteOrphanedDeclaredLicenses() =
-        db.dbQuery {
-            DeclaredLicensesTable.deleteWhere {
-                id notInSubQuery (
-                    PackagesDeclaredLicensesTable
-                        .select(PackagesDeclaredLicensesTable.declaredLicenseId.alias("id"))
-                        .where(PackagesDeclaredLicensesTable.declaredLicenseId.isNotNull())
-                        .union(
-                            ProjectsDeclaredLicensesTable
-                                .select(ProjectsDeclaredLicensesTable.declaredLicenseId.alias("id"))
-                                .where(ProjectsDeclaredLicensesTable.declaredLicenseId.isNotNull())
-                        )
-                    )
-            }
+        DeclaredLicensesTable.deleteWhereNotExists { id ->
+            PackagesDeclaredLicensesTable
+                .select(PackagesDeclaredLicensesTable.declaredLicenseId.alias("id"))
+                .where { PackagesDeclaredLicensesTable.declaredLicenseId eq id }
+                .union(
+                    ProjectsDeclaredLicensesTable
+                        .select(ProjectsDeclaredLicensesTable.declaredLicenseId.alias("id"))
+                        .where { ProjectsDeclaredLicensesTable.declaredLicenseId eq id }
+                )
         }
 
     private suspend fun deleteOrphanedIdentifiers() =
-        db.dbQuery {
-            IdentifiersTable.deleteWhere {
-                id notInSubQuery (
-                    ProjectsTable
-                        .select(ProjectsTable.identifierId.alias("id"))
-                        .where(ProjectsTable.identifierId.isNotNull())
-                        .union(
-                            PackagesTable
-                                .select(PackagesTable.identifierId.alias("id"))
-                                .where(PackagesTable.identifierId.isNotNull())
-                        )
-                        .union(
-                            IdentifiersIssuesTable
-                                .select(IdentifiersIssuesTable.identifierId.alias("id"))
-                                .where(IdentifiersIssuesTable.identifierId.isNotNull())
-                        )
-                        .union(
-                            AdvisorRunsIdentifiersTable
-                                .select(AdvisorRunsIdentifiersTable.identifierId.alias("id"))
-                                .where(AdvisorRunsIdentifiersTable.identifierId.isNotNull())
-                        )
-                        .union(
-                            PackageProvenancesTable
-                                .select(PackageProvenancesTable.identifierId.alias("id"))
-                                .where(PackageProvenancesTable.identifierId.isNotNull())
-                        )
-                        .union(
-                            RuleViolationsTable
-                                .select(RuleViolationsTable.packageIdentifierId.alias("id"))
-                                .where(RuleViolationsTable.packageIdentifierId.isNotNull())
-                        )
-                        .union(
-                            PackageCurationsTable
-                                .select(PackageCurationsTable.identifierId.alias("id"))
-                                .where(PackageCurationsTable.identifierId.isNotNull())
-                        )
-                        .union(
-                            PackageConfigurationsTable
-                                .select(PackageConfigurationsTable.identifierId.alias("id"))
-                                .where(PackageConfigurationsTable.identifierId.isNotNull())
-                        )
-                        .union(
-                            PackageLicenseChoicesTable
-                                .select(PackageLicenseChoicesTable.identifierId.alias("id"))
-                                .where(PackageLicenseChoicesTable.identifierId.isNotNull())
-                        )
-                        .union(
-                            ScannerRunsScannersTable
-                                .select(ScannerRunsScannersTable.identifierId.alias("id"))
-                                .where(ScannerRunsScannersTable.identifierId.isNotNull())
-                        )
-                        .union(
-                            OrtRunsIssuesTable
-                                .select(OrtRunsIssuesTable.identifierId.alias("id"))
-                                .where(OrtRunsIssuesTable.identifierId.isNotNull())
-                        )
-                    )
-            }
+        IdentifiersTable.deleteWhereNotExists { id ->
+            ProjectsTable
+                .select(ProjectsTable.identifierId.alias("id"))
+                .where { ProjectsTable.identifierId eq id }
+                .union(
+                    PackagesTable
+                        .select(PackagesTable.identifierId.alias("id"))
+                        .where { PackagesTable.identifierId eq id }
+                )
+                .union(
+                    IdentifiersIssuesTable
+                        .select(IdentifiersIssuesTable.identifierId.alias("id"))
+                        .where { IdentifiersIssuesTable.identifierId eq id }
+                )
+                .union(
+                    AdvisorRunsIdentifiersTable
+                        .select(AdvisorRunsIdentifiersTable.identifierId.alias("id"))
+                        .where { AdvisorRunsIdentifiersTable.identifierId eq id }
+                )
+                .union(
+                    PackageProvenancesTable
+                        .select(PackageProvenancesTable.identifierId.alias("id"))
+                        .where { PackageProvenancesTable.identifierId eq id }
+                )
+                .union(
+                    RuleViolationsTable
+                        .select(RuleViolationsTable.packageIdentifierId.alias("id"))
+                        .where { RuleViolationsTable.packageIdentifierId eq id }
+                )
+                .union(
+                    PackageCurationsTable
+                        .select(PackageCurationsTable.identifierId.alias("id"))
+                        .where { PackageCurationsTable.identifierId eq id }
+                )
+                .union(
+                    PackageConfigurationsTable
+                        .select(PackageConfigurationsTable.identifierId.alias("id"))
+                        .where { PackageConfigurationsTable.identifierId eq id }
+                )
+                .union(
+                    PackageLicenseChoicesTable
+                        .select(PackageLicenseChoicesTable.identifierId.alias("id"))
+                        .where { PackageLicenseChoicesTable.identifierId eq id }
+                )
+                .union(
+                    ScannerRunsScannersTable
+                        .select(ScannerRunsScannersTable.identifierId.alias("id"))
+                        .where { ScannerRunsScannersTable.identifierId eq id }
+                )
+                .union(
+                    OrtRunsIssuesTable
+                        .select(OrtRunsIssuesTable.identifierId.alias("id"))
+                        .where { OrtRunsIssuesTable.identifierId eq id }
+                )
         }
 
     private suspend fun deleteOrphanedVcsInfo() =
-        db.dbQuery {
-            VcsInfoTable.deleteWhere {
-                VcsInfoTable.id notInSubQuery (
+        VcsInfoTable.deleteWhereNotExists { id ->
+            val subQuery = OrtRunsTable
+                .select(OrtRunsTable.vcsId.alias("id"))
+                .union(
                     OrtRunsTable
-                        .select(OrtRunsTable.vcsId.alias("vcs_id"))
-                        .where(OrtRunsTable.vcsId.isNotNull())
-                        .union(
-                            OrtRunsTable
-                                .select(OrtRunsTable.vcsProcessedId.alias("vcs_id"))
-                                .where(OrtRunsTable.vcsProcessedId.isNotNull())
-                        )
-                        .union(
-                            ProjectsTable
-                                .select(ProjectsTable.vcsId.alias("vcs_id"))
-                                .where(ProjectsTable.vcsId.isNotNull())
-                        )
-                        .union(
-                            ProjectsTable
-                                .select(ProjectsTable.vcsProcessedId.alias("vcs_id"))
-                                .where(ProjectsTable.vcsProcessedId.isNotNull())
-                        )
-                        .union(
-                            PackagesTable
-                                .select(PackagesTable.vcsId.alias("vcs_id"))
-                                .where(PackagesTable.vcsId.isNotNull())
-                        )
-                        .union(
-                            PackagesTable
-                                .select(PackagesTable.vcsProcessedId.alias("id"))
-                                .where(PackagesTable.vcsProcessedId.isNotNull())
-                        )
-                        .union(
-                            NestedProvenancesTable
-                                .select(NestedProvenancesTable.rootVcsId.alias("id"))
-                                .where(NestedProvenancesTable.rootVcsId.isNotNull())
-                        )
-                        .union(
-                            NestedProvenanceSubRepositoriesTable
-                                .select(NestedProvenanceSubRepositoriesTable.vcsId.alias("id"))
-                                .where(NestedProvenanceSubRepositoriesTable.vcsId.isNotNull())
-                        )
-                        .union(
-                            PackageProvenancesTable
-                                .select(PackageProvenancesTable.vcsId.alias("id"))
-                                .where(PackageProvenancesTable.vcsId.isNotNull())
-                        )
-                        .union(
-                            NestedRepositoriesTable
-                                .select(NestedRepositoriesTable.vcsId.alias("id"))
-                                .where(NestedRepositoriesTable.vcsId.isNotNull())
-                        )
-                        .union(
-                            SnippetsTable
-                                .select(SnippetsTable.vcsId.alias("id"))
-                                .where(SnippetsTable.vcsId.isNotNull())
-                        )
-                    )
-            }
+                        .select(OrtRunsTable.vcsProcessedId)
+                )
+                .union(
+                    ProjectsTable
+                        .select(ProjectsTable.vcsId)
+                )
+                .union(
+                    ProjectsTable
+                        .select(ProjectsTable.vcsProcessedId)
+                )
+                .union(
+                    PackagesTable
+                        .select(PackagesTable.vcsId)
+                )
+                .union(
+                    PackagesTable
+                        .select(PackagesTable.vcsProcessedId)
+                )
+                .union(
+                    NestedProvenancesTable
+                        .select(NestedProvenancesTable.rootVcsId)
+                )
+                .union(
+                    NestedProvenanceSubRepositoriesTable
+                        .select(NestedProvenanceSubRepositoriesTable.vcsId)
+                )
+                .union(
+                    PackageProvenancesTable
+                        .select(PackageProvenancesTable.vcsId)
+                )
+                .union(
+                    NestedRepositoriesTable
+                        .select(NestedRepositoriesTable.vcsId)
+                )
+                .union(
+                    SnippetsTable
+                        .select(SnippetsTable.vcsId)
+                )
+
+            unionCondition(subQuery, id)
         }
 
     private suspend fun deleteOrphanedRemoteArtifacts() =
-        db.dbQuery {
-            RemoteArtifactsTable.deleteWhere {
-                id notInSubQuery (
+        RemoteArtifactsTable.deleteWhereNotExists { id ->
+            val subQuery = PackagesTable
+                .select(PackagesTable.binaryArtifactId.alias("id"))
+                .union(
                     PackagesTable
-                        .select(PackagesTable.binaryArtifactId.alias("id"))
-                        .where(PackagesTable.binaryArtifactId.isNotNull())
-                        .union(
-                            PackagesTable
-                                .select(PackagesTable.sourceArtifactId.alias("id"))
-                                .where(PackagesTable.sourceArtifactId.isNotNull())
-                        )
-                        .union(
-                            PackageProvenancesTable
-                                .select(PackageProvenancesTable.artifactId.alias("id"))
-                                .where(PackageProvenancesTable.artifactId.isNotNull())
-                        )
-                        .union(
-                            PackageCurationDataTable
-                                .select(PackageCurationDataTable.binaryArtifactId.alias("id"))
-                                .where(PackageCurationDataTable.binaryArtifactId.isNotNull())
-                        )
-                        .union(
-                            PackageCurationDataTable
-                                .select(PackageCurationDataTable.sourceArtifactId.alias("id"))
-                                .where(PackageCurationDataTable.sourceArtifactId.isNotNull())
-                        )
-                        .union(
-                            SnippetsTable
-                                .select(SnippetsTable.artifactId.alias("id"))
-                                .where(SnippetsTable.artifactId.isNotNull())
-                        )
-                    )
-            }
+                        .select(PackagesTable.sourceArtifactId)
+                )
+                .union(
+                    PackageProvenancesTable
+                        .select(PackageProvenancesTable.artifactId)
+                )
+                .union(
+                    PackageCurationDataTable
+                        .select(PackageCurationDataTable.binaryArtifactId)
+                )
+                .union(
+                    PackageCurationDataTable
+                        .select(PackageCurationDataTable.sourceArtifactId)
+                )
+                .union(
+                    SnippetsTable
+                        .select(SnippetsTable.artifactId)
+                )
+
+            unionCondition(subQuery, id)
         }
+}
+
+/**
+ * Add a condition to match the given [matchColumn] to the given [unionQuery]. This results in a statement of the
+ * form: SELECT * FROM (SELECT * FROM sub_query) WHERE sub_query.id = matchColumn.
+ * TODO: Check whether there is a better way to do this with Exposed.
+ */
+private fun <T : AbstractQuery<T>> unionCondition(
+    unionQuery: AbstractQuery<T>,
+    matchColumn: Column<EntityID<Long>>
+): Query {
+    val subQuery = unionQuery.alias("sub_query")
+    val queryTable = Table("sub_query")
+    val column = Column(queryTable, "id", LongColumnType())
+
+    return subQuery.selectAll()
+        .where { column eq matchColumn }
 }

--- a/services/hierarchy/src/main/kotlin/OrphanRemovalService.kt
+++ b/services/hierarchy/src/main/kotlin/OrphanRemovalService.kt
@@ -20,7 +20,6 @@
 package org.eclipse.apoapsis.ortserver.services
 
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
-import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.AdvisorRunsIdentifiersTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.AuthorsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesAnalyzerRunsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesAuthorsTable
@@ -30,23 +29,15 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ProjectsAnaly
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ProjectsAuthorsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ProjectsDeclaredLicensesTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ProjectsTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.evaluatorrun.RuleViolationsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.ortrun.OrtRunsTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageConfigurationsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageCurationDataAuthors
 import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageCurationDataTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageCurationsTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageLicenseChoicesTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsScannersTable
 import org.eclipse.apoapsis.ortserver.dao.tables.NestedProvenanceSubRepositoriesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.NestedProvenancesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.NestedRepositoriesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.PackageProvenancesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.SnippetsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.DeclaredLicensesTable
-import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersIssuesTable
-import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
-import org.eclipse.apoapsis.ortserver.dao.tables.shared.OrtRunsIssuesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.RemoteArtifactsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.VcsInfoTable
 
@@ -87,7 +78,6 @@ class OrphanRemovalService(
         logger.info("Deleted {} records from {}", deleteOrphanedProjects(), ProjectsTable.tableName)
         logger.info("Deleted {} records from {}", deleteOrphanedAuthors(), AuthorsTable.tableName)
         logger.info("Deleted {} records from {}", deleteOrphanedDeclaredLicenses(), DeclaredLicensesTable.tableName)
-        logger.info("Deleted {} records from {}", deleteOrphanedIdentifiers(), IdentifiersTable.tableName)
         logger.info("Deleted {} records from {}", deleteOrphanedVcsInfo(), VcsInfoTable.tableName)
         logger.info("Deleted {} records from {}", deleteOrphanedRemoteArtifacts(), RemoteArtifactsTable.tableName)
 
@@ -147,63 +137,6 @@ class OrphanRemovalService(
                     ProjectsDeclaredLicensesTable
                         .select(ProjectsDeclaredLicensesTable.declaredLicenseId.alias("id"))
                         .where { ProjectsDeclaredLicensesTable.declaredLicenseId eq id }
-                )
-        }
-
-    private suspend fun deleteOrphanedIdentifiers() =
-        IdentifiersTable.deleteWhereNotExists { id ->
-            ProjectsTable
-                .select(ProjectsTable.identifierId.alias("id"))
-                .where { ProjectsTable.identifierId eq id }
-                .union(
-                    PackagesTable
-                        .select(PackagesTable.identifierId.alias("id"))
-                        .where { PackagesTable.identifierId eq id }
-                )
-                .union(
-                    IdentifiersIssuesTable
-                        .select(IdentifiersIssuesTable.identifierId.alias("id"))
-                        .where { IdentifiersIssuesTable.identifierId eq id }
-                )
-                .union(
-                    AdvisorRunsIdentifiersTable
-                        .select(AdvisorRunsIdentifiersTable.identifierId.alias("id"))
-                        .where { AdvisorRunsIdentifiersTable.identifierId eq id }
-                )
-                .union(
-                    PackageProvenancesTable
-                        .select(PackageProvenancesTable.identifierId.alias("id"))
-                        .where { PackageProvenancesTable.identifierId eq id }
-                )
-                .union(
-                    RuleViolationsTable
-                        .select(RuleViolationsTable.packageIdentifierId.alias("id"))
-                        .where { RuleViolationsTable.packageIdentifierId eq id }
-                )
-                .union(
-                    PackageCurationsTable
-                        .select(PackageCurationsTable.identifierId.alias("id"))
-                        .where { PackageCurationsTable.identifierId eq id }
-                )
-                .union(
-                    PackageConfigurationsTable
-                        .select(PackageConfigurationsTable.identifierId.alias("id"))
-                        .where { PackageConfigurationsTable.identifierId eq id }
-                )
-                .union(
-                    PackageLicenseChoicesTable
-                        .select(PackageLicenseChoicesTable.identifierId.alias("id"))
-                        .where { PackageLicenseChoicesTable.identifierId eq id }
-                )
-                .union(
-                    ScannerRunsScannersTable
-                        .select(ScannerRunsScannersTable.identifierId.alias("id"))
-                        .where { ScannerRunsScannersTable.identifierId eq id }
-                )
-                .union(
-                    OrtRunsIssuesTable
-                        .select(OrtRunsIssuesTable.identifierId.alias("id"))
-                        .where { OrtRunsIssuesTable.identifierId eq id }
                 )
         }
 

--- a/tasks/src/main/kotlin/TaskRunner.kt
+++ b/tasks/src/main/kotlin/TaskRunner.kt
@@ -33,6 +33,7 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.ortrun.DaoOrtRunRepositor
 import org.eclipse.apoapsis.ortserver.dao.repositories.reporterjob.DaoReporterJobRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.ReporterJobRepository
+import org.eclipse.apoapsis.ortserver.services.OrphanRemovalService
 import org.eclipse.apoapsis.ortserver.services.OrtRunService
 import org.eclipse.apoapsis.ortserver.services.ReportStorageService
 import org.eclipse.apoapsis.ortserver.storage.Storage
@@ -124,6 +125,7 @@ private fun tasksModule(): Module =
 
         singleOf(::OrtRunService)
         singleOf(::ReportStorageService)
+        singleOf(::OrphanRemovalService)
 
         single<Task>(named("delete-old-ort-runs")) { DeleteOldOrtRunsTask.create(get(), get()) }
         single<Task>(named("delete-orphaned-entities")) { DeleteOrphanedEntitiesTask.create(get()) }

--- a/tasks/src/main/kotlin/TaskRunner.kt
+++ b/tasks/src/main/kotlin/TaskRunner.kt
@@ -128,7 +128,7 @@ private fun tasksModule(): Module =
         singleOf(::OrphanRemovalService)
 
         single<Task>(named("delete-old-ort-runs")) { DeleteOldOrtRunsTask.create(get(), get()) }
-        single<Task>(named("delete-orphaned-entities")) { DeleteOrphanedEntitiesTask.create(get()) }
+        single<Task>(named("delete-orphaned-entities")) { DeleteOrphanedEntitiesTask.create(get(), get()) }
     }
 
 /**

--- a/tasks/src/main/kotlin/impl/DeleteOrphanedEntitiesTask.kt
+++ b/tasks/src/main/kotlin/impl/DeleteOrphanedEntitiesTask.kt
@@ -19,6 +19,8 @@
 
 package org.eclipse.apoapsis.ortserver.tasks.impl
 
+import org.eclipse.apoapsis.ortserver.config.ConfigManager
+import org.eclipse.apoapsis.ortserver.config.Path
 import org.eclipse.apoapsis.ortserver.services.OrphanRemovalService
 import org.eclipse.apoapsis.ortserver.tasks.Task
 
@@ -30,22 +32,28 @@ import org.slf4j.LoggerFactory
  * during [DeleteOldOrtRunsTask] run.
  */
 class DeleteOrphanedEntitiesTask(
+    /** The object for accessing configuration data. */
+    private val config: ConfigManager,
+
     /** Service for deleting entities orphaned after ORT run deletion */
     private var orphanRemovalService: OrphanRemovalService
 ) : Task {
     companion object {
         private val logger = LoggerFactory.getLogger(DeleteOrphanedEntitiesTask::class.java)
 
+        /** The section containing configuration for orphaned entity deletion. */
+        private val ORPHAN_SECTION = Path("orphanHandlers")
+
         /**
          * Create a new instance of [DeleteOldOrtRunsTask].
          */
-        fun create(orphanRemovalService: OrphanRemovalService): DeleteOrphanedEntitiesTask {
-            return DeleteOrphanedEntitiesTask(orphanRemovalService)
+        fun create(config: ConfigManager, orphanRemovalService: OrphanRemovalService): DeleteOrphanedEntitiesTask {
+            return DeleteOrphanedEntitiesTask(config, orphanRemovalService)
         }
     }
 
     override suspend fun execute() {
         logger.info("Deleting orphaned ORT run entities.")
-        orphanRemovalService.deleteRunsOrphanedEntities()
+        orphanRemovalService.deleteRunsOrphanedEntities(config.subConfig(ORPHAN_SECTION))
     }
 }

--- a/tasks/src/main/resources/application.conf
+++ b/tasks/src/main/resources/application.conf
@@ -46,3 +46,14 @@ dataRetention {
   ortRunDays = 90
   ortRunDays = ${?DATA_RETENTION_ORT_RUN_DAYS}
 }
+
+orphanHandlers {
+  vcsInfo.limit = 1024
+  vcsInfo.limit = ${?ORPHANED_VCS_INFO_LIMIT}
+  vcsInfo.chunkSize = 64
+  vcsInfo.chunkSize = ${?ORPHANED_VCS_INFO_CHUNK_SIZE}
+  remoteArtifacts.limit = 1024
+  remoteArtifacts.limit = ${?ORPHANED_REMOTE_ARTIFACTS_LIMIT}
+  remoteArtifacts.chunkSize = 64
+  remoteArtifacts.chunkSize = ${?ORPHANED_REMOTE_ARTIFACTS_CHUNK_SIZE}
+}

--- a/tasks/src/test/kotlin/TaskRunnerTest.kt
+++ b/tasks/src/test/kotlin/TaskRunnerTest.kt
@@ -44,6 +44,7 @@ import org.eclipse.apoapsis.ortserver.dao.test.mockDatabaseModule
 import org.eclipse.apoapsis.ortserver.dao.test.unmockDatabaseModule
 import org.eclipse.apoapsis.ortserver.dao.test.verifyDatabaseModuleIncluded
 import org.eclipse.apoapsis.ortserver.tasks.impl.DeleteOldOrtRunsTask
+import org.eclipse.apoapsis.ortserver.tasks.impl.DeleteOrphanedEntitiesTask
 
 import org.koin.core.Koin
 import org.koin.core.context.startKoin
@@ -102,6 +103,13 @@ class TaskRunnerTest : KoinTest, WordSpec() {
                 checkMain { koin ->
                     val task = koin.get<Task>(named("delete-old-ort-runs"))
                     task should beInstanceOf<DeleteOldOrtRunsTask>()
+                }
+            }
+
+            "include a task to delete orphan entities" {
+                checkMain { koin ->
+                    val task = koin.get<Task>(named("delete-orphaned-entities"))
+                    task should beInstanceOf<DeleteOrphanedEntitiesTask>()
                 }
             }
         }

--- a/tasks/src/test/kotlin/impl/DeleteOrphanedEntitiesTaskTest.kt
+++ b/tasks/src/test/kotlin/impl/DeleteOrphanedEntitiesTaskTest.kt
@@ -23,23 +23,31 @@ import io.kotest.core.spec.style.StringSpec
 
 import io.mockk.coEvery
 import io.mockk.coVerify
+import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.runs
 
+import org.eclipse.apoapsis.ortserver.config.ConfigManager
+import org.eclipse.apoapsis.ortserver.config.Path
 import org.eclipse.apoapsis.ortserver.services.OrphanRemovalService
 
 class DeleteOrphanedEntitiesTaskTest : StringSpec({
     "DeleteOrphanedEntitiesTask should start orphaned entities deletion service" {
         val orphanRemovalService = mockk<OrphanRemovalService> {
-            coEvery { deleteRunsOrphanedEntities() } just runs
+            coEvery { deleteRunsOrphanedEntities(any()) } just runs
         }
 
-        val task = DeleteOrphanedEntitiesTask.create(orphanRemovalService)
+        val subConfigManager = mockk<ConfigManager>()
+        val configManager = mockk<ConfigManager> {
+            every { subConfig(Path("orphanHandlers")) } returns subConfigManager
+        }
+
+        val task = DeleteOrphanedEntitiesTask.create(configManager, orphanRemovalService)
         task.execute()
 
         coVerify {
-            orphanRemovalService.deleteRunsOrphanedEntities()
+            orphanRemovalService.deleteRunsOrphanedEntities(subConfigManager)
         }
     }
 })


### PR DESCRIPTION
This PR reworks the service for deleting orphaned entities to speed up the task execution. Refer to the single commits for further details.