### PR TITLE
feat(cli): Configure executable binary task for JVM target

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -17,6 +17,7 @@
  * License-Filename: LICENSE
  */
 
+import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 plugins {
@@ -30,7 +31,14 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.cli"
 
 kotlin {
-    // Note that the JVM is a conventional default target.
+    jvm {
+        @OptIn(ExperimentalKotlinGradlePluginApi::class)
+        binaries {
+            executable {
+                mainClass = "org.eclipse.apoapsis.ortserver.cli.OrtServerMainKt"
+            }
+        }
+    }
 
     linuxX64()
     macosArm64()


### PR DESCRIPTION
Kotlin 2.1.20 added DSL functionality to replace Gradle's application plugin [1].
Make use of this new DSL to configure the `jvmDistZip` and `jvmDistTar` tasks that can be used to package the JVM targets of the CLI.