### PR TITLE
feat(repository): add optional description field

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
@@ -458,7 +458,7 @@ fun ApiComparisonOperator.mapToModel() = ComparisonOperator.valueOf(name)
 
 fun Product.mapToApi() = ApiProduct(id, organizationId, name, description)
 
-fun Repository.mapToApi() = ApiRepository(id, organizationId, productId, type.mapToApi(), url)
+fun Repository.mapToApi() = ApiRepository(id, organizationId, productId, type.mapToApi(), url, description)
 
 fun RepositoryType.mapToApi() = ApiRepositoryType.valueOf(name)
 

--- a/api/v1/model/src/commonMain/kotlin/Repository.kt
+++ b/api/v1/model/src/commonMain/kotlin/Repository.kt
@@ -44,7 +44,10 @@ data class Repository(
     val type: RepositoryType,
 
     /** The url to the repository. */
-    val url: String
+    val url: String,
+
+    /** The description of the repository. */
+    val description: String? = null
 ) {
     companion object {
         const val INVALID_URL_MESSAGE = "The repository URL is malformed."
@@ -67,7 +70,8 @@ private fun String.isValidHost() = all { it.isLetterOrDigit() || it == '.' || it
 @Serializable
 data class CreateRepository(
     val type: RepositoryType,
-    val url: String
+    val url: String,
+    val description: String? = null
 ) {
     companion object {
         val validate: ValidatorFunc<CreateRepository> = { obj ->
@@ -93,6 +97,7 @@ data class CreateRepository(
 data class UpdateRepository(
     val type: OptionalValue<RepositoryType> = OptionalValue.Absent,
     val url: OptionalValue<String> = OptionalValue.Absent,
+    val description: OptionalValue<String?> = OptionalValue.Absent
 ) {
     companion object {
         val validate: ValidatorFunc<UpdateRepository> = { obj ->

--- a/core/src/main/kotlin/api/ProductsRoute.kt
+++ b/core/src/main/kotlin/api/ProductsRoute.kt
@@ -156,11 +156,17 @@ fun Route.products() = route("products/{productId}") {
 
             val id = call.requireIdParameter("productId")
             val createRepository = call.receive<CreateRepository>()
+            val repository = productService.createRepository(
+                createRepository.type.mapToModel(),
+                createRepository.url,
+                id,
+                createRepository.description
+            )
+                .mapToApi()
 
             call.respond(
                 HttpStatusCode.Created,
-                productService.createRepository(createRepository.type.mapToModel(), createRepository.url, id)
-                    .mapToApi()
+                repository
             )
         }
     }

--- a/core/src/main/kotlin/api/RepositoriesRoute.kt
+++ b/core/src/main/kotlin/api/RepositoriesRoute.kt
@@ -105,7 +105,8 @@ fun Route.repositories() = route("repositories/{repositoryId}") {
         val updatedRepository = repositoryService.updateRepository(
             id,
             updateRepository.type.mapToModel { it.mapToModel() },
-            updateRepository.url.mapToModel()
+            updateRepository.url.mapToModel(),
+            updateRepository.description.mapToModel()
         )
 
         call.respond(HttpStatusCode.OK, updatedRepository.mapToApi())

--- a/core/src/test/kotlin/api/DownloadsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/DownloadsRouteIntegrationTest.kt
@@ -78,10 +78,12 @@ class DownloadsRouteIntegrationTest : AbstractIntegrationTest({
         val orgId = organizationService.createOrganization(name = "name", description = "description").id
         val productId =
             organizationService.createProduct(name = "name", description = "description", organizationId = orgId).id
+        val description = "description"
         repositoryId = productService.createRepository(
             type = RepositoryType.GIT,
             url = "https://example.org/repo.git",
-            productId = productId
+            productId = productId,
+            description = description
         ).id
     }
 

--- a/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
@@ -255,7 +255,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 val createdProduct = createProduct()
 
                 superuserClient.delete("/api/v1/products/${createdProduct.id}") shouldHaveStatus
-                        HttpStatusCode.NoContent
+                    HttpStatusCode.NoContent
 
                 organizationService.listProductsForOrganization(orgId).data shouldBe emptyList()
             }
@@ -269,7 +269,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
 
                 keycloakClient.getRoles().map { it.name.value } shouldNot containAnyOf(
                     ProductPermission.getRolesForProduct(createdProduct.id) +
-                            ProductRole.getRolesForProduct(createdProduct.id)
+                        ProductRole.getRolesForProduct(createdProduct.id)
                 )
 
                 keycloakClient.getGroups().map { it.name.value } shouldNot containAnyOf(
@@ -294,19 +294,28 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 val type = RepositoryType.GIT
                 val url1 = "https://example.com/repo1.git"
                 val url2 = "https://example.com/repo2.git"
+                val description = "description"
 
-                val createdRepository1 =
-                    productService.createRepository(type = type, url = url1, productId = createdProduct.id)
-                val createdRepository2 =
-                    productService.createRepository(type = type, url = url2, productId = createdProduct.id)
+                val createdRepository1 = productService.createRepository(
+                    type = type,
+                    url = url1,
+                    productId = createdProduct.id,
+                    description = description
+                )
+                val createdRepository2 = productService.createRepository(
+                    type = type,
+                    url = url2,
+                    productId = createdProduct.id,
+                    description = description
+                )
 
                 val response = superuserClient.get("/api/v1/products/${createdProduct.id}/repositories")
 
                 response shouldHaveStatus HttpStatusCode.OK
                 response shouldHaveBody PagedResponse(
                     listOf(
-                        Repository(createdRepository1.id, orgId, createdProduct.id, type.mapToApi(), url1),
-                        Repository(createdRepository2.id, orgId, createdProduct.id, type.mapToApi(), url2)
+                        Repository(createdRepository1.id, orgId, createdProduct.id, type.mapToApi(), url1, description),
+                        Repository(createdRepository2.id, orgId, createdProduct.id, type.mapToApi(), url2, description)
                     ),
                     PagingData(
                         limit = DEFAULT_LIMIT,
@@ -325,17 +334,36 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 val type = RepositoryType.GIT
                 val url1 = "https://example.com/repo1.git"
                 val url2 = "https://example.com/repo2.git"
+                val description = "description"
 
-                productService.createRepository(type = type, url = url1, productId = createdProduct.id)
-                val createdRepository2 =
-                    productService.createRepository(type = type, url = url2, productId = createdProduct.id)
+                productService.createRepository(
+                    type = type,
+                    url = url1,
+                    productId = createdProduct.id,
+                    description = description
+                )
+                val createdRepository2 = productService.createRepository(
+                    type = type,
+                    url = url2,
+                    productId = createdProduct.id,
+                    description = description
+                )
 
                 val response =
                     superuserClient.get("/api/v1/products/${createdProduct.id}/repositories?sort=-url&limit=1")
 
                 response shouldHaveStatus HttpStatusCode.OK
                 response shouldHaveBody PagedResponse(
-                    listOf(Repository(createdRepository2.id, orgId, createdProduct.id, type.mapToApi(), url2)),
+                    listOf(
+                        Repository(
+                            createdRepository2.id,
+                            orgId,
+                            createdProduct.id,
+                            type.mapToApi(),
+                            url2,
+                            description
+                        )
+                    ),
                     PagingData(
                         limit = 1,
                         offset = 0,
@@ -359,13 +387,14 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication {
                 val createdProduct = createProduct()
 
-                val repository = CreateRepository(ApiRepositoryType.GIT, "https://example.com/repo.git")
+                val repository = CreateRepository(ApiRepositoryType.GIT, "https://example.com/repo.git", "description")
                 val response = superuserClient.post("/api/v1/products/${createdProduct.id}/repositories") {
                     setBody(repository)
                 }
 
                 response shouldHaveStatus HttpStatusCode.Created
-                response shouldHaveBody Repository(1, orgId, createdProduct.id, repository.type, repository.url)
+                response shouldHaveBody
+                    Repository(1, orgId, createdProduct.id, repository.type, repository.url, repository.description)
             }
         }
 
@@ -414,7 +443,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
 
                 keycloakClient.getRoles().map { it.name.value } should containAll(
                     RepositoryPermission.getRolesForRepository(createdRepository.id) +
-                            RepositoryRole.getRolesForRepository(createdRepository.id)
+                        RepositoryRole.getRolesForRepository(createdRepository.id)
                 )
 
                 keycloakClient.getGroups().map { it.name.value } should containAll(
@@ -506,7 +535,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 val productId = createProduct().id
 
                 superuserClient.get("/api/v1/products/$productId/secrets/999999") shouldHaveStatus
-                        HttpStatusCode.NotFound
+                    HttpStatusCode.NotFound
             }
         }
 
@@ -607,7 +636,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 response shouldHaveBody Secret(secret.name, updatedDescription)
 
                 secretRepository.getByProductIdAndName(productId, secret.name)?.mapToApi() shouldBe
-                        Secret(secret.name, updatedDescription)
+                    Secret(secret.name, updatedDescription)
             }
         }
 
@@ -662,7 +691,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 val secret = createSecret(productId)
 
                 superuserClient.delete("/api/v1/products/$productId/secrets/${secret.name}") shouldHaveStatus
-                        HttpStatusCode.NoContent
+                    HttpStatusCode.NoContent
 
                 secretRepository.listForProduct(productId).data shouldBe emptyList()
 
@@ -704,7 +733,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 val secret = createSecret(productId, path = secretErrorPath)
 
                 superuserClient.delete("/api/v1/products/$productId/secrets/${secret.name}") shouldHaveStatus
-                        HttpStatusCode.InternalServerError
+                    HttpStatusCode.InternalServerError
 
                 secretRepository.getByProductIdAndName(productId, secret.name) shouldBe secret
             }
@@ -950,15 +979,18 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
         "return vulnerabilities across repositories in the product found in latest successful advisor jobs" {
             integrationTestApplication {
                 val productId = createProduct().id
+                val description = "description"
                 val repository1Id = productService.createRepository(
                     type = RepositoryType.GIT,
                     url = "https://example.org/repo.git",
-                    productId = productId
+                    productId = productId,
+                    description = description
                 ).id
                 val repository2Id = productService.createRepository(
                     type = RepositoryType.GIT,
                     url = "https://example.org/repo2.git",
-                    productId = productId
+                    productId = productId,
+                    description = description
                 ).id
 
                 val commonVulnerability = Vulnerability(
@@ -1103,26 +1135,26 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 val commonPackage = generatePackage(Identifier("Maven", "com.example", "example", "1.0"))
 
                 val commonVulnerability = Identifier("Maven", "com.example", "example", "1.0") to
-                        listOf(
-                            generateAdvisorResult(
-                                listOf(
-                                    Vulnerability(
-                                        externalId = "CVE-2023-5234",
-                                        summary = "A vulnerability",
-                                        description = "A description",
-                                        references = listOf(
-                                            VulnerabilityReference(
-                                                url = "https://example.com",
-                                                scoringSystem = "CVSS",
-                                                severity = "CRITICAL",
-                                                score = 1.1f,
-                                                vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
-                                            )
+                    listOf(
+                        generateAdvisorResult(
+                            listOf(
+                                Vulnerability(
+                                    externalId = "CVE-2023-5234",
+                                    summary = "A vulnerability",
+                                    description = "A description",
+                                    references = listOf(
+                                        VulnerabilityReference(
+                                            url = "https://example.com",
+                                            scoringSystem = "CVSS",
+                                            severity = "CRITICAL",
+                                            score = 1.1f,
+                                            vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
                                         )
                                     )
                                 )
                             )
                         )
+                    )
 
                 val commonRuleViolation = OrtRuleViolation(
                     "rule",
@@ -1166,26 +1198,26 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                     advJob1Id,
                     mapOf(
                         Identifier("NPM", "com.example", "example2", "1.0") to
-                                listOf(
-                                    generateAdvisorResult(
-                                        listOf(
-                                            Vulnerability(
-                                                externalId = "CVE-2021-1234",
-                                                summary = "A vulnerability",
-                                                description = "A description",
-                                                references = listOf(
-                                                    VulnerabilityReference(
-                                                        url = "https://example.com",
-                                                        scoringSystem = "CVSS",
-                                                        severity = "LOW",
-                                                        score = 1.1f,
-                                                        vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
-                                                    )
+                            listOf(
+                                generateAdvisorResult(
+                                    listOf(
+                                        Vulnerability(
+                                            externalId = "CVE-2021-1234",
+                                            summary = "A vulnerability",
+                                            description = "A description",
+                                            references = listOf(
+                                                VulnerabilityReference(
+                                                    url = "https://example.com",
+                                                    scoringSystem = "CVSS",
+                                                    severity = "LOW",
+                                                    score = 1.1f,
+                                                    vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
                                                 )
                                             )
                                         )
                                     )
-                                ),
+                                )
+                            ),
                         commonVulnerability
                     )
                 )
@@ -1256,26 +1288,26 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                     advJob2Id,
                     mapOf(
                         Identifier("PyPI", "", "example", "1.0") to
-                                listOf(
-                                    generateAdvisorResult(
-                                        listOf(
-                                            Vulnerability(
-                                                externalId = "CVE-2020-2346",
-                                                summary = "A vulnerability",
-                                                description = "A description",
-                                                references = listOf(
-                                                    VulnerabilityReference(
-                                                        url = "https://example.com",
-                                                        scoringSystem = "CVSS",
-                                                        severity = "MEDIUM",
-                                                        score = 5.1f,
-                                                        vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
-                                                    )
+                            listOf(
+                                generateAdvisorResult(
+                                    listOf(
+                                        Vulnerability(
+                                            externalId = "CVE-2020-2346",
+                                            summary = "A vulnerability",
+                                            description = "A description",
+                                            references = listOf(
+                                                VulnerabilityReference(
+                                                    url = "https://example.com",
+                                                    scoringSystem = "CVSS",
+                                                    severity = "MEDIUM",
+                                                    score = 5.1f,
+                                                    vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
                                                 )
                                             )
                                         )
                                     )
-                                ),
+                                )
+                            ),
                         commonVulnerability
                     )
                 )
@@ -1471,15 +1503,18 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
         "trigger ORT runs for repositories in the product" {
             integrationTestApplication {
                 val productId = createProduct().id
+                val description = "description"
                 val repository1Id = productService.createRepository(
                     type = RepositoryType.GIT,
                     url = "https://example.com/repo1.git",
-                    productId = productId
+                    productId = productId,
+                    description = description
                 ).id
                 val repository2Id = productService.createRepository(
                     type = RepositoryType.GIT,
                     url = "https://example.com/repo2.git",
-                    productId = productId
+                    productId = productId,
+                    description = description
                 ).id
 
                 val createOrtRunAll = CreateOrtRun(

--- a/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
@@ -180,7 +180,8 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
         repositoryId = productService.createRepository(
             type = RepositoryType.GIT,
             url = "https://example.org/repo.git",
-            productId = productId
+            productId = productId,
+            description = "description"
         ).id
 
         LogFileProviderFactoryForTesting.reset()
@@ -1411,7 +1412,8 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                 val repositoryId2 = productService.createRepository(
                     type = RepositoryType.GIT,
                     url = "https://example2.org/repo.git",
-                    productId = productId2
+                    productId = productId2,
+                    description = "description"
                 ).id
 
                 val run1 = ortRunRepository.create(

--- a/dao/src/main/kotlin/repositories/repository/DaoRepositoryRepository.kt
+++ b/dao/src/main/kotlin/repositories/repository/DaoRepositoryRepository.kt
@@ -33,11 +33,12 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
 import org.jetbrains.exposed.sql.deleteWhere
 
 class DaoRepositoryRepository(private val db: Database) : RepositoryRepository {
-    override fun create(type: RepositoryType, url: String, productId: Long) = db.blockingQuery {
+    override fun create(type: RepositoryType, url: String, productId: Long, description: String?) = db.blockingQuery {
         RepositoryDao.new {
             this.type = type.name
             this.url = url
             this.productId = productId
+            this.description = description
         }.mapToModel()
     }
 
@@ -58,11 +59,17 @@ class DaoRepositoryRepository(private val db: Database) : RepositoryRepository {
         RepositoryDao.listQuery(parameters, RepositoryDao::mapToModel) { RepositoriesTable.productId eq productId }
     }
 
-    override fun update(id: Long, type: OptionalValue<RepositoryType>, url: OptionalValue<String>) = db.blockingQuery {
+    override fun update(
+        id: Long,
+        type: OptionalValue<RepositoryType>,
+        url: OptionalValue<String>,
+        description: OptionalValue<String?>
+    ) = db.blockingQuery {
         val repository = RepositoryDao[id]
 
         type.ifPresent { repository.type = it.name }
         url.ifPresent { repository.url = it }
+        description.ifPresent { repository.description = it }
 
         RepositoryDao[id].mapToModel()
     }

--- a/dao/src/main/kotlin/repositories/repository/RepositoriesTable.kt
+++ b/dao/src/main/kotlin/repositories/repository/RepositoriesTable.kt
@@ -38,6 +38,7 @@ object RepositoriesTable : SortableTable("repositories") {
 
     val type = text("type").sortable()
     val url = text("url").sortable()
+    val description = text("description").nullable()
 }
 
 class RepositoryDao(id: EntityID<Long>) : LongEntity(id) {
@@ -48,12 +49,14 @@ class RepositoryDao(id: EntityID<Long>) : LongEntity(id) {
 
     var type by RepositoriesTable.type
     var url by RepositoriesTable.url
+    var description by RepositoriesTable.description
 
     fun mapToModel() = Repository(
         id = id.value,
         organizationId = product.organization.id.value,
         productId = product.id.value,
         type = RepositoryType.forName(type),
-        url = url
+        url = url,
+        description = description
     )
 }

--- a/dao/src/main/resources/db/migration/V101__addRepositoryDescription.sql
+++ b/dao/src/main/resources/db/migration/V101__addRepositoryDescription.sql
@@ -1,0 +1,3 @@
+-- Add a description column to the repositories table.
+
+ALTER TABLE repositories ADD COLUMN description TEXT;

--- a/dao/src/test/kotlin/migrations/V65__removeUserInfoFromRepositoryUrlTest.kt
+++ b/dao/src/test/kotlin/migrations/V65__removeUserInfoFromRepositoryUrlTest.kt
@@ -27,7 +27,7 @@ import org.eclipse.apoapsis.ortserver.dao.test.DatabaseMigrationTestExtension
 
 @Suppress("ClassNaming")
 class V65__removeUserInfoFromRepositoryUrlTest : StringSpec() {
-    val extension = extension(DatabaseMigrationTestExtension("64", "65"))
+    val extension = extension(DatabaseMigrationTestExtension("64", "101"))
 
     init {
         "repository migration should remove user information from the repository URL" {
@@ -35,11 +35,13 @@ class V65__removeUserInfoFromRepositoryUrlTest : StringSpec() {
             val product2 = extension.fixtures.createProduct(name = "product2")
             val repository1 = extension.fixtures.createRepository(
                 url = "https://username:password@github.com/org/repo.git",
-                productId = product1.id
+                productId = product1.id,
+                description = null
             )
             val repository2 = extension.fixtures.createRepository(
                 url = "https://username@github.com/org/repo.git",
-                productId = product2.id
+                productId = product2.id,
+                description = null
             )
 
             extension.testAppliedMigration {
@@ -55,11 +57,13 @@ class V65__removeUserInfoFromRepositoryUrlTest : StringSpec() {
             val product1 = extension.fixtures.createProduct(name = "product1")
             val repository1 = extension.fixtures.createRepository(
                 url = "https://username:password@github.com/org/repo.git",
-                productId = product1.id
+                productId = product1.id,
+                description = null
             )
             val repository2 = extension.fixtures.createRepository(
                 url = "https://otherUsername:password@github.com/org/repo.git",
-                productId = product1.id
+                productId = product1.id,
+                description = null
             )
 
             extension.testAppliedMigration {

--- a/dao/src/test/kotlin/repositories/repository/DaoRepositoryRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/repository/DaoRepositoryRepositoryTest.kt
@@ -63,23 +63,25 @@ class DaoRepositoryRepositoryTest : StringSpec({
     "create should create an entry in the database" {
         val type = RepositoryType.GIT
         val url = "https://example.com/repo.git"
+        val description = "description"
 
-        val createdRepository = repositoryRepository.create(type, url, productId)
+        val createdRepository = repositoryRepository.create(type, url, productId, description)
 
         val dbEntry = repositoryRepository.get(createdRepository.id)
 
         dbEntry.shouldNotBeNull()
-        dbEntry shouldBe Repository(createdRepository.id, orgId, productId, type, url)
+        dbEntry shouldBe Repository(createdRepository.id, orgId, productId, type, url, description)
     }
 
     "create should throw an exception if a repository with the same url exists" {
         val type = RepositoryType.GIT
         val url = "https://example.com/repo.git"
+        val description = "description"
 
-        repositoryRepository.create(type, url, productId)
+        repositoryRepository.create(type, url, productId, description)
 
         shouldThrow<UniqueConstraintException> {
-            repositoryRepository.create(type, url, productId)
+            repositoryRepository.create(type, url, productId, description)
         }
     }
 
@@ -111,15 +113,16 @@ class DaoRepositoryRepositoryTest : StringSpec({
 
         val url1 = "https://example.com/repo1.git"
         val url2 = "https://example.com/repo2.git"
+        val description = "description"
 
-        val createdRepository1 = repositoryRepository.create(type, url1, productId)
-        val createdRepository2 = repositoryRepository.create(type, url2, productId)
+        val createdRepository1 = repositoryRepository.create(type, url1, productId, description)
+        val createdRepository2 = repositoryRepository.create(type, url2, productId, description)
 
         repositoryRepository.listForProduct(productId) shouldBe
                 ListQueryResult(
                     data = listOf(
-                        Repository(createdRepository1.id, orgId, productId, type, url1),
-                        Repository(createdRepository2.id, orgId, productId, type, url2)
+                        Repository(createdRepository1.id, orgId, productId, type, url1, description),
+                        Repository(createdRepository2.id, orgId, productId, type, url2, description)
                     ),
                     params = ListQueryParameters.DEFAULT,
                     totalCount = 2
@@ -131,18 +134,19 @@ class DaoRepositoryRepositoryTest : StringSpec({
 
         val url1 = "https://example.com/repo1.git"
         val url2 = "https://example.com/repo2.git"
+        val description = "description"
 
         val parameters = ListQueryParameters(
             sortFields = listOf(OrderField("url", OrderDirection.DESCENDING)),
             limit = 1
         )
 
-        repositoryRepository.create(type, url1, productId)
-        val createdRepository2 = repositoryRepository.create(type, url2, productId)
+        repositoryRepository.create(type, url1, productId, description)
+        val createdRepository2 = repositoryRepository.create(type, url2, productId, description)
 
         repositoryRepository.listForProduct(productId, parameters) shouldBe
                 ListQueryResult(
-                    data = listOf(Repository(createdRepository2.id, orgId, productId, type, url2)),
+                    data = listOf(Repository(createdRepository2.id, orgId, productId, type, url2, description)),
                     params = parameters,
                     totalCount = 2
                 )
@@ -150,7 +154,7 @@ class DaoRepositoryRepositoryTest : StringSpec({
 
     "update should update an entry in the database" {
         val createdRepository =
-            repositoryRepository.create(RepositoryType.GIT, "https://example.com/repo.git", productId)
+            repositoryRepository.create(RepositoryType.GIT, "https://example.com/repo.git", productId, null)
 
         val updateType = RepositoryType.SUBVERSION.asPresent()
         val updateUrl = "https://svn.example.com/repos/org/repo/trunk".asPresent()
@@ -179,9 +183,10 @@ class DaoRepositoryRepositoryTest : StringSpec({
 
         val url1 = "https://example.com/repo1.git"
         val url2 = "https://example.com/repo2.git"
+        val description = "description"
 
-        repositoryRepository.create(type, url1, productId)
-        val createdRepository2 = repositoryRepository.create(type, url2, productId)
+        repositoryRepository.create(type, url1, productId, description)
+        val createdRepository2 = repositoryRepository.create(type, url2, productId, description)
 
         val updateType = OptionalValue.Absent
         val updateUrl = url1.asPresent()
@@ -193,7 +198,7 @@ class DaoRepositoryRepositoryTest : StringSpec({
 
     "delete should delete the database entry" {
         val createdRepository =
-            repositoryRepository.create(RepositoryType.GIT, "https://example.com/repo.git", productId)
+            repositoryRepository.create(RepositoryType.GIT, "https://example.com/repo.git", productId, "description")
 
         repositoryRepository.delete(createdRepository.id)
 
@@ -205,13 +210,23 @@ class DaoRepositoryRepositoryTest : StringSpec({
     }
 
     "get should return the repository" {
-        val repository = repositoryRepository.create(RepositoryType.GIT, "https://example.com/repo.git", productId)
+        val repository = repositoryRepository.create(
+            RepositoryType.GIT,
+            "https://example.com/repo.git",
+            productId,
+            "description"
+        )
 
         repositoryRepository.get(repository.id) shouldBe repository
     }
 
     "getHierarchy should return the structure of the repository" {
-        val repository = repositoryRepository.create(RepositoryType.GIT, "https://example.com/repo.git", productId)
+        val repository = repositoryRepository.create(
+            RepositoryType.GIT,
+            "https://example.com/repo.git",
+            productId,
+            "description"
+        )
 
         val expectedHierarchy = Hierarchy(repository, fixtures.product, fixtures.organization)
 

--- a/dao/src/test/kotlin/utils/ListQueryTest.kt
+++ b/dao/src/test/kotlin/utils/ListQueryTest.kt
@@ -99,11 +99,27 @@ class ListQueryTest : StringSpec() {
 
             val organization = organizationRepository.create("Another Organization", "for testing")
             val product = productRepository.create("TestProduct", null, organization.id)
+            val description = "description"
 
-            val repo1 = repositoryRepository.create(RepositoryType.GIT, repositoryUrl.appendIndex(1), product.id)
+            val repo1 = repositoryRepository.create(
+                RepositoryType.GIT,
+                repositoryUrl.appendIndex(1),
+                product.id,
+                description
+            )
             val repo2 =
-                repositoryRepository.create(RepositoryType.SUBVERSION, repositoryUrl.appendIndex(2), product.id)
-            val repo3 = repositoryRepository.create(RepositoryType.GIT, repositoryUrl.appendIndex(3), product.id)
+                repositoryRepository.create(
+                    RepositoryType.SUBVERSION,
+                    repositoryUrl.appendIndex(2),
+                    product.id,
+                    description
+                )
+            val repo3 = repositoryRepository.create(
+                RepositoryType.GIT,
+                repositoryUrl.appendIndex(3),
+                product.id,
+                description
+            )
 
             val parameters = ListQueryParameters(
                 sortFields = listOf(
@@ -138,7 +154,12 @@ class ListQueryTest : StringSpec() {
             val organization = organizationRepository.create("Run Organization", null)
             val product = productRepository.create("Run Product", null, organization.id)
             val repo =
-                repositoryRepository.create(RepositoryType.GIT, "https://repo.example.org/run.git", product.id)
+                repositoryRepository.create(
+                    RepositoryType.GIT,
+                    "https://repo.example.org/run.git",
+                    product.id,
+                    "description"
+                )
             val runs = (1..3).map { idx ->
                 ortRunRepository.create(
                     repo.id,

--- a/dao/src/testFixtures/kotlin/Fixtures.kt
+++ b/dao/src/testFixtures/kotlin/Fixtures.kt
@@ -146,8 +146,9 @@ class Fixtures(private val db: Database) {
     fun createRepository(
         type: RepositoryType = RepositoryType.GIT,
         url: String = "https://example.com/repo.git",
-        productId: Long = product.id
-    ) = repositoryRepository.create(type, url, productId)
+        productId: Long = product.id,
+        description: String? = "description"
+    ) = repositoryRepository.create(type, url, productId, description)
 
     fun createOrtRun(
         repositoryId: Long = repository.id,

--- a/model/src/commonMain/kotlin/Repository.kt
+++ b/model/src/commonMain/kotlin/Repository.kt
@@ -49,5 +49,10 @@ data class Repository(
     /**
      * The URL of the repository.
      */
-    val url: String
+    val url: String,
+
+    /**
+    * The description of the repository.
+    * */
+    val description: String? = null,
 )

--- a/model/src/commonMain/kotlin/repositories/RepositoryRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/RepositoryRepository.kt
@@ -33,7 +33,7 @@ interface RepositoryRepository {
     /**
      * Create a repository.
      */
-    fun create(type: RepositoryType, url: String, productId: Long): Repository
+    fun create(type: RepositoryType, url: String, productId: Long, description: String?): Repository
 
     /**
      * Get a repository by [id]. Returns null if the repository is not found.
@@ -65,7 +65,8 @@ interface RepositoryRepository {
     fun update(
         id: Long,
         type: OptionalValue<RepositoryType> = OptionalValue.Absent,
-        url: OptionalValue<String> = OptionalValue.Absent
+        url: OptionalValue<String> = OptionalValue.Absent,
+        description: OptionalValue<String?> = OptionalValue.Absent
     ): Repository
 
     /**

--- a/services/hierarchy/src/main/kotlin/ProductService.kt
+++ b/services/hierarchy/src/main/kotlin/ProductService.kt
@@ -54,8 +54,13 @@ class ProductService(
     /**
      * Create a repository inside a [product][productId].
      */
-    suspend fun createRepository(type: RepositoryType, url: String, productId: Long): Repository = db.dbQueryCatching {
-        repositoryRepository.create(type, url, productId)
+    suspend fun createRepository(
+        type: RepositoryType,
+        url: String,
+        productId: Long,
+        description: String?
+    ): Repository = db.dbQueryCatching {
+        repositoryRepository.create(type, url, productId, description)
     }.onSuccess { repository ->
         runCatching {
             authorizationService.createRepositoryPermissions(repository.id)

--- a/services/hierarchy/src/main/kotlin/RepositoryService.kt
+++ b/services/hierarchy/src/main/kotlin/RepositoryService.kt
@@ -137,9 +137,10 @@ class RepositoryService(
     suspend fun updateRepository(
         repositoryId: Long,
         type: OptionalValue<RepositoryType> = OptionalValue.Absent,
-        url: OptionalValue<String> = OptionalValue.Absent
+        url: OptionalValue<String> = OptionalValue.Absent,
+        description: OptionalValue<String?> = OptionalValue.Absent
     ): Repository = db.dbQuery {
-        repositoryRepository.update(repositoryId, type, url)
+        repositoryRepository.update(repositoryId, type, url, description)
     }
 
     /**

--- a/services/hierarchy/src/test/kotlin/ProductServiceTest.kt
+++ b/services/hierarchy/src/test/kotlin/ProductServiceTest.kt
@@ -68,7 +68,12 @@ class ProductServiceTest : WordSpec({
             val service =
                 ProductService(db, productRepository, repositoryRepository, ortRunRepository, authorizationService)
             val repository =
-                service.createRepository(RepositoryType.GIT, "https://example.com/repo.git", fixtures.product.id)
+                service.createRepository(
+                    RepositoryType.GIT,
+                    "https://example.com/repo.git",
+                    fixtures.product.id,
+                    "Description"
+                )
 
             coVerify(exactly = 1) {
                 authorizationService.createRepositoryPermissions(repository.id)


### PR DESCRIPTION
✅ This PR adds support for optional descriptions in repositories, addressing issue #2509.

Just like products and organizations, repositories can now have descriptions to provide additional context — such as “Front-end code for the product” or notes on what a demo repository is showcasing.

Let me know if any adjustments are needed!

