### PR TITLE
CLI: Add progress bar when using --wait flag

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -69,6 +69,7 @@ kotlin {
                 implementation(libs.ktorClientAuth)
                 implementation(libs.ktorClientCore)
                 implementation(libs.ktorUtils)
+                implementation(libs.mordantCoroutines)
                 implementation(libs.okio)
             }
         }

--- a/cli/src/commonMain/kotlin/StartCommand.kt
+++ b/cli/src/commonMain/kotlin/StartCommand.kt
@@ -46,7 +46,7 @@ import org.eclipse.apoapsis.ortserver.cli.utils.echoMessage
 import org.eclipse.apoapsis.ortserver.cli.utils.read
 import org.eclipse.apoapsis.ortserver.client.NotFoundException
 
-internal val POLL_INTERVAL = getEnv("POLL_INTERVAL")?.toLongOrNull()?.seconds ?: 60.seconds
+internal val POLL_INTERVAL = getEnv("POLL_INTERVAL")?.toLongOrNull()?.seconds ?: 10.seconds
 
 class StartCommand : SuspendingCliktCommand(name = "start") {
     private val repositoryId by option(

--- a/cli/src/commonMain/kotlin/StartCommand.kt
+++ b/cli/src/commonMain/kotlin/StartCommand.kt
@@ -44,6 +44,7 @@ import org.eclipse.apoapsis.ortserver.cli.model.printables.toPrintable
 import org.eclipse.apoapsis.ortserver.cli.utils.createOrtServerClient
 import org.eclipse.apoapsis.ortserver.cli.utils.echoMessage
 import org.eclipse.apoapsis.ortserver.cli.utils.read
+import org.eclipse.apoapsis.ortserver.cli.utils.useJsonFormat
 import org.eclipse.apoapsis.ortserver.client.NotFoundException
 
 internal val POLL_INTERVAL = getEnv("POLL_INTERVAL")?.toLongOrNull()?.seconds ?: 10.seconds
@@ -98,16 +99,15 @@ class StartCommand : SuspendingCliktCommand(name = "start") {
 
         ContextStorage.saveLatestRunId(ortRun.id)
 
-        echoMessage(ortRun.toPrintable())
-
         if (wait) {
             while (ortRun.isRunning()) {
                 delay(POLL_INTERVAL)
                 ortRun = client.repositories.getOrtRun(repositoryId, ortRun.index)
+                if (!useJsonFormat) echoMessage(ortRun.toPrintable())
             }
-
-            echoMessage(ortRun.toPrintable())
         }
+
+        echoMessage(ortRun.toPrintable())
     }
 }
 

--- a/cli/src/commonMain/kotlin/StartCommand.kt
+++ b/cli/src/commonMain/kotlin/StartCommand.kt
@@ -21,6 +21,7 @@ package org.eclipse.apoapsis.ortserver.cli
 
 import com.github.ajalt.clikt.command.SuspendingCliktCommand
 import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.terminal
 import com.github.ajalt.clikt.parameters.groups.mutuallyExclusiveOptions
 import com.github.ajalt.clikt.parameters.groups.required
 import com.github.ajalt.clikt.parameters.options.convert
@@ -28,14 +29,25 @@ import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.long
+import com.github.ajalt.mordant.animation.coroutines.animateInCoroutine
+import com.github.ajalt.mordant.widgets.Spinner
+import com.github.ajalt.mordant.widgets.progress.percentage
+import com.github.ajalt.mordant.widgets.progress.progressBar
+import com.github.ajalt.mordant.widgets.progress.progressBarContextLayout
+import com.github.ajalt.mordant.widgets.progress.spinner
+import com.github.ajalt.mordant.widgets.progress.text
 
 import kotlin.time.Duration.Companion.seconds
 
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
 
 import okio.Path.Companion.toPath
 
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
+import org.eclipse.apoapsis.ortserver.api.v1.model.JobConfigurations
+import org.eclipse.apoapsis.ortserver.api.v1.model.Jobs
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatus
 import org.eclipse.apoapsis.ortserver.cli.model.AuthenticationError
@@ -46,6 +58,7 @@ import org.eclipse.apoapsis.ortserver.cli.utils.echoMessage
 import org.eclipse.apoapsis.ortserver.cli.utils.read
 import org.eclipse.apoapsis.ortserver.cli.utils.useJsonFormat
 import org.eclipse.apoapsis.ortserver.client.NotFoundException
+import org.eclipse.apoapsis.ortserver.client.OrtServerClient
 
 internal val POLL_INTERVAL = getEnv("POLL_INTERVAL")?.toLongOrNull()?.seconds ?: 10.seconds
 
@@ -100,15 +113,98 @@ class StartCommand : SuspendingCliktCommand(name = "start") {
         ContextStorage.saveLatestRunId(ortRun.id)
 
         if (wait) {
-            while (ortRun.isRunning()) {
-                delay(POLL_INTERVAL)
-                ortRun = client.repositories.getOrtRun(repositoryId, ortRun.index)
-                if (!useJsonFormat) echoMessage(ortRun.toPrintable())
+            if (useJsonFormat) {
+                while (ortRun.isRunning()) {
+                    delay(POLL_INTERVAL)
+                    ortRun = client.repositories.getOrtRun(repositoryId, ortRun.index)
+                }
+            } else {
+                echoMessage(ortRun.toPrintable())
+                ortRun = updateProgressBar(ortRun, client)
             }
         }
 
         echoMessage(ortRun.toPrintable())
     }
+
+    private fun updateProgressBar(ortRun: OrtRun, client: OrtServerClient): OrtRun = runBlocking {
+        val maxProgressBarValue = JobType.entries.count { it.isConfigured(ortRun.jobConfigs) }.withInitialState()
+
+        val progress = progressBarContextLayout {
+            text { context }
+            spinner(Spinner.Dots())
+            progressBar(width = 30)
+            percentage()
+        }.animateInCoroutine(
+            terminal,
+            context = "Starting",
+            total = maxProgressBarValue,
+            completed = 0
+        )
+
+        launch { progress.execute() }
+
+        var updatedOrtRun = ortRun.copy()
+        while (updatedOrtRun.isRunning()) {
+            delay(POLL_INTERVAL)
+            updatedOrtRun = client.repositories.getOrtRun(repositoryId, updatedOrtRun.index)
+            progress.update {
+                context =
+                    JobType.entries.reversed().find { it.isStarted(updatedOrtRun.jobs) }?.displayName ?: "Starting"
+                completed = JobType.entries.count { it.isFinished(updatedOrtRun.jobs) }.withInitialState()
+            }
+        }
+
+        progress.update {
+            context = "Finished"
+            completed = maxProgressBarValue
+        }
+
+        updatedOrtRun
+    }
+
+    private enum class JobType(val displayName: String) {
+        ANALYZER("Analyzing"),
+        ADVISOR("Advising"),
+        SCANNER("Scanning"),
+        EVALUATOR("Evaluating"),
+        REPORTER("Reporting"),
+        NOTIFIER("Notifying");
+
+        fun isConfigured(config: JobConfigurations) = when (this) {
+            ANALYZER -> true
+            ADVISOR -> config.advisor != null
+            SCANNER -> config.scanner != null
+            EVALUATOR -> config.evaluator != null
+            REPORTER -> config.reporter != null
+            NOTIFIER -> config.notifier != null
+        }
+
+        fun isStarted(jobs: Jobs) = when (this) {
+            ANALYZER -> jobs.analyzer != null
+            ADVISOR -> jobs.advisor != null
+            SCANNER -> jobs.scanner != null
+            EVALUATOR -> jobs.evaluator != null
+            REPORTER -> jobs.reporter != null
+            NOTIFIER -> jobs.notifier != null
+        }
+
+        fun isFinished(jobs: Jobs) = when (this) {
+            ANALYZER -> jobs.analyzer?.finishedAt != null
+            ADVISOR -> jobs.advisor?.finishedAt != null
+            SCANNER -> jobs.scanner?.finishedAt != null
+            EVALUATOR -> jobs.evaluator?.finishedAt != null
+            REPORTER -> jobs.reporter?.finishedAt != null
+            NOTIFIER -> jobs.notifier?.finishedAt != null
+        }
+    }
+
+    /**
+     * The first job status change is 'Starting' -> 'Analyzing'.
+     * Add the artificial 'Starting' state to the maximum possible progress bar value to correctly represent this in the
+     * progress bar.
+     */
+    private fun Int.withInitialState(): Long = (this + 1).toLong()
 }
 
 private fun OrtRun.isRunning() =

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -64,6 +64,7 @@ log4j = "2.24.3"
 logback = "1.5.18"
 micrometer = "1.14.5"
 mockk = "1.14.0"
+mordant = "3.0.2"
 okio = "3.11.0"
 ort = "55.3.0"
 postgres = "42.7.5"
@@ -156,6 +157,7 @@ log4jToSlf4j = { module = "org.apache.logging.log4j:log4j-to-slf4j", version.ref
 logback = { module = "ch.qos.logback:logback-classic", version.ref = "logback" }
 micrometerRegistryGraphite = { module = "io.micrometer:micrometer-registry-graphite", version.ref = "micrometer" }
 mockk = { module = "io.mockk:mockk", version.ref = "mockk" }
+mordantCoroutines = { module =  "com.github.ajalt.mordant:mordant-coroutines", version.ref = "mordant" }
 okio = { module = "com.squareup.okio:okio", version.ref = "okio" }
 ortAdvisor = { module = "org.ossreviewtoolkit:advisor", version.ref = "ort" }
 ortAdvisors = { module = "org.ossreviewtoolkit.plugins:advisors", version.ref = "ort" }


### PR DESCRIPTION
Instead of printing the run status every time the status is being polled, show a progress bar when using the `--wait` flag.
If the `--json` flag is used together with the `--wait` flag, the run status is only printed after the run finished.

![image](https://github.com/user-attachments/assets/a84e5ce0-16d8-464e-b473-5675912656de)