### PR TITLE
feat(api): Add endpoint to trigger ORT runs for all product repositories

### DIFF
--- a/core/src/main/kotlin/api/ProductsRoute.kt
+++ b/core/src/main/kotlin/api/ProductsRoute.kt
@@ -26,6 +26,7 @@ import io.github.smiley4.ktorswaggerui.dsl.routing.post
 import io.github.smiley4.ktorswaggerui.dsl.routing.put
 
 import io.ktor.http.HttpStatusCode
+import io.ktor.server.auth.principal
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -33,8 +34,10 @@ import io.ktor.server.routing.route
 
 import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToApi
 import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToModel
+import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateRepository
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateSecret
+import org.eclipse.apoapsis.ortserver.api.v1.model.Jobs
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatistics
 import org.eclipse.apoapsis.ortserver.api.v1.model.PagedResponse
 import org.eclipse.apoapsis.ortserver.api.v1.model.SortDirection
@@ -56,15 +59,22 @@ import org.eclipse.apoapsis.ortserver.core.apiDocs.getUsersForProduct
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getVulnerabilitiesAcrossRepositoriesByProductId
 import org.eclipse.apoapsis.ortserver.core.apiDocs.patchProductById
 import org.eclipse.apoapsis.ortserver.core.apiDocs.patchSecretByProductIdAndName
+import org.eclipse.apoapsis.ortserver.core.apiDocs.postOrtRunsForProduct
 import org.eclipse.apoapsis.ortserver.core.apiDocs.postRepository
 import org.eclipse.apoapsis.ortserver.core.apiDocs.postSecretForProduct
 import org.eclipse.apoapsis.ortserver.core.apiDocs.putUserToProductGroup
+import org.eclipse.apoapsis.ortserver.core.authorization.OrtPrincipal
+import org.eclipse.apoapsis.ortserver.core.authorization.getFullName
+import org.eclipse.apoapsis.ortserver.core.authorization.getUserId
+import org.eclipse.apoapsis.ortserver.core.authorization.getUsername
 import org.eclipse.apoapsis.ortserver.core.authorization.requirePermission
+import org.eclipse.apoapsis.ortserver.core.services.OrchestratorService
 import org.eclipse.apoapsis.ortserver.core.utils.pagingOptions
 import org.eclipse.apoapsis.ortserver.core.utils.requireIdParameter
 import org.eclipse.apoapsis.ortserver.core.utils.requireParameter
 import org.eclipse.apoapsis.ortserver.model.Repository
 import org.eclipse.apoapsis.ortserver.model.Secret
+import org.eclipse.apoapsis.ortserver.model.UserDisplayName
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityWithAccumulatedData
 import org.eclipse.apoapsis.ortserver.model.authorization.ProductPermission
 import org.eclipse.apoapsis.ortserver.services.IssueService
@@ -88,6 +98,7 @@ fun Route.products() = route("products/{productId}") {
     val ruleViolationService by inject<RuleViolationService>()
     val packageService by inject<PackageService>()
     val userService by inject<UserService>()
+    val orchestratorService by inject<OrchestratorService>()
 
     get(getProductById) {
         requirePermission(ProductPermission.READ)
@@ -377,6 +388,36 @@ fun Route.products() = route("products/{productId}") {
                     )
                 )
             }
+        }
+    }
+
+    route("runs") {
+        post(postOrtRunsForProduct) {
+            requirePermission(ProductPermission.TRIGGER_ORT_RUN)
+
+            val productId = call.requireIdParameter("productId")
+            val createOrtRun = call.receive<CreateOrtRun>()
+
+            val userDisplayName = call.principal<OrtPrincipal>()?.let { principal ->
+                UserDisplayName(principal.getUserId(), principal.getUsername(), principal.getFullName())
+            }
+
+            val repositoryIds = productService.getRepositoryIdsForProduct(productId)
+
+            val createdRuns = repositoryIds.mapNotNull { repositoryId ->
+                orchestratorService.createOrtRun(
+                    repositoryId,
+                    createOrtRun.revision,
+                    createOrtRun.path,
+                    createOrtRun.jobConfigs.mapToModel(),
+                    createOrtRun.jobConfigContext,
+                    createOrtRun.labels,
+                    createOrtRun.environmentConfigPath,
+                    userDisplayName
+                ).mapToApi(Jobs())
+            }
+
+            call.respond(HttpStatusCode.Created, createdRuns)
         }
     }
 

