### PR TITLE
CLI: Add `--json` option to make the CLI output machine readable

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -23,6 +23,32 @@ jobs:
       with:
         configFile: .commitlintrc.yml
 
+  completions:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Setup Java
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4
+        with:
+          distribution: temurin
+          java-version: 21
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@06832c7b30a0129d7fb559bcc6e43d26f6374244 # v4
+      - name: Generate OSC completions
+        run: |
+          scripts/cli/generate_completion_scripts.sh
+      - name: Check if completions are up-to-date
+        run: |
+          if git diff --exit-code > /dev/null; then
+            echo "Completions are up-to-date."
+          else
+            echo "Completions for OSC are not up-to-date."
+            echo "Please update the completion scripts when changing CLI commands:"
+            echo "scripts/cli/generate_completion_scripts.sh"
+            exit 1
+          fi
+
   detekt-issues:
     runs-on: ubuntu-24.04
     env:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -85,7 +85,7 @@ jobs:
       run: pnpm -C ui install --dev
 
     - name: Run ESLint
-      run: pnpm -C ui lint 
+      run: pnpm -C ui lint
 
   prettier-ui:
     runs-on: ubuntu-24.04
@@ -109,7 +109,7 @@ jobs:
       run: pnpm -C ui install --dev
 
     - name: Run Prettier
-      run: pnpm -C ui format:check 
+      run: pnpm -C ui format:check
 
   prettier-website:
     runs-on: ubuntu-24.04

--- a/cli/src/commonMain/kotlin/AuthCommand.kt
+++ b/cli/src/commonMain/kotlin/AuthCommand.kt
@@ -33,5 +33,5 @@ class AuthCommand : SuspendingNoOpCliktCommand(name = "auth") {
 }
 
 class AuthenticationError : ProgramResult(1) {
-    override val message = "Not authenticated. Please run '$COMMAND_NAME auth login'."
+    override val message = "Authentication required. Please run '$COMMAND_NAME auth login'."
 }

--- a/cli/src/commonMain/kotlin/AuthCommand.kt
+++ b/cli/src/commonMain/kotlin/AuthCommand.kt
@@ -21,7 +21,6 @@ package org.eclipse.apoapsis.ortserver.cli
 
 import com.github.ajalt.clikt.command.SuspendingNoOpCliktCommand
 import com.github.ajalt.clikt.core.Context
-import com.github.ajalt.clikt.core.ProgramResult
 import com.github.ajalt.clikt.core.subcommands
 
 class AuthCommand : SuspendingNoOpCliktCommand(name = "auth") {
@@ -30,8 +29,4 @@ class AuthCommand : SuspendingNoOpCliktCommand(name = "auth") {
     }
 
     override fun help(context: Context) = "Commands for authentication with the ORT Server."
-}
-
-class AuthenticationError : ProgramResult(1) {
-    override val message = "Authentication required. Please run '$COMMAND_NAME auth login'."
 }

--- a/cli/src/commonMain/kotlin/InfoCommand.kt
+++ b/cli/src/commonMain/kotlin/InfoCommand.kt
@@ -30,6 +30,7 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.long
 
+import org.eclipse.apoapsis.ortserver.cli.model.AuthenticationError
 import org.eclipse.apoapsis.ortserver.cli.model.printables.toPrintable
 import org.eclipse.apoapsis.ortserver.cli.utils.createOrtServerClient
 import org.eclipse.apoapsis.ortserver.cli.utils.echoMessage

--- a/cli/src/commonMain/kotlin/InfoCommand.kt
+++ b/cli/src/commonMain/kotlin/InfoCommand.kt
@@ -30,7 +30,9 @@ import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.long
 
+import org.eclipse.apoapsis.ortserver.cli.model.printables.toPrintable
 import org.eclipse.apoapsis.ortserver.cli.utils.createOrtServerClient
+import org.eclipse.apoapsis.ortserver.cli.utils.echoMessage
 import org.eclipse.apoapsis.ortserver.client.NotFoundException
 
 class InfoCommand : SuspendingCliktCommand(name = "info") {
@@ -73,7 +75,7 @@ class InfoCommand : SuspendingCliktCommand(name = "info") {
             }
         } ?: throw ProgramResult(1)
 
-        echo(json.encodeToString(ortRun))
+        echoMessage(ortRun.toPrintable())
     }
 }
 

--- a/cli/src/commonMain/kotlin/LoginCommand.kt
+++ b/cli/src/commonMain/kotlin/LoginCommand.kt
@@ -28,6 +28,7 @@ import com.github.ajalt.clikt.parameters.options.required
 import org.eclipse.apoapsis.ortserver.cli.model.AuthenticationStorage
 import org.eclipse.apoapsis.ortserver.cli.model.HostAuthenticationDetails
 import org.eclipse.apoapsis.ortserver.cli.model.Tokens
+import org.eclipse.apoapsis.ortserver.cli.utils.echoMessage
 import org.eclipse.apoapsis.ortserver.client.OrtServerClient.Companion.JSON
 import org.eclipse.apoapsis.ortserver.client.auth.AuthService
 import org.eclipse.apoapsis.ortserver.client.createDefaultHttpClient
@@ -90,6 +91,6 @@ class LoginCommand : SuspendingCliktCommand(name = "login") {
             )
         )
 
-        echo("Successfully logged in to '$baseUrl' as '$username'.")
+        echoMessage("Successfully logged in to '$baseUrl' as '$username'.")
     }
 }

--- a/cli/src/commonMain/kotlin/LogsCommand.kt
+++ b/cli/src/commonMain/kotlin/LogsCommand.kt
@@ -38,6 +38,7 @@ import okio.Path.Companion.toPath
 import org.eclipse.apoapsis.ortserver.api.v1.model.LogLevel
 import org.eclipse.apoapsis.ortserver.api.v1.model.LogSource
 import org.eclipse.apoapsis.ortserver.cli.utils.createOrtServerClient
+import org.eclipse.apoapsis.ortserver.cli.utils.echoMessage
 import org.eclipse.apoapsis.ortserver.cli.utils.mkdirs
 import org.eclipse.apoapsis.ortserver.cli.utils.writeFromChannel
 import org.eclipse.apoapsis.ortserver.client.NotFoundException
