### PR TITLE
chore: Remove unused imports

### DIFF
--- a/core/src/test/kotlin/testutils/OrtServerApplicationHelper.kt
+++ b/core/src/test/kotlin/testutils/OrtServerApplicationHelper.kt
@@ -27,8 +27,6 @@ import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import io.ktor.utils.io.KtorDsl
 
-import java.lang.IllegalArgumentException
-
 import org.jetbrains.exposed.sql.Database
 
 import org.koin.core.context.stopKoin

--- a/core/src/test/kotlin/utils/ExtensionsTest.kt
+++ b/core/src/test/kotlin/utils/ExtensionsTest.kt
@@ -26,7 +26,6 @@ import io.kotest.matchers.shouldBe
 
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.application.call
 import io.ktor.server.response.respond
 import io.ktor.server.routing.get
 


### PR DESCRIPTION
It is unclear why detekt did not report these, it also did not help to enable the alternative `NoUnusedImports` rule.