### PR TITLE
feat(analyzer): Set the default branch as ORT run revision

### DIFF
--- a/dao/src/main/kotlin/repositories/ortrun/DaoOrtRunRepository.kt
+++ b/dao/src/main/kotlin/repositories/ortrun/DaoOrtRunRepository.kt
@@ -162,6 +162,7 @@ class DaoOrtRunRepository(private val db: Database) : OrtRunRepository {
         jobConfigs: OptionalValue<JobConfigurations>,
         resolvedJobConfigs: OptionalValue<JobConfigurations>,
         resolvedJobConfigContext: OptionalValue<String?>,
+        revision: OptionalValue<String>,
         resolvedRevision: OptionalValue<String?>,
         issues: OptionalValue<Collection<Issue>>,
         labels: OptionalValue<Map<String, String>>
@@ -180,6 +181,7 @@ class DaoOrtRunRepository(private val db: Database) : OrtRunRepository {
 
         resolvedJobConfigs.ifPresent { ortRun.resolvedJobConfigs = it }
         resolvedJobConfigContext.ifPresent { ortRun.resolvedJobConfigContext = it }
+        revision.ifPresent { ortRun.revision = it }
         resolvedRevision.ifPresent { ortRun.resolvedRevision = it }
 
         issues.ifPresent { issues ->

--- a/dao/src/test/kotlin/repositories/ortrun/DaoOrtRunRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/ortrun/DaoOrtRunRepositoryTest.kt
@@ -558,6 +558,7 @@ class DaoOrtRunRepositoryTest : StringSpec({
         )
 
         val resolvedContext = "theResolvedConfigContext"
+        val revision = "main"
         val resolvedRevision = "0123456789abcdef0123456789abcdef01234567"
         val updateStatus = OrtRunStatus.ACTIVE.asPresent()
 
@@ -567,6 +568,7 @@ class DaoOrtRunRepositoryTest : StringSpec({
             jobConfigurations.asPresent(),
             resolvedJobConfigurations.asPresent(),
             resolvedContext.asPresent(),
+            revision.asPresent(),
             resolvedRevision.asPresent(),
             listOf(issue1, issue2, issue3).asPresent(),
             mapOf("label2" to label2Value, "label3" to label3Value).asPresent()
@@ -576,6 +578,7 @@ class DaoOrtRunRepositoryTest : StringSpec({
             status = updateStatus.value,
             resolvedJobConfigs = resolvedJobConfigurations,
             resolvedJobConfigContext = resolvedContext,
+            revision = revision,
             resolvedRevision = resolvedRevision,
             issues = listOf(issue1, issue2, issue3),
             labels = mapOf("label1" to labelsMap.getValue("label1"), "label2" to label2Value, "label3" to label3Value)

--- a/model/src/commonMain/kotlin/repositories/OrtRunRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/OrtRunRepository.kt
@@ -116,6 +116,7 @@ interface OrtRunRepository {
         jobConfigs: OptionalValue<JobConfigurations> = OptionalValue.Absent,
         resolvedJobConfigs: OptionalValue<JobConfigurations> = OptionalValue.Absent,
         resolvedJobConfigContext: OptionalValue<String?> = OptionalValue.Absent,
+        revision: OptionalValue<String> = OptionalValue.Absent,
         resolvedRevision: OptionalValue<String?> = OptionalValue.Absent,
         issues: OptionalValue<Collection<Issue>> = OptionalValue.Absent,
         labels: OptionalValue<Map<String, String>> = OptionalValue.Absent

--- a/workers/analyzer/src/main/kotlin/analyzer/AnalyzerDownloader.kt
+++ b/workers/analyzer/src/main/kotlin/analyzer/AnalyzerDownloader.kt
@@ -49,10 +49,12 @@ class AnalyzerDownloader {
         val vcs = VersionControlSystem.forUrl(repositoryUrl, config)
         requireNotNull(vcs) { "Could not determine the VCS for URL '$repositoryUrl'." }
 
+        val initRevision = revision.takeUnless { it.isEmpty() } ?: vcs.getDefaultBranchName(repositoryUrl)
+
         val vcsInfo = VcsInfo(
             type = vcs.type,
             url = repositoryUrl,
-            revision = revision.takeUnless { it.isEmpty() } ?: vcs.getDefaultBranchName(repositoryUrl),
+            revision = initRevision,
             path = path
         )
 
@@ -67,7 +69,7 @@ class AnalyzerDownloader {
                     "'$resolvedRevision'."
         )
 
-        return DownloadResult(outputDir, resolvedRevision)
+        return DownloadResult(outputDir, initRevision, resolvedRevision)
     }
 
     /**
@@ -96,6 +98,9 @@ class AnalyzerDownloader {
 data class DownloadResult(
     /** The directory to which the repository was downloaded. */
     val directory: File,
+
+    /** The revision used to initialize the repository. */
+    val initRevision: String,
 
     /** The resolved revision of the repository. */
     val resolvedRevision: String

--- a/workers/analyzer/src/main/kotlin/analyzer/AnalyzerWorker.kt
+++ b/workers/analyzer/src/main/kotlin/analyzer/AnalyzerWorker.kt
@@ -84,6 +84,13 @@ internal class AnalyzerWorker(
                 job.configuration.submoduleFetchStrategy
             )
 
+            if (downloadResult.initRevision != ortRun.revision) {
+                logger.info(
+                    "Updating revision of ORT run from '${ortRun.revision}' to '${downloadResult.initRevision}'."
+                )
+                ortRunService.updateRevision(ortRun.id, downloadResult.initRevision)
+            }
+
             ortRunService.updateResolvedRevision(ortRun.id, downloadResult.resolvedRevision)
 
             val resolvedEnvConfig = environmentService.setUpEnvironment(

--- a/workers/analyzer/src/test/kotlin/AnalyzerDownloaderTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerDownloaderTest.kt
@@ -53,18 +53,21 @@ class AnalyzerDownloaderTest : WordSpec({
         "use the default branch if an empty revision is given" {
             val repositoryUrl = "https://github.com/oss-review-toolkit/ort-test-data-scanner.git"
 
-            val outputDir = downloader.downloadRepository(repositoryUrl, revision = "").directory
+            val result = downloader.downloadRepository(repositoryUrl, revision = "")
 
-            with(GitCommand.run(outputDir, "branch", "--show-current").requireSuccess()) {
+            result.initRevision shouldBe "main"
+
+            with(GitCommand.run(result.directory, "branch", "--show-current").requireSuccess()) {
                 stdout.trim() shouldBe "main"
             }
         }
 
-        "return the resolved revision" {
+        "return the initial and resolved revisions" {
             val repositoryUrl = "https://github.com/oss-review-toolkit/ort-test-data-scanner.git"
 
-            val result = downloader.downloadRepository(repositoryUrl, revision = "")
+            val result = downloader.downloadRepository(repositoryUrl, revision = "main")
 
+            result.initRevision shouldBe "main"
             result.resolvedRevision shouldBe GitFactory.create().getWorkingTree(result.directory).getRevision()
         }
 

--- a/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
@@ -130,7 +130,8 @@ class AnalyzerWorkerTest : StringSpec({
         val downloader = mockk<AnalyzerDownloader> {
             // To speed up the test and to not rely on a network connection, a minimal pom file is analyzed and
             // the repository is not cloned.
-            every { downloadRepository(any(), any()) } returns DownloadResult(projectDir, "resolvedRevision")
+            every { downloadRepository(any(), any()) } returns
+                    DownloadResult(projectDir, "main", "resolvedRevision")
         }
 
         val context = mockk<WorkerContext> {
@@ -191,7 +192,8 @@ class AnalyzerWorkerTest : StringSpec({
         val downloader = mockk<AnalyzerDownloader> {
             // To speed up the test and to not rely on a network connection, a minimal pom file is analyzed and
             // the repository is not cloned.
-            every { downloadRepository(any(), any()) } returns DownloadResult(projectDir, "resolvedRevision")
+            every { downloadRepository(any(), any()) } returns
+                    DownloadResult(projectDir, "main", "resolvedRevision")
         }
 
         val context = mockk<WorkerContext> {
@@ -250,7 +252,8 @@ class AnalyzerWorkerTest : StringSpec({
         }
 
         val downloader = mockk<AnalyzerDownloader> {
-            every { downloadRepository(any(), any()) } returns DownloadResult(projectDir, "resolvedRevision")
+            every { downloadRepository(any(), any()) } returns
+                    DownloadResult(projectDir, "main", "resolvedRevision")
         }
 
         val context = mockk<WorkerContext> {
@@ -307,7 +310,8 @@ class AnalyzerWorkerTest : StringSpec({
         }
 
         val downloader = mockk<AnalyzerDownloader> {
-            every { downloadRepository(any(), any()) } returns DownloadResult(projectDir, "resolvedRevision")
+            every { downloadRepository(any(), any()) } returns
+                    DownloadResult(projectDir, "main", "resolvedRevision")
         }
 
         val context = mockk<WorkerContext>()
@@ -354,7 +358,8 @@ class AnalyzerWorkerTest : StringSpec({
         }
 
         val downloader = mockk<AnalyzerDownloader> {
-            every { downloadRepository(any(), any()) } returns DownloadResult(projectDir, "resolvedRevision")
+            every { downloadRepository(any(), any()) } returns
+                    DownloadResult(projectDir, "main", "resolvedRevision")
         }
 
         val context = mockk<WorkerContext>()
@@ -448,7 +453,8 @@ class AnalyzerWorkerTest : StringSpec({
         val downloader = mockk<AnalyzerDownloader> {
             // To speed up the test and to not rely on a network connection, a minimal pom file is analyzed and
             // the repository is not cloned.
-            every { downloadRepository(any(), any()) } returns DownloadResult(projectDir, "resolvedRevision")
+            every { downloadRepository(any(), any()) } returns
+                    DownloadResult(projectDir, "main", "resolvedRevision")
         }
 
         val context = mockk<WorkerContext> {

--- a/workers/common/src/main/kotlin/common/OrtRunService.kt
+++ b/workers/common/src/main/kotlin/common/OrtRunService.kt
@@ -539,6 +539,12 @@ class OrtRunService(
         }
     }
 
+    fun updateRevision(ortRunId: Long, revision: String) {
+        db.blockingQuery {
+            ortRunRepository.update(ortRunId, revision = revision.asPresent())
+        }
+    }
+
     fun updateResolvedRevision(ortRunId: Long, resolvedRevision: String) {
         db.blockingQuery {
             ortRunRepository.update(ortRunId, resolvedRevision = resolvedRevision.asPresent())

--- a/workers/common/src/test/kotlin/common/OrtRunServiceTest.kt
+++ b/workers/common/src/test/kotlin/common/OrtRunServiceTest.kt
@@ -1057,6 +1057,18 @@ class OrtRunServiceTest : WordSpec({
         }
     }
 
+    "updateRevision" should {
+        "update the revision" {
+            val ortRun = fixtures.ortRun
+            val revision = "main"
+
+            service.updateRevision(ortRun.id, revision)
+
+            val updatedOrtRun = fixtures.ortRunRepository.get(ortRun.id).shouldNotBeNull()
+            updatedOrtRun.revision shouldBe revision
+        }
+    }
+
     "updateResolvedRevision" should {
         "update the resolved revision" {
             val ortRun = fixtures.ortRun

--- a/workers/config/src/test/kotlin/ConfigWorkerTest.kt
+++ b/workers/config/src/test/kotlin/ConfigWorkerTest.kt
@@ -71,7 +71,7 @@ class ConfigWorkerTest : StringSpec({
 
         val ortRunRepository = mockk<OrtRunRepository> {
             every {
-                update(RUN_ID, any(), any(), any(), any(), any(), any(), any())
+                update(RUN_ID, any(), any(), any(), any(), any(), any(), any(), any())
             } returns mockk()
         }
 
@@ -102,7 +102,7 @@ class ConfigWorkerTest : StringSpec({
 
         val ortRunRepository = mockk<OrtRunRepository> {
             every {
-                update(RUN_ID, any(), any(), any(), any(), any(), any())
+                update(RUN_ID, any(), any(), any(), any(), any(), any(), any())
             } returns mockk()
         }
 
@@ -132,7 +132,7 @@ class ConfigWorkerTest : StringSpec({
 
         val ortRunRepository = mockk<OrtRunRepository> {
             every {
-                update(RUN_ID, any(), any(), any(), any(), any(), any())
+                update(RUN_ID, any(), any(), any(), any(), any(), any(), any())
             } returns mockk()
         }
 
@@ -176,7 +176,7 @@ class ConfigWorkerTest : StringSpec({
 
         val ortRunRepository = mockk<OrtRunRepository> {
             every {
-                update(RUN_ID, any(), any(), any(), any(), any(), any())
+                update(RUN_ID, any(), any(), any(), any(), any(), any(), any())
             } returns mockk()
         }
 


### PR DESCRIPTION
If an ORT run is started with an empty `revision`, the analyzer worker uses the default branch of the repository as revision. Store that as the `revision` of the ORT run to make clear what revision was used to initialize the repository.

Fixes #2082.