@@ -98,7 +99,7 @@ class LogsCommand : SuspendingCliktCommand() {
         try {
             client.runs.downloadLogs(resolvedOrtRunId, resolvedLogLevel, steps) { outputFile.writeFromChannel(it) }
 
-            echo(outputFile.toString())
+            echoMessage(outputFile.toString())
         } catch (e: NotFoundException) {
             throw LogsNotFoundException("Logs not found for run '$resolvedOrtRunId'.", e)
         }

--- a/cli/src/commonMain/kotlin/LogsCommand.kt
+++ b/cli/src/commonMain/kotlin/LogsCommand.kt
@@ -37,6 +37,7 @@ import okio.Path.Companion.toPath
 
 import org.eclipse.apoapsis.ortserver.api.v1.model.LogLevel
 import org.eclipse.apoapsis.ortserver.api.v1.model.LogSource
+import org.eclipse.apoapsis.ortserver.cli.model.AuthenticationError
 import org.eclipse.apoapsis.ortserver.cli.utils.createOrtServerClient
 import org.eclipse.apoapsis.ortserver.cli.utils.echoMessage
 import org.eclipse.apoapsis.ortserver.cli.utils.mkdirs

--- a/cli/src/commonMain/kotlin/OrtServerMain.kt
+++ b/cli/src/commonMain/kotlin/OrtServerMain.kt
@@ -19,12 +19,14 @@
 
 package org.eclipse.apoapsis.ortserver.cli
 
-import com.github.ajalt.clikt.command.SuspendingNoOpCliktCommand
+import com.github.ajalt.clikt.command.SuspendingCliktCommand
 import com.github.ajalt.clikt.command.parse
 import com.github.ajalt.clikt.completion.completionOption
 import com.github.ajalt.clikt.core.CliktError
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.versionOption
 import com.github.ajalt.mordant.platform.MultiplatformSystem.exitProcess
 
@@ -33,6 +35,7 @@ import kotlinx.serialization.json.Json
 
 import org.eclipse.apoapsis.ortserver.cli.model.OrtServerCliException
 import org.eclipse.apoapsis.ortserver.cli.utils.createOrtServerClient
+import org.eclipse.apoapsis.ortserver.cli.utils.useJsonFormat
 import org.eclipse.apoapsis.ortserver.client.OrtServerClient
 import org.eclipse.apoapsis.ortserver.client.OrtServerException
 import org.eclipse.apoapsis.ortserver.client.auth.AuthenticationException
@@ -67,7 +70,7 @@ fun main(args: Array<String>) {
     exitProcess(1)
 }
 
-class OrtServerMain : SuspendingNoOpCliktCommand(COMMAND_NAME) {
+class OrtServerMain : SuspendingCliktCommand(COMMAND_NAME) {
     init {
         completionOption(hidden = true)
 
@@ -81,9 +84,20 @@ class OrtServerMain : SuspendingNoOpCliktCommand(COMMAND_NAME) {
         )
     }
 
+    private val jsonFormat by option(
+        "--json",
+        envvar = "CLI_FORMAT_JSON",
+        help = "Print CLI messages as JSON."
+    ).flag()
+
     override fun help(context: Context) = """
         The ORT Server Client (OSC) is a Command Line Interface (CLI) to interact with an ORT Server instance.
     """.trimIndent()
+
+    override suspend fun run() {
+        // Make the jsonFormat flag available globally.
+        useJsonFormat = jsonFormat
+    }
 
     /**
      * Build the version information for the CLI and (if authenticated) for the ORT Server.

--- a/cli/src/commonMain/kotlin/OrtServerMain.kt
+++ b/cli/src/commonMain/kotlin/OrtServerMain.kt
@@ -69,7 +69,7 @@ fun main(args: Array<String>) {
 
 class OrtServerMain : SuspendingNoOpCliktCommand(COMMAND_NAME) {
     init {
-        completionOption()
+        completionOption(hidden = true)
 
         subcommands(AuthCommand(), RunsCommand())
 

--- a/cli/src/commonMain/kotlin/OrtServerMain.kt
+++ b/cli/src/commonMain/kotlin/OrtServerMain.kt
@@ -55,16 +55,16 @@ fun main(args: Array<String>) {
 
         exitProcess(0)
     } catch (e: AuthenticationException) {
-        cli.echo(e.message)
+        cli.echo(e.message, err = true)
     } catch (e: OrtServerCliException) {
-        cli.echo(e.message)
+        cli.echo(e.message, err = true)
     } catch (e: OrtServerException) {
-        cli.echo(e.message)
+        cli.echo(e.message, err = true)
     } catch (e: CliktError) {
         cli.echoFormattedHelp(e)
         cli.currentContext.exitProcess(e.statusCode)
     } catch (@Suppress("SwallowedException", "TooGenericExceptionCaught") e: Exception) {
-        cli.echo("An unexpected error occurred.")
+        cli.echo("An unexpected error occurred.", err = true)
     }
 
     exitProcess(1)

--- a/cli/src/commonMain/kotlin/OrtServerMain.kt
+++ b/cli/src/commonMain/kotlin/OrtServerMain.kt
@@ -35,6 +35,7 @@ import kotlinx.serialization.json.Json
 
 import org.eclipse.apoapsis.ortserver.cli.model.OrtServerCliException
 import org.eclipse.apoapsis.ortserver.cli.utils.createOrtServerClient
+import org.eclipse.apoapsis.ortserver.cli.utils.echoError
 import org.eclipse.apoapsis.ortserver.cli.utils.useJsonFormat
 import org.eclipse.apoapsis.ortserver.client.OrtServerClient
 import org.eclipse.apoapsis.ortserver.client.OrtServerException
@@ -55,16 +56,17 @@ fun main(args: Array<String>) {
 
         exitProcess(0)
     } catch (e: AuthenticationException) {
-        cli.echo(e.message, err = true)
+        cli.echoError(e.message)
     } catch (e: OrtServerCliException) {
-        cli.echo(e.message, err = true)
+        cli.echoError(e.message)
     } catch (e: OrtServerException) {
-        cli.echo(e.message, err = true)
+        cli.echoError(e.message)
     } catch (e: CliktError) {
+        // The jsonFormat flag is not supported for the help message.
         cli.echoFormattedHelp(e)
         cli.currentContext.exitProcess(e.statusCode)
     } catch (@Suppress("SwallowedException", "TooGenericExceptionCaught") e: Exception) {
-        cli.echo("An unexpected error occurred.", err = true)
+        cli.echoError("An unexpected error occurred.")
     }
 
     exitProcess(1)

--- a/cli/src/commonMain/kotlin/OrtServerMain.kt
+++ b/cli/src/commonMain/kotlin/OrtServerMain.kt
@@ -55,8 +55,8 @@ fun main(args: Array<String>) {
         }
 
         exitProcess(0)
-    } catch (e: AuthenticationException) {
-        cli.echoError(e.message)
+    } catch (@Suppress("SwallowedException") e: AuthenticationException) {
+        cli.echoError("Authentication failed. Please check your credentials.")
     } catch (e: OrtServerCliException) {
         cli.echoError(e.message)
     } catch (e: OrtServerException) {

--- a/cli/src/commonMain/kotlin/ReportsCommand.kt
+++ b/cli/src/commonMain/kotlin/ReportsCommand.kt
@@ -34,6 +34,7 @@ import com.github.ajalt.clikt.parameters.types.long
 import okio.Path.Companion.toPath
 
 import org.eclipse.apoapsis.ortserver.cli.utils.createOrtServerClient
+import org.eclipse.apoapsis.ortserver.cli.utils.echoMessage
 import org.eclipse.apoapsis.ortserver.cli.utils.mkdirs
 import org.eclipse.apoapsis.ortserver.cli.utils.writeFromChannel
 import org.eclipse.apoapsis.ortserver.client.NotFoundException
@@ -88,7 +89,7 @@ class ReportsCommand : SuspendingCliktCommand(name = "reports") {
             try {
                 client.runs.downloadReport(resolvedOrtRunId, fileName) { reportFile.writeFromChannel(it) }
 
-                echo(reportFile.toString())
+                echoMessage(reportFile.toString())
             } catch (e: NotFoundException) {
                 throw ReportNotFoundException("Report '$fileName' not found for run '$resolvedOrtRunId'.", e)
             }

--- a/cli/src/commonMain/kotlin/ReportsCommand.kt
+++ b/cli/src/commonMain/kotlin/ReportsCommand.kt
@@ -33,6 +33,7 @@ import com.github.ajalt.clikt.parameters.types.long
 
 import okio.Path.Companion.toPath
 
+import org.eclipse.apoapsis.ortserver.cli.model.AuthenticationError
 import org.eclipse.apoapsis.ortserver.cli.utils.createOrtServerClient
 import org.eclipse.apoapsis.ortserver.cli.utils.echoMessage
 import org.eclipse.apoapsis.ortserver.cli.utils.mkdirs

--- a/cli/src/commonMain/kotlin/StartCommand.kt
+++ b/cli/src/commonMain/kotlin/StartCommand.kt
@@ -38,6 +38,7 @@ import okio.Path.Companion.toPath
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatus
+import org.eclipse.apoapsis.ortserver.cli.model.AuthenticationError
 import org.eclipse.apoapsis.ortserver.cli.model.CliInputException
 import org.eclipse.apoapsis.ortserver.cli.model.printables.toPrintable
 import org.eclipse.apoapsis.ortserver.cli.utils.createOrtServerClient

--- a/cli/src/commonMain/kotlin/StartCommand.kt
+++ b/cli/src/commonMain/kotlin/StartCommand.kt
@@ -39,7 +39,9 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatus
 import org.eclipse.apoapsis.ortserver.cli.model.CliInputException
+import org.eclipse.apoapsis.ortserver.cli.model.printables.toPrintable
 import org.eclipse.apoapsis.ortserver.cli.utils.createOrtServerClient
+import org.eclipse.apoapsis.ortserver.cli.utils.echoMessage
 import org.eclipse.apoapsis.ortserver.cli.utils.read
 import org.eclipse.apoapsis.ortserver.client.NotFoundException
 
@@ -95,7 +97,7 @@ class StartCommand : SuspendingCliktCommand(name = "start") {
 
         ContextStorage.saveLatestRunId(ortRun.id)
 
-        echo(json.encodeToString(ortRun))
+        echoMessage(ortRun.toPrintable())
 
         if (wait) {
             while (ortRun.isRunning()) {
@@ -103,7 +105,7 @@ class StartCommand : SuspendingCliktCommand(name = "start") {
                 ortRun = client.repositories.getOrtRun(repositoryId, ortRun.index)
             }
 
-            echo(json.encodeToString(ortRun))
+            echoMessage(ortRun.toPrintable())
         }
     }
 }

--- a/cli/src/commonMain/kotlin/model/Exceptions.kt
+++ b/cli/src/commonMain/kotlin/model/Exceptions.kt
@@ -19,6 +19,9 @@
 
 package org.eclipse.apoapsis.ortserver.cli.model
 
+import com.github.ajalt.clikt.core.ProgramResult
+import org.eclipse.apoapsis.ortserver.cli.COMMAND_NAME
+
 /**
  * Base class for all exceptions caused by the ORT Server CLI.
  */
@@ -28,3 +31,10 @@ sealed class OrtServerCliException(message: String, cause: Throwable? = null) : 
  * An exception thrown when the user provides invalid input which is not handled by Clikt.
  */
 class CliInputException(message: String, cause: Throwable? = null) : OrtServerCliException(message, cause)
+
+/**
+ * An exception thrown when the user authentication or the re-authentication using a refresh token fails.
+ */
+class AuthenticationError : ProgramResult(1) {
+    override val message = "Authentication required. Please run '$COMMAND_NAME auth login'."
+}

--- a/cli/src/commonMain/kotlin/model/Exceptions.kt
+++ b/cli/src/commonMain/kotlin/model/Exceptions.kt
@@ -19,7 +19,6 @@
 
 package org.eclipse.apoapsis.ortserver.cli.model
 
-import com.github.ajalt.clikt.core.ProgramResult
 import org.eclipse.apoapsis.ortserver.cli.COMMAND_NAME
 
 /**
@@ -35,6 +34,5 @@ class CliInputException(message: String, cause: Throwable? = null) : OrtServerCl
 /**
  * An exception thrown when the user authentication or the re-authentication using a refresh token fails.
  */
-class AuthenticationError : ProgramResult(1) {
-    override val message = "Authentication required. Please run '$COMMAND_NAME auth login'."
-}
+class AuthenticationError(message: String = "Authentication required. Please run '$COMMAND_NAME auth login'.") :
+    OrtServerCliException(message, null)

--- a/cli/src/commonMain/kotlin/model/printables/CliPrintable.kt
+++ b/cli/src/commonMain/kotlin/model/printables/CliPrintable.kt
@@ -17,23 +17,12 @@
  * License-Filename: LICENSE
  */
 
-package org.eclipse.apoapsis.ortserver.cli
-
-import com.github.ajalt.clikt.command.SuspendingCliktCommand
-import com.github.ajalt.clikt.core.Context
-
-import org.eclipse.apoapsis.ortserver.cli.model.AuthenticationStorage
-import org.eclipse.apoapsis.ortserver.cli.utils.echoMessage
+package org.eclipse.apoapsis.ortserver.cli.model.printables
 
 /**
- * A command to logout from ORT Server instances.
+ * Interface that describes the way how objects can be printed in the CLI.
  */
-class LogoutCommand : SuspendingCliktCommand(name = "logout") {
-    override fun help(context: Context) = "Logout from all ORT Server instances."
-
-    override suspend fun run() {
-        AuthenticationStorage.clear()
-
-        echoMessage("Successfully logged out.")
-    }
+interface CliPrintable {
+    /** The JSON representation of this object. */
+    fun json(): String
 }

--- a/cli/src/commonMain/kotlin/model/printables/CliPrintable.kt
+++ b/cli/src/commonMain/kotlin/model/printables/CliPrintable.kt
@@ -19,10 +19,15 @@
 
 package org.eclipse.apoapsis.ortserver.cli.model.printables
 
+import com.github.ajalt.mordant.rendering.Widget
+
 /**
  * Interface that describes the way how objects can be printed in the CLI.
  */
 interface CliPrintable {
+    /** The human-readable representation of this object. */
+    fun humanReadable(): Widget
+
     /** The JSON representation of this object. */
     fun json(): String
 }

--- a/cli/src/commonMain/kotlin/model/printables/MessagePrintable.kt
+++ b/cli/src/commonMain/kotlin/model/printables/MessagePrintable.kt
@@ -19,6 +19,8 @@
 
 package org.eclipse.apoapsis.ortserver.cli.model.printables
 
+import com.github.ajalt.mordant.widgets.Text
+
 import kotlinx.serialization.Serializable
 
 import org.eclipse.apoapsis.ortserver.cli.json
@@ -28,9 +30,9 @@ import org.eclipse.apoapsis.ortserver.cli.json
  */
 @Serializable
 class MessagePrintable(private val message: String) : CliPrintable {
-    override fun json() = json.encodeToString(StringMessage(message))
+    override fun humanReadable() = Text(message)
 
-    override fun toString() = message
+    override fun json() = json.encodeToString(StringMessage(message))
 }
 
 fun String.toPrintable(): MessagePrintable = MessagePrintable(this)

--- a/cli/src/commonMain/kotlin/model/printables/MessagePrintable.kt
+++ b/cli/src/commonMain/kotlin/model/printables/MessagePrintable.kt
@@ -17,23 +17,26 @@
  * License-Filename: LICENSE
  */
 
-package org.eclipse.apoapsis.ortserver.cli
+package org.eclipse.apoapsis.ortserver.cli.model.printables
 
-import com.github.ajalt.clikt.command.SuspendingCliktCommand
-import com.github.ajalt.clikt.core.Context
+import kotlinx.serialization.Serializable
 
-import org.eclipse.apoapsis.ortserver.cli.model.AuthenticationStorage
-import org.eclipse.apoapsis.ortserver.cli.utils.echoMessage
+import org.eclipse.apoapsis.ortserver.cli.json
 
 /**
- * A command to logout from ORT Server instances.
+ * A [CliPrintable] that prints a simple [String] message.
  */
-class LogoutCommand : SuspendingCliktCommand(name = "logout") {
-    override fun help(context: Context) = "Logout from all ORT Server instances."
+@Serializable
+class MessagePrintable(private val message: String) : CliPrintable {
+    override fun json() = json.encodeToString(StringMessage(message))
 
-    override suspend fun run() {
-        AuthenticationStorage.clear()
-
-        echoMessage("Successfully logged out.")
-    }
+    override fun toString() = message
 }
+
+fun String.toPrintable(): MessagePrintable = MessagePrintable(this)
+
+/**
+ * A wrapper for JSON formatting of a String.
+ */
+@Serializable
+private data class StringMessage(val message: String)

--- a/cli/src/commonMain/kotlin/model/printables/OrtRunPrintable.kt
+++ b/cli/src/commonMain/kotlin/model/printables/OrtRunPrintable.kt
@@ -19,14 +19,91 @@
 
 package org.eclipse.apoapsis.ortserver.cli.model.printables
 
+import com.github.ajalt.mordant.rendering.TextColors.blue
+import com.github.ajalt.mordant.rendering.TextColors.cyan
+import com.github.ajalt.mordant.rendering.TextColors.green
+import com.github.ajalt.mordant.rendering.TextColors.red
+import com.github.ajalt.mordant.rendering.TextColors.yellow
+import com.github.ajalt.mordant.rendering.Widget
+import com.github.ajalt.mordant.table.GridBuilder
+import com.github.ajalt.mordant.table.grid
+
+import org.eclipse.apoapsis.ortserver.api.v1.model.JobStatus
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRun
+import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatus
 import org.eclipse.apoapsis.ortserver.cli.json
 
 /**
  * A [CliPrintable] for a formatted and reduced [OrtRun] object.
  */
 class OrtRunPrintable(private val ortRun: OrtRun) : CliPrintable {
+    override fun humanReadable(): Widget {
+        return grid {
+            row(yellow("ORT Run Information"))
+            formattedRow("ID", ortRun.id)
+            formattedRow("Repository ID", ortRun.repositoryId)
+            formattedRow("Index", ortRun.index)
+            formattedStatusRow("Status", ortRun.status)
+            formattedRow("Created", ortRun.createdAt)
+            formattedRow("Revision", ortRun.revision)
+            ortRun.path?.takeIf { it.isNotBlank() }?.also { formattedRow("Path", it) }
+            ortRun.userDisplayName?.takeIf { it.username.isNotBlank() }
+                ?.also { formattedRow("User", "${it.fullName} (${it.username})") }
+            ortRun.jobConfigContext?.takeIf { it.isNotBlank() }?.also { formattedRow("Config Context", it) }
+
+            row()
+            if (ortRun.hasAnyJobs()) {
+                row(yellow("Job Status"))
+                ortRun.jobs.analyzer?.status?.also { formattedStatusRow("Analyzer Status", it) }
+                ortRun.jobs.advisor?.status?.also { formattedStatusRow("Advisor Status", it) }
+                ortRun.jobs.scanner?.status?.also { formattedStatusRow("Scanner Status", it) }
+                ortRun.jobs.evaluator?.status?.also { formattedStatusRow("Evaluator Status", it) }
+                ortRun.jobs.reporter?.status?.also { formattedStatusRow("Reporter Status", it) }
+                ortRun.jobs.notifier?.status?.also { formattedStatusRow("Notifier Status", it) }
+            }
+        }
+    }
+
     override fun json() = json.encodeToString(ortRun)
 }
 
 fun OrtRun.toPrintable(): OrtRunPrintable = OrtRunPrintable(this)
+
+private fun GridBuilder.formattedRow(name: String, value: Any) {
+    row(blue(name), value.toString()) {
+        padding { left = 2 }
+     }
+}
+
+private fun <T : Enum<T>> GridBuilder.formattedStatusRow(name: String, status: T) {
+    val color = when (status) {
+        is OrtRunStatus -> when (status) {
+            OrtRunStatus.CREATED, OrtRunStatus.ACTIVE -> yellow
+            OrtRunStatus.FINISHED -> green
+            OrtRunStatus.FAILED -> red
+            OrtRunStatus.FINISHED_WITH_ISSUES -> cyan
+        }
+        is JobStatus -> when (status) {
+            JobStatus.CREATED, JobStatus.SCHEDULED, JobStatus.RUNNING -> yellow
+            JobStatus.FINISHED -> green
+            JobStatus.FAILED -> red
+            JobStatus.FINISHED_WITH_ISSUES -> cyan
+        }
+        else -> null
+    }
+
+    val stringStatus = status.toString()
+    if (color != null) {
+        row(blue(name), color(stringStatus)) { padding { left = 2 } }
+    } else {
+        row(blue(name), stringStatus) { padding { left = 2 } }
+    }
+}
+
+private fun OrtRun.hasAnyJobs() =
+    jobs.analyzer != null ||
+    jobs.advisor != null ||
+    jobs.scanner != null ||
+    jobs.evaluator != null ||
+    jobs.reporter != null ||
+    jobs.notifier != null

--- a/cli/src/commonMain/kotlin/model/printables/OrtRunPrintable.kt
+++ b/cli/src/commonMain/kotlin/model/printables/OrtRunPrintable.kt
@@ -17,23 +17,16 @@
  * License-Filename: LICENSE
  */
 
-package org.eclipse.apoapsis.ortserver.cli
+package org.eclipse.apoapsis.ortserver.cli.model.printables
 
-import com.github.ajalt.clikt.command.SuspendingCliktCommand
-import com.github.ajalt.clikt.core.Context
-
-import org.eclipse.apoapsis.ortserver.cli.model.AuthenticationStorage
-import org.eclipse.apoapsis.ortserver.cli.utils.echoMessage
+import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRun
+import org.eclipse.apoapsis.ortserver.cli.json
 
 /**
- * A command to logout from ORT Server instances.
+ * A [CliPrintable] for a formatted and reduced [OrtRun] object.
  */
-class LogoutCommand : SuspendingCliktCommand(name = "logout") {
-    override fun help(context: Context) = "Logout from all ORT Server instances."
-
-    override suspend fun run() {
-        AuthenticationStorage.clear()
-
-        echoMessage("Successfully logged out.")
-    }
+class OrtRunPrintable(private val ortRun: OrtRun) : CliPrintable {
+    override fun json() = json.encodeToString(ortRun)
 }
+
+fun OrtRun.toPrintable(): OrtRunPrintable = OrtRunPrintable(this)

--- a/cli/src/commonMain/kotlin/utils/PrintHelper.kt
+++ b/cli/src/commonMain/kotlin/utils/PrintHelper.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.cli.utils
+
+/**
+ * Global variable that gets toggled by a command line parameter parsed in the main entry points of the modules.
+ */
+var useJsonFormat = false

--- a/cli/src/commonMain/kotlin/utils/PrintHelper.kt
+++ b/cli/src/commonMain/kotlin/utils/PrintHelper.kt
@@ -50,8 +50,7 @@ internal fun SuspendingCliktCommand.echoMessage(message: CliPrintable) {
     if (useJsonFormat) {
         echo(message.json())
     } else {
-        // TODO: Replace with human readable formatting.
-        echo(message.toString())
+        echo(message.humanReadable())
     }
 }
 

--- a/cli/src/commonMain/kotlin/utils/PrintHelper.kt
+++ b/cli/src/commonMain/kotlin/utils/PrintHelper.kt
@@ -19,7 +19,27 @@
 
 package org.eclipse.apoapsis.ortserver.cli.utils
 
+import com.github.ajalt.clikt.command.SuspendingCliktCommand
+
+import kotlinx.serialization.Serializable
+
+import org.eclipse.apoapsis.ortserver.cli.json
+
 /**
  * Global variable that gets toggled by a command line parameter parsed in the main entry points of the modules.
  */
 var useJsonFormat = false
+
+/**
+ * Print the [message] of an error to stderr. If required as a [json][CliError] object.
+ */
+internal fun SuspendingCliktCommand.echoError(message: String?) {
+    if (useJsonFormat) {
+        echo(json.encodeToString(CliError(message)), err = true)
+    } else {
+        echo(message, err = true)
+    }
+}
+
+@Serializable
+private data class CliError(val message: String?)

--- a/cli/src/commonMain/kotlin/utils/PrintHelper.kt
+++ b/cli/src/commonMain/kotlin/utils/PrintHelper.kt
@@ -24,6 +24,8 @@ import com.github.ajalt.clikt.command.SuspendingCliktCommand
 import kotlinx.serialization.Serializable
 
 import org.eclipse.apoapsis.ortserver.cli.json
+import org.eclipse.apoapsis.ortserver.cli.model.printables.CliPrintable
+import org.eclipse.apoapsis.ortserver.cli.model.printables.toPrintable
 
 /**
  * Global variable that gets toggled by a command line parameter parsed in the main entry points of the modules.
@@ -40,6 +42,20 @@ internal fun SuspendingCliktCommand.echoError(message: String?) {
         echo(message, err = true)
     }
 }
+
+/**
+ * Print the [message] to stdout. If required as a json object.
+ */
+internal fun SuspendingCliktCommand.echoMessage(message: CliPrintable) {
+    if (useJsonFormat) {
+        echo(message.json())
+    } else {
+        // TODO: Replace with human readable formatting.
+        echo(message.toString())
+    }
+}
+
+internal fun SuspendingCliktCommand.echoMessage(message: String) = echoMessage(message.toPrintable())
 
 @Serializable
 private data class CliError(val message: String?)

--- a/cli/src/jvmTest/kotlin/InfoCommandTest.kt
+++ b/cli/src/jvmTest/kotlin/InfoCommandTest.kt
@@ -49,7 +49,7 @@ import org.eclipse.apoapsis.ortserver.client.api.RunsApi
 class InfoCommandTest : StringSpec({
     afterEach { unmockkAll() }
 
-    "info command should get ORT run by ID" {
+    "info command should get ORT run JSON by ID" {
         val ortRunId = 1L
 
         val ortRun = OrtRun(
@@ -80,6 +80,7 @@ class InfoCommandTest : StringSpec({
         val command = OrtServerMain()
         val result = command.test(
             listOf(
+                "--json",
                 "runs",
                 "info",
                 "--run-id",
@@ -95,7 +96,7 @@ class InfoCommandTest : StringSpec({
         result.output shouldContain json.encodeToString(ortRun)
     }
 
-    "info command should get ORT run by index" {
+    "info command should get ORT run JSON by index" {
         val repositoryId = 1L
         val ortRunIndex = 1L
 
@@ -127,6 +128,7 @@ class InfoCommandTest : StringSpec({
         val command = OrtServerMain()
         val result = command.test(
             listOf(
+                "--json",
                 "runs",
                 "info",
                 "--repository-id",

--- a/cli/src/jvmTest/kotlin/InfoCommandTest.kt
+++ b/cli/src/jvmTest/kotlin/InfoCommandTest.kt
@@ -177,18 +177,6 @@ class InfoCommandTest : StringSpec({
         }
     }
 
-    "info command should fail if no options are provided" {
-        val command = OrtServerMain()
-        val result = command.test(
-            listOf(
-                "runs",
-                "info"
-            )
-        )
-
-        result.statusCode shouldNotBe 0
-    }
-
     "info command should fail if both options are provided" {
         val command = OrtServerMain()
         val result = command.test(

--- a/cli/src/jvmTest/kotlin/StartCommandTest.kt
+++ b/cli/src/jvmTest/kotlin/StartCommandTest.kt
@@ -81,6 +81,7 @@ class StartCommandTest : StringSpec({
         val command = OrtServerMain()
         val result = command.test(
             listOf(
+                "--json",
                 "runs",
                 "start",
                 "--repository-id",
@@ -142,6 +143,7 @@ class StartCommandTest : StringSpec({
         val command = OrtServerMain()
         val result = command.test(
             listOf(
+                "--json",
                 "runs",
                 "start",
                 "--repository-id",

--- a/integrations/completions/osc-completion.bash
+++ b/integrations/completions/osc-completion.bash
@@ -42,6 +42,11 @@ _osc() {
           in_param=''
           continue
           ;;
+        --json)
+          __skip_opt_eq
+          in_param=''
+          continue
+          ;;
         -h|--help)
           __skip_opt_eq
           in_param=''
@@ -67,7 +72,7 @@ _osc() {
   done
   local word="${COMP_WORDS[$COMP_CWORD]}"
   if [[ "${word}" =~ ^[-] ]]; then
-    COMPREPLY=($(compgen -W '--version -v -h --help' -- "${word}"))
+    COMPREPLY=($(compgen -W '--version -v --json -h --help' -- "${word}"))
     return
   fi
 
@@ -78,6 +83,8 @@ _osc() {
 
   case "${in_param}" in
     "--version")
+      ;;
+    "--json")
       ;;
     "--help")
       ;;

--- a/integrations/completions/osc-completion.bash
+++ b/integrations/completions/osc-completion.bash
@@ -11,6 +11,17 @@ __skip_opt_eq() {
     fi
 }
 
+__complete_files() {
+   # Generate filename completions
+   local word="$1"
+   local IFS=$'\n'
+
+   # quote each completion to support spaces and special characters
+   COMPREPLY=($(compgen -o filenames -f -- "$word" | while read -r line; do
+       printf "%q\n" "$line"
+   done))
+}
+
 _osc() {
   local i=1
   local in_param=''
@@ -24,12 +35,6 @@ _osc() {
         --)
           can_parse_options=0
           (( i = i + 1 ));
-          continue
-          ;;
-        --generate-completion)
-          __skip_opt_eq
-          (( i = i + 1 ))
-          [[ ${i} -gt COMP_CWORD ]] && in_param='--generate-completion' || in_param=''
           continue
           ;;
         --version|-v)
@@ -62,7 +67,7 @@ _osc() {
   done
   local word="${COMP_WORDS[$COMP_CWORD]}"
   if [[ "${word}" =~ ^[-] ]]; then
-    COMPREPLY=($(compgen -W '--generate-completion --version -v -h --help' -- "${word}"))
+    COMPREPLY=($(compgen -W '--version -v -h --help' -- "${word}"))
     return
   fi
 
@@ -72,11 +77,9 @@ _osc() {
   [[ -z "${in_param}" ]] && in_param=${vararg_name}
 
   case "${in_param}" in
-    --generate-completion)
+    "--version")
       ;;
-    --version)
-      ;;
-    --help)
+    "--help")
       ;;
     *)
       COMPREPLY=($(compgen -W 'auth runs' -- "${word}"))
@@ -107,10 +110,6 @@ _osc_auth() {
       esac
     fi
     case "${COMP_WORDS[$i]}" in
-      info)
-        _osc_auth_info $(( i + 1 ))
-        return
-        ;;
       login)
         _osc_auth_login $(( i + 1 ))
         return
@@ -138,57 +137,10 @@ _osc_auth() {
   [[ -z "${in_param}" ]] && in_param=${vararg_name}
 
   case "${in_param}" in
-    --help)
+    "--help")
       ;;
     *)
-      COMPREPLY=($(compgen -W 'info login logout' -- "${word}"))
-      ;;
-  esac
-}
-
-_osc_auth_info() {
-  local i=$1
-  local in_param=''
-  local fixed_arg_names=()
-  local vararg_name=''
-  local can_parse_options=1
-
-  while [[ ${i} -lt $COMP_CWORD ]]; do
-    if [[ ${can_parse_options} -eq 1 ]]; then
-      case "${COMP_WORDS[$i]}" in
-        --)
-          can_parse_options=0
-          (( i = i + 1 ));
-          continue
-          ;;
-        -h|--help)
-          __skip_opt_eq
-          in_param=''
-          continue
-          ;;
-      esac
-    fi
-    case "${COMP_WORDS[$i]}" in
-      *)
-        (( i = i + 1 ))
-        # drop the head of the array
-        fixed_arg_names=("${fixed_arg_names[@]:1}")
-        ;;
-    esac
-  done
-  local word="${COMP_WORDS[$COMP_CWORD]}"
-  if [[ "${word}" =~ ^[-] ]]; then
-    COMPREPLY=($(compgen -W '-h --help' -- "${word}"))
-    return
-  fi
-
-  # We're either at an option's value, or the first remaining fixed size
-  # arg, or the vararg if there are no fixed args left
-  [[ -z "${in_param}" ]] && in_param=${fixed_arg_names[0]}
-  [[ -z "${in_param}" ]] && in_param=${vararg_name}
-
-  case "${in_param}" in
-    --help)
+      COMPREPLY=($(compgen -W 'login logout' -- "${word}"))
       ;;
   esac
 }
@@ -265,17 +217,17 @@ _osc_auth_login() {
   [[ -z "${in_param}" ]] && in_param=${vararg_name}
 
   case "${in_param}" in
-    --base-url)
+    "--base-url")
       ;;
-    --token-url)
+    "--token-url")
       ;;
-    --client-id)
+    "--client-id")
       ;;
-    --username)
+    "--username")
       ;;
-    --password)
+    "--password")
       ;;
-    --help)
+    "--help")
       ;;
   esac
 }
@@ -322,7 +274,7 @@ _osc_auth_logout() {
   [[ -z "${in_param}" ]] && in_param=${vararg_name}
 
   case "${in_param}" in
-    --help)
+    "--help")
       ;;
   esac
 }
@@ -381,7 +333,7 @@ _osc_runs() {
   [[ -z "${in_param}" ]] && in_param=${vararg_name}
 
   case "${in_param}" in
-    --help)
+    "--help")
       ;;
     *)
       COMPREPLY=($(compgen -W 'download info start' -- "${word}"))
@@ -439,7 +391,7 @@ _osc_runs_download() {
   [[ -z "${in_param}" ]] && in_param=${vararg_name}
 
   case "${in_param}" in
-    --help)
+    "--help")
       ;;
     *)
       COMPREPLY=($(compgen -W 'logs reports' -- "${word}"))
