### PR TITLE
refactor(dao): Fix the package of `JsonHashFunction`

### DIFF
--- a/dao/src/main/kotlin/utils/JsonHashFunction.kt
+++ b/dao/src/main/kotlin/utils/JsonHashFunction.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.eclipse.apoapsis.ortserver.dao.utils.utils
+package org.eclipse.apoapsis.ortserver.dao.utils
 
 import org.jetbrains.exposed.sql.CustomFunction
 import org.jetbrains.exposed.sql.Expression

--- a/workers/scanner/src/main/kotlin/scanner/OrtServerScanResultStorage.kt
+++ b/workers/scanner/src/main/kotlin/scanner/OrtServerScanResultStorage.kt
@@ -40,7 +40,7 @@ import org.eclipse.apoapsis.ortserver.dao.tables.ScanSummariesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.ScanSummaryDao
 import org.eclipse.apoapsis.ortserver.dao.tables.SnippetDao
 import org.eclipse.apoapsis.ortserver.dao.tables.SnippetFindingDao
-import org.eclipse.apoapsis.ortserver.dao.utils.utils.JsonHashFunction
+import org.eclipse.apoapsis.ortserver.dao.utils.JsonHashFunction
 import org.eclipse.apoapsis.ortserver.workers.common.mapToModel
 import org.eclipse.apoapsis.ortserver.workers.common.mapToOrt
 


### PR DESCRIPTION
There is no reason to have a `utils` package inside of another `utils` package.