### PR TITLE
Change generation of the .netrc file

### DIFF
--- a/workers/analyzer/src/main/kotlin/analyzer/AnalyzerWorker.kt
+++ b/workers/analyzer/src/main/kotlin/analyzer/AnalyzerWorker.kt
@@ -74,7 +74,7 @@ internal class AnalyzerWorker(
                     repositoryServices.map(InfrastructureService::name)
                 )
 
-                environmentService.generateNetRcFile(context, repositoryServices)
+                environmentService.setupAuthentication(context, repositoryServices)
             }
 
             val downloadResult = downloader.downloadRepository(

--- a/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
@@ -32,7 +32,6 @@ import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 import io.kotest.matchers.string.shouldContain
-import io.kotest.matchers.string.shouldNotContain
 
 import io.mockk.coEvery
 import io.mockk.every
@@ -128,18 +127,6 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
                 content shouldContain "https://center.conan.io"
                 content shouldContain "verify_ssl"
                 content shouldContain "true"
-            }
-        }
-
-        "The build environment should contain a .netrc file" {
-            runEnvironmentTest { homeFolder ->
-                val netrcFile = homeFolder.resolve(".netrc")
-                val content = netrcFile.readText()
-
-                content shouldContain "machine repo.example.org"
-                content shouldContain "login $USERNAME"
-
-                content shouldNotContain "repo2.example.org"
             }
         }
 
@@ -357,7 +344,7 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
                     resolvedJobConfigContext = null,
                     traceId = "trace-id",
                 )
-                coEvery { setupAuthentication(any()) } just runs
+                coEvery { setupAuthentication(any(), any()) } just runs
             }
 
             val repositoryFolder = File("src/test/resources/mavenProject")