@@ -525,22 +477,21 @@ _osc_runs_download_logs() {
   [[ -z "${in_param}" ]] && in_param=${vararg_name}
 
   case "${in_param}" in
-    --run-id)
+    "--run-id")
       ;;
-    --repository-id)
+    "--repository-id")
       ;;
-    --index)
+    "--index")
       ;;
-    --output-dir)
-       COMPREPLY=($(compgen -o default -- "${word}"))
+    "--output-dir")
       ;;
-    --level)
+    "--level")
       COMPREPLY=($(compgen -W 'DEBUG INFO WARN ERROR' -- "${word}"))
       ;;
-    --steps)
+    "--steps")
       COMPREPLY=($(compgen -W 'CONFIG ANALYZER ADVISOR SCANNER EVALUATOR REPORTER NOTIFIER' -- "${word}"))
       ;;
-    --help)
+    "--help")
       ;;
   esac
 }
@@ -617,18 +568,17 @@ _osc_runs_download_reports() {
   [[ -z "${in_param}" ]] && in_param=${vararg_name}
 
   case "${in_param}" in
-    --run-id)
+    "--run-id")
       ;;
-    --repository-id)
+    "--repository-id")
       ;;
-    --index)
+    "--index")
       ;;
-    --file-names)
+    "--file-names")
       ;;
