### PR TITLE
fix(ui): Separate authors by commas

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
@@ -72,7 +72,7 @@ const renderSubComponent = ({ row }: { row: Row<Project> }) => {
       {project.authors.length > 0 && (
         <div className='flex gap-2'>
           <div className='font-semibold'>Authors:</div>
-          <div>{project.authors}</div>
+          <div>{project.authors.join(', ')}</div>
         </div>
       )}
       {project.description && (


### PR DESCRIPTION
This fixes authors to be displayed in one string like

    "Danny van BruggenJúlio Vilmar GesserSebastian Kirsch"