### PR TITLE
Changes to API documentation

### DIFF
--- a/core/src/main/kotlin/apiDocs/AdminDocs.kt
+++ b/core/src/main/kotlin/apiDocs/AdminDocs.kt
@@ -28,7 +28,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.User
 
 val runPermissionsSync: OpenApiRoute.() -> Unit = {
     operationId = "runPermissionsSync"
-    summary = "Trigger the synchronization of Keycloak roles."
+    summary = "Trigger the synchronization of Keycloak roles"
     tags = listOf("Admin")
 
     request {
@@ -47,7 +47,7 @@ val runPermissionsSync: OpenApiRoute.() -> Unit = {
 
 val getUsers: OpenApiRoute.() -> Unit = {
     operationId = "getUsers"
-    summary = "Get all users of the server."
+    summary = "Get all users of the server"
     tags = listOf("Admin")
 
     request {
@@ -80,7 +80,7 @@ val getUsers: OpenApiRoute.() -> Unit = {
 
 val postUsers: OpenApiRoute.() -> Unit = {
     operationId = "postUsers"
-    summary = "Create a user, possibly with a password."
+    summary = "Create a user, possibly with a password"
     tags = listOf("Admin")
 
     request {
@@ -114,7 +114,7 @@ val postUsers: OpenApiRoute.() -> Unit = {
 
 val deleteUserByUsername: OpenApiRoute.() -> Unit = {
     operationId = "deleteUserByUsername"
-    summary = "Delete a user from the server."
+    summary = "Delete a user from the server"
     tags = listOf("Admin")
 
     request {

--- a/core/src/main/kotlin/apiDocs/DownloadsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/DownloadsDocs.kt
@@ -27,7 +27,7 @@ val getReportByRunIdAndToken: OpenApiRoute.() -> Unit = {
     operationId = "GetReportByRunIdAndToken"
     summary = "Download a report of an ORT run using a token"
     description = "This endpoint does not require authentication."
-    tags = listOf("Reports")
+    tags = listOf("Runs")
 
     request {
         pathParameter<Long>("runId") {

--- a/core/src/main/kotlin/apiDocs/DownloadsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/DownloadsDocs.kt
@@ -25,7 +25,8 @@ import io.ktor.http.HttpStatusCode
 
 val getReportByRunIdAndToken: OpenApiRoute.() -> Unit = {
     operationId = "GetReportByRunIdAndToken"
-    summary = "Download a report of an ORT run using a token. This endpoint does not require authentication."
+    summary = "Download a report of an ORT run using a token"
+    description = "This endpoint does not require authentication."
     tags = listOf("Reports")
 
     request {

--- a/core/src/main/kotlin/apiDocs/HealthDocs.kt
+++ b/core/src/main/kotlin/apiDocs/HealthDocs.kt
@@ -27,7 +27,7 @@ import org.eclipse.apoapsis.ortserver.core.api.Liveness
 
 val getLiveness: OpenApiRoute.() -> Unit = {
     operationId = "GetLiveness"
-    summary = "Get the health of the ORT server."
+    summary = "Get the health of the ORT server"
     tags = listOf("Health")
 
     response {

--- a/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
@@ -615,7 +615,7 @@ val getVulnerabilitiesAcrossRepositoriesByOrganizationId: OpenApiRoute.() -> Uni
     summary = "Get vulnerabilities from an organization"
     description = "Get the vulnerabilities from latest successful advisor runs across the repositories in an " +
             " organization."
-    tags = listOf("Vulnerabilities")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {

--- a/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
@@ -249,7 +249,7 @@ val postProduct: OpenApiRoute.() -> Unit = {
 val getSecretsByOrganizationId: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretsByOrganizationId"
     summary = "Get all secrets of an organization"
-    tags = listOf("Secrets")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {
@@ -284,7 +284,7 @@ val getSecretsByOrganizationId: OpenApiRoute.() -> Unit = {
 val getSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretByOrganizationIdAndName"
     summary = "Get details of a secret of an organization"
-    tags = listOf("Secrets")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {
@@ -310,7 +310,7 @@ val getSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
 val postSecretForOrganization: OpenApiRoute.() -> Unit = {
     operationId = "PostSecretForOrganization"
     summary = "Create a secret for an organization"
-    tags = listOf("Secrets")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {
@@ -342,7 +342,7 @@ val postSecretForOrganization: OpenApiRoute.() -> Unit = {
 val patchSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "PatchSecretByOrganizationIdAndName"
     summary = "Update a secret of an organization"
-    tags = listOf("Secrets")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {
@@ -379,7 +379,7 @@ val patchSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
 val deleteSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "DeleteSecretByOrganizationIdAndName"
     summary = "Delete a secret from an organization"
-    tags = listOf("Secrets")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {
@@ -400,7 +400,7 @@ val deleteSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
 val getInfrastructureServicesByOrganizationId: OpenApiRoute.() -> Unit = {
     operationId = "GetInfrastructureServicesByOrganizationId"
     summary = "List all infrastructure services of an organization"
-    tags = listOf("Infrastructure services")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {
@@ -447,7 +447,7 @@ val getInfrastructureServicesByOrganizationId: OpenApiRoute.() -> Unit = {
 val postInfrastructureServiceForOrganization: OpenApiRoute.() -> Unit = {
     operationId = "PostInfrastructureServiceForOrganization"
     summary = "Create an infrastructure service for an organization"
-    tags = listOf("Infrastructure services")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {
@@ -487,7 +487,7 @@ val postInfrastructureServiceForOrganization: OpenApiRoute.() -> Unit = {
 val patchInfrastructureServiceForOrganizationIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "PatchInfrastructureServiceForOrganizationIdAndName"
     summary = "Update an infrastructure service for an organization"
-    tags = listOf("Infrastructure services")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {
@@ -530,7 +530,7 @@ val patchInfrastructureServiceForOrganizationIdAndName: OpenApiRoute.() -> Unit 
 val deleteInfrastructureServiceForOrganizationIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "DeleteInfrastructureServiceForOrganizationIdAndName"
     summary = "Delete an infrastructure service from an organization"
-    tags = listOf("Infrastructure services")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {

--- a/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
@@ -551,7 +551,7 @@ val deleteInfrastructureServiceForOrganizationIdAndName: OpenApiRoute.() -> Unit
 val putUserToOrganizationGroup: OpenApiRoute.() -> Unit = {
     operationId = "PutUserToGroupOrganization"
     summary = "Add a user to a group on organization level"
-    tags = listOf("Groups")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {
@@ -582,7 +582,7 @@ val putUserToOrganizationGroup: OpenApiRoute.() -> Unit = {
 val deleteUserFromOrganizationGroup: OpenApiRoute.() -> Unit = {
     operationId = "DeleteUserFromGroupOrganization"
     summary = "Remove a user from a group on organization level"
-    tags = listOf("Groups")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {

--- a/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
@@ -54,7 +54,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.asPresent
 
 val getOrganizationById: OpenApiRoute.() -> Unit = {
     operationId = "GetOrganizationById"
-    summary = "Get details of an organization."
+    summary = "Get details of an organization"
     tags = listOf("Organizations")
 
     request {
@@ -77,7 +77,7 @@ val getOrganizationById: OpenApiRoute.() -> Unit = {
 
 val getOrganizations: OpenApiRoute.() -> Unit = {
     operationId = "GetOrganizations"
-    summary = "Get all organizations."
+    summary = "Get all organizations"
     tags = listOf("Organizations")
 
     request {
@@ -109,7 +109,7 @@ val getOrganizations: OpenApiRoute.() -> Unit = {
 
 val postOrganizations: OpenApiRoute.() -> Unit = {
     operationId = "PostOrganizations"
-    summary = "Create an organization."
+    summary = "Create an organization"
     tags = listOf("Organizations")
 
     request {
@@ -134,7 +134,7 @@ val postOrganizations: OpenApiRoute.() -> Unit = {
 
 val patchOrganizationById: OpenApiRoute.() -> Unit = {
     operationId = "PatchOrganizationById"
-    summary = "Update an organization."
+    summary = "Update an organization"
     tags = listOf("Organizations")
 
     request {
@@ -166,7 +166,7 @@ val patchOrganizationById: OpenApiRoute.() -> Unit = {
 
 val deleteOrganizationById: OpenApiRoute.() -> Unit = {
     operationId = "DeleteOrganizationById"
-    summary = "Delete an organization."
+    summary = "Delete an organization"
     tags = listOf("Organizations")
 
     request {
@@ -184,7 +184,7 @@ val deleteOrganizationById: OpenApiRoute.() -> Unit = {
 
 val getOrganizationProducts: OpenApiRoute.() -> Unit = {
     operationId = "GetOrganizationProducts"
-    summary = "Get all products of an organization."
+    summary = "Get all products of an organization"
     tags = listOf("Products")
 
     request {
@@ -220,7 +220,7 @@ val getOrganizationProducts: OpenApiRoute.() -> Unit = {
 
 val postProduct: OpenApiRoute.() -> Unit = {
     operationId = "PostProduct"
-    summary = "Create a product for an organization."
+    summary = "Create a product for an organization"
     tags = listOf("Products")
 
     request {
@@ -248,7 +248,7 @@ val postProduct: OpenApiRoute.() -> Unit = {
 
 val getSecretsByOrganizationId: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretsByOrganizationId"
-    summary = "Get all secrets of an organization."
+    summary = "Get all secrets of an organization"
     tags = listOf("Secrets")
 
     request {
@@ -283,7 +283,7 @@ val getSecretsByOrganizationId: OpenApiRoute.() -> Unit = {
 
 val getSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretByOrganizationIdAndName"
-    summary = "Get details of a secret of an organization."
+    summary = "Get details of a secret of an organization"
     tags = listOf("Secrets")
 
     request {
@@ -309,7 +309,7 @@ val getSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
 
 val postSecretForOrganization: OpenApiRoute.() -> Unit = {
     operationId = "PostSecretForOrganization"
-    summary = "Create a secret for an organization."
+    summary = "Create a secret for an organization"
     tags = listOf("Secrets")
 
     request {
@@ -341,7 +341,7 @@ val postSecretForOrganization: OpenApiRoute.() -> Unit = {
 
 val patchSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "PatchSecretByOrganizationIdAndName"
-    summary = "Update a secret of an organization."
+    summary = "Update a secret of an organization"
     tags = listOf("Secrets")
 
     request {
@@ -378,7 +378,7 @@ val patchSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
 
 val deleteSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "DeleteSecretByOrganizationIdAndName"
-    summary = "Delete a secret from an organization."
+    summary = "Delete a secret from an organization"
     tags = listOf("Secrets")
 
     request {
@@ -399,7 +399,7 @@ val deleteSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
 
 val getInfrastructureServicesByOrganizationId: OpenApiRoute.() -> Unit = {
     operationId = "GetInfrastructureServicesByOrganizationId"
-    summary = "List all infrastructure services of an organization."
+    summary = "List all infrastructure services of an organization"
     tags = listOf("Infrastructure services")
 
     request {
@@ -446,7 +446,7 @@ val getInfrastructureServicesByOrganizationId: OpenApiRoute.() -> Unit = {
 
 val postInfrastructureServiceForOrganization: OpenApiRoute.() -> Unit = {
     operationId = "PostInfrastructureServiceForOrganization"
-    summary = "Create an infrastructure service for an organization."
+    summary = "Create an infrastructure service for an organization"
     tags = listOf("Infrastructure services")
 
     request {
@@ -486,7 +486,7 @@ val postInfrastructureServiceForOrganization: OpenApiRoute.() -> Unit = {
 
 val patchInfrastructureServiceForOrganizationIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "PatchInfrastructureServiceForOrganizationIdAndName"
-    summary = "Update an infrastructure service for an organization."
+    summary = "Update an infrastructure service for an organization"
     tags = listOf("Infrastructure services")
 
     request {
@@ -529,7 +529,7 @@ val patchInfrastructureServiceForOrganizationIdAndName: OpenApiRoute.() -> Unit 
 
 val deleteInfrastructureServiceForOrganizationIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "DeleteInfrastructureServiceForOrganizationIdAndName"
-    summary = "Delete an infrastructure service from an organization."
+    summary = "Delete an infrastructure service from an organization"
     tags = listOf("Infrastructure services")
 
     request {
@@ -550,7 +550,7 @@ val deleteInfrastructureServiceForOrganizationIdAndName: OpenApiRoute.() -> Unit
 
 val putUserToOrganizationGroup: OpenApiRoute.() -> Unit = {
     operationId = "PutUserToGroupOrganization"
-    summary = "Add a user to a group on Organization level."
+    summary = "Add a user to a group on organization level"
     tags = listOf("Groups")
 
     request {
@@ -581,7 +581,7 @@ val putUserToOrganizationGroup: OpenApiRoute.() -> Unit = {
 
 val deleteUserFromOrganizationGroup: OpenApiRoute.() -> Unit = {
     operationId = "DeleteUserFromGroupOrganization"
-    summary = "Remove a user from a group on Organization level."
+    summary = "Remove a user from a group on organization level"
     tags = listOf("Groups")
 
     request {
@@ -612,7 +612,9 @@ val deleteUserFromOrganizationGroup: OpenApiRoute.() -> Unit = {
 
 val getVulnerabilitiesAcrossRepositoriesByOrganizationId: OpenApiRoute.() -> Unit = {
     operationId = "GetVulnerabilitiesAcrossRepositoriesByOrganizationId"
-    summary = "Get the vulnerabilities from latest successful advisor runs across the repositories in an organization."
+    summary = "Get vulnerabilities from an organization"
+    description = "Get the vulnerabilities from latest successful advisor runs across the repositories in an " +
+            " organization."
     tags = listOf("Vulnerabilities")
 
     request {
@@ -665,7 +667,7 @@ val getVulnerabilitiesAcrossRepositoriesByOrganizationId: OpenApiRoute.() -> Uni
 
 val getOrtRunStatisticsByOrganizationId: OpenApiRoute.() -> Unit = {
     operationId = "GetOrtRunStatisticsByOrganizationId"
-    summary = "Get statistics about ORT runs across the repositories of an organization."
+    summary = "Get statistics about ORT runs across the repositories of an organization"
     tags = listOf("Organizations")
 
     request {

--- a/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
@@ -713,10 +713,12 @@ val getOrtRunStatisticsByOrganizationId: OpenApiRoute.() -> Unit = {
 
 val getUsersForOrganization: OpenApiRoute.() -> Unit = {
     operationId = "GetUsersForOrganization"
-    summary = "Get all users that have rights for a organization, including user privileges (groups) that user have " +
-        "within organization."
-    description = "Fields available for sorting: 'username', 'firstName', 'lastName', 'email', 'group'. " +
-        "NOTE: This endpoint supports only one sort field. All fields other than first one are ignored."
+    summary = "Get all users for an organization"
+    description = "Get all users that have access rights for an organization, including the user privileges (groups) " +
+            "the user has within the organization. Fields available for sorting: 'username', 'firstName', " +
+            "'lastName', 'email', 'group'. NOTE: This endpoint supports only one sort field. All fields other than " +
+            " the first one are ignored."
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {

--- a/core/src/main/kotlin/apiDocs/ProductsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/ProductsDocs.kt
@@ -218,7 +218,7 @@ val postRepository: OpenApiRoute.() -> Unit = {
 val getSecretsByProductId: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretsByProductId"
     summary = "Get all secrets of a specific product"
-    tags = listOf("Secrets")
+    tags = listOf("Products")
 
     request {
         pathParameter<Long>("productId") {
@@ -253,7 +253,7 @@ val getSecretsByProductId: OpenApiRoute.() -> Unit = {
 val getSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretByProductIdAndName"
     summary = "Get details of a secret of a product"
-    tags = listOf("Secrets")
+    tags = listOf("Products")
 
     request {
         pathParameter<Long>("productId") {
@@ -279,7 +279,7 @@ val getSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
 val postSecretForProduct: OpenApiRoute.() -> Unit = {
     operationId = "PostSecretForProduct"
     summary = "Create a secret for a product"
-    tags = listOf("Secrets")
+    tags = listOf("Products")
 
     request {
         pathParameter<Long>("productId") {
@@ -311,7 +311,7 @@ val postSecretForProduct: OpenApiRoute.() -> Unit = {
 val patchSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "PatchSecretByProductIdAndName"
     summary = "Update a secret of a product"
-    tags = listOf("Secrets")
+    tags = listOf("Products")
 
     request {
         pathParameter<Long>("productId") {
@@ -348,7 +348,7 @@ val patchSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
 val deleteSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "DeleteSecretByProductIdAndName"
     summary = "Delete a secret from a product"
-    tags = listOf("Secrets")
+    tags = listOf("Products")
 
     request {
         pathParameter<Long>("productId") {

--- a/core/src/main/kotlin/apiDocs/ProductsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/ProductsDocs.kt
@@ -532,10 +532,12 @@ val getOrtRunStatisticsByProductId: OpenApiRoute.() -> Unit = {
 
 val getUsersForProduct: OpenApiRoute.() -> Unit = {
     operationId = "GetUsersForProduct"
-    summary = "Get all users that have rights for a product, including user privileges (groups) that user have " +
-        "within product."
-    description = "Fields available for sorting: 'username', 'firstName', 'lastName', 'email', 'group'. " +
-        "NOTE: This endpoint supports only one sort field. All fields other than first one are ignored."
+    summary = "Get all users for a product"
+    description = "Get all users that have access rights for a product, including the user privileges (groups) " +
+            "the user has within the product. Fields available for sorting: 'username', 'firstName', " +
+            "'lastName', 'email', 'group'. NOTE: This endpoint supports only one sort field. All fields other than " +
+            " the first one are ignored."
+    tags = listOf("Products")
 
     request {
         pathParameter<Long>("productId") {

--- a/core/src/main/kotlin/apiDocs/ProductsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/ProductsDocs.kt
@@ -369,7 +369,7 @@ val deleteSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
 val putUserToProductGroup: OpenApiRoute.() -> Unit = {
     operationId = "PutUserToGroupProduct"
     summary = "Add a user to a group on product level"
-    tags = listOf("Groups")
+    tags = listOf("Products")
 
     request {
         pathParameter<Long>("productId") {
@@ -400,7 +400,7 @@ val putUserToProductGroup: OpenApiRoute.() -> Unit = {
 val deleteUserFromProductGroup: OpenApiRoute.() -> Unit = {
     operationId = "DeleteUserFromGroupProduct"
     summary = "Remove a user from a group on product level"
-    tags = listOf("Groups")
+    tags = listOf("Products")
 
     request {
         pathParameter<Long>("productId") {

--- a/core/src/main/kotlin/apiDocs/ProductsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/ProductsDocs.kt
@@ -57,7 +57,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.asPresent
 
 val getProductById: OpenApiRoute.() -> Unit = {
     operationId = "GetProductById"
-    summary = "Get details of a product."
+    summary = "Get details of a product"
     tags = listOf("Products")
 
     request {
@@ -80,7 +80,7 @@ val getProductById: OpenApiRoute.() -> Unit = {
 
 val patchProductById: OpenApiRoute.() -> Unit = {
     operationId = "PatchProductById"
-    summary = "Update a product."
+    summary = "Update a product"
     tags = listOf("Products")
 
     request {
@@ -114,7 +114,7 @@ val patchProductById: OpenApiRoute.() -> Unit = {
 
 val deleteProductById: OpenApiRoute.() -> Unit = {
     operationId = "DeleteProductById"
-    summary = "Delete a product."
+    summary = "Delete a product"
     tags = listOf("Products")
 
     request {
@@ -132,7 +132,7 @@ val deleteProductById: OpenApiRoute.() -> Unit = {
 
 val getRepositoriesByProductId: OpenApiRoute.() -> Unit = {
     operationId = "GetRepositoriesByProductId"
-    summary = "Get all repositories of a product."
+    summary = "Get all repositories of a product"
     tags = listOf("Repositories")
 
     request {
@@ -180,7 +180,7 @@ val getRepositoriesByProductId: OpenApiRoute.() -> Unit = {
 
 val postRepository: OpenApiRoute.() -> Unit = {
     operationId = "CreateRepository"
-    summary = "Create a repository for a product."
+    summary = "Create a repository for a product"
     tags = listOf("Repositories")
 
     request {
@@ -217,7 +217,7 @@ val postRepository: OpenApiRoute.() -> Unit = {
 
 val getSecretsByProductId: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretsByProductId"
-    summary = "Get all secrets of a specific product."
+    summary = "Get all secrets of a specific product"
     tags = listOf("Secrets")
 
     request {
@@ -252,7 +252,7 @@ val getSecretsByProductId: OpenApiRoute.() -> Unit = {
 
 val getSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretByProductIdAndName"
-    summary = "Get details of a secret of a product."
+    summary = "Get details of a secret of a product"
     tags = listOf("Secrets")
 
     request {
@@ -278,7 +278,7 @@ val getSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
 
 val postSecretForProduct: OpenApiRoute.() -> Unit = {
     operationId = "PostSecretForProduct"
-    summary = "Create a secret for a product."
+    summary = "Create a secret for a product"
     tags = listOf("Secrets")
 
     request {
@@ -310,7 +310,7 @@ val postSecretForProduct: OpenApiRoute.() -> Unit = {
 
 val patchSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "PatchSecretByProductIdAndName"
-    summary = "Update a secret of a product."
+    summary = "Update a secret of a product"
     tags = listOf("Secrets")
 
     request {
@@ -347,7 +347,7 @@ val patchSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
 
 val deleteSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "DeleteSecretByProductIdAndName"
-    summary = "Delete a secret from a product."
+    summary = "Delete a secret from a product"
     tags = listOf("Secrets")
 
     request {
@@ -368,7 +368,7 @@ val deleteSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
 
 val putUserToProductGroup: OpenApiRoute.() -> Unit = {
     operationId = "PutUserToGroupProduct"
-    summary = "Add a user to a group on Product level."
+    summary = "Add a user to a group on product level"
     tags = listOf("Groups")
 
     request {
@@ -399,7 +399,7 @@ val putUserToProductGroup: OpenApiRoute.() -> Unit = {
 
 val deleteUserFromProductGroup: OpenApiRoute.() -> Unit = {
     operationId = "DeleteUserFromGroupProduct"
-    summary = "Remove a user from a group on Product level."
+    summary = "Remove a user from a group on product level"
     tags = listOf("Groups")
 
     request {
@@ -430,7 +430,8 @@ val deleteUserFromProductGroup: OpenApiRoute.() -> Unit = {
 
 val getVulnerabilitiesAcrossRepositoriesByProductId: OpenApiRoute.() -> Unit = {
     operationId = "GetVulnerabilitiesAcrossRepositoriesByProductId"
-    summary = "Get the vulnerabilities from latest successful advisor runs across the repositories in a product."
+    summary = "Get vulnerabilities from a product"
+    description = "Get the vulnerabilities from latest successful advisor runs across the repositories in a product."
     tags = listOf("Vulnerabilities")
 
     request {
@@ -483,7 +484,7 @@ val getVulnerabilitiesAcrossRepositoriesByProductId: OpenApiRoute.() -> Unit = {
 
 val getOrtRunStatisticsByProductId: OpenApiRoute.() -> Unit = {
     operationId = "GetOrtRunStatisticsByProductId"
-    summary = "Get statistics about ORT runs across the repositories of a product."
+    summary = "Get statistics about ORT runs across the repositories of a product"
     tags = listOf("Products")
 
     request {
@@ -591,7 +592,7 @@ private val minimalJobConfigurations = JobConfigurations(
 
 val postOrtRunsForProduct: OpenApiRoute.() -> Unit = {
     operationId = "postOrtRunsForProduct"
-    summary = "Create ORT runs for all repositories under a product."
+    summary = "Create ORT runs for all repositories under a product"
     tags = listOf("Products")
 
     request {

--- a/core/src/main/kotlin/apiDocs/ProductsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/ProductsDocs.kt
@@ -432,7 +432,7 @@ val getVulnerabilitiesAcrossRepositoriesByProductId: OpenApiRoute.() -> Unit = {
     operationId = "GetVulnerabilitiesAcrossRepositoriesByProductId"
     summary = "Get vulnerabilities from a product"
     description = "Get the vulnerabilities from latest successful advisor runs across the repositories in a product."
-    tags = listOf("Vulnerabilities")
+    tags = listOf("Products")
 
     request {
         pathParameter<Long>("productId") {

--- a/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
@@ -751,10 +751,12 @@ val deleteUserFromRepositoryGroup: OpenApiRoute.() -> Unit = {
 
 val getUsersForRepository: OpenApiRoute.() -> Unit = {
     operationId = "GetUsersForRepository"
-    summary = "Get all users that have rights for a repository, including privileges (groups) that user have within " +
-        "repository."
-    description = "Fields available for sorting: 'username', 'firstName', 'lastName', 'email', 'group'. " +
-        "NOTE: This endpoint supports only one sort field. All fields other than first one are ignored."
+    summary = "Get all users for a repository"
+    description = "Get all users that have access rights for a repository, including the user privileges (groups) " +
+            "the user has within the repository. Fields available for sorting: 'username', 'firstName', " +
+            "'lastName', 'email', 'group'. NOTE: This endpoint supports only one sort field. All fields other than " +
+            " the first one are ignored."
+    tags = listOf("Repositories")
 
     request {
         pathParameter<Long>("repositoryId") {

--- a/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
@@ -539,7 +539,7 @@ val deleteOrtRunByIndex: OpenApiRoute.() -> Unit = {
 val getSecretsByRepositoryId: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretsByRepositoryId"
     summary = "Get all secrets of a repository"
-    tags = listOf("Secrets")
+    tags = listOf("Repositories")
 
     request {
         pathParameter<Long>("repositoryId") {
@@ -574,7 +574,7 @@ val getSecretsByRepositoryId: OpenApiRoute.() -> Unit = {
 val getSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretByRepositoryIdAndName"
     summary = "Get details of a secret of a repository"
-    tags = listOf("Secrets")
+    tags = listOf("Repositories")
 
     request {
         pathParameter<Long>("repositoryId") {
@@ -600,7 +600,7 @@ val getSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
 val postSecretForRepository: OpenApiRoute.() -> Unit = {
     operationId = "PostSecretForRepository"
     summary = "Create a secret for a repository"
-    tags = listOf("Secrets")
+    tags = listOf("Repositories")
 
     request {
         pathParameter<Long>("repositoryId") {
@@ -632,7 +632,7 @@ val postSecretForRepository: OpenApiRoute.() -> Unit = {
 val patchSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "PatchSecretByRepositoryIdAndName"
     summary = "Update a secret of a repository"
-    tags = listOf("Secrets")
+    tags = listOf("Repositories")
 
     request {
         pathParameter<Long>("repositoryId") {
@@ -669,7 +669,7 @@ val patchSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
 val deleteSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "DeleteSecretByRepositoryIdAndName"
     summary = "Delete a secret from a repository"
-    tags = listOf("Secrets")
+    tags = listOf("Repositories")
 
     request {
         pathParameter<Long>("repositoryId") {

--- a/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
@@ -690,7 +690,7 @@ val deleteSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
 val putUserToRepositoryGroup: OpenApiRoute.() -> Unit = {
     operationId = "PutUserToGroupRepository"
     summary = "Add a user to a group on repository level"
-    tags = listOf("Groups")
+    tags = listOf("Repositories")
 
     request {
         pathParameter<Long>("repositoryId") {
@@ -721,7 +721,7 @@ val putUserToRepositoryGroup: OpenApiRoute.() -> Unit = {
 val deleteUserFromRepositoryGroup: OpenApiRoute.() -> Unit = {
     operationId = "DeleteUserFromGroupRepository"
     summary = "Remove a user from a group on repository level"
-    tags = listOf("Groups")
+    tags = listOf("Repositories")
 
     request {
         pathParameter<Long>("repositoryId") {

--- a/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
@@ -242,7 +242,7 @@ fun createJobSummary(offset: Duration, status: JobStatus = JobStatus.FINISHED): 
 
 val getRepositoryById: OpenApiRoute.() -> Unit = {
     operationId = "GetRepositoryById"
-    summary = "Get details of a repository."
+    summary = "Get details of a repository"
     tags = listOf("Repositories")
 
     request {
@@ -271,7 +271,7 @@ val getRepositoryById: OpenApiRoute.() -> Unit = {
 
 val patchRepositoryById: OpenApiRoute.() -> Unit = {
     operationId = "PatchRepositoryById"
-    summary = "Update a repository."
+    summary = "Update a repository"
     tags = listOf("Repositories")
 
     request {
@@ -309,7 +309,7 @@ val patchRepositoryById: OpenApiRoute.() -> Unit = {
 
 val deleteRepositoryById: OpenApiRoute.() -> Unit = {
     operationId = "DeleteRepositoryById"
-    summary = "Delete a repository."
+    summary = "Delete a repository"
     tags = listOf("Repositories")
 
     request {
@@ -327,7 +327,7 @@ val deleteRepositoryById: OpenApiRoute.() -> Unit = {
 
 val getOrtRunsByRepositoryId: OpenApiRoute.() -> Unit = {
     operationId = "getOrtRunsByRepositoryId"
-    summary = "Get all ORT runs of a repository."
+    summary = "Get all ORT runs of a repository"
     tags = listOf("Repositories")
 
     request {
@@ -405,7 +405,7 @@ val getOrtRunsByRepositoryId: OpenApiRoute.() -> Unit = {
 
 val postOrtRun: OpenApiRoute.() -> Unit = {
     operationId = "postOrtRun"
-    summary = "Create an ORT run for a repository."
+    summary = "Create an ORT run for a repository"
     tags = listOf("Repositories")
 
     request {
@@ -465,7 +465,7 @@ val postOrtRun: OpenApiRoute.() -> Unit = {
 
 val getOrtRunByIndex: OpenApiRoute.() -> Unit = {
     operationId = "getOrtRunByIndex"
-    summary = "Get details of an ORT run of a repository."
+    summary = "Get details of an ORT run of a repository"
     tags = listOf("Repositories")
 
     request {
@@ -511,7 +511,7 @@ val getOrtRunByIndex: OpenApiRoute.() -> Unit = {
 
 val deleteOrtRunByIndex: OpenApiRoute.() -> Unit = {
     operationId = "deleteOrtRunByIndex"
-    summary = "Delete an ORT run of a repository."
+    summary = "Delete an ORT run of a repository"
     description = "This operation deletes an ORT run and all generated data, including the generated reports."
     tags = listOf("Repositories")
 
@@ -538,7 +538,7 @@ val deleteOrtRunByIndex: OpenApiRoute.() -> Unit = {
 
 val getSecretsByRepositoryId: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretsByRepositoryId"
-    summary = "Get all secrets of a repository."
+    summary = "Get all secrets of a repository"
     tags = listOf("Secrets")
 
     request {
@@ -573,7 +573,7 @@ val getSecretsByRepositoryId: OpenApiRoute.() -> Unit = {
 
 val getSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretByRepositoryIdAndName"
-    summary = "Get details of a secret of a repository."
+    summary = "Get details of a secret of a repository"
     tags = listOf("Secrets")
 
     request {
@@ -599,7 +599,7 @@ val getSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
 
 val postSecretForRepository: OpenApiRoute.() -> Unit = {
     operationId = "PostSecretForRepository"
-    summary = "Create a secret for a repository."
+    summary = "Create a secret for a repository"
     tags = listOf("Secrets")
 
     request {
@@ -631,7 +631,7 @@ val postSecretForRepository: OpenApiRoute.() -> Unit = {
 
 val patchSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "PatchSecretByRepositoryIdAndName"
-    summary = "Update a secret of a repository."
+    summary = "Update a secret of a repository"
     tags = listOf("Secrets")
 
     request {
@@ -668,7 +668,7 @@ val patchSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
 
 val deleteSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "DeleteSecretByRepositoryIdAndName"
-    summary = "Delete a secret from a repository."
+    summary = "Delete a secret from a repository"
     tags = listOf("Secrets")
 
     request {
@@ -689,7 +689,7 @@ val deleteSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
 
 val putUserToRepositoryGroup: OpenApiRoute.() -> Unit = {
     operationId = "PutUserToGroupRepository"
-    summary = "Add a user to a group on Repository level."
+    summary = "Add a user to a group on repository level"
     tags = listOf("Groups")
 
     request {
@@ -720,7 +720,7 @@ val putUserToRepositoryGroup: OpenApiRoute.() -> Unit = {
 
 val deleteUserFromRepositoryGroup: OpenApiRoute.() -> Unit = {
     operationId = "DeleteUserFromGroupRepository"
-    summary = "Remove a user from a group on Repository level."
+    summary = "Remove a user from a group on repository level"
     tags = listOf("Groups")
 
     request {

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -131,7 +131,7 @@ val deleteOrtRunById: OpenApiRoute.() -> Unit = {
 val getReportByRunIdAndFileName: OpenApiRoute.() -> Unit = {
     operationId = "GetReportByRunIdAndFileName"
     summary = "Download a report of an ORT run"
-    tags = listOf("Reports")
+    tags = listOf("Runs")
 
     request {
         pathParameter<Long>("runId") {
@@ -159,7 +159,7 @@ val getReportByRunIdAndFileName: OpenApiRoute.() -> Unit = {
 val getLogsByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetLogsByRunId"
     summary = "Download an archive with selected logs of an ORT run"
-    tags = listOf("Logs")
+    tags = listOf("Runs")
 
     request {
         pathParameter<Long>("runId") {
@@ -197,7 +197,7 @@ val getLogsByRunId: OpenApiRoute.() -> Unit = {
 val getIssuesByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetIssuesByRunId"
     summary = "Get the issues of an ORT run"
-    tags = listOf("Issues")
+    tags = listOf("Runs")
 
     request {
         pathParameter<Long>("runId") {
@@ -241,7 +241,7 @@ val getIssuesByRunId: OpenApiRoute.() -> Unit = {
 val getVulnerabilitiesByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetVulnerabilitiesByRunId"
     summary = "Get the vulnerabilities found in an ORT run"
-    tags = listOf("Vulnerabilities")
+    tags = listOf("Runs")
 
     request {
         pathParameter<Long>("runId") {
@@ -297,7 +297,7 @@ val getVulnerabilitiesByRunId: OpenApiRoute.() -> Unit = {
 val getRuleViolationsByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetRuleViolationsByRunId"
     summary = "Get the rule violations found in an ORT run"
-    tags = listOf("RuleViolations")
+    tags = listOf("Runs")
 
     request {
         pathParameter<Long>("runId") {
@@ -367,7 +367,7 @@ val getRuleViolationsByRunId: OpenApiRoute.() -> Unit = {
 val getPackagesByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetPackagesByRunId"
     summary = "Get the packages found in an ORT run"
-    tags = listOf("Packages")
+    tags = listOf("Runs")
 
     request {
         pathParameter<Long>("runId") {
@@ -465,7 +465,7 @@ val getPackagesByRunId: OpenApiRoute.() -> Unit = {
 val getProjectsByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetProjectsByRunId"
     summary = "Get the projects found in an ORT run"
-    tags = listOf("Projects")
+    tags = listOf("Runs")
 
     request {
         pathParameter<Long>("runId") {

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -64,7 +64,7 @@ import org.eclipse.apoapsis.ortserver.model.LogSource
 
 val getOrtRunById: OpenApiRoute.() -> Unit = {
     operationId = "getOrtRunById"
-    summary = "Get details of an ORT run."
+    summary = "Get details of an ORT run"
     tags = listOf("Runs")
 
     request {
@@ -107,7 +107,7 @@ val getOrtRunById: OpenApiRoute.() -> Unit = {
 
 val deleteOrtRunById: OpenApiRoute.() -> Unit = {
     operationId = "deleteOrtRunById"
-    summary = "Delete an ORT run."
+    summary = "Delete an ORT run"
     description = "This operation deletes an ORT run and all generated data, including the generated reports."
     tags = listOf("Runs")
 
@@ -130,7 +130,7 @@ val deleteOrtRunById: OpenApiRoute.() -> Unit = {
 
 val getReportByRunIdAndFileName: OpenApiRoute.() -> Unit = {
     operationId = "GetReportByRunIdAndFileName"
-    summary = "Download a report of an ORT run."
+    summary = "Download a report of an ORT run"
     tags = listOf("Reports")
 
     request {
@@ -158,7 +158,7 @@ val getReportByRunIdAndFileName: OpenApiRoute.() -> Unit = {
 
 val getLogsByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetLogsByRunId"
-    summary = "Download an archive with selected logs of an ORT run."
+    summary = "Download an archive with selected logs of an ORT run"
     tags = listOf("Logs")
 
     request {
@@ -196,7 +196,7 @@ val getLogsByRunId: OpenApiRoute.() -> Unit = {
 
 val getIssuesByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetIssuesByRunId"
-    summary = "Get the issues of an ORT run."
+    summary = "Get the issues of an ORT run"
     tags = listOf("Issues")
 
     request {
@@ -240,7 +240,7 @@ val getIssuesByRunId: OpenApiRoute.() -> Unit = {
 
 val getVulnerabilitiesByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetVulnerabilitiesByRunId"
-    summary = "Get the vulnerabilities found in an ORT run."
+    summary = "Get the vulnerabilities found in an ORT run"
     tags = listOf("Vulnerabilities")
 
     request {
@@ -296,7 +296,7 @@ val getVulnerabilitiesByRunId: OpenApiRoute.() -> Unit = {
 
 val getRuleViolationsByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetRuleViolationsByRunId"
-    summary = "Get the rule violations found in an ORT run."
+    summary = "Get the rule violations found in an ORT run"
     tags = listOf("RuleViolations")
 
     request {
@@ -366,7 +366,7 @@ val getRuleViolationsByRunId: OpenApiRoute.() -> Unit = {
 
 val getPackagesByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetPackagesByRunId"
-    summary = "Get the packages found in an ORT run."
+    summary = "Get the packages found in an ORT run"
     tags = listOf("Packages")
 
     request {
@@ -464,7 +464,7 @@ val getPackagesByRunId: OpenApiRoute.() -> Unit = {
 
 val getProjectsByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetProjectsByRunId"
-    summary = "Get the projects found in an ORT run."
+    summary = "Get the projects found in an ORT run"
     tags = listOf("Projects")
 
     request {
@@ -519,7 +519,7 @@ val getProjectsByRunId: OpenApiRoute.() -> Unit = {
 
 val getOrtRuns: OpenApiRoute.() -> Unit = {
     operationId = "getOrtRuns"
-    summary = "Get all ORT runs."
+    summary = "Get all ORT runs"
     tags = listOf("Runs")
 
     request {
@@ -584,7 +584,7 @@ val getOrtRuns: OpenApiRoute.() -> Unit = {
 
 val getOrtRunStatistics: OpenApiRoute.() -> Unit = {
     operationId = "getOrtRunStatistics"
-    summary = "Get statistics about an ORT run."
+    summary = "Get statistics about an ORT run"
     tags = listOf("Runs")
 
     request {
@@ -633,7 +633,7 @@ val getOrtRunStatistics: OpenApiRoute.() -> Unit = {
 
 val getLicensesForPackagesByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetLicensesForPackagesByRunId"
-    summary = "Get the licenses for packages found in an ORT run."
+    summary = "Get the licenses for packages found in an ORT run"
     tags = listOf("Runs")
 
     request {

--- a/core/src/main/kotlin/apiDocs/VersionsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/VersionsDocs.kt
@@ -25,7 +25,7 @@ import io.ktor.http.HttpStatusCode
 
 val getVersions: OpenApiRoute.() -> Unit = {
     operationId = "getVersions"
-    summary = "Get the versions of the ORT server and other components."
+    summary = "Get the versions of the ORT server and other components"
     tags = listOf("Versions")
 
     response {

--- a/core/src/main/kotlin/plugins/OpenApi.kt
+++ b/core/src/main/kotlin/plugins/OpenApi.kt
@@ -103,8 +103,8 @@ fun Application.configureOpenApi() {
             tag("Products") { }
             tag("Repositories") { }
             tag("Runs") { }
-            tag("Reports") { }
-            tag("Logs") { }
+            tag("Admin") { }
+            tag("Versions") { }
         }
 
         schemas {

--- a/core/src/main/kotlin/plugins/OpenApi.kt
+++ b/core/src/main/kotlin/plugins/OpenApi.kt
@@ -103,8 +103,6 @@ fun Application.configureOpenApi() {
             tag("Products") { }
             tag("Repositories") { }
             tag("Runs") { }
-            tag("Secrets") { }
-            tag("Infrastructure services") { }
             tag("Reports") { }
             tag("Logs") { }
         }


### PR DESCRIPTION
The API documentation (Swagger, webpage) has become unnecessarily fragmented, introducing somewhat arbitrary top-level groups that make it difficult to find a particular endpoint.  Also the new users endpoints were incorrectly documented and left untagged. 

This PR implements some major changes to the API documents, by reducing the number of top-level groups, and grouping the corresponding endpoints to under the groups where they semantically belong. Endpoint summaries and descriptions are also reworded a bit, to keep the summaries as brief as possible and aligned with each other.

![Screenshot from 2025-04-04 08-38-42](https://github.com/user-attachments/assets/ceae5248-b31f-4750-aadc-057469da35a2)

Open question: @mnonnenmacher I also tried some methods to order the endpoints manually inside groups to a better semantic order, but without success. Swagger seems to order the endpoints in a group somewhat arbitrarily. Would you have suggestions for that?