-    --output-dir)
-       COMPREPLY=($(compgen -o default -- "${word}"))
+    "--output-dir")
       ;;
-    --help)
+    "--help")
       ;;
   esac
 }
@@ -693,13 +643,13 @@ _osc_runs_info() {
   [[ -z "${in_param}" ]] && in_param=${vararg_name}
 
   case "${in_param}" in
-    --run-id)
+    "--run-id")
       ;;
-    --repository-id)
+    "--repository-id")
       ;;
-    --index)
+    "--index")
       ;;
-    --help)
+    "--help")
       ;;
   esac
 }
@@ -769,16 +719,15 @@ _osc_runs_start() {
   [[ -z "${in_param}" ]] && in_param=${vararg_name}
 
   case "${in_param}" in
-    --repository-id)
+    "--repository-id")
       ;;
-    --wait)
+    "--wait")
       ;;
-    --parameters-file)
-       COMPREPLY=($(compgen -o default -- "${word}"))
+    "--parameters-file")
       ;;
-    --parameters)
+    "--parameters")
       ;;
-    --help)
+    "--help")
       ;;
   esac
 }

--- a/integrations/completions/osc-completion.fish
+++ b/integrations/completions/osc-completion.fish
@@ -6,24 +6,16 @@
 set -l osc_subcommands 'auth runs'
 
 ## Options for osc