--- a/core/src/main/kotlin/apiDocs/ProductsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/ProductsDocs.kt
@@ -23,11 +23,17 @@ import io.github.smiley4.ktorswaggerui.dsl.routes.OpenApiRoute
 
 import io.ktor.http.HttpStatusCode
 
+import org.eclipse.apoapsis.ortserver.api.v1.model.AdvisorJobConfiguration
+import org.eclipse.apoapsis.ortserver.api.v1.model.AnalyzerJobConfiguration
+import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateRepository
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateSecret
 import org.eclipse.apoapsis.ortserver.api.v1.model.EcosystemStats
 import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
+import org.eclipse.apoapsis.ortserver.api.v1.model.JobConfigurations
+import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatistics
+import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatus
 import org.eclipse.apoapsis.ortserver.api.v1.model.PagedResponse
 import org.eclipse.apoapsis.ortserver.api.v1.model.PagingData
 import org.eclipse.apoapsis.ortserver.api.v1.model.Product
@@ -564,6 +570,96 @@ val getUsersForProduct: OpenApiRoute.() -> Unit = {
                             offset = 0,
                             totalCount = 1,
                             sortProperties = listOf(SortProperty("username", SortDirection.ASCENDING))
+                        )
+                    )
+                }
+            }
+        }
+    }
+}
+
+private val minimalJobConfigurations = JobConfigurations(
+    analyzer = AnalyzerJobConfiguration(
+        skipExcluded = true
+    ),
+    advisor = AdvisorJobConfiguration(
+        skipExcluded = true
+    )
+)
+
+val postOrtRunsForProduct: OpenApiRoute.() -> Unit = {
+    operationId = "postOrtRunsForProduct"
+    summary = "Create ORT runs for all repositories under a product."
+    tags = listOf("Products")
+
+    request {
+        pathParameter<Long>("productId") {
+            description = "The product's ID."
+        }
+
+        jsonBody<CreateOrtRun> {
+            example("Create ORT runs using minimal job configurations (defaults)") {
+                value = CreateOrtRun(
+                    revision = "main",
+                    jobConfigs = minimalJobConfigurations
+                )
+            }
+
+            example("Create ORT runs using full job configurations") {
+                value = CreateOrtRun(
+                    revision = "main",
+                    jobConfigs = fullJobConfigurations,
+                    labels = mapOf("label key" to "label value"),
+                    path = "optional VCS sub-path",
+                    jobConfigContext = "optional context",
+                )
+            }
+        }
+    }
+
+    response {
+        HttpStatusCode.Created to {
+            description = "Success"
+            jsonBody<List<OrtRun>> {
+                example("Create ORT runs") {
+                    value = listOf(
+                        OrtRun(
+                            id = 1,
+                            index = 2,
+                            organizationId = 1,
+                            productId = 1,
+                            repositoryId = 1,
+                            revision = "main",
+                            createdAt = CREATED_AT,
+                            jobConfigs = fullJobConfigurations,
+                            resolvedJobConfigs = fullJobConfigurations,
+                            jobs = jobs,
+                            status = OrtRunStatus.CREATED,
+                            finishedAt = null,
+                            labels = mapOf("label key" to "label value"),
+                            issues = emptyList(),
+                            jobConfigContext = null,
+                            resolvedJobConfigContext = null,
+                            traceId = "35b67724-a85b-4cc3-b2a4-60fd914634e7"
+                        ),
+                        OrtRun(
+                            id = 2,
+                            index = 1,
+                            organizationId = 1,
+                            productId = 1,
+                            repositoryId = 2,
+                            revision = "main",
+                            createdAt = CREATED_AT,
+                            jobConfigs = fullJobConfigurations,
+                            resolvedJobConfigs = fullJobConfigurations,
+                            jobs = jobs,
+                            status = OrtRunStatus.CREATED,
+                            finishedAt = null,
+                            labels = mapOf("label key" to "label value"),
+                            issues = emptyList(),
+                            jobConfigContext = null,
+                            resolvedJobConfigContext = null,
+                            traceId = "35b67724-a85b-4cc3-b2a4-60fd914634e7"
                         )
                     )
                 }

--- a/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
@@ -53,9 +53,12 @@ import kotlinx.datetime.Clock
 
 import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToApi
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrganization
+import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateRepository
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateSecret
 import org.eclipse.apoapsis.ortserver.api.v1.model.EcosystemStats
+import org.eclipse.apoapsis.ortserver.api.v1.model.JobConfigurations
+import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatistics
 import org.eclipse.apoapsis.ortserver.api.v1.model.PagedResponse
 import org.eclipse.apoapsis.ortserver.api.v1.model.PagingData
@@ -1464,6 +1467,67 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
 
             requestShouldRequireRole(ProductPermission.READ.roleName(productId)) {
                 get("/api/v1/products/$productId/users")
+            }
+        }
+    }
+
+    "POST /products/{productId}/runs" should {
+        "trigger ORT runs for repositories in the product" {
+            integrationTestApplication {
+                val productId = createProduct().id
+                val repository1Id = productService.createRepository(
+                    type = RepositoryType.GIT,
+                    url = "https://example.com/repo1.git",
+                    productId = productId
+                ).id
+                val repository2Id = productService.createRepository(
+                    type = RepositoryType.GIT,
+                    url = "https://example.com/repo2.git",
+                    productId = productId
+                ).id
+
+                val createOrtRun = CreateOrtRun(
+                    revision = "main",
+                    path = "",
+                    jobConfigs = JobConfigurations(),
+                    jobConfigContext = null,
+                    labels = emptyMap(),
+                    environmentConfigPath = null
+                )
+
+                val response = superuserClient.post("/api/v1/products/$productId/runs") {
+                    setBody(createOrtRun)
+                }
+
+                response shouldHaveStatus HttpStatusCode.Created
+
+                val createdRuns = response.body<List<OrtRun>>()
+                createdRuns shouldHaveSize 2
+
+                val repositoryIds = createdRuns.map { run ->
+                    dbExtension.fixtures.ortRunRepository.get(run.id)?.repositoryId
+                }
+                repositoryIds shouldContainExactlyInAnyOrder listOf(repository1Id, repository2Id)
+            }
+        }
+
+        "require ProductPermission.TRIGGER_ORT_RUN" {
+            val createdProduct = createProduct()
+            requestShouldRequireRole(
+                ProductPermission.TRIGGER_ORT_RUN.roleName(createdProduct.id),
+                HttpStatusCode.Created
+            ) {
+                val createOrtRun = CreateOrtRun(
+                    revision = "main",
+                    path = "",
+                    jobConfigs = JobConfigurations(),
+                    jobConfigContext = null,
+                    labels = emptyMap(),
+                    environmentConfigPath = null
+                )
+                post("/api/v1/products/${createdProduct.id}/runs") {
+                    setBody(createOrtRun)
+                }
             }
         }
     }

--- a/model/src/commonMain/kotlin/authorization/ProductPermission.kt
+++ b/model/src/commonMain/kotlin/authorization/ProductPermission.kt
@@ -46,6 +46,9 @@ enum class ProductPermission {
     /** Permission to create a [Repository] for the [Product]. */
     CREATE_REPOSITORY,
 
+    /** Permission to trigger an ORT run for the [repositories][Repository] of the [Product]. */
+    TRIGGER_ORT_RUN,
+
     /** Permission to delete the [Product]. */
     DELETE;
 

--- a/model/src/commonMain/kotlin/authorization/ProductRole.kt
+++ b/model/src/commonMain/kotlin/authorization/ProductRole.kt
@@ -50,7 +50,8 @@ enum class ProductRole(
             ProductPermission.READ,
             ProductPermission.WRITE,
             ProductPermission.READ_REPOSITORIES,
-            ProductPermission.CREATE_REPOSITORY
+            ProductPermission.CREATE_REPOSITORY,
+            ProductPermission.TRIGGER_ORT_RUN
         ),
         includedRepositoryRole = RepositoryRole.WRITER
     ),


### PR DESCRIPTION
This commit introduces an endpoint to trigger consistent ORT runs across
all repositories belonging to a product. It addresses the need for
efficient product-wide analysis while maintaining individual run tracking
and configuration uniformity.

The implementation retrieves all repository IDs using
`getRepositoryIdsForProduct` and creates an ORT run for each via the
`OrchestratorService` with identical parameters (`revision`, `jobConfigs`,
`labels` etc.). It requires `TRIGGER_ORT_RUN` permission for security and
returns created runs with status `201`.