--- a/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
@@ -143,7 +143,7 @@ class AnalyzerWorkerTest : StringSpec({
         val infrastructureServices = listOf<InfrastructureService>(mockk(relaxed = true), mockk(relaxed = true))
         val envService = mockk<EnvironmentService> {
             every { findInfrastructureServicesForRepository(context, null) } returns infrastructureServices
-            coEvery { generateNetRcFile(context, infrastructureServices) } just runs
+            coEvery { setupAuthentication(context, infrastructureServices) } just runs
             coEvery {
                 setUpEnvironment(context, projectDir, null, infrastructureServices)
             } returns ResolvedEnvironmentConfig()
@@ -170,7 +170,7 @@ class AnalyzerWorkerTest : StringSpec({
             }
 
             coVerifyOrder {
-                envService.generateNetRcFile(context, infrastructureServices)
+                envService.setupAuthentication(context, infrastructureServices)
                 downloader.downloadRepository(repository.url, ortRun.revision)
                 envService.setUpEnvironment(context, projectDir, null, infrastructureServices)
             }
@@ -226,7 +226,7 @@ class AnalyzerWorkerTest : StringSpec({
             }
 
             coVerify(exactly = 0) {
-                envService.generateNetRcFile(any(), any())
+                envService.setupAuthentication(any(), any())
             }
 
             coVerify {

--- a/workers/common/src/main/kotlin/common/context/AuthenticationListener.kt
+++ b/workers/common/src/main/kotlin/common/context/AuthenticationListener.kt
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.common.context
+
+/**
+ * A data class defining an event that is triggered when [OrtServerAuthenticator] successfully authenticates a request.
+ */
+data class AuthenticationEvent(
+    /** The name of the infrastructure service whose credentials are used for authentication. */
+    val serviceName: String
+)
+
+/**
+ * An interface for listeners that receive notifications about successful authentications performed by
+ * [OrtServerAuthenticator].
+ *
+ * An implementation of this interface can be added to [OrtServerAuthenticator]. It is then always invoked when a
+ * request is successfully authenticated using the credentials of a specific infrastructure service. The purpose
+ * behind this interface is to have a mechanism to dynamically update the environment based on the infrastructure
+ * services that are involved in the current operation. This is especially necessary when dealing with external tools
+ * that rely on the content of the _.netrc_ file for authentication. Since this file is limited and allows only one
+ * set of credentials per host, it cannot be generated beforehand based on all infrastructure services defined; this
+ * would lead to conflicts if there are multiple services for the same host. Instead, the idea is to keep track of the
+ * set of infrastructure services that are currently referenced and also update the content of the _.netrc_ file if
+ * this changes. This is, of course, not a perfect solution. It requires that the [OrtServerAuthenticator] is always
+ * called before an external tool is launched.
+ */
+interface AuthenticationListener {
+    /**
+     * Notify this listener about a successful authentication with the details provided by the given
+     * [authenticationEvent].
+     */
+    fun onAuthentication(authenticationEvent: AuthenticationEvent)
+}

--- a/workers/common/src/main/kotlin/common/context/WorkerContext.kt
+++ b/workers/common/src/main/kotlin/common/context/WorkerContext.kt
@@ -108,7 +108,10 @@ interface WorkerContext : AutoCloseable {
 
     /**
      * Install the given list of [services] in ORT Server's authenticator, so that their credentials can be used to
-     * access the corresponding URLs.
+     * access the corresponding URLs. Optionally, install the given [listener] for authentication events.
      */
-    suspend fun setupAuthentication(services: Collection<InfrastructureService>)
+    suspend fun setupAuthentication(
+        services: Collection<InfrastructureService>,
+        listener: AuthenticationListener? = null
+    )
 }

--- a/workers/common/src/main/kotlin/common/context/WorkerContextImpl.kt
+++ b/workers/common/src/main/kotlin/common/context/WorkerContextImpl.kt
@@ -192,10 +192,7 @@ internal class WorkerContextImpl(
     override fun close() {
         tempDirectories.forEach { it.safeDeleteRecursively() }
 
-        // During the worker execution, ORT's authenticator was typically installed. Uninstall it first, which
-        // will restore OrtServerAuthenticator as default authenticator.
         OrtAuthenticator.uninstall()
-        OrtServerAuthenticator.uninstall()
     }
 
     /**

--- a/workers/common/src/main/kotlin/common/context/WorkerContextImpl.kt
+++ b/workers/common/src/main/kotlin/common/context/WorkerContextImpl.kt
@@ -170,7 +170,10 @@ internal class WorkerContextImpl(
         return downloadConfigurationFiles(containedFiles, targetDirectory)
     }
 
-    override suspend fun setupAuthentication(services: Collection<InfrastructureService>) {
+    override suspend fun setupAuthentication(
+        services: Collection<InfrastructureService>,
+        listener: AuthenticationListener?
+    ) {
         val serviceSecrets = services.flatMapTo(mutableSetOf()) { service ->
             listOf(service.usernameSecret, service.passwordSecret)
         }
@@ -183,6 +186,7 @@ internal class WorkerContextImpl(
         }
 
         authenticator.updateAuthenticatedServices(authServices)
+        authenticator.updateAuthenticationListener(listener)
     }
 
     override fun close() {

--- a/workers/common/src/main/kotlin/common/env/EnvironmentModule.kt
+++ b/workers/common/src/main/kotlin/common/env/EnvironmentModule.kt
@@ -49,7 +49,6 @@ fun buildEnvironmentModule(): Module = module {
                 GitConfigGenerator.create(get()),
                 GitCredentialsGenerator(),
                 MavenSettingsGenerator(),
-                NetRcGenerator(),
                 NpmRcGenerator(),
                 NuGetGenerator(),
                 YarnRcGenerator()

--- a/workers/common/src/main/kotlin/common/env/EnvironmentService.kt
+++ b/workers/common/src/main/kotlin/common/env/EnvironmentService.kt
@@ -145,7 +145,9 @@ class EnvironmentService(
             }.awaitAll()
         }
 
-        context.setupAuthentication(definitions.map(EnvironmentServiceDefinition::service))
+        val services = definitions.map(EnvironmentServiceDefinition::service)
+        val netRcManager = NetRcManager.create(context, services)
+        context.setupAuthentication(services, netRcManager)
     }
 
     /**

--- a/workers/common/src/main/kotlin/common/env/EnvironmentService.kt
+++ b/workers/common/src/main/kotlin/common/env/EnvironmentService.kt
@@ -149,22 +149,24 @@ class EnvironmentService(
     }
 
     /**
-     * Generate the _.netrc_ file based on the given [services]. Use the given [context] to access required
-     * information. This is a special variant of the [generateConfigFiles] function that focuses only on the
-     * _.netrc_ file.
+     * Perform the required steps to set up authentication information for the current worker execution based on the
+     * given [services]. Use the given [context] to access required information. This is a special variant of the
+     * [setUpEnvironment] function that focuses only on credentials and does not generate other package
+     * manager-specific configuration files.
      */
-    suspend fun generateNetRcFile(context: WorkerContext, services: Collection<InfrastructureService>) {
+    suspend fun setupAuthentication(context: WorkerContext, services: Collection<InfrastructureService>) {
         val definitions = services.map { EnvironmentServiceDefinition(it) }
         generateConfigFiles(context, definitions)
     }
 
     /**
-     * Generate the _.netrc_ file for the current ORT run as defined by the given [context]. Load the infrastructure
-     * services associated with the current run from the database and process their credentials. This function can be
-     * used by workers running after the Analyzer, which has initialized the required information.
+     * Perform the required steps to set up authentication information for the current worker execution in the current
+     * ORT run as defined by the given [context]. Load the infrastructure services associated with the current run from
+     * the database and process their credentials. This function can be used by workers running after the Analyzer,
+     * which has initialized the required information.
      */
-    suspend fun generateNetRcFileForCurrentRun(context: WorkerContext) {
-        generateNetRcFile(context, infrastructureServiceRepository.listForRun(context.ortRun.id))
+    suspend fun setupAuthenticationForCurrentRun(context: WorkerContext) {
+        setupAuthentication(context, infrastructureServiceRepository.listForRun(context.ortRun.id))
     }
 
     /**

--- a/workers/common/src/main/kotlin/common/env/NetRcManager.kt
+++ b/workers/common/src/main/kotlin/common/env/NetRcManager.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.common.env
+
+import java.net.URI
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
+import org.eclipse.apoapsis.ortserver.model.InfrastructureService
+import org.eclipse.apoapsis.ortserver.utils.logging.runBlocking
+import org.eclipse.apoapsis.ortserver.workers.common.context.AuthenticationEvent
+import org.eclipse.apoapsis.ortserver.workers.common.context.AuthenticationListener
+import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
+import org.eclipse.apoapsis.ortserver.workers.common.env.definition.EnvironmentServiceDefinition
+
+import org.slf4j.LoggerFactory
+
+/**
+ * An internal helper class to dynamically update the content of the `.netrc` file when there is a change in the
+ * authentication state.
+ *
+ * An instance of this class is created when setting up the environment for executing a worker. It is initialized with
+ * the set of infrastructure services currently available. It is also registered at the central authenticator used by
+ * ORT Server. Its task is to figure out, based on authentication events, which infrastructure services are currently
+ * referenced. These are then written into the `.netrc` file, if they have the corresponding credentials type. This
+ * should prevent conflicts with multiple services for the same host.
+ */
+internal class NetRcManager(
+    /** The current [WorkerContext]. */
+    private val context: WorkerContext,
+
+    /** The currently known set of infrastructure services. */
+    services: Collection<InfrastructureService>
+) : AuthenticationListener {
+    companion object {
+        private val logger = LoggerFactory.getLogger(NetRcManager::class.java)
+
+        /**
+         * Create a new instance of [NetRcManager] and initialize it with the given [context] and [services].
+         */
+        fun create(context: WorkerContext, services: Collection<InfrastructureService>): NetRcManager =
+            NetRcManager(context, services)
+    }
+
+    /** A map with all relevant services using the service name as key. */
+    private val netRcServices = services.filter { CredentialsType.NETRC_FILE in it.credentialsTypes }
+        .associateBy { it.name }
+
+    /**
+     * Stores the services for which authentication events have been received. These are the services that are
+     * currently referenced from the `.netrc` file. The key is the host for which a service is responsible for.
+     */
+    private val authenticatedServices = mutableMapOf<String, EnvironmentServiceDefinition>()
+
+    /** A mutex to guard access to the authenticated services and updates of the `.netrc` file. */
+    private val mutex = Mutex()
+
+    override fun onAuthentication(authenticationEvent: AuthenticationEvent) {
+        logger.info("Received authentication event for service '${authenticationEvent.serviceName}'.")
+
+        netRcServices[authenticationEvent.serviceName]?.also { service ->
+            runBlocking { updateNetRcServices(service) }
+        }
+    }
+
+    /**
+     * Return a new instance of [ConfigFileBuilder] to be used for creating the `.netrc` file.
+     */
+    internal fun createConfigFileBuilder(): ConfigFileBuilder = ConfigFileBuilder(context)
+
+    /**
+     * Return a new instance of [NetRcGenerator] that is going to be called to generate the `.netrc` file.
+     */
+    internal fun createNetRcGenerator(): NetRcGenerator = NetRcGenerator()
+
+    /**
+     * Perform an update of the `.netrc` file after receiving an authentication event for the given [service].
+     */
+    private suspend fun updateNetRcServices(service: InfrastructureService) {
+        val serviceUri = URI.create(service.url)
+        val serviceHost = serviceUri.host
+
+        val builder = createConfigFileBuilder()
+        val generator = createNetRcGenerator()
+
+        mutex.withLock {
+            if (authenticatedServices[serviceHost]?.service != service) {
+                logger.info("Updating .netrc file. Adding service '${service.name}' for host '$serviceHost'.")
+
+                authenticatedServices[serviceHost] = EnvironmentServiceDefinition(service, service.credentialsTypes)
+                generator.generate(builder, authenticatedServices.values)
+            }
+        }
+    }
+}

--- a/workers/common/src/test/kotlin/common/context/WorkerContextFactoryTest.kt
+++ b/workers/common/src/test/kotlin/common/context/WorkerContextFactoryTest.kt
@@ -464,6 +464,7 @@ class WorkerContextFactoryTest : WordSpec({
         "pass services with resolved secrets to the ORT Server authenticator" {
             val authenticator = mockk<OrtServerAuthenticator> {
                 every { updateAuthenticatedServices(any()) } just runs
+                every { updateAuthenticationListener(any()) } just runs
             }
             every { OrtServerAuthenticator.install() } returns authenticator
 
@@ -503,12 +504,14 @@ class WorkerContextFactoryTest : WordSpec({
                 organization = null,
                 product = null
             )
+            val listener = mockk<AuthenticationListener>()
 
-            context.setupAuthentication(listOf(service1, service2))
+            context.setupAuthentication(listOf(service1, service2), listener)
 
             val slotAuthServices = slot<Collection<AuthenticatedService>>()
             verify {
                 authenticator.updateAuthenticatedServices(capture(slotAuthServices))
+                authenticator.updateAuthenticationListener(listener)
             }
 
             val expectedAuthServices = listOf(

--- a/workers/common/src/test/kotlin/common/context/WorkerContextFactoryTest.kt
+++ b/workers/common/src/test/kotlin/common/context/WorkerContextFactoryTest.kt
@@ -46,7 +46,6 @@ import io.mockk.runs
 import io.mockk.slot
 import io.mockk.unmockkAll
 import io.mockk.verify
-import io.mockk.verifyOrder
 
 import org.eclipse.apoapsis.ortserver.config.ConfigFileProviderFactoryForTesting
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
@@ -453,9 +452,8 @@ class WorkerContextFactoryTest : WordSpec({
             val helper = ContextFactoryTestHelper()
             helper.factory.withContext(RUN_ID) { }
 
-            verifyOrder {
+            verify {
                 OrtAuthenticator.uninstall()
-                OrtServerAuthenticator.uninstall()
             }
         }
     }

--- a/workers/common/src/test/kotlin/common/env/EnvironmentServiceTest.kt
+++ b/workers/common/src/test/kotlin/common/env/EnvironmentServiceTest.kt
@@ -359,7 +359,7 @@ class EnvironmentServiceTest : WordSpec({
         }
     }
 
-    "generateNetRcFile" should {
+    "setupAuthentication" should {
         "produce the correct file using the NetRcGenerator" {
             val context = mockk<WorkerContext>(relaxed = true)
             val services = listOf(
@@ -370,7 +370,7 @@ class EnvironmentServiceTest : WordSpec({
             val generator = mockGenerator()
 
             val environmentService = EnvironmentService(mockk(), listOf(generator), mockk())
-            environmentService.generateNetRcFile(context, services)
+            environmentService.setupAuthentication(context, services)
 
             val args = generator.verify(context)
             args.second.map { it.service } shouldContainExactlyInAnyOrder services
@@ -390,13 +390,13 @@ class EnvironmentServiceTest : WordSpec({
             serviceRepository.expectServiceAssignments()
 
             val environmentService = EnvironmentService(serviceRepository, emptyList(), mockk())
-            environmentService.generateNetRcFile(context, services)
+            environmentService.setupAuthentication(context, services)
 
             coVerify { context.setupAuthentication(services) }
         }
     }
 
-    "generateNetRcFileForCurrentRun" should {
+    "setupAuthenticationForCurrentRun" should {
         "produce the correct file with services stored in the database" {
             val context = mockContext()
             val services = listOf(
@@ -411,7 +411,7 @@ class EnvironmentServiceTest : WordSpec({
             val generator = mockGenerator()
 
             val environmentService = EnvironmentService(serviceRepository, listOf(generator), mockk())
-            environmentService.generateNetRcFileForCurrentRun(context)
+            environmentService.setupAuthenticationForCurrentRun(context)
 
             val args = generator.verify(context)
             args.second.map { it.service } shouldContainExactlyInAnyOrder services
@@ -429,7 +429,7 @@ class EnvironmentServiceTest : WordSpec({
             }
 
             val environmentService = EnvironmentService(serviceRepository, emptyList(), mockk())
-            environmentService.generateNetRcFileForCurrentRun(context)
+            environmentService.setupAuthenticationForCurrentRun(context)
 
             coVerify { context.setupAuthentication(services) }
         }

--- a/workers/common/src/test/kotlin/common/env/NetRcManagerTest.kt
+++ b/workers/common/src/test/kotlin/common/env/NetRcManagerTest.kt
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.common.env
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.runs
+import io.mockk.slot
+import io.mockk.spyk
+import io.mockk.unmockkAll
+
+import java.net.URI
+
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
+import org.eclipse.apoapsis.ortserver.model.InfrastructureService
+import org.eclipse.apoapsis.ortserver.workers.common.context.AuthenticationEvent
+import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
+import org.eclipse.apoapsis.ortserver.workers.common.env.MockConfigFileBuilder.Companion.createInfrastructureService
+import org.eclipse.apoapsis.ortserver.workers.common.env.definition.EnvironmentServiceDefinition
+
+class NetRcManagerTest : WordSpec({
+    afterEach {
+        unmockkAll()
+    }
+
+    "createConfigFileBuilder()" should {
+        "create a correct builder object" {
+            val context = mockk<WorkerContext>()
+            val manager = NetRcManager.create(context, emptyList())
+
+            val builder = manager.createConfigFileBuilder()
+
+            builder.context shouldBe context
+        }
+    }
+
+    "createNetRcGenerator()" should {
+        "create a correct generator object" {
+            val context = mockk<WorkerContext>()
+            val mockBuilder = MockConfigFileBuilder()
+            val definition = EnvironmentServiceDefinition(
+                createInfrastructureService(
+                    "https://repo.example.org",
+                    MockConfigFileBuilder.Companion.createSecret("s1"),
+                    MockConfigFileBuilder.Companion.createSecret("s2")
+                )
+            )
+
+            val manager = NetRcManager.create(context, emptyList())
+            val generator = manager.createNetRcGenerator()
+
+            generator.generate(mockBuilder.builder, listOf(definition))
+
+            mockBuilder.homeFileName shouldBe ".netrc"
+        }
+    }
+
+    "onAuthentication()" should {
+        "write an entry to the .netrc file when a service is authenticated" {
+            val service = createInfrastructureService()
+            val services = listOf(service)
+
+            val mockBuilder = mockk<ConfigFileBuilder>()
+            val mockGenerator = mockk<NetRcGenerator> {
+                coEvery { generate(mockBuilder, any()) } just runs
+            }
+            val manager = createNetRcManagerSpy(mockBuilder, mockGenerator, services)
+
+            manager.onAuthentication(AuthenticationEvent(service.name))
+
+            val slotServices = slot<Collection<EnvironmentServiceDefinition>>()
+            coVerify {
+                mockGenerator.generate(mockBuilder, capture(slotServices))
+            }
+
+            slotServices.captured.map(EnvironmentServiceDefinition::service) shouldContainExactlyInAnyOrder services
+        }
+
+        "ignore services with unknown names" {
+            val service1 = createInfrastructureService()
+            val service2 = createInfrastructureService(url = "https://repo.example.org/other")
+
+            val mockBuilder = mockk<ConfigFileBuilder>()
+            val mockGenerator = mockk<NetRcGenerator>()
+            val manager = createNetRcManagerSpy(mockBuilder, mockGenerator, listOf(service1))
+
+            manager.onAuthentication(AuthenticationEvent(service2.name))
+
+            coVerify(exactly = 0) {
+                mockGenerator.generate(any(), any())
+            }
+        }
+
+        "ignore services with other credentials types" {
+            val service = createInfrastructureService(credentialsTypes = setOf(CredentialsType.GIT_CREDENTIALS_FILE))
+            val mockBuilder = mockk<ConfigFileBuilder>()
+            val mockGenerator = mockk<NetRcGenerator>()
+            val manager = createNetRcManagerSpy(mockBuilder, mockGenerator, listOf(service))
+
+            manager.onAuthentication(AuthenticationEvent(service.name))
+
+            coVerify(exactly = 0) {
+                mockGenerator.generate(any(), any())
+            }
+        }
+
+        "add another service to the netrc file when it is authenticated" {
+            val service1 = createInfrastructureService()
+            val service2 = createInfrastructureService(url = "https://repo2.example.org/other")
+            val services = listOf(service1, service2)
+
+            val mockBuilder = mockk<ConfigFileBuilder>()
+            val mockGenerator = mockk<NetRcGenerator> {
+                coEvery { generate(mockBuilder, any()) } just runs
+            }
+            val manager = createNetRcManagerSpy(mockBuilder, mockGenerator, services)
+
+            manager.onAuthentication(AuthenticationEvent(service1.name))
+            manager.onAuthentication(AuthenticationEvent(service2.name))
+
+            val slotServices = mutableListOf<Collection<EnvironmentServiceDefinition>>()
+            coVerify {
+                mockGenerator.generate(mockBuilder, capture(slotServices))
+            }
+
+            slotServices shouldHaveSize 2
+            slotServices[1].map(EnvironmentServiceDefinition::service) shouldContainExactlyInAnyOrder services
+        }
+
+        "replace a service for a specific host in the .netrc file" {
+            val service1 = createInfrastructureService()
+            val service2Url = URI.create(service1.url).resolve("other-repo.git").toString()
+            val service2 = createInfrastructureService(url = service2Url)
+
+            val mockBuilder = mockk<ConfigFileBuilder>()
+            val mockGenerator = mockk<NetRcGenerator> {
+                coEvery { generate(mockBuilder, any()) } just runs
+            }
+            val manager = createNetRcManagerSpy(mockBuilder, mockGenerator, listOf(service1, service2))
+
+            manager.onAuthentication(AuthenticationEvent(service1.name))
+            manager.onAuthentication(AuthenticationEvent(service2.name))
+
+            val slotServices = mutableListOf<Collection<EnvironmentServiceDefinition>>()
+            coVerify {
+                mockGenerator.generate(mockBuilder, capture(slotServices))
+            }
+
+            slotServices shouldHaveSize 2
+            slotServices[1].map(EnvironmentServiceDefinition::service) shouldContainExactlyInAnyOrder listOf(service2)
+        }
+
+        "not write the .netrc file if there are no changes" {
+            val service = createInfrastructureService()
+
+            val mockBuilder = mockk<ConfigFileBuilder>()
+            val mockGenerator = mockk<NetRcGenerator> {
+                coEvery { generate(mockBuilder, any()) } just runs
+            }
+            val manager = createNetRcManagerSpy(mockBuilder, mockGenerator, listOf(service))
+
+            manager.onAuthentication(AuthenticationEvent(service.name))
+            manager.onAuthentication(AuthenticationEvent(service.name))
+
+            coVerify(exactly = 1) {
+                mockGenerator.generate(mockBuilder, any())
+            }
+        }
+    }
+})
+
+/**
+ * Create a spy for a [NetRcManager] instance that is prepared to use the given [mockBuilder] and [mockBuilder], and
+ * which is initialized with the given [services].
+ */
+private fun createNetRcManagerSpy(
+    mockBuilder: ConfigFileBuilder,
+    mockGenerator: NetRcGenerator,
+    services: Collection<InfrastructureService>
+): NetRcManager =
+    spyk(NetRcManager.create(mockk(), services)) {
+        every { createConfigFileBuilder() } returns mockBuilder
+        every { createNetRcGenerator() } returns mockGenerator
+    }

--- a/workers/reporter/src/main/kotlin/reporter/ReporterWorker.kt
+++ b/workers/reporter/src/main/kotlin/reporter/ReporterWorker.kt
@@ -89,7 +89,7 @@ internal class ReporterWorker(
         }
 
         contextFactory.withContext(job.ortRunId) { context ->
-            environmentService.generateNetRcFileForCurrentRun(context)
+            environmentService.setupAuthenticationForCurrentRun(context)
 
             val reporterRunnerResult = runner.run(
                 job.ortRunId,

--- a/workers/reporter/src/test/kotlin/reporter/ReporterWorkerTest.kt
+++ b/workers/reporter/src/test/kotlin/reporter/ReporterWorkerTest.kt
@@ -161,7 +161,7 @@ class ReporterWorkerTest : StringSpec({
         val contextFactory = mockContextFactory(context)
 
         val environmentService = mockk<EnvironmentService> {
-            coEvery { generateNetRcFileForCurrentRun(context) } just runs
+            coEvery { setupAuthenticationForCurrentRun(context) } just runs
         }
 
         val runnerResult = ReporterRunnerResult(
@@ -200,7 +200,7 @@ class ReporterWorkerTest : StringSpec({
         coVerify {
             ortRunService.storeReporterRun(capture(slotReporterRun))
             ortRunService.storeIssues(ORT_RUN_ID, runnerResult.issues)
-            environmentService.generateNetRcFileForCurrentRun(context)
+            environmentService.setupAuthenticationForCurrentRun(context)
         }
 
         slotReporterRun.captured.reports shouldContainExactlyInAnyOrder listOf(
@@ -277,7 +277,7 @@ class ReporterWorkerTest : StringSpec({
         val contextFactory = mockContextFactory(context)
 
         val environmentService = mockk<EnvironmentService> {
-            coEvery { generateNetRcFileForCurrentRun(context) } just runs
+            coEvery { setupAuthenticationForCurrentRun(context) } just runs
         }
 
         val runnerResult = ReporterRunnerResult(
@@ -316,7 +316,7 @@ class ReporterWorkerTest : StringSpec({
         coVerify {
             ortRunService.storeReporterRun(capture(slotReporterRun))
             ortRunService.storeIssues(ORT_RUN_ID, runnerResult.issues)
-            environmentService.generateNetRcFileForCurrentRun(context)
+            environmentService.setupAuthenticationForCurrentRun(context)
         }
 
         slotReporterRun.captured.reports shouldContainExactlyInAnyOrder listOf(

--- a/workers/scanner/src/main/kotlin/scanner/ScannerWorker.kt
+++ b/workers/scanner/src/main/kotlin/scanner/ScannerWorker.kt
@@ -75,7 +75,7 @@ class ScannerWorker(
         }
 
         contextFactory.withContext(scannerJob.ortRunId) { context ->
-            environmentService.generateNetRcFileForCurrentRun(context)
+            environmentService.setupAuthenticationForCurrentRun(context)
 
             val scannerRunId = ortRunService.createScannerRun(scannerJob.id).id
 

--- a/workers/scanner/src/test/kotlin/ScannerWorkerTest.kt
+++ b/workers/scanner/src/test/kotlin/ScannerWorkerTest.kt
@@ -157,7 +157,7 @@ class ScannerWorkerTest : StringSpec({
         }
 
         val environmentService = mockk<EnvironmentService> {
-            coEvery { generateNetRcFileForCurrentRun(context) } just runs
+            coEvery { setupAuthenticationForCurrentRun(context) } just runs
         }
 
         val worker = ScannerWorker(mockk(), runner, ortRunService, contextFactory, environmentService)
@@ -171,7 +171,7 @@ class ScannerWorkerTest : StringSpec({
             verify(exactly = 1) { ortRunService.finalizeScannerRun(capture(slotScannerRun), any()) }
             slotScannerRun.captured.scanners shouldBe mapOf(mappedIdentifier to setOf("scanner1", "scanner2"))
 
-            coVerify { environmentService.generateNetRcFileForCurrentRun(context) }
+            coVerify { environmentService.setupAuthenticationForCurrentRun(context) }
         }
     }
 
@@ -287,7 +287,7 @@ class ScannerWorkerTest : StringSpec({
         }
 
         val environmentService = mockk<EnvironmentService> {
-            coEvery { generateNetRcFileForCurrentRun(context) } just runs
+            coEvery { setupAuthenticationForCurrentRun(context) } just runs
         }
 
         val worker = ScannerWorker(mockk(), runner, ortRunService, contextFactory, environmentService)
@@ -323,7 +323,7 @@ class ScannerWorkerTest : StringSpec({
                 }
             slotIssues.captured shouldContainExactlyInAnyOrder expectedIssues
 
-            coVerify { environmentService.generateNetRcFileForCurrentRun(context) }
+            coVerify { environmentService.setupAuthenticationForCurrentRun(context) }
         }
     }
 
@@ -388,7 +388,7 @@ class ScannerWorkerTest : StringSpec({
         }
 
         val environmentService = mockk<EnvironmentService> {
-            coEvery { generateNetRcFileForCurrentRun(context) } just runs
+            coEvery { setupAuthenticationForCurrentRun(context) } just runs
         }
 
         val worker = ScannerWorker(mockk(), runner, ortRunService, contextFactory, environmentService)


### PR DESCRIPTION
This PR changes the way the `.netrc` file is generated with the goal to keep it in sync with the infrastructure services that are used by the current worker. This should avoid conflicts with multiple services referring to the same host.

Refer to the single commits for further information.