-complete -c osc -n "not __fish_seen_subcommand_from $osc_subcommands" -l generate-completion -r
-complete -c osc -n "not __fish_seen_subcommand_from $osc_subcommands" -l version -s v -d 'Show the version and exit.'
+complete -c osc -n "not __fish_seen_subcommand_from $osc_subcommands" -l version -s v -d 'Show the version of the CLI and the ORT Server if authenticated.'
 complete -c osc -n "not __fish_seen_subcommand_from $osc_subcommands" -s h -l help -d 'Show this message and exit'
 
 
 ### Setup for auth
-set -l osc_auth_subcommands 'info login logout'
+set -l osc_auth_subcommands 'login logout'
 complete -c osc -f -n __fish_use_subcommand -a auth -d 'Commands for authentication with the ORT Server.'
 
 ## Options for auth
 complete -c osc -n "__fish_seen_subcommand_from auth" -s h -l help -d 'Show this message and exit'
-
-
-### Setup for info
-complete -c osc -f -n "__fish_seen_subcommand_from auth; and not __fish_seen_subcommand_from $osc_auth_subcommands" -a info -d 'Show information about the current authentication status.'
-
-## Options for info
-complete -c osc -n "__fish_seen_subcommand_from info" -s h -l help -d 'Show this message and exit'
 
 
 ### Setup for login
