### PR TITLE
ui: Tune some UI colors

### DIFF
--- a/ui/src/components/charts/job-durations.tsx
+++ b/ui/src/components/charts/job-durations.tsx
@@ -45,23 +45,23 @@ import { ToastError } from '../toast-error';
 const chartConfig = {
   analyzer: {
     label: 'Analyzer',
-    color: 'hsl(var(--chart-analyzer))',
+    color: 'var(--analyzer)',
   },
   advisor: {
     label: 'Advisor',
-    color: 'hsl(var(--chart-advisor))',
+    color: 'var(--advisor)',
   },
   scanner: {
     label: 'Scanner',
-    color: 'hsl(var(--chart-scanner))',
+    color: 'var(--scanner)',
   },
   evaluator: {
     label: 'Evaluator',
-    color: 'hsl(var(--chart-evaluator))',
+    color: 'var(--evaluator)',
   },
   reporter: {
     label: 'Reporter',
-    color: 'hsl(var(--chart-reporter))',
+    color: 'var(--reporter)',
   },
 } satisfies ChartConfig;
 

--- a/ui/src/globals.css
+++ b/ui/src/globals.css
@@ -78,13 +78,13 @@
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
 
-    /* Custom chart colors, taken from ORT brand colors */
-    /* https://oss-review-toolkit.org/ort/              */
-    --chart-analyzer: 178 52% 61%;
-    --chart-advisor: 270 29% 60%;
-    --chart-scanner: 351 58% 72%;
-    --chart-evaluator: 205 66% 59%;
-    --chart-reporter: 22 86% 64%;
+    /* Custom colors for workers, taken from ORT brand colors */
+    /* https://oss-review-toolkit.org/ort/                    */
+    --analyzer: rgb(0, 175, 170);
+    --advisor: rgb(153, 123, 183);
+    --scanner: rgb(209, 78, 96);
+    --evaluator: rgb(51, 153, 204);
+    --reporter: rgb(242, 144, 86);
   }
 
   .dark {
@@ -121,14 +121,6 @@
     --chart-3: 30 80% 55%;
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
-
-    /* Custom chart colors, taken from ORT brand colors */
-    /* https://oss-review-toolkit.org/ort/              */
-    --chart-analyzer: 178 52% 61%;
-    --chart-advisor: 270 29% 60%;
-    --chart-scanner: 351 58% 72%;
-    --chart-evaluator: 205 66% 59%;
-    --chart-reporter: 22 86% 64%;
   }
 }
 

--- a/ui/src/globals.css
+++ b/ui/src/globals.css
@@ -85,6 +85,9 @@
     --scanner: rgb(209, 78, 96);
     --evaluator: rgb(51, 153, 204);
     --reporter: rgb(242, 144, 86);
