### PR TITLE
Reword and refactor some endpoints in the API documentation

### DIFF
--- a/core/src/main/kotlin/apiDocs/AdminDocs.kt
+++ b/core/src/main/kotlin/apiDocs/AdminDocs.kt
@@ -28,7 +28,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.User
 
 val runPermissionsSync: OpenApiRoute.() -> Unit = {
     operationId = "runPermissionsSync"
-    summary = "Trigger the synchronization of Keycloak roles."
+    summary = "Trigger the synchronization of Keycloak roles"
     tags = listOf("Admin")
 
     request {
@@ -47,7 +47,7 @@ val runPermissionsSync: OpenApiRoute.() -> Unit = {
 
 val getUsers: OpenApiRoute.() -> Unit = {
     operationId = "getUsers"
-    summary = "Get all users of the server."
+    summary = "Get all users of the server"
     tags = listOf("Admin")
 
     request {
@@ -80,7 +80,7 @@ val getUsers: OpenApiRoute.() -> Unit = {
 
 val postUsers: OpenApiRoute.() -> Unit = {
     operationId = "postUsers"
-    summary = "Create a user, possibly with a password."
+    summary = "Create a user, possibly with a password"
     tags = listOf("Admin")
 
     request {
@@ -114,7 +114,7 @@ val postUsers: OpenApiRoute.() -> Unit = {
 
 val deleteUserByUsername: OpenApiRoute.() -> Unit = {
     operationId = "deleteUserByUsername"
-    summary = "Delete a user from the server."
+    summary = "Delete a user from the server"
     tags = listOf("Admin")
 
     request {

--- a/core/src/main/kotlin/apiDocs/DownloadsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/DownloadsDocs.kt
@@ -27,7 +27,7 @@ val getReportByRunIdAndToken: OpenApiRoute.() -> Unit = {
     operationId = "GetReportByRunIdAndToken"
     summary = "Download a report of an ORT run using a token"
     description = "This endpoint does not require authentication."
-    tags = listOf("Reports")
+    tags = listOf("Runs")
 
     request {
         pathParameter<Long>("runId") {

--- a/core/src/main/kotlin/apiDocs/DownloadsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/DownloadsDocs.kt
@@ -25,7 +25,8 @@ import io.ktor.http.HttpStatusCode
 
 val getReportByRunIdAndToken: OpenApiRoute.() -> Unit = {
     operationId = "GetReportByRunIdAndToken"
-    summary = "Download a report of an ORT run using a token. This endpoint does not require authentication."
+    summary = "Download a report of an ORT run using a token"
+    description = "This endpoint does not require authentication."
     tags = listOf("Reports")
 
     request {

--- a/core/src/main/kotlin/apiDocs/HealthDocs.kt
+++ b/core/src/main/kotlin/apiDocs/HealthDocs.kt
@@ -27,7 +27,7 @@ import org.eclipse.apoapsis.ortserver.core.api.Liveness
 
 val getLiveness: OpenApiRoute.() -> Unit = {
     operationId = "GetLiveness"
-    summary = "Get the health of the ORT server."
+    summary = "Get the health of the ORT server"
     tags = listOf("Health")
 
     response {

--- a/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
@@ -185,7 +185,7 @@ val deleteOrganizationById: OpenApiRoute.() -> Unit = {
 val getOrganizationProducts: OpenApiRoute.() -> Unit = {
     operationId = "GetOrganizationProducts"
     summary = "Get all products of an organization"
-    tags = listOf("Products")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {
@@ -221,7 +221,7 @@ val getOrganizationProducts: OpenApiRoute.() -> Unit = {
 val postProduct: OpenApiRoute.() -> Unit = {
     operationId = "PostProduct"
     summary = "Create a product for an organization"
-    tags = listOf("Products")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {
@@ -249,7 +249,7 @@ val postProduct: OpenApiRoute.() -> Unit = {
 val getSecretsByOrganizationId: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretsByOrganizationId"
     summary = "Get all secrets of an organization"
-    tags = listOf("Secrets")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {
@@ -284,7 +284,7 @@ val getSecretsByOrganizationId: OpenApiRoute.() -> Unit = {
 val getSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretByOrganizationIdAndName"
     summary = "Get details of a secret of an organization"
-    tags = listOf("Secrets")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {
@@ -310,7 +310,7 @@ val getSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
 val postSecretForOrganization: OpenApiRoute.() -> Unit = {
     operationId = "PostSecretForOrganization"
     summary = "Create a secret for an organization"
-    tags = listOf("Secrets")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {
@@ -342,7 +342,7 @@ val postSecretForOrganization: OpenApiRoute.() -> Unit = {
 val patchSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "PatchSecretByOrganizationIdAndName"
     summary = "Update a secret of an organization"
-    tags = listOf("Secrets")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {
@@ -379,7 +379,7 @@ val patchSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
 val deleteSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "DeleteSecretByOrganizationIdAndName"
     summary = "Delete a secret from an organization"
-    tags = listOf("Secrets")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {
@@ -400,7 +400,7 @@ val deleteSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
 val getInfrastructureServicesByOrganizationId: OpenApiRoute.() -> Unit = {
     operationId = "GetInfrastructureServicesByOrganizationId"
     summary = "List all infrastructure services of an organization"
-    tags = listOf("Infrastructure services")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {
@@ -447,7 +447,7 @@ val getInfrastructureServicesByOrganizationId: OpenApiRoute.() -> Unit = {
 val postInfrastructureServiceForOrganization: OpenApiRoute.() -> Unit = {
     operationId = "PostInfrastructureServiceForOrganization"
     summary = "Create an infrastructure service for an organization"
-    tags = listOf("Infrastructure services")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {
@@ -487,7 +487,7 @@ val postInfrastructureServiceForOrganization: OpenApiRoute.() -> Unit = {
 val patchInfrastructureServiceForOrganizationIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "PatchInfrastructureServiceForOrganizationIdAndName"
     summary = "Update an infrastructure service for an organization"
-    tags = listOf("Infrastructure services")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {
@@ -530,7 +530,7 @@ val patchInfrastructureServiceForOrganizationIdAndName: OpenApiRoute.() -> Unit 
 val deleteInfrastructureServiceForOrganizationIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "DeleteInfrastructureServiceForOrganizationIdAndName"
     summary = "Delete an infrastructure service from an organization"
-    tags = listOf("Infrastructure services")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {
@@ -551,7 +551,7 @@ val deleteInfrastructureServiceForOrganizationIdAndName: OpenApiRoute.() -> Unit
 val putUserToOrganizationGroup: OpenApiRoute.() -> Unit = {
     operationId = "PutUserToGroupOrganization"
     summary = "Add a user to a group on organization level"
-    tags = listOf("Groups")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {
@@ -582,7 +582,7 @@ val putUserToOrganizationGroup: OpenApiRoute.() -> Unit = {
 val deleteUserFromOrganizationGroup: OpenApiRoute.() -> Unit = {
     operationId = "DeleteUserFromGroupOrganization"
     summary = "Remove a user from a group on organization level"
-    tags = listOf("Groups")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {
@@ -615,7 +615,7 @@ val getVulnerabilitiesAcrossRepositoriesByOrganizationId: OpenApiRoute.() -> Uni
     summary = "Get vulnerabilities from an organization"
     description = "Get the vulnerabilities from latest successful advisor runs across the repositories in an " +
             " organization."
-    tags = listOf("Vulnerabilities")
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {

--- a/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
@@ -54,7 +54,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.asPresent
 
 val getOrganizationById: OpenApiRoute.() -> Unit = {
     operationId = "GetOrganizationById"
-    summary = "Get details of an organization."
+    summary = "Get details of an organization"
     tags = listOf("Organizations")
 
     request {
@@ -77,7 +77,7 @@ val getOrganizationById: OpenApiRoute.() -> Unit = {
 
 val getOrganizations: OpenApiRoute.() -> Unit = {
     operationId = "GetOrganizations"
-    summary = "Get all organizations."
+    summary = "Get all organizations"
     tags = listOf("Organizations")
 
     request {
@@ -109,7 +109,7 @@ val getOrganizations: OpenApiRoute.() -> Unit = {
 
 val postOrganizations: OpenApiRoute.() -> Unit = {
     operationId = "PostOrganizations"
-    summary = "Create an organization."
+    summary = "Create an organization"
     tags = listOf("Organizations")
 
     request {
@@ -134,7 +134,7 @@ val postOrganizations: OpenApiRoute.() -> Unit = {
 
 val patchOrganizationById: OpenApiRoute.() -> Unit = {
     operationId = "PatchOrganizationById"
-    summary = "Update an organization."
+    summary = "Update an organization"
     tags = listOf("Organizations")
 
     request {
@@ -166,7 +166,7 @@ val patchOrganizationById: OpenApiRoute.() -> Unit = {
 
 val deleteOrganizationById: OpenApiRoute.() -> Unit = {
     operationId = "DeleteOrganizationById"
-    summary = "Delete an organization."
+    summary = "Delete an organization"
     tags = listOf("Organizations")
 
     request {
@@ -184,7 +184,7 @@ val deleteOrganizationById: OpenApiRoute.() -> Unit = {
 
 val getOrganizationProducts: OpenApiRoute.() -> Unit = {
     operationId = "GetOrganizationProducts"
-    summary = "Get all products of an organization."
+    summary = "Get all products of an organization"
     tags = listOf("Products")
 
     request {
@@ -220,7 +220,7 @@ val getOrganizationProducts: OpenApiRoute.() -> Unit = {
 
 val postProduct: OpenApiRoute.() -> Unit = {
     operationId = "PostProduct"
-    summary = "Create a product for an organization."
+    summary = "Create a product for an organization"
     tags = listOf("Products")
 
     request {
@@ -248,7 +248,7 @@ val postProduct: OpenApiRoute.() -> Unit = {
 
 val getSecretsByOrganizationId: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretsByOrganizationId"
-    summary = "Get all secrets of an organization."
+    summary = "Get all secrets of an organization"
     tags = listOf("Secrets")
 
     request {
@@ -283,7 +283,7 @@ val getSecretsByOrganizationId: OpenApiRoute.() -> Unit = {
 
 val getSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretByOrganizationIdAndName"
-    summary = "Get details of a secret of an organization."
+    summary = "Get details of a secret of an organization"
     tags = listOf("Secrets")
 
     request {
@@ -309,7 +309,7 @@ val getSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
 
 val postSecretForOrganization: OpenApiRoute.() -> Unit = {
     operationId = "PostSecretForOrganization"
-    summary = "Create a secret for an organization."
+    summary = "Create a secret for an organization"
     tags = listOf("Secrets")
 
     request {
@@ -341,7 +341,7 @@ val postSecretForOrganization: OpenApiRoute.() -> Unit = {
 
 val patchSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "PatchSecretByOrganizationIdAndName"
-    summary = "Update a secret of an organization."
+    summary = "Update a secret of an organization"
     tags = listOf("Secrets")
 
     request {
@@ -378,7 +378,7 @@ val patchSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
 
 val deleteSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "DeleteSecretByOrganizationIdAndName"
-    summary = "Delete a secret from an organization."
+    summary = "Delete a secret from an organization"
     tags = listOf("Secrets")
 
     request {
@@ -399,7 +399,7 @@ val deleteSecretByOrganizationIdAndName: OpenApiRoute.() -> Unit = {
 
 val getInfrastructureServicesByOrganizationId: OpenApiRoute.() -> Unit = {
     operationId = "GetInfrastructureServicesByOrganizationId"
-    summary = "List all infrastructure services of an organization."
+    summary = "List all infrastructure services of an organization"
     tags = listOf("Infrastructure services")
 
     request {
@@ -446,7 +446,7 @@ val getInfrastructureServicesByOrganizationId: OpenApiRoute.() -> Unit = {
 
 val postInfrastructureServiceForOrganization: OpenApiRoute.() -> Unit = {
     operationId = "PostInfrastructureServiceForOrganization"
-    summary = "Create an infrastructure service for an organization."
+    summary = "Create an infrastructure service for an organization"
     tags = listOf("Infrastructure services")
 
     request {
@@ -486,7 +486,7 @@ val postInfrastructureServiceForOrganization: OpenApiRoute.() -> Unit = {
 
 val patchInfrastructureServiceForOrganizationIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "PatchInfrastructureServiceForOrganizationIdAndName"
-    summary = "Update an infrastructure service for an organization."
+    summary = "Update an infrastructure service for an organization"
     tags = listOf("Infrastructure services")
 
     request {
@@ -529,7 +529,7 @@ val patchInfrastructureServiceForOrganizationIdAndName: OpenApiRoute.() -> Unit 
 
 val deleteInfrastructureServiceForOrganizationIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "DeleteInfrastructureServiceForOrganizationIdAndName"
-    summary = "Delete an infrastructure service from an organization."
+    summary = "Delete an infrastructure service from an organization"
     tags = listOf("Infrastructure services")
 
     request {
@@ -550,7 +550,7 @@ val deleteInfrastructureServiceForOrganizationIdAndName: OpenApiRoute.() -> Unit
 
 val putUserToOrganizationGroup: OpenApiRoute.() -> Unit = {
     operationId = "PutUserToGroupOrganization"
-    summary = "Add a user to a group on Organization level."
+    summary = "Add a user to a group on organization level"
     tags = listOf("Groups")
 
     request {
@@ -581,7 +581,7 @@ val putUserToOrganizationGroup: OpenApiRoute.() -> Unit = {
 
 val deleteUserFromOrganizationGroup: OpenApiRoute.() -> Unit = {
     operationId = "DeleteUserFromGroupOrganization"
-    summary = "Remove a user from a group on Organization level."
+    summary = "Remove a user from a group on organization level"
     tags = listOf("Groups")
 
     request {
@@ -612,7 +612,9 @@ val deleteUserFromOrganizationGroup: OpenApiRoute.() -> Unit = {
 
 val getVulnerabilitiesAcrossRepositoriesByOrganizationId: OpenApiRoute.() -> Unit = {
     operationId = "GetVulnerabilitiesAcrossRepositoriesByOrganizationId"
-    summary = "Get the vulnerabilities from latest successful advisor runs across the repositories in an organization."
+    summary = "Get vulnerabilities from an organization"
+    description = "Get the vulnerabilities from latest successful advisor runs across the repositories in an " +
+            " organization."
     tags = listOf("Vulnerabilities")
 
     request {
@@ -665,7 +667,7 @@ val getVulnerabilitiesAcrossRepositoriesByOrganizationId: OpenApiRoute.() -> Uni
 
 val getOrtRunStatisticsByOrganizationId: OpenApiRoute.() -> Unit = {
     operationId = "GetOrtRunStatisticsByOrganizationId"
-    summary = "Get statistics about ORT runs across the repositories of an organization."
+    summary = "Get statistics about ORT runs across the repositories of an organization"
     tags = listOf("Organizations")
 
     request {

--- a/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
@@ -713,10 +713,12 @@ val getOrtRunStatisticsByOrganizationId: OpenApiRoute.() -> Unit = {
 
 val getUsersForOrganization: OpenApiRoute.() -> Unit = {
     operationId = "GetUsersForOrganization"
-    summary = "Get all users that have rights for a organization, including user privileges (groups) that user have " +
-        "within organization."
-    description = "Fields available for sorting: 'username', 'firstName', 'lastName', 'email', 'group'. " +
-        "NOTE: This endpoint supports only one sort field. All fields other than first one are ignored."
+    summary = "Get all users for an organization"
+    description = "Get all users that have access rights for an organization, including the user privileges (groups) " +
+            "the user has within the organization. Fields available for sorting: 'username', 'firstName', " +
+            "'lastName', 'email', 'group'. NOTE: This endpoint supports only one sort field. All fields other than " +
+            " the first one are ignored."
+    tags = listOf("Organizations")
 
     request {
         pathParameter<Long>("organizationId") {

--- a/core/src/main/kotlin/apiDocs/ProductsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/ProductsDocs.kt
@@ -532,10 +532,12 @@ val getOrtRunStatisticsByProductId: OpenApiRoute.() -> Unit = {
 
 val getUsersForProduct: OpenApiRoute.() -> Unit = {
     operationId = "GetUsersForProduct"
-    summary = "Get all users that have rights for a product, including user privileges (groups) that user have " +
-        "within product."
-    description = "Fields available for sorting: 'username', 'firstName', 'lastName', 'email', 'group'. " +
-        "NOTE: This endpoint supports only one sort field. All fields other than first one are ignored."
+    summary = "Get all users for a product"
+    description = "Get all users that have access rights for a product, including the user privileges (groups) " +
+            "the user has within the product. Fields available for sorting: 'username', 'firstName', " +
+            "'lastName', 'email', 'group'. NOTE: This endpoint supports only one sort field. All fields other than " +
+            " the first one are ignored."
+    tags = listOf("Products")
 
     request {
         pathParameter<Long>("productId") {

--- a/core/src/main/kotlin/apiDocs/ProductsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/ProductsDocs.kt
@@ -133,7 +133,7 @@ val deleteProductById: OpenApiRoute.() -> Unit = {
 val getRepositoriesByProductId: OpenApiRoute.() -> Unit = {
     operationId = "GetRepositoriesByProductId"
     summary = "Get all repositories of a product"
-    tags = listOf("Repositories")
+    tags = listOf("Products")
 
     request {
         pathParameter<Long>("productId") {
@@ -181,7 +181,7 @@ val getRepositoriesByProductId: OpenApiRoute.() -> Unit = {
 val postRepository: OpenApiRoute.() -> Unit = {
     operationId = "CreateRepository"
     summary = "Create a repository for a product"
-    tags = listOf("Repositories")
+    tags = listOf("Products")
 
     request {
         pathParameter<Long>("productId") {
@@ -218,7 +218,7 @@ val postRepository: OpenApiRoute.() -> Unit = {
 val getSecretsByProductId: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretsByProductId"
     summary = "Get all secrets of a specific product"
-    tags = listOf("Secrets")
+    tags = listOf("Products")
 
     request {
         pathParameter<Long>("productId") {
@@ -253,7 +253,7 @@ val getSecretsByProductId: OpenApiRoute.() -> Unit = {
 val getSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretByProductIdAndName"
     summary = "Get details of a secret of a product"
-    tags = listOf("Secrets")
+    tags = listOf("Products")
 
     request {
         pathParameter<Long>("productId") {
@@ -279,7 +279,7 @@ val getSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
 val postSecretForProduct: OpenApiRoute.() -> Unit = {
     operationId = "PostSecretForProduct"
     summary = "Create a secret for a product"
-    tags = listOf("Secrets")
+    tags = listOf("Products")
 
     request {
         pathParameter<Long>("productId") {
@@ -311,7 +311,7 @@ val postSecretForProduct: OpenApiRoute.() -> Unit = {
 val patchSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "PatchSecretByProductIdAndName"
     summary = "Update a secret of a product"
-    tags = listOf("Secrets")
+    tags = listOf("Products")
 
     request {
         pathParameter<Long>("productId") {
@@ -348,7 +348,7 @@ val patchSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
 val deleteSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "DeleteSecretByProductIdAndName"
     summary = "Delete a secret from a product"
-    tags = listOf("Secrets")
+    tags = listOf("Products")
 
     request {
         pathParameter<Long>("productId") {
@@ -369,7 +369,7 @@ val deleteSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
 val putUserToProductGroup: OpenApiRoute.() -> Unit = {
     operationId = "PutUserToGroupProduct"
     summary = "Add a user to a group on product level"
-    tags = listOf("Groups")
+    tags = listOf("Products")
 
     request {
         pathParameter<Long>("productId") {
@@ -400,7 +400,7 @@ val putUserToProductGroup: OpenApiRoute.() -> Unit = {
 val deleteUserFromProductGroup: OpenApiRoute.() -> Unit = {
     operationId = "DeleteUserFromGroupProduct"
     summary = "Remove a user from a group on product level"
-    tags = listOf("Groups")
+    tags = listOf("Products")
 
     request {
         pathParameter<Long>("productId") {
@@ -432,7 +432,7 @@ val getVulnerabilitiesAcrossRepositoriesByProductId: OpenApiRoute.() -> Unit = {
     operationId = "GetVulnerabilitiesAcrossRepositoriesByProductId"
     summary = "Get vulnerabilities from a product"
     description = "Get the vulnerabilities from latest successful advisor runs across the repositories in a product."
-    tags = listOf("Vulnerabilities")
+    tags = listOf("Products")
 
     request {
         pathParameter<Long>("productId") {

--- a/core/src/main/kotlin/apiDocs/ProductsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/ProductsDocs.kt
@@ -57,7 +57,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.asPresent
 
 val getProductById: OpenApiRoute.() -> Unit = {
     operationId = "GetProductById"
-    summary = "Get details of a product."
+    summary = "Get details of a product"
     tags = listOf("Products")
 
     request {
@@ -80,7 +80,7 @@ val getProductById: OpenApiRoute.() -> Unit = {
 
 val patchProductById: OpenApiRoute.() -> Unit = {
     operationId = "PatchProductById"
-    summary = "Update a product."
+    summary = "Update a product"
     tags = listOf("Products")
 
     request {
@@ -114,7 +114,7 @@ val patchProductById: OpenApiRoute.() -> Unit = {
 
 val deleteProductById: OpenApiRoute.() -> Unit = {
     operationId = "DeleteProductById"
-    summary = "Delete a product."
+    summary = "Delete a product"
     tags = listOf("Products")
 
     request {
@@ -132,7 +132,7 @@ val deleteProductById: OpenApiRoute.() -> Unit = {
 
 val getRepositoriesByProductId: OpenApiRoute.() -> Unit = {
     operationId = "GetRepositoriesByProductId"
-    summary = "Get all repositories of a product."
+    summary = "Get all repositories of a product"
     tags = listOf("Repositories")
 
     request {
@@ -180,7 +180,7 @@ val getRepositoriesByProductId: OpenApiRoute.() -> Unit = {
 
 val postRepository: OpenApiRoute.() -> Unit = {
     operationId = "CreateRepository"
-    summary = "Create a repository for a product."
+    summary = "Create a repository for a product"
     tags = listOf("Repositories")
 
     request {
@@ -217,7 +217,7 @@ val postRepository: OpenApiRoute.() -> Unit = {
 
 val getSecretsByProductId: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretsByProductId"
-    summary = "Get all secrets of a specific product."
+    summary = "Get all secrets of a specific product"
     tags = listOf("Secrets")
 
     request {
@@ -252,7 +252,7 @@ val getSecretsByProductId: OpenApiRoute.() -> Unit = {
 
 val getSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretByProductIdAndName"
-    summary = "Get details of a secret of a product."
+    summary = "Get details of a secret of a product"
     tags = listOf("Secrets")
 
     request {
@@ -278,7 +278,7 @@ val getSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
 
 val postSecretForProduct: OpenApiRoute.() -> Unit = {
     operationId = "PostSecretForProduct"
-    summary = "Create a secret for a product."
+    summary = "Create a secret for a product"
     tags = listOf("Secrets")
 
     request {
@@ -310,7 +310,7 @@ val postSecretForProduct: OpenApiRoute.() -> Unit = {
 
 val patchSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "PatchSecretByProductIdAndName"
-    summary = "Update a secret of a product."
+    summary = "Update a secret of a product"
     tags = listOf("Secrets")
 
     request {
@@ -347,7 +347,7 @@ val patchSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
 
 val deleteSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "DeleteSecretByProductIdAndName"
-    summary = "Delete a secret from a product."
+    summary = "Delete a secret from a product"
     tags = listOf("Secrets")
 
     request {
@@ -368,7 +368,7 @@ val deleteSecretByProductIdAndName: OpenApiRoute.() -> Unit = {
 
 val putUserToProductGroup: OpenApiRoute.() -> Unit = {
     operationId = "PutUserToGroupProduct"
-    summary = "Add a user to a group on Product level."
+    summary = "Add a user to a group on product level"
     tags = listOf("Groups")
 
     request {
@@ -399,7 +399,7 @@ val putUserToProductGroup: OpenApiRoute.() -> Unit = {
 
 val deleteUserFromProductGroup: OpenApiRoute.() -> Unit = {
     operationId = "DeleteUserFromGroupProduct"
-    summary = "Remove a user from a group on Product level."
+    summary = "Remove a user from a group on product level"
     tags = listOf("Groups")
 
     request {
@@ -430,7 +430,8 @@ val deleteUserFromProductGroup: OpenApiRoute.() -> Unit = {
 
 val getVulnerabilitiesAcrossRepositoriesByProductId: OpenApiRoute.() -> Unit = {
     operationId = "GetVulnerabilitiesAcrossRepositoriesByProductId"
-    summary = "Get the vulnerabilities from latest successful advisor runs across the repositories in a product."
+    summary = "Get vulnerabilities from a product"
+    description = "Get the vulnerabilities from latest successful advisor runs across the repositories in a product."
     tags = listOf("Vulnerabilities")
 
     request {
@@ -483,7 +484,7 @@ val getVulnerabilitiesAcrossRepositoriesByProductId: OpenApiRoute.() -> Unit = {
 
 val getOrtRunStatisticsByProductId: OpenApiRoute.() -> Unit = {
     operationId = "GetOrtRunStatisticsByProductId"
-    summary = "Get statistics about ORT runs across the repositories of a product."
+    summary = "Get statistics about ORT runs across the repositories of a product"
     tags = listOf("Products")
 
     request {
@@ -591,7 +592,7 @@ private val minimalJobConfigurations = JobConfigurations(
 
 val postOrtRunsForProduct: OpenApiRoute.() -> Unit = {
     operationId = "postOrtRunsForProduct"
-    summary = "Create ORT runs for all repositories under a product."
+    summary = "Create ORT runs for all repositories under a product"
     tags = listOf("Products")
 
     request {

--- a/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
@@ -751,10 +751,12 @@ val deleteUserFromRepositoryGroup: OpenApiRoute.() -> Unit = {
 
 val getUsersForRepository: OpenApiRoute.() -> Unit = {
     operationId = "GetUsersForRepository"
-    summary = "Get all users that have rights for a repository, including privileges (groups) that user have within " +
-        "repository."
-    description = "Fields available for sorting: 'username', 'firstName', 'lastName', 'email', 'group'. " +
-        "NOTE: This endpoint supports only one sort field. All fields other than first one are ignored."
+    summary = "Get all users for a repository"
+    description = "Get all users that have access rights for a repository, including the user privileges (groups) " +
+            "the user has within the repository. Fields available for sorting: 'username', 'firstName', " +
+            "'lastName', 'email', 'group'. NOTE: This endpoint supports only one sort field. All fields other than " +
+            " the first one are ignored."
+    tags = listOf("Repositories")
 
     request {
         pathParameter<Long>("repositoryId") {

--- a/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
@@ -539,7 +539,7 @@ val deleteOrtRunByIndex: OpenApiRoute.() -> Unit = {
 val getSecretsByRepositoryId: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretsByRepositoryId"
     summary = "Get all secrets of a repository"
-    tags = listOf("Secrets")
+    tags = listOf("Repositories")
 
     request {
         pathParameter<Long>("repositoryId") {
@@ -574,7 +574,7 @@ val getSecretsByRepositoryId: OpenApiRoute.() -> Unit = {
 val getSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretByRepositoryIdAndName"
     summary = "Get details of a secret of a repository"
-    tags = listOf("Secrets")
+    tags = listOf("Repositories")
 
     request {
         pathParameter<Long>("repositoryId") {
@@ -600,7 +600,7 @@ val getSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
 val postSecretForRepository: OpenApiRoute.() -> Unit = {
     operationId = "PostSecretForRepository"
     summary = "Create a secret for a repository"
-    tags = listOf("Secrets")
+    tags = listOf("Repositories")
 
     request {
         pathParameter<Long>("repositoryId") {
@@ -632,7 +632,7 @@ val postSecretForRepository: OpenApiRoute.() -> Unit = {
 val patchSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "PatchSecretByRepositoryIdAndName"
     summary = "Update a secret of a repository"
-    tags = listOf("Secrets")
+    tags = listOf("Repositories")
 
     request {
         pathParameter<Long>("repositoryId") {
@@ -669,7 +669,7 @@ val patchSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
 val deleteSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "DeleteSecretByRepositoryIdAndName"
     summary = "Delete a secret from a repository"
-    tags = listOf("Secrets")
+    tags = listOf("Repositories")
 
     request {
         pathParameter<Long>("repositoryId") {
@@ -690,7 +690,7 @@ val deleteSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
 val putUserToRepositoryGroup: OpenApiRoute.() -> Unit = {
     operationId = "PutUserToGroupRepository"
     summary = "Add a user to a group on repository level"
-    tags = listOf("Groups")
+    tags = listOf("Repositories")
 
     request {
         pathParameter<Long>("repositoryId") {
@@ -721,7 +721,7 @@ val putUserToRepositoryGroup: OpenApiRoute.() -> Unit = {
 val deleteUserFromRepositoryGroup: OpenApiRoute.() -> Unit = {
     operationId = "DeleteUserFromGroupRepository"
     summary = "Remove a user from a group on repository level"
-    tags = listOf("Groups")
+    tags = listOf("Repositories")
 
     request {
         pathParameter<Long>("repositoryId") {

--- a/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
@@ -242,7 +242,7 @@ fun createJobSummary(offset: Duration, status: JobStatus = JobStatus.FINISHED): 
 
 val getRepositoryById: OpenApiRoute.() -> Unit = {
     operationId = "GetRepositoryById"
-    summary = "Get details of a repository."
+    summary = "Get details of a repository"
     tags = listOf("Repositories")
 
     request {
@@ -271,7 +271,7 @@ val getRepositoryById: OpenApiRoute.() -> Unit = {
 
 val patchRepositoryById: OpenApiRoute.() -> Unit = {
     operationId = "PatchRepositoryById"
-    summary = "Update a repository."
+    summary = "Update a repository"
     tags = listOf("Repositories")
 
     request {
@@ -309,7 +309,7 @@ val patchRepositoryById: OpenApiRoute.() -> Unit = {
 
 val deleteRepositoryById: OpenApiRoute.() -> Unit = {
     operationId = "DeleteRepositoryById"
-    summary = "Delete a repository."
+    summary = "Delete a repository"
     tags = listOf("Repositories")
 
     request {
@@ -327,7 +327,7 @@ val deleteRepositoryById: OpenApiRoute.() -> Unit = {
 
 val getOrtRunsByRepositoryId: OpenApiRoute.() -> Unit = {
     operationId = "getOrtRunsByRepositoryId"
-    summary = "Get all ORT runs of a repository."
+    summary = "Get all ORT runs of a repository"
     tags = listOf("Repositories")
 
     request {
@@ -405,7 +405,7 @@ val getOrtRunsByRepositoryId: OpenApiRoute.() -> Unit = {
 
 val postOrtRun: OpenApiRoute.() -> Unit = {
     operationId = "postOrtRun"
-    summary = "Create an ORT run for a repository."
+    summary = "Create an ORT run for a repository"
     tags = listOf("Repositories")
 
     request {
@@ -465,7 +465,7 @@ val postOrtRun: OpenApiRoute.() -> Unit = {
 
 val getOrtRunByIndex: OpenApiRoute.() -> Unit = {
     operationId = "getOrtRunByIndex"
-    summary = "Get details of an ORT run of a repository."
+    summary = "Get details of an ORT run of a repository"
     tags = listOf("Repositories")
 
     request {
@@ -511,7 +511,7 @@ val getOrtRunByIndex: OpenApiRoute.() -> Unit = {
 
 val deleteOrtRunByIndex: OpenApiRoute.() -> Unit = {
     operationId = "deleteOrtRunByIndex"
-    summary = "Delete an ORT run of a repository."
+    summary = "Delete an ORT run of a repository"
     description = "This operation deletes an ORT run and all generated data, including the generated reports."
     tags = listOf("Repositories")
 
@@ -538,7 +538,7 @@ val deleteOrtRunByIndex: OpenApiRoute.() -> Unit = {
 
 val getSecretsByRepositoryId: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretsByRepositoryId"
-    summary = "Get all secrets of a repository."
+    summary = "Get all secrets of a repository"
     tags = listOf("Secrets")
 
     request {
@@ -573,7 +573,7 @@ val getSecretsByRepositoryId: OpenApiRoute.() -> Unit = {
 
 val getSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "GetSecretByRepositoryIdAndName"
-    summary = "Get details of a secret of a repository."
+    summary = "Get details of a secret of a repository"
     tags = listOf("Secrets")
 
     request {
@@ -599,7 +599,7 @@ val getSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
 
 val postSecretForRepository: OpenApiRoute.() -> Unit = {
     operationId = "PostSecretForRepository"
-    summary = "Create a secret for a repository."
+    summary = "Create a secret for a repository"
     tags = listOf("Secrets")
 
     request {
@@ -631,7 +631,7 @@ val postSecretForRepository: OpenApiRoute.() -> Unit = {
 
 val patchSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "PatchSecretByRepositoryIdAndName"
-    summary = "Update a secret of a repository."
+    summary = "Update a secret of a repository"
     tags = listOf("Secrets")
 
     request {
@@ -668,7 +668,7 @@ val patchSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
 
 val deleteSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
     operationId = "DeleteSecretByRepositoryIdAndName"
-    summary = "Delete a secret from a repository."
+    summary = "Delete a secret from a repository"
     tags = listOf("Secrets")
 
     request {
@@ -689,7 +689,7 @@ val deleteSecretByRepositoryIdAndName: OpenApiRoute.() -> Unit = {
 
 val putUserToRepositoryGroup: OpenApiRoute.() -> Unit = {
     operationId = "PutUserToGroupRepository"
-    summary = "Add a user to a group on Repository level."
+    summary = "Add a user to a group on repository level"
     tags = listOf("Groups")
 
     request {
@@ -720,7 +720,7 @@ val putUserToRepositoryGroup: OpenApiRoute.() -> Unit = {
 
 val deleteUserFromRepositoryGroup: OpenApiRoute.() -> Unit = {
     operationId = "DeleteUserFromGroupRepository"
-    summary = "Remove a user from a group on Repository level."
+    summary = "Remove a user from a group on repository level"
     tags = listOf("Groups")
 
     request {

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -131,7 +131,7 @@ val deleteOrtRunById: OpenApiRoute.() -> Unit = {
 val getReportByRunIdAndFileName: OpenApiRoute.() -> Unit = {
     operationId = "GetReportByRunIdAndFileName"
     summary = "Download a report of an ORT run"
-    tags = listOf("Reports")
+    tags = listOf("Runs")
 
     request {
         pathParameter<Long>("runId") {
@@ -159,7 +159,7 @@ val getReportByRunIdAndFileName: OpenApiRoute.() -> Unit = {
 val getLogsByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetLogsByRunId"
     summary = "Download an archive with selected logs of an ORT run"
-    tags = listOf("Logs")
+    tags = listOf("Runs")
 
     request {
         pathParameter<Long>("runId") {
@@ -197,7 +197,7 @@ val getLogsByRunId: OpenApiRoute.() -> Unit = {
 val getIssuesByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetIssuesByRunId"
     summary = "Get the issues of an ORT run"
-    tags = listOf("Issues")
+    tags = listOf("Runs")
 
     request {
         pathParameter<Long>("runId") {
@@ -241,7 +241,7 @@ val getIssuesByRunId: OpenApiRoute.() -> Unit = {
 val getVulnerabilitiesByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetVulnerabilitiesByRunId"
     summary = "Get the vulnerabilities found in an ORT run"
-    tags = listOf("Vulnerabilities")
+    tags = listOf("Runs")
 
     request {
         pathParameter<Long>("runId") {
@@ -297,7 +297,7 @@ val getVulnerabilitiesByRunId: OpenApiRoute.() -> Unit = {
 val getRuleViolationsByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetRuleViolationsByRunId"
     summary = "Get the rule violations found in an ORT run"
-    tags = listOf("RuleViolations")
+    tags = listOf("Runs")
 
     request {
         pathParameter<Long>("runId") {
@@ -367,7 +367,7 @@ val getRuleViolationsByRunId: OpenApiRoute.() -> Unit = {
 val getPackagesByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetPackagesByRunId"
     summary = "Get the packages found in an ORT run"
-    tags = listOf("Packages")
+    tags = listOf("Runs")
 
     request {
         pathParameter<Long>("runId") {
@@ -465,7 +465,7 @@ val getPackagesByRunId: OpenApiRoute.() -> Unit = {
 val getProjectsByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetProjectsByRunId"
     summary = "Get the projects found in an ORT run"
-    tags = listOf("Projects")
+    tags = listOf("Runs")
 
     request {
         pathParameter<Long>("runId") {

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -64,7 +64,7 @@ import org.eclipse.apoapsis.ortserver.model.LogSource
 
 val getOrtRunById: OpenApiRoute.() -> Unit = {
     operationId = "getOrtRunById"
-    summary = "Get details of an ORT run."
+    summary = "Get details of an ORT run"
     tags = listOf("Runs")
 
     request {
@@ -107,7 +107,7 @@ val getOrtRunById: OpenApiRoute.() -> Unit = {
 
 val deleteOrtRunById: OpenApiRoute.() -> Unit = {
     operationId = "deleteOrtRunById"
-    summary = "Delete an ORT run."
+    summary = "Delete an ORT run"
     description = "This operation deletes an ORT run and all generated data, including the generated reports."
     tags = listOf("Runs")
 
@@ -130,7 +130,7 @@ val deleteOrtRunById: OpenApiRoute.() -> Unit = {
 
 val getReportByRunIdAndFileName: OpenApiRoute.() -> Unit = {
     operationId = "GetReportByRunIdAndFileName"
-    summary = "Download a report of an ORT run."
+    summary = "Download a report of an ORT run"
     tags = listOf("Reports")
 
     request {
@@ -158,7 +158,7 @@ val getReportByRunIdAndFileName: OpenApiRoute.() -> Unit = {
 
 val getLogsByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetLogsByRunId"
-    summary = "Download an archive with selected logs of an ORT run."
+    summary = "Download an archive with selected logs of an ORT run"
     tags = listOf("Logs")
 
     request {
@@ -196,7 +196,7 @@ val getLogsByRunId: OpenApiRoute.() -> Unit = {
 
 val getIssuesByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetIssuesByRunId"
-    summary = "Get the issues of an ORT run."
+    summary = "Get the issues of an ORT run"
     tags = listOf("Issues")
 
     request {
@@ -240,7 +240,7 @@ val getIssuesByRunId: OpenApiRoute.() -> Unit = {
 
 val getVulnerabilitiesByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetVulnerabilitiesByRunId"
-    summary = "Get the vulnerabilities found in an ORT run."
+    summary = "Get the vulnerabilities found in an ORT run"
     tags = listOf("Vulnerabilities")
 
     request {
@@ -296,7 +296,7 @@ val getVulnerabilitiesByRunId: OpenApiRoute.() -> Unit = {
 
 val getRuleViolationsByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetRuleViolationsByRunId"
-    summary = "Get the rule violations found in an ORT run."
+    summary = "Get the rule violations found in an ORT run"
     tags = listOf("RuleViolations")
 
     request {
@@ -366,7 +366,7 @@ val getRuleViolationsByRunId: OpenApiRoute.() -> Unit = {
 
 val getPackagesByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetPackagesByRunId"
-    summary = "Get the packages found in an ORT run."
+    summary = "Get the packages found in an ORT run"
     tags = listOf("Packages")
 
     request {
@@ -464,7 +464,7 @@ val getPackagesByRunId: OpenApiRoute.() -> Unit = {
 
 val getProjectsByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetProjectsByRunId"
-    summary = "Get the projects found in an ORT run."
+    summary = "Get the projects found in an ORT run"
     tags = listOf("Projects")
 
     request {
@@ -519,7 +519,7 @@ val getProjectsByRunId: OpenApiRoute.() -> Unit = {
 
 val getOrtRuns: OpenApiRoute.() -> Unit = {
     operationId = "getOrtRuns"
-    summary = "Get all ORT runs."
+    summary = "Get all ORT runs"
     tags = listOf("Runs")
 
     request {
@@ -584,7 +584,7 @@ val getOrtRuns: OpenApiRoute.() -> Unit = {
 
 val getOrtRunStatistics: OpenApiRoute.() -> Unit = {
     operationId = "getOrtRunStatistics"
-    summary = "Get statistics about an ORT run."
+    summary = "Get statistics about an ORT run"
     tags = listOf("Runs")
 
     request {
@@ -633,7 +633,7 @@ val getOrtRunStatistics: OpenApiRoute.() -> Unit = {
 
 val getLicensesForPackagesByRunId: OpenApiRoute.() -> Unit = {
     operationId = "GetLicensesForPackagesByRunId"
-    summary = "Get the licenses for packages found in an ORT run."
+    summary = "Get the licenses for packages found in an ORT run"
     tags = listOf("Runs")
 
     request {

--- a/core/src/main/kotlin/apiDocs/VersionsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/VersionsDocs.kt
@@ -25,7 +25,7 @@ import io.ktor.http.HttpStatusCode
 
 val getVersions: OpenApiRoute.() -> Unit = {
     operationId = "getVersions"
-    summary = "Get the versions of the ORT server and other components."
+    summary = "Get the versions of the ORT server and other components"
     tags = listOf("Versions")
 
     response {

--- a/core/src/main/kotlin/plugins/OpenApi.kt
+++ b/core/src/main/kotlin/plugins/OpenApi.kt
@@ -103,10 +103,8 @@ fun Application.configureOpenApi() {
             tag("Products") { }
             tag("Repositories") { }
             tag("Runs") { }
-            tag("Secrets") { }
-            tag("Infrastructure services") { }
-            tag("Reports") { }
-            tag("Logs") { }
+            tag("Admin") { }
+            tag("Versions") { }
         }
 
         schemas {

--- a/ui/src/routes/organizations/$orgId/-components/organization-product-table.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-product-table.tsx
@@ -26,8 +26,8 @@ import {
 import { Loader2 } from 'lucide-react';
 
 import {
-  useProductsServiceGetApiV1OrganizationsByOrganizationIdProducts,
-  useRepositoriesServiceGetApiV1ProductsByProductIdRepositories,
+  useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdProducts,
+  useProductsServiceGetApiV1ProductsByProductIdRepositories,
 } from '@/api/queries';
 import { PagedResponse_Product, Product } from '@/api/requests';
 import { DataTable } from '@/components/data-table/data-table';
@@ -75,7 +75,7 @@ const columns = [
     size: 60,
     cell: function CellComponent({ row }) {
       const { data, isPending, isError } =
-        useRepositoriesServiceGetApiV1ProductsByProductIdRepositories({
+        useProductsServiceGetApiV1ProductsByProductIdRepositories({
           productId: row.original.id,
           limit: 1,
         });
@@ -101,7 +101,7 @@ const columns = [
     header: 'Last Run Status',
     cell: function CellComponent({ row }) {
       const { data, isPending, isError } =
-        useRepositoriesServiceGetApiV1ProductsByProductIdRepositories({
+        useProductsServiceGetApiV1ProductsByProductIdRepositories({
           productId: row.original.id,
           limit: 1,
         });
@@ -128,7 +128,7 @@ const columns = [
     header: 'Last Run Date',
     cell: function CellComponent({ row }) {
       const { data, isPending, isError } =
-        useRepositoriesServiceGetApiV1ProductsByProductIdRepositories({
+        useProductsServiceGetApiV1ProductsByProductIdRepositories({
           productId: row.original.id,
           limit: 1,
         });
@@ -154,7 +154,7 @@ const columns = [
     header: 'Last Job Status',
     cell: function CellComponent({ row }) {
       const { data, isPending, isError } =
-        useRepositoriesServiceGetApiV1ProductsByProductIdRepositories({
+        useProductsServiceGetApiV1ProductsByProductIdRepositories({
           productId: row.original.id,
           limit: 1,
         });
@@ -191,7 +191,7 @@ export const OrganizationProductTable = () => {
     error: prodError,
     isPending: prodIsPending,
     isError: prodIsError,
-  } = useProductsServiceGetApiV1OrganizationsByOrganizationIdProducts({
+  } = useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdProducts({
     organizationId: Number.parseInt(params.orgId),
     limit: pageSize,
     offset: pageIndex * pageSize,

--- a/ui/src/routes/organizations/$orgId/-components/organization-products-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-products-statistics-card.tsx
@@ -20,7 +20,7 @@
 import { Link } from '@tanstack/react-router';
 import { Files, PlusIcon } from 'lucide-react';
 
-import { useProductsServiceGetApiV1OrganizationsByOrganizationIdProducts } from '@/api/queries';
+import { useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdProducts } from '@/api/queries';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { StatisticsCard } from '@/components/statistics-card';
 import { ToastError } from '@/components/toast-error';
@@ -43,7 +43,7 @@ export const OrganizationProductsStatisticsCard = ({
   className,
 }: OrganizationProductsStatisticsCardProps) => {
   const { data, isPending, isError, error } =
-    useProductsServiceGetApiV1OrganizationsByOrganizationIdProducts({
+    useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdProducts({
       organizationId: Number.parseInt(orgId),
       limit: 1,
     });

--- a/ui/src/routes/organizations/$orgId/create-product/index.tsx
+++ b/ui/src/routes/organizations/$orgId/create-product/index.tsx
@@ -23,7 +23,7 @@ import { Loader2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
-import { useProductsServicePostApiV1OrganizationsByOrganizationIdProducts } from '@/api/queries';
+import { useOrganizationsServicePostApiV1OrganizationsByOrganizationIdProducts } from '@/api/queries';
 import { ApiError } from '@/api/requests';
 import { asOptionalField } from '@/components/form/as-optional-field';
 import { OptionalInput } from '@/components/form/optional-input';
@@ -59,7 +59,7 @@ const CreateProductPage = () => {
   const { refreshUser } = useUser();
 
   const { mutateAsync, isPending } =
-    useProductsServicePostApiV1OrganizationsByOrganizationIdProducts({
+    useOrganizationsServicePostApiV1OrganizationsByOrganizationIdProducts({
       onSuccess(data) {
         // Refresh the user token and data to get the new roles after creating a new product.
         refreshUser();

--- a/ui/src/routes/organizations/$orgId/infrastructure-services/$serviceName/edit/index.tsx
+++ b/ui/src/routes/organizations/$orgId/infrastructure-services/$serviceName/edit/index.tsx
@@ -25,11 +25,11 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import {
-  useInfrastructureServicesServiceGetApiV1OrganizationsByOrganizationIdInfrastructureServicesKey,
-  useInfrastructureServicesServicePatchApiV1OrganizationsByOrganizationIdInfrastructureServicesByServiceName,
+  useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdInfrastructureServicesKey,
+  useOrganizationsServicePatchApiV1OrganizationsByOrganizationIdInfrastructureServicesByServiceName,
 } from '@/api/queries';
-import { useSecretsServiceGetApiV1OrganizationsByOrganizationIdSecretsSuspense } from '@/api/queries/suspense';
-import { ApiError, InfrastructureServicesService } from '@/api/requests';
+import { useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdSecretsSuspense } from '@/api/queries/suspense';
+import { ApiError, OrganizationsService } from '@/api/requests';
 import { MultiSelectField } from '@/components/form/multi-select-field';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { ToastError } from '@/components/toast-error';
@@ -76,10 +76,12 @@ const EditInfrastructureServicePage = () => {
   const params = Route.useParams();
 
   const { data: secrets } =
-    useSecretsServiceGetApiV1OrganizationsByOrganizationIdSecretsSuspense({
-      organizationId: Number.parseInt(params.orgId),
-      limit: ALL_ITEMS,
-    });
+    useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdSecretsSuspense(
+      {
+        organizationId: Number.parseInt(params.orgId),
+        limit: ALL_ITEMS,
+      }
+    );
 
   /* Search service details from all infrastructure services of the organization
    * TODO: Edit this to fetch the details from:
@@ -88,11 +90,11 @@ const EditInfrastructureServicePage = () => {
    */
   const { data: infrastructureServices } = useSuspenseQuery({
     queryKey: [
-      useInfrastructureServicesServiceGetApiV1OrganizationsByOrganizationIdInfrastructureServicesKey,
+      useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdInfrastructureServicesKey,
       params.orgId,
     ],
     queryFn: () =>
-      InfrastructureServicesService.getApiV1OrganizationsByOrganizationIdInfrastructureServices(
+      OrganizationsService.getApiV1OrganizationsByOrganizationIdInfrastructureServices(
         {
           organizationId: Number.parseInt(params.orgId),
           limit: ALL_ITEMS,
@@ -105,7 +107,7 @@ const EditInfrastructureServicePage = () => {
   );
 
   const { mutateAsync, isPending } =
-    useInfrastructureServicesServicePatchApiV1OrganizationsByOrganizationIdInfrastructureServicesByServiceName(
+    useOrganizationsServicePatchApiV1OrganizationsByOrganizationIdInfrastructureServicesByServiceName(
       {
         onSuccess(data) {
           toast.info('Edit Infrastructure Service', {
@@ -361,11 +363,11 @@ export const Route = createFileRoute(
   loader: async ({ context, params }) => {
     await context.queryClient.ensureQueryData({
       queryKey: [
-        useInfrastructureServicesServiceGetApiV1OrganizationsByOrganizationIdInfrastructureServicesKey,
+        useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdInfrastructureServicesKey,
         params.orgId,
       ],
       queryFn: () =>
-        InfrastructureServicesService.getApiV1OrganizationsByOrganizationIdInfrastructureServices(
+        OrganizationsService.getApiV1OrganizationsByOrganizationIdInfrastructureServices(
           {
             organizationId: Number.parseInt(params.orgId),
             limit: ALL_ITEMS,

--- a/ui/src/routes/organizations/$orgId/infrastructure-services/create/index.tsx
+++ b/ui/src/routes/organizations/$orgId/infrastructure-services/create/index.tsx
@@ -23,8 +23,8 @@ import { Loader2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
-import { useInfrastructureServicesServicePostApiV1OrganizationsByOrganizationIdInfrastructureServices } from '@/api/queries';
-import { useSecretsServiceGetApiV1OrganizationsByOrganizationIdSecretsSuspense } from '@/api/queries/suspense';
+import { useOrganizationsServicePostApiV1OrganizationsByOrganizationIdInfrastructureServices } from '@/api/queries';
+import { useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdSecretsSuspense } from '@/api/queries/suspense';
 import { ApiError } from '@/api/requests';
 import { MultiSelectField } from '@/components/form/multi-select-field';
 import { ToastError } from '@/components/toast-error';
@@ -73,13 +73,15 @@ const CreateInfrastructureServicePage = () => {
   const params = Route.useParams();
 
   const { data: secrets } =
-    useSecretsServiceGetApiV1OrganizationsByOrganizationIdSecretsSuspense({
-      organizationId: Number.parseInt(params.orgId),
-      limit: ALL_ITEMS,
-    });
+    useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdSecretsSuspense(
+      {
+        organizationId: Number.parseInt(params.orgId),
+        limit: ALL_ITEMS,
+      }
+    );
 
   const { mutateAsync, isPending } =
-    useInfrastructureServicesServicePostApiV1OrganizationsByOrganizationIdInfrastructureServices(
+    useOrganizationsServicePostApiV1OrganizationsByOrganizationIdInfrastructureServices(
       {
         onSuccess(data) {
           toast.info('Create Infrastructure Service', {

--- a/ui/src/routes/organizations/$orgId/infrastructure-services/index.tsx
+++ b/ui/src/routes/organizations/$orgId/infrastructure-services/index.tsx
@@ -28,14 +28,14 @@ import {
 import { EditIcon, PlusIcon } from 'lucide-react';
 
 import {
-  useInfrastructureServicesServiceDeleteApiV1OrganizationsByOrganizationIdInfrastructureServicesByServiceName,
-  useInfrastructureServicesServiceGetApiV1OrganizationsByOrganizationIdInfrastructureServices,
-  useInfrastructureServicesServiceGetApiV1OrganizationsByOrganizationIdInfrastructureServicesKey,
+  useOrganizationsServiceDeleteApiV1OrganizationsByOrganizationIdInfrastructureServicesByServiceName,
   useOrganizationsServiceGetApiV1OrganizationsByOrganizationId,
+  useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdInfrastructureServices,
+  useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdInfrastructureServicesKey,
 } from '@/api/queries';
 import {
-  prefetchUseInfrastructureServicesServiceGetApiV1OrganizationsByOrganizationIdInfrastructureServices,
   prefetchUseOrganizationsServiceGetApiV1OrganizationsByOrganizationId,
+  prefetchUseOrganizationsServiceGetApiV1OrganizationsByOrganizationIdInfrastructureServices,
 } from '@/api/queries/prefetch';
 import { ApiError, InfrastructureService } from '@/api/requests';
 import { DataTable } from '@/components/data-table/data-table';
@@ -68,7 +68,7 @@ const ActionCell = ({ row }: CellContext<InfrastructureService, unknown>) => {
   const queryClient = useQueryClient();
 
   const { mutateAsync: delService } =
-    useInfrastructureServicesServiceDeleteApiV1OrganizationsByOrganizationIdInfrastructureServicesByServiceName(
+    useOrganizationsServiceDeleteApiV1OrganizationsByOrganizationIdInfrastructureServicesByServiceName(
       {
         onSuccess() {
           toast.info('Delete Infrastructure Service', {
@@ -76,7 +76,7 @@ const ActionCell = ({ row }: CellContext<InfrastructureService, unknown>) => {
           });
           queryClient.invalidateQueries({
             queryKey: [
-              useInfrastructureServicesServiceGetApiV1OrganizationsByOrganizationIdInfrastructureServicesKey,
+              useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdInfrastructureServicesKey,
             ],
           });
         },
@@ -143,7 +143,7 @@ const InfrastructureServices = () => {
     error: infraError,
     isPending: infraIsPending,
     isError: infraIsError,
-  } = useInfrastructureServicesServiceGetApiV1OrganizationsByOrganizationIdInfrastructureServices(
+  } = useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdInfrastructureServices(
     {
       organizationId: Number.parseInt(params.orgId),
       limit: pageSize,
@@ -298,7 +298,7 @@ export const Route = createFileRoute(
           organizationId: Number.parseInt(params.orgId),
         }
       ),
-      prefetchUseInfrastructureServicesServiceGetApiV1OrganizationsByOrganizationIdInfrastructureServices(
+      prefetchUseOrganizationsServiceGetApiV1OrganizationsByOrganizationIdInfrastructureServices(
         context.queryClient,
         {
           organizationId: Number.parseInt(params.orgId),

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repositories-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repositories-statistics-card.tsx
@@ -20,7 +20,7 @@
 import { Link } from '@tanstack/react-router';
 import { Files, PlusIcon } from 'lucide-react';
 
-import { useRepositoriesServiceGetApiV1ProductsByProductIdRepositories } from '@/api/queries';
+import { useProductsServiceGetApiV1ProductsByProductIdRepositories } from '@/api/queries';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { StatisticsCard } from '@/components/statistics-card';
 import { ToastError } from '@/components/toast-error';
@@ -45,7 +45,7 @@ export const ProductRepositoriesStatisticsCard = ({
   className,
 }: ProductRepositoriesStatisticsCardProps) => {
   const { data, isPending, isError, error } =
-    useRepositoriesServiceGetApiV1ProductsByProductIdRepositories({
+    useProductsServiceGetApiV1ProductsByProductIdRepositories({
       productId: Number.parseInt(productId),
       limit: 1,
     });

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repository-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repository-table.tsx
@@ -24,7 +24,7 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 
-import { useRepositoriesServiceGetApiV1ProductsByProductIdRepositories } from '@/api/queries';
+import { useProductsServiceGetApiV1ProductsByProductIdRepositories } from '@/api/queries';
 import { PagedResponse_Repository, Repository } from '@/api/requests';
 import { DataTable } from '@/components/data-table/data-table';
 import { LoadingIndicator } from '@/components/loading-indicator';
@@ -122,7 +122,7 @@ export const ProductRepositoryTable = () => {
     error: reposError,
     isPending: reposIsPending,
     isError: reposIsError,
-  } = useRepositoriesServiceGetApiV1ProductsByProductIdRepositories({
+  } = useProductsServiceGetApiV1ProductsByProductIdRepositories({
     productId: Number.parseInt(params.productId),
     limit: pageSize,
     offset: pageIndex * pageSize,

--- a/ui/src/routes/organizations/$orgId/products/$productId/create-repository/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/create-repository/index.tsx
@@ -23,7 +23,7 @@ import { Loader2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
-import { useRepositoriesServicePostApiV1ProductsByProductIdRepositories } from '@/api/queries';
+import { useProductsServicePostApiV1ProductsByProductIdRepositories } from '@/api/queries';
 import { $RepositoryType, ApiError } from '@/api/requests';
 import { ToastError } from '@/components/toast-error';
 import { Button } from '@/components/ui/button';
@@ -64,7 +64,7 @@ const CreateRepositoryPage = () => {
   const { refreshUser } = useUser();
 
   const { mutateAsync, isPending } =
-    useRepositoriesServicePostApiV1ProductsByProductIdRepositories({
+    useProductsServicePostApiV1ProductsByProductIdRepositories({
       onSuccess(data) {
         // Refresh the user token and data to get the new roles after creating a new repository.
         refreshUser();

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/$secretName/edit/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/$secretName/edit/index.tsx
@@ -25,10 +25,10 @@ import { useForm } from 'react-hook-form';
 import z from 'zod';
 
 import {
-  useSecretsServiceGetApiV1RepositoriesByRepositoryIdSecretsBySecretNameKey,
-  useSecretsServicePatchApiV1RepositoriesByRepositoryIdSecretsBySecretName,
+  useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdSecretsBySecretNameKey,
+  useRepositoriesServicePatchApiV1RepositoriesByRepositoryIdSecretsBySecretName,
 } from '@/api/queries';
-import { ApiError, SecretsService } from '@/api/requests';
+import { ApiError, RepositoriesService } from '@/api/requests';
 import { PasswordInput } from '@/components/form/password-input';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { ToastError } from '@/components/toast-error';
@@ -65,15 +65,17 @@ const EditRepositorySecretPage = () => {
 
   const { data: secret } = useSuspenseQuery({
     queryKey: [
-      useSecretsServiceGetApiV1RepositoriesByRepositoryIdSecretsBySecretNameKey,
+      useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdSecretsBySecretNameKey,
       params.repoId,
       params.secretName,
     ],
     queryFn: () =>
-      SecretsService.getApiV1RepositoriesByRepositoryIdSecretsBySecretName({
-        repositoryId: Number.parseInt(params.repoId),
-        secretName: params.secretName,
-      }),
+      RepositoriesService.getApiV1RepositoriesByRepositoryIdSecretsBySecretName(
+        {
+          repositoryId: Number.parseInt(params.repoId),
+          secretName: params.secretName,
+        }
+      ),
   });
 
   const form = useForm<EditSecretFormValues>({
@@ -86,31 +88,33 @@ const EditRepositorySecretPage = () => {
   });
 
   const { mutateAsync: editSecret, isPending } =
-    useSecretsServicePatchApiV1RepositoriesByRepositoryIdSecretsBySecretName({
-      onSuccess(data) {
-        toast.info('Edit Repository Secret', {
-          description: `Secret "${data.name}" updated successfully.`,
-        });
-        navigate({
-          to: '/organizations/$orgId/products/$productId/repositories/$repoId/secrets',
-          params: {
-            orgId: params.orgId,
-            productId: params.productId,
-            repoId: params.repoId,
-          },
-        });
-      },
-      onError(error: ApiError) {
-        toast.error(error.message, {
-          description: <ToastError error={error} />,
-          duration: Infinity,
-          cancel: {
-            label: 'Dismiss',
-            onClick: () => {},
-          },
-        });
-      },
-    });
+    useRepositoriesServicePatchApiV1RepositoriesByRepositoryIdSecretsBySecretName(
+      {
+        onSuccess(data) {
+          toast.info('Edit Repository Secret', {
+            description: `Secret "${data.name}" updated successfully.`,
+          });
+          navigate({
+            to: '/organizations/$orgId/products/$productId/repositories/$repoId/secrets',
+            params: {
+              orgId: params.orgId,
+              productId: params.productId,
+              repoId: params.repoId,
+            },
+          });
+        },
+        onError(error: ApiError) {
+          toast.error(error.message, {
+            description: <ToastError error={error} />,
+            duration: Infinity,
+            cancel: {
+              label: 'Dismiss',
+              onClick: () => {},
+            },
+          });
+        },
+      }
+    );
 
   const onSubmit = (values: EditSecretFormValues) => {
     editSecret({
@@ -215,15 +219,17 @@ export const Route = createFileRoute(
   loader: async ({ context, params }) => {
     await context.queryClient.ensureQueryData({
       queryKey: [
-        useSecretsServiceGetApiV1RepositoriesByRepositoryIdSecretsBySecretNameKey,
+        useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdSecretsBySecretNameKey,
         params.repoId,
         params.secretName,
       ],
       queryFn: () =>
-        SecretsService.getApiV1RepositoriesByRepositoryIdSecretsBySecretName({
-          repositoryId: Number.parseInt(params.repoId),
-          secretName: params.secretName,
-        }),
+        RepositoriesService.getApiV1RepositoriesByRepositoryIdSecretsBySecretName(
+          {
+            repositoryId: Number.parseInt(params.repoId),
+            secretName: params.secretName,
+          }
+        ),
     });
   },
   component: EditRepositorySecretPage,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/create-secret/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/create-secret/index.tsx
@@ -23,7 +23,7 @@ import { Loader2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
-import { useSecretsServicePostApiV1RepositoriesByRepositoryIdSecrets } from '@/api/queries';
+import { useRepositoriesServicePostApiV1RepositoriesByRepositoryIdSecrets } from '@/api/queries';
 import { ApiError } from '@/api/requests';
 import { PasswordInput } from '@/components/form/password-input';
 import { ToastError } from '@/components/toast-error';
@@ -56,7 +56,7 @@ const CreateRepositorySecretPage = () => {
   const params = Route.useParams();
 
   const { mutateAsync, isPending } =
-    useSecretsServicePostApiV1RepositoriesByRepositoryIdSecrets({
+    useRepositoriesServicePostApiV1RepositoriesByRepositoryIdSecrets({
       onSuccess(data) {
         toast.info('Create Repository Secret', {
           description: `New repository secret "${data.name}" created successfully.`,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/index.tsx
@@ -28,14 +28,14 @@ import {
 import { EditIcon, PlusIcon } from 'lucide-react';
 
 import {
+  useRepositoriesServiceDeleteApiV1RepositoriesByRepositoryIdSecretsBySecretName,
   useRepositoriesServiceGetApiV1RepositoriesByRepositoryId,
-  useSecretsServiceDeleteApiV1RepositoriesByRepositoryIdSecretsBySecretName,
-  useSecretsServiceGetApiV1RepositoriesByRepositoryIdSecrets,
-  useSecretsServiceGetApiV1RepositoriesByRepositoryIdSecretsKey,
+  useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdSecrets,
+  useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdSecretsKey,
 } from '@/api/queries';
 import {
   prefetchUseRepositoriesServiceGetApiV1RepositoriesByRepositoryId,
-  prefetchUseSecretsServiceGetApiV1RepositoriesByRepositoryIdSecrets,
+  prefetchUseRepositoriesServiceGetApiV1RepositoriesByRepositoryIdSecrets,
 } from '@/api/queries/prefetch';
 import { useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdSuspense } from '@/api/queries/suspense';
 import { ApiError, Secret } from '@/api/requests';
@@ -74,28 +74,30 @@ const ActionCell = ({ row }: CellContext<Secret, unknown>) => {
     });
 
   const { mutateAsync: deleteSecret } =
-    useSecretsServiceDeleteApiV1RepositoriesByRepositoryIdSecretsBySecretName({
-      onSuccess() {
-        toast.info('Delete Secret', {
-          description: `Secret "${row.original.name}" deleted successfully.`,
-        });
-        queryClient.invalidateQueries({
-          queryKey: [
-            useSecretsServiceGetApiV1RepositoriesByRepositoryIdSecretsKey,
-          ],
-        });
-      },
-      onError(error: ApiError) {
-        toast.error(error.message, {
-          description: <ToastError error={error} />,
-          duration: Infinity,
-          cancel: {
-            label: 'Dismiss',
-            onClick: () => {},
-          },
-        });
-      },
-    });
+    useRepositoriesServiceDeleteApiV1RepositoriesByRepositoryIdSecretsBySecretName(
+      {
+        onSuccess() {
+          toast.info('Delete Secret', {
+            description: `Secret "${row.original.name}" deleted successfully.`,
+          });
+          queryClient.invalidateQueries({
+            queryKey: [
+              useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdSecretsKey,
+            ],
+          });
+        },
+        onError(error: ApiError) {
+          toast.error(error.message, {
+            description: <ToastError error={error} />,
+            duration: Infinity,
+            cancel: {
+              label: 'Dismiss',
+              onClick: () => {},
+            },
+          });
+        },
+      }
+    );
 
   return (
     <div className='flex items-center justify-end gap-1'>
@@ -170,7 +172,7 @@ const RepositorySecrets = () => {
     error: secretsError,
     isPending: secretsIsPending,
     isError: secretsIsError,
-  } = useSecretsServiceGetApiV1RepositoriesByRepositoryIdSecrets({
+  } = useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdSecrets({
     repositoryId: Number.parseInt(params.repoId),
     limit: pageSize,
     offset: pageIndex * pageSize,
@@ -268,7 +270,7 @@ export const Route = createFileRoute(
           repositoryId: Number.parseInt(params.repoId),
         }
       ),
-      prefetchUseSecretsServiceGetApiV1RepositoriesByRepositoryIdSecrets(
+      prefetchUseRepositoriesServiceGetApiV1RepositoriesByRepositoryIdSecrets(
         context.queryClient,
         {
           repositoryId: Number.parseInt(params.repoId),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/-components/repository-users-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/-components/repository-users-table.tsx
@@ -28,10 +28,10 @@ import { Eye, Pen, Shield } from 'lucide-react';
 
 import {
   useAdminServiceDeleteApiV1AdminUsers,
-  useDefaultServiceGetApiV1RepositoriesByRepositoryIdUsers,
-  useDefaultServiceGetApiV1RepositoriesByRepositoryIdUsersKey,
   useGroupsServiceDeleteApiV1RepositoriesByRepositoryIdGroupsByGroupId,
   useGroupsServicePutApiV1RepositoriesByRepositoryIdGroupsByGroupId,
+  useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdUsers,
+  useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdUsersKey,
 } from '@/api/queries';
 import { ApiError, UserWithGroups } from '@/api/requests';
 import { DataTable } from '@/components/data-table/data-table.tsx';
@@ -110,7 +110,7 @@ const columns = [
           });
           queryClient.invalidateQueries({
             queryKey: [
-              useDefaultServiceGetApiV1RepositoriesByRepositoryIdUsersKey,
+              useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdUsersKey,
             ],
           });
         },
@@ -131,7 +131,7 @@ const columns = [
           onSuccess(_response, parameters) {
             queryClient.invalidateQueries({
               queryKey: [
-                useDefaultServiceGetApiV1RepositoriesByRepositoryIdUsersKey,
+                useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdUsersKey,
               ],
             });
             toast.info('Join Group', {
@@ -261,7 +261,7 @@ export const RepositoryUsersTable = () => {
   const pageIndex = page - 1;
 
   const { data: usersWithGroups } =
-    useDefaultServiceGetApiV1RepositoriesByRepositoryIdUsers({
+    useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdUsers({
       repositoryId: Number.parseInt(repoId),
       limit: pageSize,
       offset: pageIndex * pageSize,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/-components/repository-users-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/-components/repository-users-table.tsx
@@ -28,10 +28,10 @@ import { Eye, Pen, Shield } from 'lucide-react';
 
 import {
   useAdminServiceDeleteApiV1AdminUsers,
-  useGroupsServiceDeleteApiV1RepositoriesByRepositoryIdGroupsByGroupId,
-  useGroupsServicePutApiV1RepositoriesByRepositoryIdGroupsByGroupId,
+  useRepositoriesServiceDeleteApiV1RepositoriesByRepositoryIdGroupsByGroupId,
   useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdUsers,
   useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdUsersKey,
+  useRepositoriesServicePutApiV1RepositoriesByRepositoryIdGroupsByGroupId,
 } from '@/api/queries';
 import { ApiError, UserWithGroups } from '@/api/requests';
 import { DataTable } from '@/components/data-table/data-table.tsx';
@@ -127,48 +127,52 @@ const columns = [
       });
 
       const { mutateAsync: joinGroup, isPending: isJoinGroupPending } =
-        useGroupsServicePutApiV1RepositoriesByRepositoryIdGroupsByGroupId({
-          onSuccess(_response, parameters) {
-            queryClient.invalidateQueries({
-              queryKey: [
-                useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdUsersKey,
-              ],
-            });
-            toast.info('Join Group', {
-              description: `User "${row.original.user.username}" joined group ${parameters.groupId} successfully.`,
-            });
-          },
-          onError(error: ApiError) {
-            toast.error(error.message, {
-              description: <ToastError error={error} />,
-              duration: Infinity,
-              cancel: {
-                label: 'Dismiss',
-                onClick: () => {},
-              },
-            });
-          },
-        });
+        useRepositoriesServicePutApiV1RepositoriesByRepositoryIdGroupsByGroupId(
+          {
+            onSuccess(_response, parameters) {
+              queryClient.invalidateQueries({
+                queryKey: [
+                  useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdUsersKey,
+                ],
+              });
+              toast.info('Join Group', {
+                description: `User "${row.original.user.username}" joined group ${parameters.groupId} successfully.`,
+              });
+            },
+            onError(error: ApiError) {
+              toast.error(error.message, {
+                description: <ToastError error={error} />,
+                duration: Infinity,
+                cancel: {
+                  label: 'Dismiss',
+                  onClick: () => {},
+                },
+              });
+            },
+          }
+        );
 
       const { mutateAsync: leaveGroup, isPending: isLeaveGroupPending } =
-        useGroupsServiceDeleteApiV1RepositoriesByRepositoryIdGroupsByGroupId({
-          onSuccess(_response, parameters) {
-            // Intentionally, no queryClient.invalidateQueries() here. This is done after joining the new group.
-            toast.info('Leave Group', {
-              description: `User "${row.original.user.username}" left group ${parameters.groupId} successfully.`,
-            });
-          },
-          onError(error: ApiError) {
-            toast.error(error.message, {
-              description: <ToastError error={error} />,
-              duration: Infinity,
-              cancel: {
-                label: 'Dismiss',
-                onClick: () => {},
-              },
-            });
-          },
-        });
+        useRepositoriesServiceDeleteApiV1RepositoriesByRepositoryIdGroupsByGroupId(
+          {
+            onSuccess(_response, parameters) {
+              // Intentionally, no queryClient.invalidateQueries() here. This is done after joining the new group.
+              toast.info('Leave Group', {
+                description: `User "${row.original.user.username}" left group ${parameters.groupId} successfully.`,
+              });
+            },
+            onError(error: ApiError) {
+              toast.error(error.message, {
+                description: <ToastError error={error} />,
+                duration: Infinity,
+                cancel: {
+                  label: 'Dismiss',
+                  onClick: () => {},
+                },
+              });
+            },
+          }
+        );
 
       // Leave all groups except the one to join.
       async function leaveOtherGroups(joinGroupId: string) {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/index.tsx
@@ -25,9 +25,9 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import {
-  useDefaultServiceGetApiV1RepositoriesByRepositoryIdUsersKey,
   useGroupsServiceDeleteApiV1RepositoriesByRepositoryIdGroupsByGroupId,
   useGroupsServicePutApiV1RepositoriesByRepositoryIdGroupsByGroupId,
+  useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdUsersKey,
 } from '@/api/queries';
 import { useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdSuspense } from '@/api/queries/suspense';
 import { ApiError } from '@/api/requests';
@@ -88,7 +88,7 @@ const ManageUsers = () => {
       onSuccess() {
         queryClient.invalidateQueries({
           queryKey: [
-            useDefaultServiceGetApiV1RepositoriesByRepositoryIdUsersKey,
+            useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdUsersKey,
           ],
         });
         toast.info('Add User', {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/index.tsx
@@ -25,9 +25,9 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import {
-  useGroupsServiceDeleteApiV1RepositoriesByRepositoryIdGroupsByGroupId,
-  useGroupsServicePutApiV1RepositoriesByRepositoryIdGroupsByGroupId,
+  useRepositoriesServiceDeleteApiV1RepositoriesByRepositoryIdGroupsByGroupId,
   useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdUsersKey,
+  useRepositoriesServicePutApiV1RepositoriesByRepositoryIdGroupsByGroupId,
 } from '@/api/queries';
 import { useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdSuspense } from '@/api/queries/suspense';
 import { ApiError } from '@/api/requests';
@@ -84,7 +84,7 @@ const ManageUsers = () => {
   const queryClient = useQueryClient();
 
   const { mutateAsync: addUser, isPending: isAddUserPending } =
-    useGroupsServicePutApiV1RepositoriesByRepositoryIdGroupsByGroupId({
+    useRepositoriesServicePutApiV1RepositoriesByRepositoryIdGroupsByGroupId({
       onSuccess() {
         queryClient.invalidateQueries({
           queryKey: [
@@ -108,7 +108,7 @@ const ManageUsers = () => {
     });
 
   const { mutateAsync: leaveGroup, isPending: isLeaveGroupPending } =
-    useGroupsServiceDeleteApiV1RepositoriesByRepositoryIdGroupsByGroupId({
+    useRepositoriesServiceDeleteApiV1RepositoriesByRepositoryIdGroupsByGroupId({
       onError(error: ApiError) {
         // There is no error when trying to remove a user from a group he actually is not a member of.
         toast.error(error.message, {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/route.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/route.tsx
@@ -19,7 +19,7 @@
 
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
 
-import { ensureUseDefaultServiceGetApiV1RepositoriesByRepositoryIdUsersData } from '@/api/queries/ensureQueryData.ts';
+import { ensureUseRepositoriesServiceGetApiV1RepositoriesByRepositoryIdUsersData } from '@/api/queries/ensureQueryData.ts';
 import { paginationSearchParameterSchema } from '@/schemas';
 
 export const Route = createFileRoute(
@@ -40,7 +40,7 @@ export const Route = createFileRoute(
     const pageIndex = page - 1;
 
     // Ensure the data is available in the query cache when the component is rendered.
-    await ensureUseDefaultServiceGetApiV1RepositoriesByRepositoryIdUsersData(
+    await ensureUseRepositoriesServiceGetApiV1RepositoriesByRepositoryIdUsersData(
       queryClient,
       {
         limit: pageSize,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues/index.tsx
@@ -32,7 +32,7 @@ import {
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useMemo, useState } from 'react';
 
-import { useIssuesServiceGetApiV1RunsByRunIdIssues } from '@/api/queries';
+import { useRunsServiceGetApiV1RunsByRunIdIssues } from '@/api/queries';
 import { prefetchUseRepositoriesServiceGetApiV1RepositoriesByRepositoryIdRunsByOrtRunIndex } from '@/api/queries/prefetch';
 import { useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdRunsByOrtRunIndexSuspense } from '@/api/queries/suspense';
 import { Issue, Severity } from '@/api/requests';
@@ -304,7 +304,7 @@ const IssuesComponent = () => {
     isPending,
     isError,
     error,
-  } = useIssuesServiceGetApiV1RunsByRunIdIssues({
+  } = useRunsServiceGetApiV1RunsByRunIdIssues({
     runId: ortRun.id,
     limit: ALL_ITEMS,
   });

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
@@ -27,12 +27,12 @@ import {
 } from '@tanstack/react-table';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 
-import { usePackagesServiceGetApiV1RunsByRunIdPackages } from '@/api/queries';
+import { useRunsServiceGetApiV1RunsByRunIdPackages } from '@/api/queries';
 import { prefetchUseRepositoriesServiceGetApiV1RepositoriesByRepositoryIdRunsByOrtRunIndex } from '@/api/queries/prefetch';
 import {
-  usePackagesServiceGetApiV1RunsByRunIdPackagesSuspense,
   useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdRunsByOrtRunIndexSuspense,
   useRunsServiceGetApiV1RunsByRunIdPackagesLicensesSuspense,
+  useRunsServiceGetApiV1RunsByRunIdPackagesSuspense,
 } from '@/api/queries/suspense';
 import { Package } from '@/api/requests';
 import { DataTable } from '@/components/data-table/data-table';
@@ -167,7 +167,7 @@ const PackagesComponent = () => {
     );
 
   const { data: totalPackages } =
-    usePackagesServiceGetApiV1RunsByRunIdPackagesSuspense({
+    useRunsServiceGetApiV1RunsByRunIdPackagesSuspense({
       runId: ortRun.id,
       limit: 1,
     });
@@ -182,7 +182,7 @@ const PackagesComponent = () => {
     isPending,
     isError,
     error,
-  } = usePackagesServiceGetApiV1RunsByRunIdPackages({
+  } = useRunsServiceGetApiV1RunsByRunIdPackages({
     runId: ortRun.id,
     limit: pageSize,
     offset: pageIndex * pageSize,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
@@ -32,7 +32,7 @@ import {
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useMemo } from 'react';
 
-import { useProjectsServiceGetApiV1RunsByRunIdProjects } from '@/api/queries';
+import { useRunsServiceGetApiV1RunsByRunIdProjects } from '@/api/queries';
 import { prefetchUseRepositoriesServiceGetApiV1RepositoriesByRepositoryIdRunsByOrtRunIndex } from '@/api/queries/prefetch';
 import { useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdRunsByOrtRunIndexSuspense } from '@/api/queries/suspense';
 import { Project } from '@/api/requests';
@@ -204,7 +204,7 @@ const ProjectsComponent = () => {
     isPending,
     isError,
     error,
-  } = useProjectsServiceGetApiV1RunsByRunIdProjects({
+  } = useRunsServiceGetApiV1RunsByRunIdProjects({
     runId: ortRun.id,
     limit: ALL_ITEMS,
   });

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
@@ -34,7 +34,7 @@ import { useMemo } from 'react';
 import { prefetchUseRepositoriesServiceGetApiV1RepositoriesByRepositoryIdRunsByOrtRunIndex } from '@/api/queries/prefetch';
 import {
   useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdRunsByOrtRunIndexSuspense,
-  useRuleViolationsServiceGetApiV1RunsByRunIdRuleViolationsSuspense,
+  useRunsServiceGetApiV1RunsByRunIdRuleViolationsSuspense,
 } from '@/api/queries/suspense';
 import { RuleViolation, Severity } from '@/api/requests';
 import { DataTable } from '@/components/data-table/data-table';
@@ -233,7 +233,7 @@ const RuleViolationsComponent = () => {
     );
 
   const { data: ruleViolations } =
-    useRuleViolationsServiceGetApiV1RunsByRunIdRuleViolationsSuspense({
+    useRunsServiceGetApiV1RunsByRunIdRuleViolationsSuspense({
       runId: ortRun.id,
       limit: ALL_ITEMS,
     });

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
@@ -31,7 +31,7 @@ import {
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useMemo } from 'react';
 
-import { useVulnerabilitiesServiceGetApiV1RunsByRunIdVulnerabilities } from '@/api/queries';
+import { useRunsServiceGetApiV1RunsByRunIdVulnerabilities } from '@/api/queries';
 import { prefetchUseRepositoriesServiceGetApiV1RepositoriesByRepositoryIdRunsByOrtRunIndex } from '@/api/queries/prefetch';
 import { useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdRunsByOrtRunIndexSuspense } from '@/api/queries/suspense';
 import {
@@ -306,7 +306,7 @@ const VulnerabilitiesComponent = () => {
     isPending,
     isError,
     error,
-  } = useVulnerabilitiesServiceGetApiV1RunsByRunIdVulnerabilities({
+  } = useRunsServiceGetApiV1RunsByRunIdVulnerabilities({
     runId: ortRun.id,
     limit: ALL_ITEMS,
   });

--- a/ui/src/routes/organizations/$orgId/products/$productId/secrets/$secretName/edit/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/secrets/$secretName/edit/index.tsx
@@ -25,10 +25,10 @@ import { useForm } from 'react-hook-form';
 import z from 'zod';
 
 import {
-  useSecretsServiceGetApiV1ProductsByProductIdSecretsBySecretNameKey,
-  useSecretsServicePatchApiV1ProductsByProductIdSecretsBySecretName,
+  useProductsServiceGetApiV1ProductsByProductIdSecretsBySecretNameKey,
+  useProductsServicePatchApiV1ProductsByProductIdSecretsBySecretName,
 } from '@/api/queries';
-import { ApiError, SecretsService } from '@/api/requests';
+import { ApiError, ProductsService } from '@/api/requests';
 import { PasswordInput } from '@/components/form/password-input';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { ToastError } from '@/components/toast-error';
@@ -65,12 +65,12 @@ const EditProductSecretPage = () => {
 
   const { data: secret } = useSuspenseQuery({
     queryKey: [
-      useSecretsServiceGetApiV1ProductsByProductIdSecretsBySecretNameKey,
+      useProductsServiceGetApiV1ProductsByProductIdSecretsBySecretNameKey,
       params.productId,
       params.secretName,
     ],
     queryFn: () =>
-      SecretsService.getApiV1ProductsByProductIdSecretsBySecretName({
+      ProductsService.getApiV1ProductsByProductIdSecretsBySecretName({
         productId: Number.parseInt(params.productId),
         secretName: params.secretName,
       }),
@@ -86,7 +86,7 @@ const EditProductSecretPage = () => {
   });
 
   const { mutateAsync: editSecret, isPending } =
-    useSecretsServicePatchApiV1ProductsByProductIdSecretsBySecretName({
+    useProductsServicePatchApiV1ProductsByProductIdSecretsBySecretName({
       onSuccess(data) {
         toast.info('Edit Product Secret', {
           description: `Secret "${data.name}" updated successfully.`,
@@ -207,12 +207,12 @@ export const Route = createFileRoute(
   loader: async ({ context, params }) => {
     await context.queryClient.ensureQueryData({
       queryKey: [
-        useSecretsServiceGetApiV1ProductsByProductIdSecretsBySecretNameKey,
+        useProductsServiceGetApiV1ProductsByProductIdSecretsBySecretNameKey,
         params.productId,
         params.secretName,
       ],
       queryFn: () =>
-        SecretsService.getApiV1ProductsByProductIdSecretsBySecretName({
+        ProductsService.getApiV1ProductsByProductIdSecretsBySecretName({
           productId: Number.parseInt(params.productId),
           secretName: params.secretName,
         }),

--- a/ui/src/routes/organizations/$orgId/products/$productId/secrets/create-secret/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/secrets/create-secret/index.tsx
@@ -23,7 +23,7 @@ import { Loader2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
-import { useSecretsServicePostApiV1ProductsByProductIdSecrets } from '@/api/queries';
+import { useProductsServicePostApiV1ProductsByProductIdSecrets } from '@/api/queries';
 import { ApiError } from '@/api/requests';
 import { PasswordInput } from '@/components/form/password-input';
 import { ToastError } from '@/components/toast-error';
@@ -56,7 +56,7 @@ const CreateProductSecretPage = () => {
   const params = Route.useParams();
 
   const { mutateAsync, isPending } =
-    useSecretsServicePostApiV1ProductsByProductIdSecrets({
+    useProductsServicePostApiV1ProductsByProductIdSecrets({
       onSuccess(data) {
         toast.info('Create Product Secret', {
           description: `New product secret "${data.name}" created successfully.`,

--- a/ui/src/routes/organizations/$orgId/products/$productId/secrets/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/secrets/index.tsx
@@ -28,14 +28,14 @@ import {
 import { EditIcon, PlusIcon } from 'lucide-react';
 
 import {
+  useProductsServiceDeleteApiV1ProductsByProductIdSecretsBySecretName,
   useProductsServiceGetApiV1ProductsByProductId,
-  useSecretsServiceDeleteApiV1ProductsByProductIdSecretsBySecretName,
-  useSecretsServiceGetApiV1ProductsByProductIdSecrets,
-  useSecretsServiceGetApiV1ProductsByProductIdSecretsKey,
+  useProductsServiceGetApiV1ProductsByProductIdSecrets,
+  useProductsServiceGetApiV1ProductsByProductIdSecretsKey,
 } from '@/api/queries';
 import {
   prefetchUseProductsServiceGetApiV1ProductsByProductId,
-  prefetchUseSecretsServiceGetApiV1ProductsByProductIdSecrets,
+  prefetchUseProductsServiceGetApiV1ProductsByProductIdSecrets,
 } from '@/api/queries/prefetch';
 import { useProductsServiceGetApiV1ProductsByProductIdSuspense } from '@/api/queries/suspense';
 import { ApiError, Secret } from '@/api/requests';
@@ -74,13 +74,13 @@ const ActionCell = ({ row }: CellContext<Secret, unknown>) => {
     });
 
   const { mutateAsync: deleteSecret } =
-    useSecretsServiceDeleteApiV1ProductsByProductIdSecretsBySecretName({
+    useProductsServiceDeleteApiV1ProductsByProductIdSecretsBySecretName({
       onSuccess() {
         toast.info('Delete Secret', {
           description: `Secret "${row.original.name}" deleted successfully.`,
         });
         queryClient.invalidateQueries({
-          queryKey: [useSecretsServiceGetApiV1ProductsByProductIdSecretsKey],
+          queryKey: [useProductsServiceGetApiV1ProductsByProductIdSecretsKey],
         });
       },
       onError(error: ApiError) {
@@ -166,7 +166,7 @@ const ProductSecrets = () => {
     error: secretsError,
     isPending: secretsIsPending,
     isError: secretsIsError,
-  } = useSecretsServiceGetApiV1ProductsByProductIdSecrets({
+  } = useProductsServiceGetApiV1ProductsByProductIdSecrets({
     productId: Number(params.productId),
     limit: pageSize,
     offset: pageIndex * pageSize,
@@ -263,7 +263,7 @@ export const Route = createFileRoute(
           productId: Number.parseInt(params.productId),
         }
       ),
-      prefetchUseSecretsServiceGetApiV1ProductsByProductIdSecrets(
+      prefetchUseProductsServiceGetApiV1ProductsByProductIdSecrets(
         context.queryClient,
         {
           productId: Number(params.productId),

--- a/ui/src/routes/organizations/$orgId/products/$productId/users/-components/product-users-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/users/-components/product-users-table.tsx
@@ -28,10 +28,10 @@ import { Eye, Pen, Shield } from 'lucide-react';
 
 import {
   useAdminServiceDeleteApiV1AdminUsers,
-  useGroupsServiceDeleteApiV1ProductsByProductIdGroupsByGroupId,
-  useGroupsServicePutApiV1ProductsByProductIdGroupsByGroupId,
+  useProductsServiceDeleteApiV1ProductsByProductIdGroupsByGroupId,
   useProductsServiceGetApiV1ProductsByProductIdUsers,
   useProductsServiceGetApiV1ProductsByProductIdUsersKey,
+  useProductsServicePutApiV1ProductsByProductIdGroupsByGroupId,
 } from '@/api/queries';
 import { ApiError, UserWithGroups } from '@/api/requests';
 import { DataTable } from '@/components/data-table/data-table.tsx';
@@ -125,7 +125,7 @@ const columns = [
       });
 
       const { mutateAsync: joinGroup, isPending: isJoinGroupPending } =
-        useGroupsServicePutApiV1ProductsByProductIdGroupsByGroupId({
+        useProductsServicePutApiV1ProductsByProductIdGroupsByGroupId({
           onSuccess(_response, parameters) {
             queryClient.invalidateQueries({
               queryKey: [useProductsServiceGetApiV1ProductsByProductIdUsersKey],
@@ -147,7 +147,7 @@ const columns = [
         });
 
       const { mutateAsync: leaveGroup, isPending: isLeaveGroupPending } =
-        useGroupsServiceDeleteApiV1ProductsByProductIdGroupsByGroupId({
+        useProductsServiceDeleteApiV1ProductsByProductIdGroupsByGroupId({
           onSuccess(_response, parameters) {
             // Intentionally, no queryClient.invalidateQueries() here. This is done after joining the new group.
             toast.info('Leave Group', {

--- a/ui/src/routes/organizations/$orgId/products/$productId/users/-components/product-users-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/users/-components/product-users-table.tsx
@@ -28,10 +28,10 @@ import { Eye, Pen, Shield } from 'lucide-react';
 
 import {
   useAdminServiceDeleteApiV1AdminUsers,
-  useDefaultServiceGetApiV1ProductsByProductIdUsers,
-  useDefaultServiceGetApiV1ProductsByProductIdUsersKey,
   useGroupsServiceDeleteApiV1ProductsByProductIdGroupsByGroupId,
   useGroupsServicePutApiV1ProductsByProductIdGroupsByGroupId,
+  useProductsServiceGetApiV1ProductsByProductIdUsers,
+  useProductsServiceGetApiV1ProductsByProductIdUsersKey,
 } from '@/api/queries';
 import { ApiError, UserWithGroups } from '@/api/requests';
 import { DataTable } from '@/components/data-table/data-table.tsx';
@@ -109,7 +109,7 @@ const columns = [
             description: `User "${row.original.user.username}" deleted successfully.`,
           });
           queryClient.invalidateQueries({
-            queryKey: [useDefaultServiceGetApiV1ProductsByProductIdUsersKey],
+            queryKey: [useProductsServiceGetApiV1ProductsByProductIdUsersKey],
           });
         },
         onError(error: ApiError) {
@@ -128,7 +128,7 @@ const columns = [
         useGroupsServicePutApiV1ProductsByProductIdGroupsByGroupId({
           onSuccess(_response, parameters) {
             queryClient.invalidateQueries({
-              queryKey: [useDefaultServiceGetApiV1ProductsByProductIdUsersKey],
+              queryKey: [useProductsServiceGetApiV1ProductsByProductIdUsersKey],
             });
             toast.info('Join Group', {
               description: `User "${row.original.user.username}" joined group ${parameters.groupId} successfully.`,
@@ -255,7 +255,7 @@ export const ProductUsersTable = () => {
   const pageIndex = page - 1;
 
   const { data: usersWithGroups } =
-    useDefaultServiceGetApiV1ProductsByProductIdUsers({
+    useProductsServiceGetApiV1ProductsByProductIdUsers({
       productId: Number.parseInt(productId),
       limit: pageSize,
       offset: pageIndex * pageSize,

--- a/ui/src/routes/organizations/$orgId/products/$productId/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/users/index.tsx
@@ -25,9 +25,9 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import {
-  useDefaultServiceGetApiV1ProductsByProductIdUsersKey,
   useGroupsServiceDeleteApiV1ProductsByProductIdGroupsByGroupId,
   useGroupsServicePutApiV1ProductsByProductIdGroupsByGroupId,
+  useProductsServiceGetApiV1ProductsByProductIdUsersKey,
 } from '@/api/queries';
 import { useProductsServiceGetApiV1ProductsByProductIdSuspense } from '@/api/queries/suspense';
 import { ApiError } from '@/api/requests';
@@ -87,7 +87,7 @@ const ManageUsers = () => {
     useGroupsServicePutApiV1ProductsByProductIdGroupsByGroupId({
       onSuccess() {
         queryClient.invalidateQueries({
-          queryKey: [useDefaultServiceGetApiV1ProductsByProductIdUsersKey],
+          queryKey: [useProductsServiceGetApiV1ProductsByProductIdUsersKey],
         });
         toast.info('Add User', {
           description: `User "${form.getValues().username}" added successfully to group "${form.getValues().groupId.toUpperCase()}".`,

--- a/ui/src/routes/organizations/$orgId/products/$productId/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/users/index.tsx
@@ -25,9 +25,9 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import {
-  useGroupsServiceDeleteApiV1ProductsByProductIdGroupsByGroupId,
-  useGroupsServicePutApiV1ProductsByProductIdGroupsByGroupId,
+  useProductsServiceDeleteApiV1ProductsByProductIdGroupsByGroupId,
   useProductsServiceGetApiV1ProductsByProductIdUsersKey,
+  useProductsServicePutApiV1ProductsByProductIdGroupsByGroupId,
 } from '@/api/queries';
 import { useProductsServiceGetApiV1ProductsByProductIdSuspense } from '@/api/queries/suspense';
 import { ApiError } from '@/api/requests';
@@ -84,7 +84,7 @@ const ManageUsers = () => {
   const queryClient = useQueryClient();
 
   const { mutateAsync: addUser, isPending: isAddUserPending } =
-    useGroupsServicePutApiV1ProductsByProductIdGroupsByGroupId({
+    useProductsServicePutApiV1ProductsByProductIdGroupsByGroupId({
       onSuccess() {
         queryClient.invalidateQueries({
           queryKey: [useProductsServiceGetApiV1ProductsByProductIdUsersKey],
@@ -106,7 +106,7 @@ const ManageUsers = () => {
     });
 
   const { mutateAsync: leaveGroup, isPending: isLeaveGroupPending } =
-    useGroupsServiceDeleteApiV1ProductsByProductIdGroupsByGroupId({
+    useProductsServiceDeleteApiV1ProductsByProductIdGroupsByGroupId({
       onError(error: ApiError) {
         // There is no error when trying to remove a user from a group he actually is not a member of.
         toast.error(error.message, {

--- a/ui/src/routes/organizations/$orgId/products/$productId/users/route.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/users/route.tsx
@@ -19,7 +19,7 @@
 
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
 
-import { ensureUseDefaultServiceGetApiV1ProductsByProductIdUsersData } from '@/api/queries/ensureQueryData.ts';
+import { ensureUseProductsServiceGetApiV1ProductsByProductIdUsersData } from '@/api/queries/ensureQueryData.ts';
 import { paginationSearchParameterSchema } from '@/schemas';
 
 export const Route = createFileRoute(
@@ -40,7 +40,7 @@ export const Route = createFileRoute(
     const pageIndex = page - 1;
 
     // Ensure the data is available in the query cache when the component is rendered.
-    await ensureUseDefaultServiceGetApiV1ProductsByProductIdUsersData(
+    await ensureUseProductsServiceGetApiV1ProductsByProductIdUsersData(
       queryClient,
       {
         limit: pageSize,

--- a/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/-components/product-vulnerability-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/-components/product-vulnerability-table.tsx
@@ -31,7 +31,7 @@ import {
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useEffect, useMemo } from 'react';
 
-import { useVulnerabilitiesServiceGetApiV1ProductsByProductIdVulnerabilities } from '@/api/queries';
+import { useProductsServiceGetApiV1ProductsByProductIdVulnerabilities } from '@/api/queries';
 import { ProductVulnerability, VulnerabilityRating } from '@/api/requests';
 import { DataTable } from '@/components/data-table/data-table';
 import { LoadingIndicator } from '@/components/loading-indicator';
@@ -129,7 +129,7 @@ export const ProductVulnerabilityTable = ({
     isPending,
     isError,
     error,
-  } = useVulnerabilitiesServiceGetApiV1ProductsByProductIdVulnerabilities({
+  } = useProductsServiceGetApiV1ProductsByProductIdVulnerabilities({
     productId: Number.parseInt(params.productId),
     limit: ALL_ITEMS,
   });

--- a/ui/src/routes/organizations/$orgId/secrets/$secretName/edit/index.tsx
+++ b/ui/src/routes/organizations/$orgId/secrets/$secretName/edit/index.tsx
@@ -25,10 +25,10 @@ import { useForm } from 'react-hook-form';
 import z from 'zod';
 
 import {
-  useSecretsServiceGetApiV1OrganizationsByOrganizationIdSecretsBySecretNameKey,
-  useSecretsServicePatchApiV1OrganizationsByOrganizationIdSecretsBySecretName,
+  useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdSecretsBySecretNameKey,
+  useOrganizationsServicePatchApiV1OrganizationsByOrganizationIdSecretsBySecretName,
 } from '@/api/queries';
-import { ApiError, SecretsService } from '@/api/requests';
+import { ApiError, OrganizationsService } from '@/api/requests';
 import { PasswordInput } from '@/components/form/password-input';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { ToastError } from '@/components/toast-error';
@@ -66,15 +66,17 @@ const EditOrganizationSecretPage = () => {
 
   const { data: secret } = useSuspenseQuery({
     queryKey: [
-      useSecretsServiceGetApiV1OrganizationsByOrganizationIdSecretsBySecretNameKey,
+      useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdSecretsBySecretNameKey,
       params.orgId,
       params.secretName,
     ],
     queryFn: () =>
-      SecretsService.getApiV1OrganizationsByOrganizationIdSecretsBySecretName({
-        organizationId: Number.parseInt(params.orgId),
-        secretName: params.secretName,
-      }),
+      OrganizationsService.getApiV1OrganizationsByOrganizationIdSecretsBySecretName(
+        {
+          organizationId: Number.parseInt(params.orgId),
+          secretName: params.secretName,
+        }
+      ),
   });
 
   const form = useForm<EditSecretFormValues>({
@@ -87,7 +89,7 @@ const EditOrganizationSecretPage = () => {
   });
 
   const { mutateAsync: editSecret, isPending } =
-    useSecretsServicePatchApiV1OrganizationsByOrganizationIdSecretsBySecretName(
+    useOrganizationsServicePatchApiV1OrganizationsByOrganizationIdSecretsBySecretName(
       {
         onSuccess(data) {
           toast.info('Edit organization secret', {
@@ -220,12 +222,12 @@ export const Route = createFileRoute(
   loader: async ({ context, params }) => {
     await context.queryClient.ensureQueryData({
       queryKey: [
-        useSecretsServiceGetApiV1OrganizationsByOrganizationIdSecretsBySecretNameKey,
+        useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdSecretsBySecretNameKey,
         params.orgId,
         params.secretName,
       ],
       queryFn: () =>
-        SecretsService.getApiV1OrganizationsByOrganizationIdSecretsBySecretName(
+        OrganizationsService.getApiV1OrganizationsByOrganizationIdSecretsBySecretName(
           {
             organizationId: Number.parseInt(params.orgId),
             secretName: params.secretName,

--- a/ui/src/routes/organizations/$orgId/secrets/create-secret/index.tsx
+++ b/ui/src/routes/organizations/$orgId/secrets/create-secret/index.tsx
@@ -23,7 +23,7 @@ import { Loader2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
-import { useSecretsServicePostApiV1OrganizationsByOrganizationIdSecrets } from '@/api/queries';
+import { useOrganizationsServicePostApiV1OrganizationsByOrganizationIdSecrets } from '@/api/queries';
 import { ApiError } from '@/api/requests';
 import { PasswordInput } from '@/components/form/password-input.tsx';
 import { ToastError } from '@/components/toast-error';
@@ -56,7 +56,7 @@ const CreateOrganizationSecretPage = () => {
   const params = Route.useParams();
 
   const { mutateAsync, isPending } =
-    useSecretsServicePostApiV1OrganizationsByOrganizationIdSecrets({
+    useOrganizationsServicePostApiV1OrganizationsByOrganizationIdSecrets({
       onSuccess(data) {
         toast.info('Create Organization Secret', {
           description: `New organization secret "${data.name}" created successfully.`,

--- a/ui/src/routes/organizations/$orgId/secrets/index.tsx
+++ b/ui/src/routes/organizations/$orgId/secrets/index.tsx
@@ -28,14 +28,14 @@ import {
 import { EditIcon, PlusIcon } from 'lucide-react';
 
 import {
+  useOrganizationsServiceDeleteApiV1OrganizationsByOrganizationIdSecretsBySecretName,
   useOrganizationsServiceGetApiV1OrganizationsByOrganizationId,
-  useSecretsServiceDeleteApiV1OrganizationsByOrganizationIdSecretsBySecretName,
-  useSecretsServiceGetApiV1OrganizationsByOrganizationIdSecrets,
-  useSecretsServiceGetApiV1OrganizationsByOrganizationIdSecretsKey,
+  useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdSecrets,
+  useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdSecretsKey,
 } from '@/api/queries';
 import {
   prefetchUseOrganizationsServiceGetApiV1OrganizationsByOrganizationId,
-  prefetchUseSecretsServiceGetApiV1OrganizationsByOrganizationIdSecrets,
+  prefetchUseOrganizationsServiceGetApiV1OrganizationsByOrganizationIdSecrets,
 } from '@/api/queries/prefetch';
 import { useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdSuspense } from '@/api/queries/suspense';
 import { ApiError, Secret } from '@/api/requests';
@@ -74,7 +74,7 @@ const ActionCell = ({ row }: CellContext<Secret, unknown>) => {
     });
 
   const { mutateAsync: delSecret } =
-    useSecretsServiceDeleteApiV1OrganizationsByOrganizationIdSecretsBySecretName(
+    useOrganizationsServiceDeleteApiV1OrganizationsByOrganizationIdSecretsBySecretName(
       {
         onSuccess() {
           toast.info('Delete Secret', {
@@ -82,7 +82,7 @@ const ActionCell = ({ row }: CellContext<Secret, unknown>) => {
           });
           queryClient.invalidateQueries({
             queryKey: [
-              useSecretsServiceGetApiV1OrganizationsByOrganizationIdSecretsKey,
+              useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdSecretsKey,
             ],
           });
         },
@@ -166,7 +166,7 @@ const OrganizationSecrets = () => {
     error: secretsError,
     isPending: secretsIsPending,
     isError: secretsIsError,
-  } = useSecretsServiceGetApiV1OrganizationsByOrganizationIdSecrets({
+  } = useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdSecrets({
     organizationId: Number.parseInt(params.orgId),
     limit: pageSize,
     offset: pageIndex * pageSize,
@@ -260,7 +260,7 @@ export const Route = createFileRoute('/organizations/$orgId/secrets/')({
           organizationId: Number.parseInt(params.orgId),
         }
       ),
-      prefetchUseSecretsServiceGetApiV1OrganizationsByOrganizationIdSecrets(
+      prefetchUseOrganizationsServiceGetApiV1OrganizationsByOrganizationIdSecrets(
         context.queryClient,
         {
           organizationId: Number.parseInt(params.orgId),

--- a/ui/src/routes/organizations/$orgId/users/-components/organization-users-table.tsx
+++ b/ui/src/routes/organizations/$orgId/users/-components/organization-users-table.tsx
@@ -28,10 +28,10 @@ import { Eye, Pen, Shield } from 'lucide-react';
 
 import {
   useAdminServiceDeleteApiV1AdminUsers,
-  useGroupsServiceDeleteApiV1OrganizationsByOrganizationIdGroupsByGroupId,
-  useGroupsServicePutApiV1OrganizationsByOrganizationIdGroupsByGroupId,
+  useOrganizationsServiceDeleteApiV1OrganizationsByOrganizationIdGroupsByGroupId,
   useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdUsers,
   useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdUsersKey,
+  useOrganizationsServicePutApiV1OrganizationsByOrganizationIdGroupsByGroupId,
 } from '@/api/queries';
 import { ApiError, UserWithGroups } from '@/api/requests';
 import { DataTable } from '@/components/data-table/data-table.tsx';
@@ -127,31 +127,33 @@ const columns = [
       });
 
       const { mutateAsync: joinGroup, isPending: isJoinGroupPending } =
-        useGroupsServicePutApiV1OrganizationsByOrganizationIdGroupsByGroupId({
-          onSuccess(_response, parameters) {
-            queryClient.invalidateQueries({
-              queryKey: [
-                useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdUsersKey,
-              ],
-            });
-            toast.info('Join Group', {
-              description: `User "${row.original.user.username}" joined group ${parameters.groupId} successfully.`,
-            });
-          },
-          onError(error: ApiError) {
-            toast.error(error.message, {
-              description: <ToastError error={error} />,
-              duration: Infinity,
-              cancel: {
-                label: 'Dismiss',
-                onClick: () => {},
-              },
-            });
-          },
-        });
+        useOrganizationsServicePutApiV1OrganizationsByOrganizationIdGroupsByGroupId(
+          {
+            onSuccess(_response, parameters) {
+              queryClient.invalidateQueries({
+                queryKey: [
+                  useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdUsersKey,
+                ],
+              });
+              toast.info('Join Group', {
+                description: `User "${row.original.user.username}" joined group ${parameters.groupId} successfully.`,
+              });
+            },
+            onError(error: ApiError) {
+              toast.error(error.message, {
+                description: <ToastError error={error} />,
+                duration: Infinity,
+                cancel: {
+                  label: 'Dismiss',
+                  onClick: () => {},
+                },
+              });
+            },
+          }
+        );
 
       const { mutateAsync: leaveGroup, isPending: isLeaveGroupPending } =
-        useGroupsServiceDeleteApiV1OrganizationsByOrganizationIdGroupsByGroupId(
+        useOrganizationsServiceDeleteApiV1OrganizationsByOrganizationIdGroupsByGroupId(
           {
             onSuccess(_response, parameters) {
               // Intentionally, no queryClient.invalidateQueries() here. This is done after joining the new group.

--- a/ui/src/routes/organizations/$orgId/users/-components/organization-users-table.tsx
+++ b/ui/src/routes/organizations/$orgId/users/-components/organization-users-table.tsx
@@ -28,10 +28,10 @@ import { Eye, Pen, Shield } from 'lucide-react';
 
 import {
   useAdminServiceDeleteApiV1AdminUsers,
-  useDefaultServiceGetApiV1OrganizationsByOrganizationIdUsers,
-  useDefaultServiceGetApiV1OrganizationsByOrganizationIdUsersKey,
   useGroupsServiceDeleteApiV1OrganizationsByOrganizationIdGroupsByGroupId,
   useGroupsServicePutApiV1OrganizationsByOrganizationIdGroupsByGroupId,
+  useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdUsers,
+  useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdUsersKey,
 } from '@/api/queries';
 import { ApiError, UserWithGroups } from '@/api/requests';
 import { DataTable } from '@/components/data-table/data-table.tsx';
@@ -110,7 +110,7 @@ const columns = [
           });
           queryClient.invalidateQueries({
             queryKey: [
-              useDefaultServiceGetApiV1OrganizationsByOrganizationIdUsersKey,
+              useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdUsersKey,
             ],
           });
         },
@@ -131,7 +131,7 @@ const columns = [
           onSuccess(_response, parameters) {
             queryClient.invalidateQueries({
               queryKey: [
-                useDefaultServiceGetApiV1OrganizationsByOrganizationIdUsersKey,
+                useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdUsersKey,
               ],
             });
             toast.info('Join Group', {
@@ -261,7 +261,7 @@ export const OrganizationUsersTable = () => {
   const pageIndex = page - 1;
 
   const { data: usersWithGroups } =
-    useDefaultServiceGetApiV1OrganizationsByOrganizationIdUsers({
+    useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdUsers({
       organizationId: Number.parseInt(orgId),
       limit: pageSize,
       offset: pageIndex * pageSize,

--- a/ui/src/routes/organizations/$orgId/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/users/index.tsx
@@ -25,9 +25,9 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import {
-  useDefaultServiceGetApiV1OrganizationsByOrganizationIdUsersKey,
   useGroupsServiceDeleteApiV1OrganizationsByOrganizationIdGroupsByGroupId,
   useGroupsServicePutApiV1OrganizationsByOrganizationIdGroupsByGroupId,
+  useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdUsersKey,
 } from '@/api/queries';
 import { useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdSuspense } from '@/api/queries/suspense';
 import { ApiError } from '@/api/requests';
@@ -88,7 +88,7 @@ const ManageUsers = () => {
       onSuccess() {
         queryClient.invalidateQueries({
           queryKey: [
-            useDefaultServiceGetApiV1OrganizationsByOrganizationIdUsersKey,
+            useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdUsersKey,
           ],
         });
         toast.info('Add User', {

--- a/ui/src/routes/organizations/$orgId/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/users/index.tsx
@@ -25,9 +25,9 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import {
-  useGroupsServiceDeleteApiV1OrganizationsByOrganizationIdGroupsByGroupId,
-  useGroupsServicePutApiV1OrganizationsByOrganizationIdGroupsByGroupId,
+  useOrganizationsServiceDeleteApiV1OrganizationsByOrganizationIdGroupsByGroupId,
   useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdUsersKey,
+  useOrganizationsServicePutApiV1OrganizationsByOrganizationIdGroupsByGroupId,
 } from '@/api/queries';
 import { useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdSuspense } from '@/api/queries/suspense';
 import { ApiError } from '@/api/requests';
@@ -84,43 +84,47 @@ const ManageUsers = () => {
   const queryClient = useQueryClient();
 
   const { mutateAsync: addUser, isPending: isAddUserPending } =
-    useGroupsServicePutApiV1OrganizationsByOrganizationIdGroupsByGroupId({
-      onSuccess() {
-        queryClient.invalidateQueries({
-          queryKey: [
-            useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdUsersKey,
-          ],
-        });
-        toast.info('Add User', {
-          description: `User "${form.getValues().username}" added successfully to group "${form.getValues().groupId.toUpperCase()}".`,
-        });
-      },
-      onError(error: ApiError) {
-        toast.error(error.message, {
-          description: <ToastError error={error} />,
-          duration: Infinity,
-          cancel: {
-            label: 'Dismiss',
-            onClick: () => {},
-          },
-        });
-      },
-    });
+    useOrganizationsServicePutApiV1OrganizationsByOrganizationIdGroupsByGroupId(
+      {
+        onSuccess() {
+          queryClient.invalidateQueries({
+            queryKey: [
+              useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdUsersKey,
+            ],
+          });
+          toast.info('Add User', {
+            description: `User "${form.getValues().username}" added successfully to group "${form.getValues().groupId.toUpperCase()}".`,
+          });
+        },
+        onError(error: ApiError) {
+          toast.error(error.message, {
+            description: <ToastError error={error} />,
+            duration: Infinity,
+            cancel: {
+              label: 'Dismiss',
+              onClick: () => {},
+            },
+          });
+        },
+      }
+    );
 
   const { mutateAsync: leaveGroup, isPending: isLeaveGroupPending } =
-    useGroupsServiceDeleteApiV1OrganizationsByOrganizationIdGroupsByGroupId({
-      onError(error: ApiError) {
-        // There is no error when trying to remove a user from a group he actually is not a member of.
-        toast.error(error.message, {
-          description: <ToastError error={error} />,
-          duration: Infinity,
-          cancel: {
-            label: 'Dismiss',
-            onClick: () => {},
-          },
-        });
-      },
-    });
+    useOrganizationsServiceDeleteApiV1OrganizationsByOrganizationIdGroupsByGroupId(
+      {
+        onError(error: ApiError) {
+          // There is no error when trying to remove a user from a group he actually is not a member of.
+          toast.error(error.message, {
+            description: <ToastError error={error} />,
+            duration: Infinity,
+            cancel: {
+              label: 'Dismiss',
+              onClick: () => {},
+            },
+          });
+        },
+      }
+    );
 
   // The user might accidentally try to add a user to a group, although the user already has a group assignment.
   // In this case, leave any potential other groups before adding the user to the new group.

--- a/ui/src/routes/organizations/$orgId/users/route.tsx
+++ b/ui/src/routes/organizations/$orgId/users/route.tsx
@@ -19,7 +19,7 @@
 
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
 
-import { ensureUseDefaultServiceGetApiV1OrganizationsByOrganizationIdUsersData } from '@/api/queries/ensureQueryData.ts';
+import { ensureUseOrganizationsServiceGetApiV1OrganizationsByOrganizationIdUsersData } from '@/api/queries/ensureQueryData.ts';
 import { paginationSearchParameterSchema } from '@/schemas';
 
 export const Route = createFileRoute('/organizations/$orgId/users')({
@@ -38,7 +38,7 @@ export const Route = createFileRoute('/organizations/$orgId/users')({
     const pageIndex = page - 1;
 
     // Ensure the data is available in the query cache when the component is rendered.
-    await ensureUseDefaultServiceGetApiV1OrganizationsByOrganizationIdUsersData(
+    await ensureUseOrganizationsServiceGetApiV1OrganizationsByOrganizationIdUsersData(
       queryClient,
       {
         limit: pageSize,

--- a/ui/src/routes/organizations/$orgId/vulnerabilities/-components/organization-vulnerability-table.tsx
+++ b/ui/src/routes/organizations/$orgId/vulnerabilities/-components/organization-vulnerability-table.tsx
@@ -28,7 +28,7 @@ import {
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useMemo } from 'react';
 
-import { useVulnerabilitiesServiceGetApiV1OrganizationsByOrganizationIdVulnerabilities } from '@/api/queries';
+import { useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdVulnerabilities } from '@/api/queries';
 import { OrganizationVulnerability } from '@/api/requests';
 import { DataTable } from '@/components/data-table/data-table';
 import { LoadingIndicator } from '@/components/loading-indicator';
@@ -124,7 +124,7 @@ export const OrganizationVulnerabilityTable = () => {
     error,
     isPending,
     isError,
-  } = useVulnerabilitiesServiceGetApiV1OrganizationsByOrganizationIdVulnerabilities(
+  } = useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdVulnerabilities(
     {
       organizationId: Number.parseInt(params.orgId),
       limit: pageSize,

--- a/ui/src/routes/organizations/$orgId/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/vulnerabilities/index.tsx
@@ -20,7 +20,7 @@
 import { createFileRoute } from '@tanstack/react-router';
 
 import { prefetchUseOrganizationsServiceGetApiV1OrganizationsByOrganizationId } from '@/api/queries/prefetch';
-import { useVulnerabilitiesServiceGetApiV1OrganizationsByOrganizationIdVulnerabilitiesSuspense } from '@/api/queries/suspense';
+import { useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdVulnerabilitiesSuspense } from '@/api/queries/suspense';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import {
   Card,
@@ -39,7 +39,7 @@ const OrganizationVulnerabilitiesComponent = () => {
   const params = Route.useParams();
 
   const { data: vulnerabilities } =
-    useVulnerabilitiesServiceGetApiV1OrganizationsByOrganizationIdVulnerabilitiesSuspense(
+    useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdVulnerabilitiesSuspense(
       {
         organizationId: Number.parseInt(params.orgId),
         limit: 1,


### PR DESCRIPTION
The API documentation (Swagger, webpage) has become unnecessarily fragmented, introducing somewhat arbitrary top-level groups that make it difficult to find a particular endpoint. Also the new users endpoints were incorrectly documented and left untagged.

This PR implements some major changes to the API documents, by reducing the number of top-level groups, and grouping the corresponding endpoints to under the groups where they semantically belong. Endpoint summaries and descriptions are also reworded a bit, to keep the summaries as brief as possible and aligned with each other.

Top-level grouping:

![Screenshot from 2025-04-04 08-38-42](https://github.com/user-attachments/assets/7160cb96-5238-458d-9851-33879390fe2a)

As an example, the "Runs" group:

![Screenshot from 2025-04-04 10-49-56](https://github.com/user-attachments/assets/6ea00047-883d-4265-af97-a43ed50553f3)

With these changes, the OpenAPI React query client generation library that the UI uses is also producing simpler query hooks to use and remember, due to reduced amount of "top-level" groups to choose from, when choosing a query hook for an endpoint.

The PR is tested locally by building all images, running Docker Compose and testing the UI image for any errors in queries. Also a test ORT run was done, no API errors seen.