@@ -47,7 +39,7 @@ complete -c osc -n "__fish_seen_subcommand_from logout" -s h -l help -d 'Show th
 
 ### Setup for runs
 set -l osc_runs_subcommands 'download info start'
-complete -c osc -f -n __fish_use_subcommand -a runs -d 'Commands for managing runs on the ORT Server.'
+complete -c osc -f -n __fish_use_subcommand -a runs -d 'Commands to manage runs.'
 
 ## Options for runs
 complete -c osc -n "__fish_seen_subcommand_from runs" -s h -l help -d 'Show this message and exit'
@@ -55,39 +47,39 @@ complete -c osc -n "__fish_seen_subcommand_from runs" -s h -l help -d 'Show this
 
 ### Setup for download
 set -l osc_runs_download_subcommands 'logs reports'
-complete -c osc -f -n "__fish_seen_subcommand_from runs; and not __fish_seen_subcommand_from $osc_runs_subcommands" -a download -d 'Commands for downloading results and detailed information about ORT runs.'
+complete -c osc -f -n "__fish_seen_subcommand_from runs; and not __fish_seen_subcommand_from $osc_runs_subcommands" -a download -d 'Commands to download files for a run.'
 
 ## Options for download
 complete -c osc -n "__fish_seen_subcommand_from download" -s h -l help -d 'Show this message and exit'
 
 
 ### Setup for logs
