### PR TITLE
fix(ui): Always display run creation date and user info on separate rows

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/last-run-date.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/last-run-date.tsx
@@ -67,7 +67,7 @@ export const LastRunDate = ({ repoId }: { repoId: number }) => {
   const run = runs.data[0];
 
   return (
-    <div>
+    <div className='flex flex-col items-start'>
       {run.finishedAt ? (
         <TimestampWithUTC timestamp={run.finishedAt} />
       ) : (


### PR DESCRIPTION
Please see the commit for details.