### PR TITLE
Add custom footer content

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
@@ -26,6 +26,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.AdvisorJobConfiguration as Ap
 import org.eclipse.apoapsis.ortserver.api.v1.model.AnalyzerJob as ApiAnalyzerJob
 import org.eclipse.apoapsis.ortserver.api.v1.model.AnalyzerJobConfiguration as ApiAnalyzerJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.ComparisonOperator as ApiComparisonOperator
+import org.eclipse.apoapsis.ortserver.api.v1.model.ContentManagementSection as ApiContentManagementSection
 import org.eclipse.apoapsis.ortserver.api.v1.model.CredentialsType as ApiCredentialsType
 import org.eclipse.apoapsis.ortserver.api.v1.model.EcosystemStats as ApiEcosystemStats
 import org.eclipse.apoapsis.ortserver.api.v1.model.EnvironmentConfig as ApiEnvironmentConfig
@@ -95,6 +96,7 @@ import org.eclipse.apoapsis.ortserver.model.AdvisorJob
 import org.eclipse.apoapsis.ortserver.model.AdvisorJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.AnalyzerJob
 import org.eclipse.apoapsis.ortserver.model.AnalyzerJobConfiguration
+import org.eclipse.apoapsis.ortserver.model.ContentManagementSection
 import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.EcosystemStats
 import org.eclipse.apoapsis.ortserver.model.EnvironmentConfig
@@ -899,5 +901,12 @@ fun Project.mapToApi() = ApiProject(
 )
 
 fun UserDisplayName.mapToApi() = ApiUserDisplayName(username, fullName)
+
+fun ContentManagementSection.mapToApi() = ApiContentManagementSection(
+    id = id,
+    isEnabled = isEnabled,
+    markdown = markdown,
+    updatedAt = updatedAt
+)
 
 fun OidcConfig.mapToApi() = ApiOidcConfig(accessTokenUrl, clientId)

--- a/api/v1/model/src/commonMain/kotlin/ContentManagementSection.kt
+++ b/api/v1/model/src/commonMain/kotlin/ContentManagementSection.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.api.v1.model
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+
+/**
+ * Markdown-formatted text to be displayed in UI sections.
+ */
+@Serializable
+data class ContentManagementSection(
+    val id: String,
+    val isEnabled: Boolean,
+    val markdown: String,
+    val updatedAt: Instant
+)
+
+/**
+ * Request object for the update of a section.
+ */
+@Serializable
+data class UpdateContentManagementSection(
+    val isEnabled: Boolean,
+    val markdown: String
+)