-complete -c osc -f -n "__fish_seen_subcommand_from download; and not __fish_seen_subcommand_from $osc_runs_download_subcommands" -a logs -d 'Download logs for an ORT run.'
+complete -c osc -f -n "__fish_seen_subcommand_from download; and not __fish_seen_subcommand_from $osc_runs_download_subcommands" -a logs -d 'Download a ZIP archive with logs for a run.'
 
 ## Options for logs
 complete -c osc -n "__fish_seen_subcommand_from logs" -l run-id -r -d 'The ID of the ORT run.'
 complete -c osc -n "__fish_seen_subcommand_from logs" -l repository-id -r -d 'The ID of the repository.'
 complete -c osc -n "__fish_seen_subcommand_from logs" -l index -r -d 'The index of the ORT run.'
-complete -c osc -n "__fish_seen_subcommand_from logs" -l output-dir -s o -r -F -d 'The directory to download the logs to.'
+complete -c osc -n "__fish_seen_subcommand_from logs" -l output-dir -s o -r -d 'The directory to download the logs to.'
 complete -c osc -n "__fish_seen_subcommand_from logs" -l level -r -fa "DEBUG INFO WARN ERROR" -d 'The log level of the logs to download, one of DEBUG, INFO, WARN, ERROR.'
 complete -c osc -n "__fish_seen_subcommand_from logs" -l steps -r -fa "CONFIG ANALYZER ADVISOR SCANNER EVALUATOR REPORTER NOTIFIER" -d 'The run steps for which logs are to be retrieved, separated by commas.'
 complete -c osc -n "__fish_seen_subcommand_from logs" -s h -l help -d 'Show this message and exit'
 
 
 ### Setup for reports
-complete -c osc -f -n "__fish_seen_subcommand_from download; and not __fish_seen_subcommand_from $osc_runs_download_subcommands" -a reports -d 'Download reports from an ORT run.'
+complete -c osc -f -n "__fish_seen_subcommand_from download; and not __fish_seen_subcommand_from $osc_runs_download_subcommands" -a reports -d 'Download reports for a run.'
 
 ## Options for reports
-complete -c osc -n "__fish_seen_subcommand_from reports" -l run-id -r -d 'The ID of the ORT run.'
+complete -c osc -n "__fish_seen_subcommand_from reports" -l run-id -r -d 'The ID of the ORT run, or the latest one started via osc.'
 complete -c osc -n "__fish_seen_subcommand_from reports" -l repository-id -r -d 'The ID of the repository.'
 complete -c osc -n "__fish_seen_subcommand_from reports" -l index -r -d 'The index of the ORT run.'
 complete -c osc -n "__fish_seen_subcommand_from reports" -l file-names -l filenames -r -d 'The names of the files to download, separated by commas.'
-complete -c osc -n "__fish_seen_subcommand_from reports" -l output-dir -s o -r -F -d 'The directory to download the reports to.'
+complete -c osc -n "__fish_seen_subcommand_from reports" -l output-dir -s o -r -d 'The directory to download the reports to.'
 complete -c osc -n "__fish_seen_subcommand_from reports" -s h -l help -d 'Show this message and exit'
 
 
 ### Setup for info
-complete -c osc -f -n "__fish_seen_subcommand_from runs; and not __fish_seen_subcommand_from $osc_runs_subcommands" -a info -d 'Show information about an ORT run.'
+complete -c osc -f -n "__fish_seen_subcommand_from runs; and not __fish_seen_subcommand_from $osc_runs_subcommands" -a info -d 'Print information about a run.'
 
 ## Options for info
 complete -c osc -n "__fish_seen_subcommand_from info" -l run-id -r -d 'The ID of the ORT run.'
@@ -97,12 +89,12 @@ complete -c osc -n "__fish_seen_subcommand_from info" -s h -l help -d 'Show this
 
 
 ### Setup for start
-complete -c osc -f -n "__fish_seen_subcommand_from runs; and not __fish_seen_subcommand_from $osc_runs_subcommands" -a start -d 'Start a new ORT run.'
+complete -c osc -f -n "__fish_seen_subcommand_from runs; and not __fish_seen_subcommand_from $osc_runs_subcommands" -a start -d 'Start a new run.'
 
 ## Options for start
 complete -c osc -n "__fish_seen_subcommand_from start" -l repository-id -r -d 'The ID of the repository.'
 complete -c osc -n "__fish_seen_subcommand_from start" -l wait -d 'Wait for the run to finish.'
-complete -c osc -n "__fish_seen_subcommand_from start" -l parameters-file -r -F -d 'The path to the Create ORT run configuration file!'
-complete -c osc -n "__fish_seen_subcommand_from start" -l parameters -r -d 'The Create ORT run configuration as a string.'
+complete -c osc -n "__fish_seen_subcommand_from start" -l parameters-file -r -d 'The path to a JSON file containing the run configuration (see https://eclipse-apoapsis.github.io/ort-server/api/post-ort-run).'
+complete -c osc -n "__fish_seen_subcommand_from start" -l parameters -r -d 'The run configuration as a JSON string (see https://eclipse-apoapsis.github.io/ort-server/api/post-ort-run).'
 complete -c osc -n "__fish_seen_subcommand_from start" -s h -l help -d 'Show this message and exit'
 

--- a/integrations/completions/osc-completion.fish
+++ b/integrations/completions/osc-completion.fish
@@ -7,6 +7,7 @@ set -l osc_subcommands 'auth runs'
 
 ## Options for osc
 complete -c osc -n "not __fish_seen_subcommand_from $osc_subcommands" -l version -s v -d 'Show the version of the CLI and the ORT Server if authenticated.'
+complete -c osc -n "not __fish_seen_subcommand_from $osc_subcommands" -l json -d 'Print CLI messages as JSON.'
 complete -c osc -n "not __fish_seen_subcommand_from $osc_subcommands" -s h -l help -d 'Show this message and exit'
 
 

--- a/integrations/completions/osc-completion.zsh
+++ b/integrations/completions/osc-completion.zsh
@@ -16,6 +16,17 @@ __skip_opt_eq() {
     fi
 }
 
+__complete_files() {
+   # Generate filename completions
+   local word="$1"
+   local IFS=$'\n'
+
+   # quote each completion to support spaces and special characters
+   COMPREPLY=($(compgen -o filenames -f -- "$word" | while read -r line; do
+       printf "%q\n" "$line"
+   done))
+}
+
 _osc() {
   local i=1
   local in_param=''
@@ -29,12 +40,6 @@ _osc() {
         --)
           can_parse_options=0
           (( i = i + 1 ));
-          continue
-          ;;
-        --generate-completion)
-          __skip_opt_eq
-          (( i = i + 1 ))
-          [[ ${i} -gt COMP_CWORD ]] && in_param='--generate-completion' || in_param=''
           continue
           ;;
         --version|-v)
@@ -67,7 +72,7 @@ _osc() {
   done
   local word="${COMP_WORDS[$COMP_CWORD]}"
   if [[ "${word}" =~ ^[-] ]]; then
-    COMPREPLY=($(compgen -W '--generate-completion --version -v -h --help' -- "${word}"))
+    COMPREPLY=($(compgen -W '--version -v -h --help' -- "${word}"))
     return
   fi
 
@@ -77,11 +82,9 @@ _osc() {
   [[ -z "${in_param}" ]] && in_param=${vararg_name}
 
   case "${in_param}" in
-    --generate-completion)
+    "--version")
       ;;
-    --version)
-      ;;
-    --help)
+    "--help")
       ;;
     *)
       COMPREPLY=($(compgen -W 'auth runs' -- "${word}"))
@@ -112,10 +115,6 @@ _osc_auth() {
       esac
     fi
     case "${COMP_WORDS[$i]}" in
-      info)
-        _osc_auth_info $(( i + 1 ))
-        return
-        ;;
       login)
         _osc_auth_login $(( i + 1 ))
         return