+    --traffic-light-green: rgb(0, 164, 0);
+    --traffic-light-yellow: rgb(255, 186, 0);
+    --traffic-light-red: rgb(250, 56, 62);
   }
 
   .dark {

--- a/ui/src/helpers/get-status-class.ts
+++ b/ui/src/helpers/get-status-class.ts
@@ -81,7 +81,7 @@ const RULE_VIOLATION_SEVERITY_BG_COLOR: {
 } = {
   ERROR: 'bg-traffic-light-red',
   WARNING: 'bg-traffic-light-yellow',
-  HINT: 'bg-neutral-300',
+  HINT: 'bg-blue-300',
 } as const;
 
 const ISSUE_SEVERITY_BG_COLOR: {
@@ -89,7 +89,7 @@ const ISSUE_SEVERITY_BG_COLOR: {
 } = {
   ERROR: 'bg-traffic-light-red',
   WARNING: 'bg-traffic-light-yellow',
-  HINT: 'bg-neutral-300',
+  HINT: 'bg-blue-300',
 } as const;
 
 // TailwindCSS class accessor functions

--- a/ui/src/helpers/get-status-class.ts
+++ b/ui/src/helpers/get-status-class.ts
@@ -49,9 +49,9 @@ const STATUS_BACKGROUND_COLOR: {
   SCHEDULED: 'bg-blue-300',
   RUNNING: 'bg-blue-500',
   ACTIVE: 'bg-blue-500',
-  FAILED: 'bg-red-500',
-  FINISHED: 'bg-green-500',
-  FINISHED_WITH_ISSUES: 'bg-yellow-500',
+  FAILED: 'bg-traffic-light-red',
+  FINISHED: 'bg-traffic-light-green',
+  FINISHED_WITH_ISSUES: 'bg-traffic-light-yellow',
 } as const;
 
 const STATUS_FONT_COLOR: { [K in Exclude<Status, undefined>]: string } = {
@@ -59,9 +59,9 @@ const STATUS_FONT_COLOR: { [K in Exclude<Status, undefined>]: string } = {
   SCHEDULED: 'text-blue-300',
   RUNNING: 'text-blue-500',
   ACTIVE: 'text-blue-500',
-  FAILED: 'text-red-500',
-  FINISHED: 'text-green-500',
-  FINISHED_WITH_ISSUES: 'text-yellow-500',
+  FAILED: 'text-traffic-light-red',
+  FINISHED: 'text-traffic-light-green',
+  FINISHED_WITH_ISSUES: 'text-traffic-light-yellow',
 } as const;
 
 const STATUS_CLASS: {
@@ -79,16 +79,16 @@ const STATUS_CLASS: {
 const RULE_VIOLATION_SEVERITY_BG_COLOR: {
   [K in Severity]: string;
 } = {
-  ERROR: 'bg-red-600',
-  WARNING: 'bg-amber-500',
+  ERROR: 'bg-traffic-light-red',
+  WARNING: 'bg-traffic-light-yellow',
   HINT: 'bg-neutral-300',
 } as const;
 
 const ISSUE_SEVERITY_BG_COLOR: {
   [K in Severity]: string;
 } = {
-  ERROR: 'bg-red-600',
-  WARNING: 'bg-amber-500',
+  ERROR: 'bg-traffic-light-red',
+  WARNING: 'bg-traffic-light-yellow',
   HINT: 'bg-neutral-300',
 } as const;
 
@@ -129,11 +129,11 @@ export function getVulnerabilityRatingBackgroundColor(
 ): string {
   switch (rating) {
     case 'CRITICAL':
-      return 'bg-red-600';
+      return 'bg-traffic-light-red';
     case 'HIGH':
       return 'bg-orange-600';
     case 'MEDIUM':
-      return 'bg-amber-500';
+      return 'bg-traffic-light-yellow';
     case 'LOW':
       return 'bg-yellow-400';
     case 'NONE':

--- a/ui/src/helpers/get-status-class.ts
+++ b/ui/src/helpers/get-status-class.ts
@@ -131,11 +131,11 @@ export function getVulnerabilityRatingBackgroundColor(
     case 'CRITICAL':
       return 'bg-traffic-light-red';
     case 'HIGH':
-      return 'bg-orange-600';
+      return 'bg-orange-400';
     case 'MEDIUM':
       return 'bg-traffic-light-yellow';
     case 'LOW':
-      return 'bg-yellow-400';
+      return 'bg-yellow-300';
     case 'NONE':
     default:
       return 'bg-neutral-300';

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -38,6 +38,11 @@ export default {
         ring: 'hsl(var(--ring))',
         background: 'hsl(var(--background))',
         foreground: 'hsl(var(--foreground))',
+        analyzer: 'var(--analyzer)',
+        advisor: 'var(--advisor)',
+        scanner: 'var(--scanner)',
+        evaluator: 'var(--evaluator)',
+        reporter: 'var(--reporter)',
         primary: {
           DEFAULT: 'hsl(var(--primary))',
           foreground: 'hsl(var(--primary-foreground))',

--- a/ui/tailwind.config.js
+++ b/ui/tailwind.config.js
@@ -43,6 +43,9 @@ export default {
         scanner: 'var(--scanner)',
         evaluator: 'var(--evaluator)',
         reporter: 'var(--reporter)',
+        'traffic-light-green': 'var(--traffic-light-green)',
+        'traffic-light-yellow': 'var(--traffic-light-yellow)',
+        'traffic-light-red': 'var(--traffic-light-red)',
         primary: {
           DEFAULT: 'hsl(var(--primary))',
           foreground: 'hsl(var(--primary-foreground))',


### PR DESCRIPTION
To assist in reviewing the PR, I've provided a page which shows all currently used colors (some of which are tuned in this PR) for different indicators. This page will possibly be part of the Admin section, once the customizable footer support is added, because it belongs to a same section ("Customization") - so the page is not part of this PR.

![Screenshot from 2025-04-17 12-19-33](https://github.com/user-attachments/assets/1703ef7c-6c44-4f11-b4b2-94dcefac944e)

![Screenshot from 2025-04-17 12-38-10](https://github.com/user-attachments/assets/969b69b6-5145-4153-8ca6-1883bea625f4)

Please see the commits for details.