--- a/components/authorization/implementation/src/main/kotlin/Extensions.kt
+++ b/components/authorization/implementation/src/main/kotlin/Extensions.kt
@@ -89,3 +89,12 @@ fun RoutingContext.requirePermission(requiredRole: String) {
 fun RoutingContext.requireSuperuser() {
     requirePermission(Superuser.ROLE_NAME)
 }
+
+/**
+ * Require that the [OrtPrincipal] of the current [call] is authenticated. Throw an [AuthorizationException] otherwise.
+ */
+fun RoutingContext.requireAuthenticated() {
+    if (call.principal<OrtPrincipal>() == null) {
+        throw AuthorizationException()
+    }
+}

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -71,6 +71,7 @@ dependencies {
     implementation(projects.model)
     implementation(projects.secrets.secretsSpi)
     implementation(projects.services.authorizationService)
+    implementation(projects.services.contentManagementService)
     implementation(projects.services.hierarchyService)
     implementation(projects.services.infrastructureService)
     implementation(projects.services.reportStorageService)

--- a/core/src/main/kotlin/apiDocs/AdminDocs.kt
+++ b/core/src/main/kotlin/apiDocs/AdminDocs.kt
@@ -23,7 +23,9 @@ import io.github.smiley4.ktoropenapi.config.RouteConfig
 
 import io.ktor.http.HttpStatusCode
 
+import org.eclipse.apoapsis.ortserver.api.v1.model.ContentManagementSection
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateUser
+import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateContentManagementSection
 import org.eclipse.apoapsis.ortserver.api.v1.model.User
 
 val runPermissionsSync: RouteConfig.() -> Unit = {
@@ -130,6 +132,74 @@ val deleteUserByUsername: RouteConfig.() -> Unit = {
 
         HttpStatusCode.InternalServerError to {
             description = "The user does not exist."
+        }
+    }
+}
+
+val getSectionById: RouteConfig.() -> Unit = {
+    operationId = "GetSectionById"
+    summary = "Get a dynamic UI text section by ID."
+    tags = listOf("Admin")
+
+    request {
+        pathParameter<String>("sectionId") {
+            description = "The section's ID."
+        }
+    }
+
+    response {
+        HttpStatusCode.OK to {
+            description = "Success"
+            jsonBody<ContentManagementSection> {
+                example("Get section") {
+                    value = ContentManagementSection(
+                        id = "footer",
+                        isEnabled = true,
+                        markdown = "## Footer",
+                        updatedAt = CREATED_AT
+                    )
+                }
+            }
+        }
+    }
+}
+
+val patchSectionById: RouteConfig.() -> Unit = {
+    operationId = "PatchSectionById"
+    summary = "Update a dynamic UI text section by ID."
+    tags = listOf("Admin")
+
+    request {
+        pathParameter<String>("sectionId") {
+            description = "The section's ID."
+        }
+
+        jsonBody<UpdateContentManagementSection> {
+            example("Update Section") {
+                value = """
+                    {
+                        "isEnabled": true,
+                        "markdown": "# This is a new footer"
+                    }
+                """.trimIndent()
+            }
+            description = "Set the values that should be updated."
+        }
+    }
+
+    response {
+        HttpStatusCode.OK to {
+            description = "Success"
+            jsonBody<ContentManagementSection> {
+                example("Update Section") {
+                    value = ContentManagementSection(
+                        id = "footer",
+                        isEnabled = true,
+                        markdown = "## Footer",
+                        updatedAt = CREATED_AT
+                    )
+                }
+            }
         }
     }
 }

--- a/core/src/main/kotlin/di/Module.kt
+++ b/core/src/main/kotlin/di/Module.kt
@@ -67,6 +67,7 @@ import org.eclipse.apoapsis.ortserver.model.repositories.ScannerJobRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.SecretRepository
 import org.eclipse.apoapsis.ortserver.secrets.SecretStorage
 import org.eclipse.apoapsis.ortserver.services.AuthorizationService
+import org.eclipse.apoapsis.ortserver.services.ContentManagementService
 import org.eclipse.apoapsis.ortserver.services.DefaultAuthorizationService
 import org.eclipse.apoapsis.ortserver.services.InfrastructureServiceService
 import org.eclipse.apoapsis.ortserver.services.IssueService
@@ -159,6 +160,7 @@ fun ortServerModule(config: ApplicationConfig, setupDatabase: Boolean = true) = 
     single { ProjectService(get()) }
     single { UserService(get()) }
     single { OrtRunService(get(), get(), get(), get()) }
+    single { ContentManagementService(get()) }
     singleOf(::ReportStorageService)
     singleOf(::InfrastructureServiceService)
 }

--- a/dao/src/main/kotlin/repositories/contentSection/ContentManagementSectionTable.kt
+++ b/dao/src/main/kotlin/repositories/contentSection/ContentManagementSectionTable.kt
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.dao.repositories.contentSection
+
+import org.eclipse.apoapsis.ortserver.dao.utils.transformToDatabasePrecision
+import org.eclipse.apoapsis.ortserver.model.ContentManagementSection
+
+import org.jetbrains.exposed.dao.Entity
+import org.jetbrains.exposed.dao.EntityClass
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.dao.id.IdTable
+import org.jetbrains.exposed.sql.Column
+import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
+
+/**
+ * A table that represents Markdown-formatted text to be displayed in UI sections.
+ */
+object ContentManagementSectionTable : IdTable<String>("content_management_sections") {
+    /**
+     * Unique identifier for the section.
+     */
+    override val id: Column<EntityID<String>> = text("id").entityId()
+
+    val isEnabled = bool("is_enabled").default(false)
+
+    val markdown = text("markdown")
+
+    val updatedAt = timestamp("updated_at")
+}
+
+class ContentManagementSectionDao(id: EntityID<String>) : Entity<String>(id) {
+    companion object : EntityClass<String, ContentManagementSectionDao>(ContentManagementSectionTable)
+
+    var isEnabled by ContentManagementSectionTable.isEnabled
+    var markdown by ContentManagementSectionTable.markdown
+    var updatedAt by ContentManagementSectionTable.updatedAt.transformToDatabasePrecision()
+
+    fun mapToModel() = ContentManagementSection(
+        id = id.value,
+        isEnabled = isEnabled,
+        markdown = markdown,
+        updatedAt = updatedAt
+    )
+}

--- a/dao/src/main/resources/db/migration/V100__addContentManagementSections.sql
+++ b/dao/src/main/resources/db/migration/V100__addContentManagementSections.sql
@@ -1,0 +1,38 @@
+-- Content Management: Markdown-formatted text to be displayed in UI sections.
+CREATE TABLE content_management_sections (
+    id TEXT PRIMARY KEY,
+    is_enabled BOOLEAN NOT NULL DEFAULT FALSE,
+    markdown TEXT NOT NULL,
+    updated_at TIMESTAMP NOT NULL
+);
+
+INSERT INTO content_management_sections (id, is_enabled, markdown, updated_at)
+VALUES (
+           'footer',
+           false,
+           $markdown$
+Please use layout markers like this:
+
+Content inside a "align-left" layout marker is aligned to the left of the footer.
+Content inside a "align-right" layout marker is aligned to the right of the footer.
+
+::: align-left
+**ORT Server**
+A scalable application to automate software compliance checks.
+:::
+
+::: align-right
+[API](https://eclipse-apoapsis.github.io/ort-server/api/ort-server-api)
+:::
+
+::: align-right
+[Issues](https://github.com/eclipse-apoapsis/ort-server/issues)
+:::
+
+::: align-right
+[Visit on Github.com](https://github.com/eclipse-apoapsis/ort-server)
+:::
+    $markdown$,
+    NOW()
+);
+

--- a/model/src/commonMain/kotlin/ContentManagementSection.kt
+++ b/model/src/commonMain/kotlin/ContentManagementSection.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.model
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Serializable
+
+/**
+ * Markdown-formatted text to be displayed in UI sections.
+ */
+@Serializable
+data class ContentManagementSection(
+    val id: String,
+    val isEnabled: Boolean,
+    val markdown: String,
+    val updatedAt: Instant
+)

--- a/services/content-management/build.gradle.kts
+++ b/services/content-management/build.gradle.kts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+plugins {
+    // Apply precompiled plugins.
+    id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
+}
+
+group = "org.eclipse.apoapsis.ortserver.services"
+
+dependencies {
+    api(projects.model)
+
+    api(libs.exposedCore)
+
+    implementation(projects.dao)
+
+    runtimeOnly(libs.logback)
+
+    testImplementation(testFixtures(projects.dao))
+
+    testImplementation(libs.kotestRunnerJunit5)
+    testImplementation(libs.mockk)
+}

--- a/services/content-management/src/main/kotlin/ContentManagementService.kt
+++ b/services/content-management/src/main/kotlin/ContentManagementService.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.services
+
+import kotlinx.datetime.Clock
+
+import org.eclipse.apoapsis.ortserver.dao.dbQuery
+import org.eclipse.apoapsis.ortserver.dao.repositories.contentSection.ContentManagementSectionDao
+import org.eclipse.apoapsis.ortserver.model.ContentManagementSection
+
+import org.jetbrains.exposed.sql.Database
+
+class ContentManagementService(private val db: Database) {
+    suspend fun findSectionById(id: String): ContentManagementSection? = db.dbQuery(readOnly = true) {
+        ContentManagementSectionDao[id].mapToModel()
+    }
+
+    suspend fun updateSectionById(
+        id: String,
+        isEnabled: Boolean,
+        markdown: String
+    ): ContentManagementSection = db.dbQuery {
+        val section = ContentManagementSectionDao[id]
+
+        section.isEnabled = isEnabled
+        section.markdown = markdown
+        section.updatedAt = Clock.System.now()
+
+        ContentManagementSectionDao[id].mapToModel()
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -51,6 +51,7 @@ include(":secrets:spi")
 include(":secrets:scaleway")
 include(":secrets:vault")
 include(":services:authorization")
+include(":services:content-management")
 include(":services:hierarchy")
 include(":services:infrastructure")
 include(":services:report-storage")
@@ -89,6 +90,7 @@ project(":config:spi").name = "config-spi"
 project(":logaccess:spi").name = "logaccess-spi"
 project(":secrets:spi").name = "secrets-spi"
 project(":services:authorization").name = "authorization-service"
+project(":services:content-management").name = "content-management-service"
 project(":services:hierarchy").name = "hierarchy-service"
 project(":services:infrastructure").name = "infrastructure-service"
 project(":services:report-storage").name = "report-storage-service"

--- a/ui/src/components/footer.tsx
+++ b/ui/src/components/footer.tsx
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { useAdminServiceGetApiV1AdminContentManagementSectionsBySectionId } from '@/api/queries';
+import { MarkdownRenderer } from '@/components/markdown-renderer.tsx';
+
+function extractColumns(
+  markdown: string,
+  alignment: 'left' | 'right'
+): string[] {
+  const regex = new RegExp(
+    `:::\\s?align-${alignment}\\s+([\\s\\S]*?)\\s+:::`,
+    'g'
+  );
+  const matches = [];
+  let match;
+
+  while ((match = regex.exec(markdown)) !== null) {
+    if (match[1] !== undefined) {
+      matches.push(match[1].trim());
+    }
+  }
+
+  return matches;
+}
+
+export function Footer() {
+  const { data } =
+    useAdminServiceGetApiV1AdminContentManagementSectionsBySectionId({
+      sectionId: 'footer',
+    });
+
+  const markdown = data?.markdown || '';
+  const enabled = data?.isEnabled || false;
+
+  const columnsAlignedLeft = extractColumns(markdown, 'left');
+  const columnsAlignedRight = extractColumns(markdown, 'right');
+  return (
+    enabled && (
+      <footer className='bg-muted text-muted-foreground w-full border-t text-sm'>
+        <div className='mx-auto flex max-w-screen-xl flex-col items-center justify-between gap-4 p-4 sm:flex-row md:gap-8 md:p-8'>
+          <nav className='flex flex-col gap-4 sm:flex-row sm:items-start'>
+            {columnsAlignedLeft.map((content, index) => (
+              <MarkdownRenderer key={index} markdown={content} />
+            ))}
+          </nav>
+          <nav className='flex flex-col gap-4 sm:flex-row sm:items-start'>
+            {columnsAlignedRight.map((content, index) => (
+              <MarkdownRenderer key={index} markdown={content} />
+            ))}
+          </nav>
+        </div>
+      </footer>
+    )
+  );
+}

--- a/ui/src/routes/__root.tsx
+++ b/ui/src/routes/__root.tsx
@@ -22,6 +22,7 @@ import { createRootRouteWithContext, Outlet } from '@tanstack/react-router';
 import React, { Suspense } from 'react';
 
 import { RouterContext } from '@/app';
+import { Footer } from '@/components/footer';
 import { Header } from '@/components/header';
 
 // Don't use Router devtools in production.
@@ -42,6 +43,7 @@ const RootComponent = () => {
         <main className='flex h-full flex-col gap-4 p-4 md:w-full md:items-center md:gap-8 md:p-8'>
           <Outlet />
         </main>
+        <Footer />
       </div>
       <Suspense>
         <TanStackRouterDevtools />

--- a/ui/src/routes/admin/content-management/footer/index.tsx
+++ b/ui/src/routes/admin/content-management/footer/index.tsx
@@ -1,0 +1,216 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useQueryClient } from '@tanstack/react-query';
+import { createFileRoute } from '@tanstack/react-router';
+import { Loader2 } from 'lucide-react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import {
+  useAdminServiceGetApiV1AdminContentManagementSectionsBySectionId,
+  useAdminServiceGetApiV1AdminContentManagementSectionsBySectionIdKey,
+  useAdminServicePatchApiV1AdminContentManagementSectionsBySectionId,
+} from '@/api/queries';
+import { ApiError } from '@/api/requests';
+import { LoadingIndicator } from '@/components/loading-indicator.tsx';
+import { ToastError } from '@/components/toast-error.tsx';
+import { Button } from '@/components/ui/button.tsx';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card.tsx';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Switch } from '@/components/ui/switch';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip.tsx';
+import { toast } from '@/lib/toast.ts';
+
+const formSchema = z.object({
+  markdown: z.string().min(1, 'Markdown content is required'),
+  isEnabled: z.boolean(),
+});
+
+function FooterEditorComponent() {
+  const queryClient = useQueryClient();
+
+  const {
+    data: contentManagementSection,
+    isFetching,
+    error,
+    isError,
+  } = useAdminServiceGetApiV1AdminContentManagementSectionsBySectionId({
+    sectionId: 'footer',
+  });
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      markdown: contentManagementSection?.markdown || '',
+      isEnabled: contentManagementSection?.isEnabled || false,
+    },
+  });
+
+  const { mutateAsync, isPending } =
+    useAdminServicePatchApiV1AdminContentManagementSectionsBySectionId({
+      onSuccess() {
+        queryClient.invalidateQueries({
+          queryKey: [
+            useAdminServiceGetApiV1AdminContentManagementSectionsBySectionIdKey,
+          ],
+        });
+        toast.info('Footer saved', {
+          description: `Footer saved successfully.`,
+        });
+      },
+      onError(error: ApiError) {
+        toast.error(error.message, {
+          description: <ToastError error={error} />,
+          duration: Infinity,
+          cancel: {
+            label: 'Dismiss',
+            onClick: () => {},
+          },
+        });
+      },
+    });
+
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    await mutateAsync({
+      requestBody: {
+        isEnabled: values.isEnabled,
+        markdown: values.markdown,
+      },
+      sectionId: 'footer',
+    });
+  }
+
+  if (isFetching) {
+    return <LoadingIndicator />;
+  }
+
+  if (isError) {
+    toast.error('Unable to load data', {
+      description: <ToastError error={error} />,
+      duration: Infinity,
+      cancel: {
+        label: 'Dismiss',
+        onClick: () => {},
+      },
+    });
+    return;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Footer</CardTitle>
+        <CardDescription>
+          Use Markdown to customize the footer content, and toggle the footer
+          section on or off.
+        </CardDescription>
+      </CardHeader>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>
+          <CardContent className='space-y-4'>
+            <FormField
+              control={form.control}
+              name='markdown'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Footer Content</FormLabel>
+                  <FormControl>
+                    <textarea
+                      placeholder='Write some markdown...'
+                      rows={25}
+                      className='border-input bg-background bg-muted/50 min-h-[200px] w-full rounded-md border p-2 font-mono text-sm'
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name='isEnabled'
+              render={({ field }) => (
+                <FormItem className='flex items-center gap-2'>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                  <FormLabel>Show footer</FormLabel>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </CardContent>
+          <CardFooter className='flex gap-2'>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type='button'
+                  variant='outline'
+                  onClick={() => form.reset()}
+                >
+                  Reset
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                Revert to the saved footer content and clear unsaved edits.
+              </TooltipContent>
+            </Tooltip>
+            <Button type='submit' disabled={isPending}>
+              {isPending ? (
+                <>
+                  <span className='sr-only'>Saving ...</span>
+                  <Loader2 size={16} className='mx-3 animate-spin' />
+                </>
+              ) : (
+                'Save'
+              )}
+            </Button>
+          </CardFooter>
+        </form>
+      </Form>
+    </Card>
+  );
+}
+
+export const Route = createFileRoute('/admin/content-management/footer/')({
+  component: FooterEditorComponent,
+});

--- a/ui/src/routes/admin/route.tsx
+++ b/ui/src/routes/admin/route.tsx
@@ -18,7 +18,14 @@
  */
 
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
-import { Blocks, Eye, KeyRound, ListVideo, User } from 'lucide-react';
+import {
+  Blocks,
+  Eye,
+  KeyRound,
+  ListVideo,
+  PanelBottom,
+  User,
+} from 'lucide-react';
 
 import { PageLayout } from '@/components/page-layout';
 import { SidebarNavProps } from '@/components/sidebar';
@@ -66,6 +73,16 @@ const Layout = () => {
           title: 'Runs',
           to: '/admin/runs',
           icon: () => <ListVideo className='h-4 w-4' />,
+        },
+      ],
+    },
+    {
+      label: 'Content Management',
+      items: [
+        {
+          title: 'Footer',
+          to: '/admin/content-management/footer',
+          icon: () => <PanelBottom className='h-4 w-4' />,
         },
       ],
     },


### PR DESCRIPTION
Add a REST API endpoint to consume and update dynamic content for the footer section of the UI, add a footer section to the UI that uses this endpoint, and add a configuration panel in the admin section of the UI that allows to view and update the dynamic footer content.

See the respective commits for details.

Fixes #2344.
