### PR TITLE
refactor(ui): Consistenly use only Lucide React icons

### DIFF
--- a/ui/src/components/data-table/data-table-pagination.tsx
+++ b/ui/src/components/data-table/data-table-pagination.tsx
@@ -17,13 +17,13 @@
  * License-Filename: LICENSE
  */
 
-import {
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  DoubleArrowLeftIcon,
-  DoubleArrowRightIcon,
-} from '@radix-ui/react-icons';
 import { Link, LinkOptions, useNavigate } from '@tanstack/react-router';
+import {
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+} from 'lucide-react';
 import { useEffect, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -129,7 +129,7 @@ export function DataTablePagination({
               disabled={currentPage <= 1}
               onClick={() => setPage(1)}
             >
-              <DoubleArrowLeftIcon className='size-4' aria-hidden='true' />
+              <ChevronsLeft className='size-4' aria-hidden='true' />
             </Button>
           </Link>
           <Link
@@ -144,7 +144,7 @@ export function DataTablePagination({
               disabled={currentPage <= 1}
               onClick={() => setPage((prevPage) => prevPage - 1)}
             >
-              <ChevronLeftIcon className='size-4' aria-hidden='true' />
+              <ChevronLeft className='size-4' aria-hidden='true' />
             </Button>
           </Link>
           <Link
@@ -159,7 +159,7 @@ export function DataTablePagination({
               disabled={currentPage >= totalPages}
               onClick={() => setPage((prevPage) => prevPage + 1)}
             >
-              <ChevronRightIcon className='size-4' aria-hidden='true' />
+              <ChevronRight className='size-4' aria-hidden='true' />
             </Button>
           </Link>
           <Link
@@ -174,7 +174,7 @@ export function DataTablePagination({
               onClick={() => setPage(totalPages)}
               disabled={currentPage >= totalPages}
             >
-              <DoubleArrowRightIcon className='size-4' aria-hidden='true' />
+              <ChevronsRight className='size-4' aria-hidden='true' />
             </Button>
           </Link>
         </div>

--- a/ui/src/components/data-table/filter-multi-select.tsx
+++ b/ui/src/components/data-table/filter-multi-select.tsx
@@ -17,8 +17,7 @@
  * License-Filename: LICENSE
  */
 
-import { CheckIcon } from '@radix-ui/react-icons';
-import { Filter } from 'lucide-react';
+import { Check, Filter } from 'lucide-react';
 import * as React from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -98,7 +97,7 @@ export function FilterMultiSelect<TValue>({
                           : 'opacity-50 [&_svg]:invisible'
                       )}
                     >
-                      <CheckIcon className={cn('h-4 w-4')} />
+                      <Check className={cn('h-4 w-4')} />
                     </div>
                     {option.icon && (
                       <option.icon className='text-muted-foreground mr-2 h-4 w-4' />

--- a/ui/src/components/ui/breadcrumb.tsx
+++ b/ui/src/components/ui/breadcrumb.tsx
@@ -7,8 +7,8 @@
  * SPDX-License-Identifier: MIT
  */
 
-import { ChevronRightIcon, DotsHorizontalIcon } from '@radix-ui/react-icons';
 import { Slot } from '@radix-ui/react-slot';
+import { ChevronRight, Ellipsis } from 'lucide-react';
 import * as React from 'react';
 
 import { cn } from '@/lib/utils';
@@ -84,7 +84,7 @@ function BreadcrumbSeparator({
       className={cn('[&>svg]:size-3.5', className)}
       {...props}
     >
-      {children ?? <ChevronRightIcon />}
+      {children ?? <ChevronRight />}
     </li>
   );
 }
@@ -101,7 +101,7 @@ function BreadcrumbEllipsis({
       className={cn('flex size-9 items-center justify-center', className)}
       {...props}
     >
-      <DotsHorizontalIcon className='size-4' />
+      <Ellipsis className='size-4' />
       <span className='sr-only'>More</span>
     </span>
   );


### PR DESCRIPTION
Icons have been replaced by looking up their visual appearance at [1] and finding a similar one at [2].

[1]: https://react-icons.github.io/react-icons/
[2]: https://lucide.dev/icons/