### PR TITLE
feat(ui): Enable assignment of users to groups

### DIFF
--- a/ui/src/components/delete-icon-button.tsx
+++ b/ui/src/components/delete-icon-button.tsx
@@ -25,6 +25,7 @@ import { Button } from './ui/button';
 
 type DeleteIconButtonProps = {
   className?: string;
+  disabled?: boolean;
 };
 
 const DeleteIconButton = forwardRef<HTMLButtonElement, DeleteIconButtonProps>(

--- a/ui/src/components/ellipsis-icon-button.tsx
+++ b/ui/src/components/ellipsis-icon-button.tsx
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { EllipsisIcon } from 'lucide-react';
+import { forwardRef } from 'react';
+
+import { cn } from '@/lib/utils';
+import { Button } from './ui/button';
+
+type EllipsisIconButtonProps = {
+  className?: string;
+  disabled?: boolean;
+};
+
+const EllipsisIconButton = forwardRef<
+  HTMLButtonElement,
+  EllipsisIconButtonProps
+>(({ className, ...props }, ref) => {
+  return (
+    <Button
+      size='sm'
+      variant='outline'
+      {...props}
+      className={cn('h-8 px-2', className)}
+      ref={ref}
+    >
+      <span className='sr-only'>Delete</span>
+      <EllipsisIcon size={16} />
+    </Button>
+  );
+});
+EllipsisIconButton.displayName = 'EllipsisIconButton';
+
+export { EllipsisIconButton };

--- a/ui/src/components/ui/user-group-row-actions.tsx
+++ b/ui/src/components/ui/user-group-row-actions.tsx
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { Row } from '@tanstack/react-table';
+import { Eye, Pen, Shield } from 'lucide-react';
+
+import { UserGroup, UserWithGroups } from '@/api/requests';
+import { EllipsisIconButton } from '@/components/ellipsis-icon-button.tsx';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu.tsx';
+
+type UserGroupRowActionsProps = {
+  row: Row<UserWithGroups>;
+  onJoinAdminsGroup: (user: UserWithGroups) => Promise<void>;
+  onJoinWritersGroup: (user: UserWithGroups) => Promise<void>;
+  onJoinReadersGroup: (user: UserWithGroups) => Promise<void>;
+  disabled: boolean;
+};
+
+/**
+ * Component for rendering row actions in a user group table.
+ * Provides options to join different user groups (ADMINS, WRITERS, READERS).
+ *
+ * @param {UserGroupRowActionsProps} props - The props for the component.
+ * @returns {JSX.Element} The rendered component.
+ */
+export function UserGroupRowActions({
+  row,
+  onJoinAdminsGroup,
+  onJoinWritersGroup,
+  onJoinReadersGroup,
+  ...nativeButtonAttributes // From standard HTML button attributes
+}: UserGroupRowActionsProps) {
+  const userWithGroups: UserWithGroups = row.original;
+  const groups: UserGroup[] = row.original.groups;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <EllipsisIconButton {...nativeButtonAttributes} />
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent side='bottom' align='end'>
+        {!groups.includes('ADMINS') && (
+          <DropdownMenuItem onSelect={() => onJoinAdminsGroup(userWithGroups)}>
+            <div className='flex items-center gap-x-2'>
+              <span>Join ADMINS</span>
+              <Shield size={16} />
+            </div>
+          </DropdownMenuItem>
+        )}
+
+        {!groups.includes('WRITERS') && (
+          <DropdownMenuItem onSelect={() => onJoinWritersGroup(userWithGroups)}>
+            <div className='flex items-center gap-x-2'>
+              <span>Join WRITERS</span>
+              <Pen size={16} />
+            </div>
+          </DropdownMenuItem>
+        )}
+
+        {!groups.includes('READERS') && (
+          <DropdownMenuItem onSelect={() => onJoinReadersGroup(userWithGroups)}>
+            <div className='flex items-center gap-x-2'>
+              <span>Join READERS</span>
+              <Eye size={16} />
+            </div>
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/-components/repository-users-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/-components/repository-users-table.tsx
@@ -1,0 +1,302 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { useQueryClient } from '@tanstack/react-query';
+import { getRouteApi } from '@tanstack/react-router';
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import { Eye, Pen, Shield } from 'lucide-react';
+
+import {
+  useAdminServiceDeleteApiV1AdminUsers,
+  useDefaultServiceGetApiV1RepositoriesByRepositoryIdUsers,
+  useDefaultServiceGetApiV1RepositoriesByRepositoryIdUsersKey,
+  useGroupsServiceDeleteApiV1RepositoriesByRepositoryIdGroupsByGroupId,
+  useGroupsServicePutApiV1RepositoriesByRepositoryIdGroupsByGroupId,
+} from '@/api/queries';
+import { ApiError, UserWithGroups } from '@/api/requests';
+import { DataTable } from '@/components/data-table/data-table.tsx';
+import { DeleteDialog } from '@/components/delete-dialog.tsx';
+import { DeleteIconButton } from '@/components/delete-icon-button.tsx';
+import { ToastError } from '@/components/toast-error.tsx';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { UserGroupRowActions } from '@/components/ui/user-group-row-actions.tsx';
+import { useUser } from '@/hooks/use-user.ts';
+import { toast } from '@/lib/toast.ts';
+
+const columnHelper = createColumnHelper<UserWithGroups>();
+
+const columns = [
+  columnHelper.accessor('user.username', {
+    header: 'Username',
+    cell: ({ row }) => <>{row.original.user.username}</>,
+  }),
+  columnHelper.accessor('user.firstName', {
+    header: 'First name',
+    cell: ({ row }) => <>{row.original.user.firstName}</>,
+  }),
+  columnHelper.accessor('user.lastName', {
+    header: 'Last name',
+    cell: ({ row }) => <>{row.original.user.lastName}</>,
+  }),
+  columnHelper.accessor('user.email', {
+    header: 'Email address',
+    cell: ({ row }) => <>{row.original.user.email}</>,
+  }),
+  columnHelper.accessor('groups', {
+    header: 'Group',
+    cell: ({ row }) => {
+      const groups = row.original.groups;
+      let IconComponent;
+      let effectiveGroup = '';
+      if (groups.includes('ADMINS')) {
+        IconComponent = Shield;
+        effectiveGroup = 'ADMINS';
+      } else if (groups.includes('WRITERS')) {
+        IconComponent = Pen;
+        effectiveGroup = 'WRITERS';
+      } else if (groups.includes('READERS')) {
+        IconComponent = Eye;
+        effectiveGroup = 'READERS';
+      } else {
+        return <>{groups.join(' ')}</>;
+      }
+
+      return (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <IconComponent size={16} />
+          </TooltipTrigger>
+          <TooltipContent>{effectiveGroup}</TooltipContent>
+        </Tooltip>
+      );
+    },
+  }),
+  columnHelper.display({
+    id: 'actions',
+    header: () => <div>Actions</div>,
+    cell: function CellComponent({ row }) {
+      const queryClient = useQueryClient();
+      const params = routeApi.useParams();
+      const repoId = Number.parseInt(params.repoId);
+
+      const { mutateAsync: delUser } = useAdminServiceDeleteApiV1AdminUsers({
+        onSuccess() {
+          toast.info('Delete User', {
+            description: `User "${row.original.user.username}" deleted successfully.`,
+          });
+          queryClient.invalidateQueries({
+            queryKey: [
+              useDefaultServiceGetApiV1RepositoriesByRepositoryIdUsersKey,
+            ],
+          });
+        },
+        onError(error: ApiError) {
+          toast.error(error.message, {
+            description: <ToastError error={error} />,
+            duration: Infinity,
+            cancel: {
+              label: 'Dismiss',
+              onClick: () => {},
+            },
+          });
+        },
+      });
+
+      const { mutateAsync: joinGroup, isPending: isJoinGroupPending } =
+        useGroupsServicePutApiV1RepositoriesByRepositoryIdGroupsByGroupId({
+          onSuccess(_response, parameters) {
+            queryClient.invalidateQueries({
+              queryKey: [
+                useDefaultServiceGetApiV1RepositoriesByRepositoryIdUsersKey,
+              ],
+            });
+            toast.info('Join Group', {
+              description: `User "${row.original.user.username}" joined group ${parameters.groupId} successfully.`,
+            });
+          },
+          onError(error: ApiError) {
+            toast.error(error.message, {
+              description: <ToastError error={error} />,
+              duration: Infinity,
+              cancel: {
+                label: 'Dismiss',
+                onClick: () => {},
+              },
+            });
+          },
+        });
+
+      const { mutateAsync: leaveGroup, isPending: isLeaveGroupPending } =
+        useGroupsServiceDeleteApiV1RepositoriesByRepositoryIdGroupsByGroupId({
+          onSuccess(_response, parameters) {
+            // Intentionally, no queryClient.invalidateQueries() here. This is done after joining the new group.
+            toast.info('Leave Group', {
+              description: `User "${row.original.user.username}" left group ${parameters.groupId} successfully.`,
+            });
+          },
+          onError(error: ApiError) {
+            toast.error(error.message, {
+              description: <ToastError error={error} />,
+              duration: Infinity,
+              cancel: {
+                label: 'Dismiss',
+                onClick: () => {},
+              },
+            });
+          },
+        });
+
+      // Leave all groups except the one to join.
+      async function leaveOtherGroups(joinGroupId: string) {
+        const groups = row.original.groups;
+        const otherGroups = groups.filter((group) => group !== joinGroupId);
+
+        for (const group of otherGroups) {
+          await leaveGroup({
+            repositoryId: repoId,
+            groupId: group,
+            requestBody: {
+              username: row.original.user.username,
+            },
+          });
+        }
+      }
+
+      async function joinAdminsGroup() {
+        await leaveOtherGroups('ADMINS');
+        await joinGroup({
+          repositoryId: repoId,
+          groupId: 'ADMINS',
+          requestBody: {
+            username: row.original.user.username,
+          },
+        });
+      }
+
+      async function joinWritersGroup() {
+        await leaveOtherGroups('WRITERS');
+        await joinGroup({
+          repositoryId: repoId,
+          groupId: 'WRITERS',
+          requestBody: {
+            username: row.original.user.username,
+          },
+        });
+      }
+
+      async function joinReadersGroup() {
+        await leaveOtherGroups('READERS');
+        await joinGroup({
+          repositoryId: repoId,
+          groupId: 'READERS',
+          requestBody: {
+            username: row.original.user.username,
+          },
+        });
+      }
+
+      return row.original.user.username !== useUser().username ? (
+        <div className='flex gap-2'>
+          <Tooltip delayDuration={300}>
+            <TooltipTrigger asChild>
+              <UserGroupRowActions
+                row={row}
+                onJoinAdminsGroup={joinAdminsGroup}
+                onJoinWritersGroup={joinWritersGroup}
+                onJoinReadersGroup={joinReadersGroup}
+                disabled={isJoinGroupPending || isLeaveGroupPending}
+              />
+            </TooltipTrigger>
+            <TooltipContent>Join group</TooltipContent>
+          </Tooltip>
+
+          <DeleteDialog
+            thingName={'user'}
+            thingId={row.original.user.username}
+            uiComponent={<DeleteIconButton className='text-red-500' />}
+            onDelete={() => delUser({ username: row.original.user.username })}
+          />
+        </div>
+      ) : (
+        <div className='flex justify-end'>
+          <DeleteIconButton disabled={true} />
+        </div>
+      );
+    },
+  }),
+];
+
+const routeApi = getRouteApi(
+  '/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users'
+);
+
+export const RepositoryUsersTable = () => {
+  const { repoId } = routeApi.useParams();
+  const search = routeApi.useSearch();
+  const { page = 1, pageSize = 10 } = search;
+  const pageIndex = page - 1;
+
+  const { data: usersWithGroups } =
+    useDefaultServiceGetApiV1RepositoriesByRepositoryIdUsers({
+      repositoryId: Number.parseInt(repoId),
+      limit: pageSize,
+      offset: pageIndex * pageSize,
+      sort: 'username',
+    });
+
+  const table = useReactTable({
+    data: usersWithGroups?.data || [],
+    columns: columns,
+    pageCount: Math.ceil(
+      (usersWithGroups?.pagination.totalCount ?? 0) / pageSize
+    ),
+    manualPagination: true, // Using server-side pagination
+    state: {
+      pagination: {
+        pageIndex: pageIndex,
+        pageSize: pageSize,
+      },
+    },
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <DataTable
+      table={table}
+      setCurrentPageOptions={(currentPage) => {
+        return {
+          search: { ...search, page: currentPage },
+        };
+      }}
+      setPageSizeOptions={(size) => {
+        return {
+          search: { ...search, page: 1, pageSize: size },
+        };
+      }}
+    />
+  );
+};

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/index.tsx
@@ -145,7 +145,7 @@ const ManageUsers = () => {
         <CardDescription className='flex flex-col gap-2'>
           <span>
             Assign or remove users to different groups in repository:{' '}
-            <span className='font-semibold'>{repository.url}</span>.
+            <span className='font-semibold'>{repository.url}</span>
           </span>
           <span>
             READERS: Can view the repository.

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/index.tsx
@@ -26,6 +26,7 @@ import { z } from 'zod';
 
 import {
   useDefaultServiceGetApiV1RepositoriesByRepositoryIdUsersKey,
+  useGroupsServiceDeleteApiV1RepositoriesByRepositoryIdGroupsByGroupId,
   useGroupsServicePutApiV1RepositoriesByRepositoryIdGroupsByGroupId,
 } from '@/api/queries';
 import { useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdSuspense } from '@/api/queries/suspense';
@@ -106,7 +107,47 @@ const ManageUsers = () => {
       },
     });
 
+  const { mutateAsync: leaveGroup, isPending: isLeaveGroupPending } =
+    useGroupsServiceDeleteApiV1RepositoriesByRepositoryIdGroupsByGroupId({
+      onError(error: ApiError) {
+        // There is no error when trying to remove a user from a group he actually is not a member of.
+        toast.error(error.message, {
+          description: <ToastError error={error} />,
+          duration: Infinity,
+          cancel: {
+            label: 'Dismiss',
+            onClick: () => {},
+          },
+        });
+      },
+    });
+
+  // The user might accidentally try to add a user to a group, although the user already has a group assignment.
+  // In this case, leave any potential other groups before adding the user to the new group.
+  async function leaveOtherGroups(
+    joinGroupId: string,
+    username: string,
+    repositoryId: number
+  ) {
+    const groups = ['admins', 'writers', 'readers'];
+    const otherGroups = groups.filter((group) => group !== joinGroupId);
+
+    for (const group of otherGroups) {
+      await leaveGroup({
+        repositoryId: repositoryId,
+        groupId: group,
+        requestBody: {
+          username: username,
+        },
+      });
+    }
+  }
   async function onAddUser(values: z.infer<typeof formSchema>) {
+    await leaveOtherGroups(
+      values.groupId,
+      values.username,
+      Number.parseInt(params.repoId)
+    );
     await addUser({
       repositoryId: Number.parseInt(params.repoId),
       groupId: values.groupId,
@@ -193,7 +234,7 @@ const ManageUsers = () => {
               disabled={isAddUserPending}
               onClick={form.handleSubmit(onAddUser)}
             >
-              {isAddUserPending ? (
+              {isAddUserPending || isLeaveGroupPending ? (
                 <>
                   <span className='sr-only'>Adding user...</span>
                   <Loader2 size={16} className='mx-3 animate-spin' />

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/index.tsx
@@ -147,13 +147,14 @@ const ManageUsers = () => {
             Assign or remove users to different groups in repository:{' '}
             <span className='font-semibold'>{repository.url}</span>
           </span>
-          <span>
-            READERS: Can view the repository.
-            <br />
-            WRITERS: Can view and edit the repository.
-            <br />
-            ADMINS: Can view, edit, and delete the repository.
-          </span>
+          <div className='grid grid-cols-[auto_1fr] items-center gap-x-1 gap-y-1'>
+            <Eye size={16} />
+            <span>READERS can view the repository.</span>
+            <Pen size={16} />
+            <span>WRITERS can view and edit the repository.</span>
+            <Shield size={16} />
+            <span>ADMINS can view, edit, and delete the repository.</span>
+          </div>
           <span>NOTE: The username must already exist in Keycloak.</span>
         </CardDescription>
       </CardHeader>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/index.tsx
@@ -18,16 +18,16 @@
  */
 
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-import { Loader2 } from 'lucide-react';
+import { Eye, Loader2, Pen, Shield } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import {
-  useGroupsServiceDeleteApiV1RepositoriesByRepositoryIdGroupsByGroupId,
+  useDefaultServiceGetApiV1RepositoriesByRepositoryIdUsersKey,
   useGroupsServicePutApiV1RepositoriesByRepositoryIdGroupsByGroupId,
 } from '@/api/queries';
-import { prefetchUseRepositoriesServiceGetApiV1RepositoriesByRepositoryId } from '@/api/queries/prefetch';
 import { useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdSuspense } from '@/api/queries/suspense';
 import { ApiError } from '@/api/requests';
 import { ToastError } from '@/components/toast-error';
@@ -36,7 +36,6 @@ import {
   Card,
   CardContent,
   CardDescription,
-  CardFooter,
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
@@ -58,6 +57,7 @@ import {
 } from '@/components/ui/select';
 import { toast } from '@/lib/toast';
 import { groupsSchema } from '@/schemas';
+import { RepositoryUsersTable } from './-components/repository-users-table';
 
 const formSchema = z.object({
   username: z.string().min(1),
@@ -80,30 +80,18 @@ const ManageUsers = () => {
       repositoryId: Number.parseInt(params.repoId),
     });
 
+  const queryClient = useQueryClient();
+
   const { mutateAsync: addUser, isPending: isAddUserPending } =
     useGroupsServicePutApiV1RepositoriesByRepositoryIdGroupsByGroupId({
       onSuccess() {
+        queryClient.invalidateQueries({
+          queryKey: [
+            useDefaultServiceGetApiV1RepositoriesByRepositoryIdUsersKey,
+          ],
+        });
         toast.info('Add User', {
           description: `User "${form.getValues().username}" added successfully to group "${form.getValues().groupId.toUpperCase()}".`,
-        });
-      },
-      onError(error: ApiError) {
-        toast.error(error.message, {
-          description: <ToastError error={error} />,
-          duration: Infinity,
-          cancel: {
-            label: 'Dismiss',
-            onClick: () => {},
-          },
-        });
-      },
-    });
-
-  const { mutateAsync: removeUser, isPending: isRemoveUserPending } =
-    useGroupsServiceDeleteApiV1RepositoriesByRepositoryIdGroupsByGroupId({
-      onSuccess() {
-        toast.info('Remove User', {
-          description: `User "${form.getValues().username}" removed successfully from group "${form.getValues().groupId.toUpperCase()}".`,
         });
       },
       onError(error: ApiError) {
@@ -126,16 +114,8 @@ const ManageUsers = () => {
         username: values.username,
       },
     });
-  }
 
-  async function onRemoveUser(values: z.infer<typeof formSchema>) {
-    await removeUser({
-      repositoryId: Number.parseInt(params.repoId),
-      groupId: values.groupId,
-      requestBody: {
-        username: values.username,
-      },
-    });
+    form.setValue('username', '');
   }
 
   return (
@@ -158,9 +138,9 @@ const ManageUsers = () => {
           <span>NOTE: The username must already exist in Keycloak.</span>
         </CardDescription>
       </CardHeader>
-      <Form {...form}>
-        <form className='space-y-8'>
-          <CardContent className='space-y-4'>
+      <CardContent className='space-y-4'>
+        <Form {...form}>
+          <form className='space-y-8'>
             <FormField
               control={form.control}
               name='username'
@@ -174,7 +154,6 @@ const ManageUsers = () => {
                 </FormItem>
               )}
             />
-
             <FormField
               control={form.control}
               name='groupId'
@@ -193,7 +172,12 @@ const ManageUsers = () => {
                     <SelectContent>
                       {groupsSchema.options.map((group) => (
                         <SelectItem key={group} value={group}>
-                          {group.toUpperCase()}
+                          <div className='flex items-center gap-2'>
+                            {group === 'admins' && <Shield size={16} />}
+                            {group === 'writers' && <Pen size={16} />}
+                            {group === 'readers' && <Eye size={16} />}
+                            {group.toUpperCase()}
+                          </div>
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -202,9 +186,9 @@ const ManageUsers = () => {
                 </FormItem>
               )}
             />
-          </CardContent>
-          <CardFooter className='gap-2'>
             <Button
+              size='sm'
+              className='ml-auto gap-1'
               type='submit'
               disabled={isAddUserPending}
               onClick={form.handleSubmit(onAddUser)}
@@ -215,26 +199,13 @@ const ManageUsers = () => {
                   <Loader2 size={16} className='mx-3 animate-spin' />
                 </>
               ) : (
-                'Add User'
+                'Add User to Group'
               )}
             </Button>
-            <Button
-              type='submit'
-              disabled={isRemoveUserPending}
-              onClick={form.handleSubmit(onRemoveUser)}
-            >
-              {isRemoveUserPending ? (
-                <>
-                  <span className='sr-only'>Removing user...</span>
-                  <Loader2 size={16} className='mx-3 animate-spin' />
-                </>
-              ) : (
-                'Remove User'
-              )}
-            </Button>
-          </CardFooter>
-        </form>
-      </Form>
+          </form>
+        </Form>
+        <RepositoryUsersTable />
+      </CardContent>
     </Card>
   );
 };
@@ -242,13 +213,5 @@ const ManageUsers = () => {
 export const Route = createFileRoute(
   '/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/'
 )({
-  loader: async ({ context, params }) => {
-    await prefetchUseRepositoriesServiceGetApiV1RepositoriesByRepositoryId(
-      context.queryClient,
-      {
-        repositoryId: Number.parseInt(params.repoId),
-      }
-    );
-  },
   component: ManageUsers,
 });

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/route.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/route.tsx
@@ -19,6 +19,7 @@
 
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
 
+import { ensureUseDefaultServiceGetApiV1RepositoriesByRepositoryIdUsersData } from '@/api/queries/ensureQueryData.ts';
 import { paginationSearchParameterSchema } from '@/schemas';
 
 export const Route = createFileRoute(
@@ -28,6 +29,27 @@ export const Route = createFileRoute(
 
   // Route’s query string parameters (centralized)
   validateSearch: paginationSearchParameterSchema,
+  loaderDeps: ({ search: { page, pageSize } }) => ({
+    page,
+    pageSize,
+  }),
+  loader: async ({ context, deps, params }) => {
+    const { queryClient } = context;
+    const { page = 1, pageSize = 10 } = deps;
+    const { repoId } = params;
+    const pageIndex = page - 1;
+
+    // Ensure the data is available in the query cache when the component is rendered.
+    await ensureUseDefaultServiceGetApiV1RepositoriesByRepositoryIdUsersData(
+      queryClient,
+      {
+        limit: pageSize,
+        offset: pageIndex * pageSize,
+        repositoryId: Number.parseInt(repoId),
+        sort: 'username',
+      }
+    );
+  },
   beforeLoad: ({ context, params }) => {
     if (
       !context.auth.hasRole([

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/route.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/route.tsx
@@ -19,10 +19,15 @@
 
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
 
+import { paginationSearchParameterSchema } from '@/schemas';
+
 export const Route = createFileRoute(
   '/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users'
 )({
   component: () => <Outlet />,
+
+  // Route’s query string parameters (centralized)
+  validateSearch: paginationSearchParameterSchema,
   beforeLoad: ({ context, params }) => {
     if (
       !context.auth.hasRole([

--- a/ui/src/routes/organizations/$orgId/products/$productId/users/-components/product-users-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/users/-components/product-users-table.tsx
@@ -1,0 +1,296 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { useQueryClient } from '@tanstack/react-query';
+import { getRouteApi } from '@tanstack/react-router';
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import { Eye, Pen, Shield } from 'lucide-react';
+
+import {
+  useAdminServiceDeleteApiV1AdminUsers,
+  useDefaultServiceGetApiV1ProductsByProductIdUsers,
+  useDefaultServiceGetApiV1ProductsByProductIdUsersKey,
+  useGroupsServiceDeleteApiV1ProductsByProductIdGroupsByGroupId,
+  useGroupsServicePutApiV1ProductsByProductIdGroupsByGroupId,
+} from '@/api/queries';
+import { ApiError, UserWithGroups } from '@/api/requests';
+import { DataTable } from '@/components/data-table/data-table.tsx';
+import { DeleteDialog } from '@/components/delete-dialog.tsx';
+import { DeleteIconButton } from '@/components/delete-icon-button.tsx';
+import { ToastError } from '@/components/toast-error.tsx';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { UserGroupRowActions } from '@/components/ui/user-group-row-actions.tsx';
+import { useUser } from '@/hooks/use-user.ts';
+import { toast } from '@/lib/toast.ts';
+
+const columnHelper = createColumnHelper<UserWithGroups>();
+
+const columns = [
+  columnHelper.accessor('user.username', {
+    header: 'Username',
+    cell: ({ row }) => <>{row.original.user.username}</>,
+  }),
+  columnHelper.accessor('user.firstName', {
+    header: 'First name',
+    cell: ({ row }) => <>{row.original.user.firstName}</>,
+  }),
+  columnHelper.accessor('user.lastName', {
+    header: 'Last name',
+    cell: ({ row }) => <>{row.original.user.lastName}</>,
+  }),
+  columnHelper.accessor('user.email', {
+    header: 'Email address',
+    cell: ({ row }) => <>{row.original.user.email}</>,
+  }),
+  columnHelper.accessor('groups', {
+    header: 'Group',
+    cell: ({ row }) => {
+      const groups = row.original.groups;
+      let IconComponent;
+      let effectiveGroup = '';
+      if (groups.includes('ADMINS')) {
+        IconComponent = Shield;
+        effectiveGroup = 'ADMINS';
+      } else if (groups.includes('WRITERS')) {
+        IconComponent = Pen;
+        effectiveGroup = 'WRITERS';
+      } else if (groups.includes('READERS')) {
+        IconComponent = Eye;
+        effectiveGroup = 'READERS';
+      } else {
+        return <>{groups.join(' ')}</>;
+      }
+
+      return (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <IconComponent size={16} />
+          </TooltipTrigger>
+          <TooltipContent>{effectiveGroup}</TooltipContent>
+        </Tooltip>
+      );
+    },
+  }),
+  columnHelper.display({
+    id: 'actions',
+    header: () => <div>Actions</div>,
+    cell: function CellComponent({ row }) {
+      const queryClient = useQueryClient();
+      const params = routeApi.useParams();
+      const productId = Number.parseInt(params.productId);
+
+      const { mutateAsync: delUser } = useAdminServiceDeleteApiV1AdminUsers({
+        onSuccess() {
+          toast.info('Delete User', {
+            description: `User "${row.original.user.username}" deleted successfully.`,
+          });
+          queryClient.invalidateQueries({
+            queryKey: [useDefaultServiceGetApiV1ProductsByProductIdUsersKey],
+          });
+        },
+        onError(error: ApiError) {
+          toast.error(error.message, {
+            description: <ToastError error={error} />,
+            duration: Infinity,
+            cancel: {
+              label: 'Dismiss',
+              onClick: () => {},
+            },
+          });
+        },
+      });
+
+      const { mutateAsync: joinGroup, isPending: isJoinGroupPending } =
+        useGroupsServicePutApiV1ProductsByProductIdGroupsByGroupId({
+          onSuccess(_response, parameters) {
+            queryClient.invalidateQueries({
+              queryKey: [useDefaultServiceGetApiV1ProductsByProductIdUsersKey],
+            });
+            toast.info('Join Group', {
+              description: `User "${row.original.user.username}" joined group ${parameters.groupId} successfully.`,
+            });
+          },
+          onError(error: ApiError) {
+            toast.error(error.message, {
+              description: <ToastError error={error} />,
+              duration: Infinity,
+              cancel: {
+                label: 'Dismiss',
+                onClick: () => {},
+              },
+            });
+          },
+        });
+
+      const { mutateAsync: leaveGroup, isPending: isLeaveGroupPending } =
+        useGroupsServiceDeleteApiV1ProductsByProductIdGroupsByGroupId({
+          onSuccess(_response, parameters) {
+            // Intentionally, no queryClient.invalidateQueries() here. This is done after joining the new group.
+            toast.info('Leave Group', {
+              description: `User "${row.original.user.username}" left group ${parameters.groupId} successfully.`,
+            });
+          },
+          onError(error: ApiError) {
+            toast.error(error.message, {
+              description: <ToastError error={error} />,
+              duration: Infinity,
+              cancel: {
+                label: 'Dismiss',
+                onClick: () => {},
+              },
+            });
+          },
+        });
+
+      // Leave all groups except the one to join.
+      async function leaveOtherGroups(joinGroupId: string) {
+        const groups = row.original.groups;
+        const otherGroups = groups.filter((group) => group !== joinGroupId);
+
+        for (const group of otherGroups) {
+          await leaveGroup({
+            productId: productId,
+            groupId: group,
+            requestBody: {
+              username: row.original.user.username,
+            },
+          });
+        }
+      }
+
+      async function joinAdminsGroup() {
+        await leaveOtherGroups('ADMINS');
+        await joinGroup({
+          productId: productId,
+          groupId: 'ADMINS',
+          requestBody: {
+            username: row.original.user.username,
+          },
+        });
+      }
+
+      async function joinWritersGroup() {
+        await leaveOtherGroups('WRITERS');
+        await joinGroup({
+          productId: productId,
+          groupId: 'WRITERS',
+          requestBody: {
+            username: row.original.user.username,
+          },
+        });
+      }
+
+      async function joinReadersGroup() {
+        await leaveOtherGroups('READERS');
+        await joinGroup({
+          productId: productId,
+          groupId: 'READERS',
+          requestBody: {
+            username: row.original.user.username,
+          },
+        });
+      }
+
+      return row.original.user.username !== useUser().username ? (
+        <div className='flex gap-2'>
+          <Tooltip delayDuration={300}>
+            <TooltipTrigger asChild>
+              <UserGroupRowActions
+                row={row}
+                onJoinAdminsGroup={joinAdminsGroup}
+                onJoinWritersGroup={joinWritersGroup}
+                onJoinReadersGroup={joinReadersGroup}
+                disabled={isJoinGroupPending || isLeaveGroupPending}
+              />
+            </TooltipTrigger>
+            <TooltipContent>Join group</TooltipContent>
+          </Tooltip>
+
+          <DeleteDialog
+            thingName={'user'}
+            thingId={row.original.user.username}
+            uiComponent={<DeleteIconButton className='text-red-500' />}
+            onDelete={() => delUser({ username: row.original.user.username })}
+          />
+        </div>
+      ) : (
+        <div className='flex justify-end'>
+          <DeleteIconButton disabled={true} />
+        </div>
+      );
+    },
+  }),
+];
+
+const routeApi = getRouteApi('/organizations/$orgId/products/$productId/users');
+
+export const ProductUsersTable = () => {
+  const { productId } = routeApi.useParams();
+  const search = routeApi.useSearch();
+  const { page = 1, pageSize = 10 } = search;
+  const pageIndex = page - 1;
+
+  const { data: usersWithGroups } =
+    useDefaultServiceGetApiV1ProductsByProductIdUsers({
+      productId: Number.parseInt(productId),
+      limit: pageSize,
+      offset: pageIndex * pageSize,
+      sort: 'username',
+    });
+
+  const table = useReactTable({
+    data: usersWithGroups?.data || [],
+    columns: columns,
+    pageCount: Math.ceil(
+      (usersWithGroups?.pagination.totalCount ?? 0) / pageSize
+    ),
+    manualPagination: true, // Using server-side pagination
+    state: {
+      pagination: {
+        pageIndex: pageIndex,
+        pageSize: pageSize,
+      },
+    },
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <DataTable
+      table={table}
+      setCurrentPageOptions={(currentPage) => {
+        return {
+          search: { ...search, page: currentPage },
+        };
+      }}
+      setPageSizeOptions={(size) => {
+        return {
+          search: { ...search, page: 1, pageSize: size },
+        };
+      }}
+    />
+  );
+};

--- a/ui/src/routes/organizations/$orgId/products/$productId/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/users/index.tsx
@@ -145,7 +145,7 @@ const ManageUsers = () => {
         <CardDescription className='flex flex-col gap-2'>
           <span>
             Assign or remove users to different groups in product:{' '}
-            <span className='font-semibold'>{product.name}</span>.
+            <span className='font-semibold'>{product.name}</span>
           </span>
           <span>
             READERS: Can view the product and its repositories.

--- a/ui/src/routes/organizations/$orgId/products/$productId/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/users/index.tsx
@@ -18,16 +18,16 @@
  */
 
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useQueryClient } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-import { Loader2 } from 'lucide-react';
+import { Eye, Loader2, Pen, Shield } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import {
-  useGroupsServiceDeleteApiV1ProductsByProductIdGroupsByGroupId,
+  useDefaultServiceGetApiV1ProductsByProductIdUsersKey,
   useGroupsServicePutApiV1ProductsByProductIdGroupsByGroupId,
 } from '@/api/queries';
-import { prefetchUseProductsServiceGetApiV1ProductsByProductId } from '@/api/queries/prefetch';
 import { useProductsServiceGetApiV1ProductsByProductIdSuspense } from '@/api/queries/suspense';
 import { ApiError } from '@/api/requests';
 import { ToastError } from '@/components/toast-error';
@@ -36,7 +36,6 @@ import {
   Card,
   CardContent,
   CardDescription,
-  CardFooter,
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
@@ -58,6 +57,7 @@ import {
 } from '@/components/ui/select';
 import { toast } from '@/lib/toast';
 import { groupsSchema } from '@/schemas';
+import { ProductUsersTable } from './-components/product-users-table';
 
 const formSchema = z.object({
   username: z.string().min(1),
@@ -80,30 +80,16 @@ const ManageUsers = () => {
       productId: Number.parseInt(params.productId),
     });
 
+  const queryClient = useQueryClient();
+
   const { mutateAsync: addUser, isPending: isAddUserPending } =
     useGroupsServicePutApiV1ProductsByProductIdGroupsByGroupId({
       onSuccess() {
+        queryClient.invalidateQueries({
+          queryKey: [useDefaultServiceGetApiV1ProductsByProductIdUsersKey],
+        });
         toast.info('Add User', {
           description: `User "${form.getValues().username}" added successfully to group "${form.getValues().groupId.toUpperCase()}".`,
-        });
-      },
-      onError(error: ApiError) {
-        toast.error(error.message, {
-          description: <ToastError error={error} />,
-          duration: Infinity,
-          cancel: {
-            label: 'Dismiss',
-            onClick: () => {},
-          },
-        });
-      },
-    });
-
-  const { mutateAsync: removeUser, isPending: isRemoveUserPending } =
-    useGroupsServiceDeleteApiV1ProductsByProductIdGroupsByGroupId({
-      onSuccess() {
-        toast.info('Remove User', {
-          description: `User "${form.getValues().username}" removed successfully from group "${form.getValues().groupId.toUpperCase()}".`,
         });
       },
       onError(error: ApiError) {
@@ -126,16 +112,8 @@ const ManageUsers = () => {
         username: values.username,
       },
     });
-  }
 
-  async function onRemoveUser(values: z.infer<typeof formSchema>) {
-    await removeUser({
-      productId: Number.parseInt(params.productId),
-      groupId: values.groupId,
-      requestBody: {
-        username: values.username,
-      },
-    });
+    form.setValue('username', '');
   }
 
   return (
@@ -163,9 +141,9 @@ const ManageUsers = () => {
           <span>NOTE: The username must already exist in Keycloak.</span>
         </CardDescription>
       </CardHeader>
-      <Form {...form}>
-        <form className='space-y-8'>
-          <CardContent className='space-y-4'>
+      <CardContent className='space-y-4'>
+        <Form {...form}>
+          <form className='space-y-8'>
             <FormField
               control={form.control}
               name='username'
@@ -179,7 +157,6 @@ const ManageUsers = () => {
                 </FormItem>
               )}
             />
-
             <FormField
               control={form.control}
               name='groupId'
@@ -198,7 +175,12 @@ const ManageUsers = () => {
                     <SelectContent>
                       {groupsSchema.options.map((group) => (
                         <SelectItem key={group} value={group}>
-                          {group.toUpperCase()}
+                          <div className='flex items-center gap-2'>
+                            {group === 'admins' && <Shield size={16} />}
+                            {group === 'writers' && <Pen size={16} />}
+                            {group === 'readers' && <Eye size={16} />}
+                            {group.toUpperCase()}
+                          </div>
                         </SelectItem>
                       ))}
                     </SelectContent>
@@ -207,9 +189,9 @@ const ManageUsers = () => {
                 </FormItem>
               )}
             />
-          </CardContent>
-          <CardFooter className='gap-2'>
             <Button
+              size='sm'
+              className='ml-auto gap-1'
               type='submit'
               disabled={isAddUserPending}
               onClick={form.handleSubmit(onAddUser)}
@@ -220,26 +202,13 @@ const ManageUsers = () => {
                   <Loader2 size={16} className='mx-3 animate-spin' />
                 </>
               ) : (
-                'Add User'
+                'Add User to Group'
               )}
             </Button>
-            <Button
-              type='submit'
-              disabled={isRemoveUserPending}
-              onClick={form.handleSubmit(onRemoveUser)}
-            >
-              {isRemoveUserPending ? (
-                <>
-                  <span className='sr-only'>Removing user...</span>
-                  <Loader2 size={16} className='mx-3 animate-spin' />
-                </>
-              ) : (
-                'Remove User'
-              )}
-            </Button>
-          </CardFooter>
-        </form>
-      </Form>
+          </form>
+        </Form>
+        <ProductUsersTable />
+      </CardContent>
     </Card>
   );
 };
@@ -247,13 +216,5 @@ const ManageUsers = () => {
 export const Route = createFileRoute(
   '/organizations/$orgId/products/$productId/users/'
 )({
-  loader: async ({ context, params }) => {
-    await prefetchUseProductsServiceGetApiV1ProductsByProductId(
-      context.queryClient,
-      {
-        productId: Number.parseInt(params.productId),
-      }
-    );
-  },
   component: ManageUsers,
 });

--- a/ui/src/routes/organizations/$orgId/products/$productId/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/users/index.tsx
@@ -26,6 +26,7 @@ import { z } from 'zod';
 
 import {
   useDefaultServiceGetApiV1ProductsByProductIdUsersKey,
+  useGroupsServiceDeleteApiV1ProductsByProductIdGroupsByGroupId,
   useGroupsServicePutApiV1ProductsByProductIdGroupsByGroupId,
 } from '@/api/queries';
 import { useProductsServiceGetApiV1ProductsByProductIdSuspense } from '@/api/queries/suspense';
@@ -104,7 +105,48 @@ const ManageUsers = () => {
       },
     });
 
+  const { mutateAsync: leaveGroup, isPending: isLeaveGroupPending } =
+    useGroupsServiceDeleteApiV1ProductsByProductIdGroupsByGroupId({
+      onError(error: ApiError) {
+        // There is no error when trying to remove a user from a group he actually is not a member of.
+        toast.error(error.message, {
+          description: <ToastError error={error} />,
+          duration: Infinity,
+          cancel: {
+            label: 'Dismiss',
+            onClick: () => {},
+          },
+        });
+      },
+    });
+
+  // The user might accidentally try to add a user to a group, although the user already has a group assignment.
+  // In this case, leave any potential other groups before adding the user to the new group.
+  async function leaveOtherGroups(
+    joinGroupId: string,
+    username: string,
+    productId: number
+  ) {
+    const groups = ['admins', 'writers', 'readers'];
+    const otherGroups = groups.filter((group) => group !== joinGroupId);
+
+    for (const group of otherGroups) {
+      await leaveGroup({
+        productId: productId,
+        groupId: group,
+        requestBody: {
+          username: username,
+        },
+      });
+    }
+  }
+
   async function onAddUser(values: z.infer<typeof formSchema>) {
+    await leaveOtherGroups(
+      values.groupId,
+      values.username,
+      Number.parseInt(params.productId)
+    );
     await addUser({
       productId: Number.parseInt(params.productId),
       groupId: values.groupId,
@@ -196,7 +238,7 @@ const ManageUsers = () => {
               disabled={isAddUserPending}
               onClick={form.handleSubmit(onAddUser)}
             >
-              {isAddUserPending ? (
+              {isAddUserPending || isLeaveGroupPending ? (
                 <>
                   <span className='sr-only'>Adding user...</span>
                   <Loader2 size={16} className='mx-3 animate-spin' />

--- a/ui/src/routes/organizations/$orgId/products/$productId/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/users/index.tsx
@@ -147,13 +147,19 @@ const ManageUsers = () => {
             Assign or remove users to different groups in product:{' '}
             <span className='font-semibold'>{product.name}</span>
           </span>
-          <span>
-            READERS: Can view the product and its repositories.
-            <br />
-            WRITERS: Can view and edit the product and its repositories.
-            <br />
-            ADMINS: Can view, edit, and delete the product and its repositories.
-          </span>
+          <div className='grid grid-cols-[auto_1fr] items-center gap-x-1 gap-y-1'>
+            <Eye size={16} />
+            <span>READERS can view the product and its repositories.</span>
+            <Pen size={16} />
+            <span>
+              WRITERS can view and edit the product and its repositories.
+            </span>
+            <Shield size={16} />
+            <span>
+              ADMINS can view, edit, and delete the product and its
+              repositories.
+            </span>
+          </div>
           <span>NOTE: The username must already exist in Keycloak.</span>
         </CardDescription>
       </CardHeader>

--- a/ui/src/routes/organizations/$orgId/products/$productId/users/route.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/users/route.tsx
@@ -19,6 +19,7 @@
 
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
 
+import { ensureUseDefaultServiceGetApiV1ProductsByProductIdUsersData } from '@/api/queries/ensureQueryData.ts';
 import { paginationSearchParameterSchema } from '@/schemas';
 
 export const Route = createFileRoute(
@@ -28,6 +29,27 @@ export const Route = createFileRoute(
 
   // Route’s query string parameters (centralized)
   validateSearch: paginationSearchParameterSchema,
+  loaderDeps: ({ search: { page, pageSize } }) => ({
+    page,
+    pageSize,
+  }),
+  loader: async ({ context, deps, params }) => {
+    const { queryClient } = context;
+    const { page = 1, pageSize = 10 } = deps;
+    const { productId } = params;
+    const pageIndex = page - 1;
+
+    // Ensure the data is available in the query cache when the component is rendered.
+    await ensureUseDefaultServiceGetApiV1ProductsByProductIdUsersData(
+      queryClient,
+      {
+        limit: pageSize,
+        offset: pageIndex * pageSize,
+        productId: Number.parseInt(productId),
+        sort: 'username',
+      }
+    );
+  },
   beforeLoad: ({ context, params }) => {
     if (
       !context.auth.hasRole([

--- a/ui/src/routes/organizations/$orgId/products/$productId/users/route.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/users/route.tsx
@@ -19,10 +19,15 @@
 
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
 
+import { paginationSearchParameterSchema } from '@/schemas';
+
 export const Route = createFileRoute(
   '/organizations/$orgId/products/$productId/users'
 )({
   component: () => <Outlet />,
+
+  // Route’s query string parameters (centralized)
+  validateSearch: paginationSearchParameterSchema,
   beforeLoad: ({ context, params }) => {
     if (
       !context.auth.hasRole([

--- a/ui/src/routes/organizations/$orgId/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/users/index.tsx
@@ -147,16 +147,23 @@ const ManageUsers = () => {
             Assign or remove users to different groups in organization:{' '}
             <span className='font-semibold'>{organization.name}</span>
           </span>
-          <span>
-            READERS: Can view the organization and its projects and
-            repositories.
-            <br />
-            WRITERS: Can view and edit the organization and its projects and
-            repositories.
-            <br />
-            ADMINS: Can view, edit, and delete the organization and its projects
-            and repositories.
-          </span>
+          <div className='grid grid-cols-[auto_1fr] items-center gap-x-1 gap-y-1'>
+            <Eye size={16} />
+            <span>
+              READERS can view the organization and its projects and
+              repositories.
+            </span>
+            <Pen size={16} />
+            <span>
+              WRITERS can view and edit the organization and its projects and
+              repositories.
+            </span>
+            <Shield size={16} />
+            <span>
+              ADMINS can view, edit, and delete the organization and its
+              projects and repositories.
+            </span>
+          </div>
           <span>NOTE: The username must already exist in Keycloak.</span>
         </CardDescription>
       </CardHeader>

--- a/ui/src/routes/organizations/$orgId/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/users/index.tsx
@@ -145,7 +145,7 @@ const ManageUsers = () => {
         <CardDescription className='flex flex-col gap-2'>
           <span>
             Assign or remove users to different groups in organization:{' '}
-            <span className='font-semibold'>{organization.name}</span>.
+            <span className='font-semibold'>{organization.name}</span>
           </span>
           <span>
             READERS: Can view the organization and its projects and

--- a/ui/src/routes/organizations/$orgId/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/users/index.tsx
@@ -26,6 +26,7 @@ import { z } from 'zod';
 
 import {
   useDefaultServiceGetApiV1OrganizationsByOrganizationIdUsersKey,
+  useGroupsServiceDeleteApiV1OrganizationsByOrganizationIdGroupsByGroupId,
   useGroupsServicePutApiV1OrganizationsByOrganizationIdGroupsByGroupId,
 } from '@/api/queries';
 import { useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdSuspense } from '@/api/queries/suspense';
@@ -106,7 +107,48 @@ const ManageUsers = () => {
       },
     });
 
+  const { mutateAsync: leaveGroup, isPending: isLeaveGroupPending } =
+    useGroupsServiceDeleteApiV1OrganizationsByOrganizationIdGroupsByGroupId({
+      onError(error: ApiError) {
+        // There is no error when trying to remove a user from a group he actually is not a member of.
+        toast.error(error.message, {
+          description: <ToastError error={error} />,
+          duration: Infinity,
+          cancel: {
+            label: 'Dismiss',
+            onClick: () => {},
+          },
+        });
+      },
+    });
+
+  // The user might accidentally try to add a user to a group, although the user already has a group assignment.
+  // In this case, leave any potential other groups before adding the user to the new group.
+  async function leaveOtherGroups(
+    joinGroupId: string,
+    username: string,
+    organizationId: number
+  ) {
+    const groups = ['admins', 'writers', 'readers'];
+    const otherGroups = groups.filter((group) => group !== joinGroupId);
+
+    for (const group of otherGroups) {
+      await leaveGroup({
+        organizationId: organizationId,
+        groupId: group,
+        requestBody: {
+          username: username,
+        },
+      });
+    }
+  }
+
   async function onAddUser(values: z.infer<typeof formSchema>) {
+    await leaveOtherGroups(
+      values.groupId,
+      values.username,
+      Number.parseInt(params.orgId)
+    );
     await addUser({
       organizationId: Number.parseInt(params.orgId),
       groupId: values.groupId,
@@ -202,7 +244,7 @@ const ManageUsers = () => {
               disabled={isAddUserPending}
               onClick={form.handleSubmit(onAddUser)}
             >
-              {isAddUserPending ? (
+              {isAddUserPending || isLeaveGroupPending ? (
                 <>
                   <span className='sr-only'>Adding user...</span>
                   <Loader2 size={16} className='mx-3 animate-spin' />

--- a/ui/src/routes/organizations/$orgId/users/route.tsx
+++ b/ui/src/routes/organizations/$orgId/users/route.tsx
@@ -19,8 +19,13 @@
 
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
 
+import { paginationSearchParameterSchema } from '@/schemas';
+
 export const Route = createFileRoute('/organizations/$orgId/users')({
   component: () => <Outlet />,
+
+  // Route’s query string parameters (centralized)
+  validateSearch: paginationSearchParameterSchema,
   beforeLoad: ({ context, params }) => {
     if (
       !context.auth.hasRole([


### PR DESCRIPTION
On the level of Organizations, Products and Repositories allow admins to assign users to one one of the groups ADMINS, WRITERS or READERS, and also allow to change the assignments and delete users. Existing users and their respective role assignments are displayed in a table.

For details, please have a look at the respective commit messages.

Fixes #2053.

![image](https://github.com/user-attachments/assets/9965a970-709c-4e2c-b321-ba631aeedbb8)