@@ -143,57 +142,10 @@ _osc_auth() {
   [[ -z "${in_param}" ]] && in_param=${vararg_name}
 
   case "${in_param}" in
-    --help)
+    "--help")
       ;;
     *)
-      COMPREPLY=($(compgen -W 'info login logout' -- "${word}"))
-      ;;
-  esac
-}
-
-_osc_auth_info() {
-  local i=$1
-  local in_param=''
-  local fixed_arg_names=()
-  local vararg_name=''
-  local can_parse_options=1
-
-  while [[ ${i} -lt $COMP_CWORD ]]; do
-    if [[ ${can_parse_options} -eq 1 ]]; then
-      case "${COMP_WORDS[$i]}" in
-        --)
-          can_parse_options=0
-          (( i = i + 1 ));
-          continue
-          ;;
-        -h|--help)
-          __skip_opt_eq
-          in_param=''
-          continue
-          ;;
-      esac
-    fi
-    case "${COMP_WORDS[$i]}" in
-      *)
-        (( i = i + 1 ))
-        # drop the head of the array
-        fixed_arg_names=("${fixed_arg_names[@]:1}")
-        ;;
-    esac
-  done
-  local word="${COMP_WORDS[$COMP_CWORD]}"
-  if [[ "${word}" =~ ^[-] ]]; then
-    COMPREPLY=($(compgen -W '-h --help' -- "${word}"))
-    return
-  fi
-
-  # We're either at an option's value, or the first remaining fixed size
-  # arg, or the vararg if there are no fixed args left
-  [[ -z "${in_param}" ]] && in_param=${fixed_arg_names[0]}
-  [[ -z "${in_param}" ]] && in_param=${vararg_name}
-
-  case "${in_param}" in
-    --help)
+      COMPREPLY=($(compgen -W 'login logout' -- "${word}"))
       ;;
   esac
 }
@@ -270,17 +222,17 @@ _osc_auth_login() {
   [[ -z "${in_param}" ]] && in_param=${vararg_name}
 
   case "${in_param}" in
-    --base-url)
+    "--base-url")
       ;;
-    --token-url)
+    "--token-url")
       ;;
-    --client-id)
+    "--client-id")
       ;;
-    --username)
+    "--username")
       ;;
-    --password)
+    "--password")
       ;;
-    --help)
+    "--help")
       ;;
   esac
 }
@@ -327,7 +279,7 @@ _osc_auth_logout() {
   [[ -z "${in_param}" ]] && in_param=${vararg_name}
 
   case "${in_param}" in
-    --help)
+    "--help")
       ;;
   esac
 }
@@ -386,7 +338,7 @@ _osc_runs() {
   [[ -z "${in_param}" ]] && in_param=${vararg_name}
 
   case "${in_param}" in
-    --help)
+    "--help")
       ;;
     *)
       COMPREPLY=($(compgen -W 'download info start' -- "${word}"))
@@ -444,7 +396,7 @@ _osc_runs_download() {
   [[ -z "${in_param}" ]] && in_param=${vararg_name}
 
   case "${in_param}" in
-    --help)
+    "--help")
       ;;
     *)
       COMPREPLY=($(compgen -W 'logs reports' -- "${word}"))
@@ -530,22 +482,21 @@ _osc_runs_download_logs() {
   [[ -z "${in_param}" ]] && in_param=${vararg_name}
 
   case "${in_param}" in
-    --run-id)
+    "--run-id")
       ;;
-    --repository-id)
+    "--repository-id")
       ;;
-    --index)
+    "--index")
       ;;
-    --output-dir)
-       COMPREPLY=($(compgen -o default -- "${word}"))
+    "--output-dir")
       ;;
-    --level)
+    "--level")
       COMPREPLY=($(compgen -W 'DEBUG INFO WARN ERROR' -- "${word}"))
       ;;
-    --steps)
+    "--steps")
       COMPREPLY=($(compgen -W 'CONFIG ANALYZER ADVISOR SCANNER EVALUATOR REPORTER NOTIFIER' -- "${word}"))
       ;;
-    --help)
+    "--help")
       ;;
   esac
 }
@@ -622,18 +573,17 @@ _osc_runs_download_reports() {
   [[ -z "${in_param}" ]] && in_param=${vararg_name}
 
   case "${in_param}" in
-    --run-id)
+    "--run-id")
       ;;
-    --repository-id)
+    "--repository-id")
       ;;
-    --index)
+    "--index")
       ;;
-    --file-names)
+    "--file-names")
       ;;
-    --output-dir)
-       COMPREPLY=($(compgen -o default -- "${word}"))
+    "--output-dir")
       ;;
-    --help)
+    "--help")
       ;;
   esac
 }
@@ -698,13 +648,13 @@ _osc_runs_info() {
   [[ -z "${in_param}" ]] && in_param=${vararg_name}
 
   case "${in_param}" in
-    --run-id)
+    "--run-id")
       ;;
-    --repository-id)
+    "--repository-id")
       ;;
-    --index)
+    "--index")
       ;;
-    --help)
+    "--help")
       ;;
   esac
 }
@@ -774,16 +724,15 @@ _osc_runs_start() {
   [[ -z "${in_param}" ]] && in_param=${vararg_name}
 
   case "${in_param}" in
-    --repository-id)
+    "--repository-id")
       ;;
-    --wait)
+    "--wait")
       ;;
-    --parameters-file)
-       COMPREPLY=($(compgen -o default -- "${word}"))
+    "--parameters-file")
       ;;
-    --parameters)
+    "--parameters")
       ;;
-    --help)
+    "--help")
       ;;
   esac
 }

--- a/integrations/completions/osc-completion.zsh
+++ b/integrations/completions/osc-completion.zsh
@@ -47,6 +47,11 @@ _osc() {
           in_param=''
           continue
           ;;
+        --json)
+          __skip_opt_eq
+          in_param=''
+          continue
+          ;;
         -h|--help)
           __skip_opt_eq
           in_param=''
@@ -72,7 +77,7 @@ _osc() {
   done
   local word="${COMP_WORDS[$COMP_CWORD]}"
   if [[ "${word}" =~ ^[-] ]]; then
-    COMPREPLY=($(compgen -W '--version -v -h --help' -- "${word}"))
+    COMPREPLY=($(compgen -W '--version -v --json -h --help' -- "${word}"))
     return
   fi
 
@@ -83,6 +88,8 @@ _osc() {
 
   case "${in_param}" in
     "--version")
+      ;;
+    "--json")
       ;;
     "--help")
       ;;

--- a/scripts/cli/generate_completion_scripts.sh
+++ b/scripts/cli/generate_completion_scripts.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+#
+
+GIT_ROOT=$(git rev-parse --show-toplevel)
+
+(cd $GIT_ROOT &&
+  ./gradlew :cli:jvmRun --args='--generate-completion=bash' -DmainClass=org.eclipse.apoapsis.ortserver.cli.OrtServerMainKt --quiet > integrations/completions/osc-completion.bash &&
+  ./gradlew :cli:jvmRun --args='--generate-completion=fish' -DmainClass=org.eclipse.apoapsis.ortserver.cli.OrtServerMainKt --quiet > integrations/completions/osc-completion.fish &&
+  ./gradlew :cli:jvmRun --args='--generate-completion=zsh' -DmainClass=org.eclipse.apoapsis.ortserver.cli.OrtServerMainKt --quiet > integrations/completions/osc-completion.zsh
+)


### PR DESCRIPTION
Example for the human-readable `osc runs info` command:
![image](https://github.com/user-attachments/assets/ef42f37a-1551-4f2d-bff7-3b70c9f7c710)
