### PR TITLE
Prepare enabling and disabling ORT plugins globally

### DIFF
--- a/components/plugin-manager/api/src/commonMain/kotlin/PluginDescriptor.kt
+++ b/components/plugin-manager/api/src/commonMain/kotlin/PluginDescriptor.kt
@@ -30,7 +30,8 @@ data class PluginDescriptor(
     val type: PluginType,
     val displayName: String,
     val description: String,
-    val options: List<PluginOption> = emptyList()
+    val options: List<PluginOption> = emptyList(),
+    val enabled: Boolean
 )
 
 /**

--- a/components/plugin-manager/implementation/build.gradle.kts
+++ b/components/plugin-manager/implementation/build.gradle.kts
@@ -20,6 +20,9 @@
 plugins {
     id("ort-server-kotlin-jvm-conventions")
     id("ort-server-publication-conventions")
+
+    // Apply third-party plugins.
+    alias(libs.plugins.kotlinSerialization)
 }
 
 group = "org.eclipse.apoapsis.ortserver.components.pluginmanager"
@@ -40,7 +43,12 @@ dependencies {
     api(projects.components.pluginManager.api)
 
     implementation(projects.components.authorization.implementation)
+    implementation(projects.dao)
+    implementation(projects.shared.ktorUtils)
 
+    implementation(libs.exposedCore)
+    implementation(libs.exposedJson)
+    implementation(libs.exposedKotlinDatetime)
     implementation(libs.ktorOpenApi)
     implementation(libs.ktorServerCore)
     implementation(libs.ortAdvisor)
@@ -58,6 +66,7 @@ dependencies {
     implementation(platform(libs.ortScanners))
 
     testImplementation(testFixtures(projects.clients.keycloak))
+    testImplementation(testFixtures(projects.dao))
 
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestAssertionsKtor)

--- a/components/plugin-manager/implementation/build.gradle.kts
+++ b/components/plugin-manager/implementation/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation(libs.exposedJson)
     implementation(libs.exposedKotlinDatetime)
     implementation(libs.ktorOpenApi)
+    implementation(libs.ktorServerAuth)
     implementation(libs.ktorServerCore)
     implementation(libs.ortAdvisor)
     implementation(libs.ortAnalyzer)

--- a/components/plugin-manager/implementation/src/main/kotlin/Plugin.kt
+++ b/components/plugin-manager/implementation/src/main/kotlin/Plugin.kt
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.components.pluginmanager
+
+internal enum class PluginState { ENABLED, DISABLED }
+
+internal class Plugin(private var state: PluginState = PluginState.ENABLED) {
+    fun apply(event: PluginEvent) = apply {
+        state = when (event.payload) {
+            is PluginEnabled -> PluginState.ENABLED
+            is PluginDisabled -> PluginState.DISABLED
+        }
+    }
+
+    fun applyAll(events: List<PluginEvent>) = apply {
+        events.forEach { apply(it) }
+    }
+
+    fun isEnabled(): Boolean = state == PluginState.ENABLED
+}

--- a/components/plugin-manager/implementation/src/main/kotlin/PluginEvent.kt
+++ b/components/plugin-manager/implementation/src/main/kotlin/PluginEvent.kt
@@ -23,7 +23,7 @@ import kotlinx.datetime.Instant
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-internal data class PluginEvent(
+data class PluginEvent(
     val pluginType: PluginType,
     val pluginId: String,
     val version: Long,
@@ -34,7 +34,7 @@ internal data class PluginEvent(
 
 /** The base class for all plugin event payloads. */
 @Serializable
-internal sealed class PluginEventPayload
+sealed class PluginEventPayload
 
 /** The payload for a plugin enabled event. */
 @Serializable

--- a/components/plugin-manager/implementation/src/main/kotlin/PluginEvent.kt
+++ b/components/plugin-manager/implementation/src/main/kotlin/PluginEvent.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.components.pluginmanager
+
+import kotlinx.datetime.Instant
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+internal data class PluginEvent(
+    val pluginType: PluginType,
+    val pluginId: String,
+    val version: Long,
+    val payload: PluginEventPayload,
+    val createdAt: Instant,
+    val createdBy: String
+)
+
+/** The base class for all plugin event payloads. */
+@Serializable
+internal sealed class PluginEventPayload
+
+/** The payload for a plugin enabled event. */
+@Serializable
+@SerialName("PluginEnabled")
+internal object PluginEnabled : PluginEventPayload()
+
+/** The payload for a plugin disabled event. */
+@Serializable
+@SerialName("PluginDisabled")
+internal object PluginDisabled : PluginEventPayload()

--- a/components/plugin-manager/implementation/src/main/kotlin/PluginEventStore.kt
+++ b/components/plugin-manager/implementation/src/main/kotlin/PluginEventStore.kt
@@ -28,6 +28,7 @@ import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
 import org.jetbrains.exposed.sql.selectAll
+import org.jetbrains.exposed.sql.upsert
 
 import org.ossreviewtoolkit.model.utils.DatabaseUtils.transaction
 
@@ -47,6 +48,28 @@ class PluginEventStore(private val db: Database) {
             it[payload] = pluginEvent.payload
             it[createdAt] = pluginEvent.createdAt
             it[createdBy] = pluginEvent.createdBy
+        }
+
+        updateReadModel(pluginEvent)
+    }
+
+    private fun updateReadModel(pluginEvent: PluginEvent): Unit = db.transaction {
+        when (pluginEvent.payload) {
+            is PluginDisabled -> {
+                PluginsReadModel.upsert {
+                    it[pluginType] = pluginEvent.pluginType
+                    it[pluginId] = pluginEvent.pluginId
+                    it[enabled] = false
+                }
+            }
+
+            is PluginEnabled -> {
+                PluginsReadModel.upsert {
+                    it[pluginType] = pluginEvent.pluginType
+                    it[pluginId] = pluginEvent.pluginId
+                    it[enabled] = true
+                }
+            }
         }
     }
 
@@ -72,4 +95,12 @@ internal object PluginEvents : Table("plugin_events") {
     val createdBy = text("created_by")
 
     override val primaryKey = PrimaryKey(pluginType, pluginId, version)
+}
+
+internal object PluginsReadModel : Table("plugins_read_model") {
+    val pluginType = enumerationByName<PluginType>("plugin_type", 255)
+    val pluginId = text("plugin_id")
+    val enabled = bool("enabled").default(false)
+
+    override val primaryKey = PrimaryKey(pluginType, pluginId)
 }

--- a/components/plugin-manager/implementation/src/main/kotlin/PluginEventStore.kt
+++ b/components/plugin-manager/implementation/src/main/kotlin/PluginEventStore.kt
@@ -31,7 +31,7 @@ import org.jetbrains.exposed.sql.selectAll
 
 import org.ossreviewtoolkit.model.utils.DatabaseUtils.transaction
 
-internal class PluginEventStore(private val db: Database) {
+class PluginEventStore(private val db: Database) {
     fun loadEvents(pluginType: PluginType, pluginId: String): List<PluginEvent> = db.transaction {
         PluginEvents.selectAll()
             .where { PluginEvents.pluginType eq pluginType and (PluginEvents.pluginId eq pluginId) }

--- a/components/plugin-manager/implementation/src/main/kotlin/PluginEventStore.kt
+++ b/components/plugin-manager/implementation/src/main/kotlin/PluginEventStore.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.components.pluginmanager
+
+import org.eclipse.apoapsis.ortserver.dao.utils.jsonb
+
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.ResultRow
+import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.and
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
+import org.jetbrains.exposed.sql.selectAll
+
+import org.ossreviewtoolkit.model.utils.DatabaseUtils.transaction
+
+internal class PluginEventStore(private val db: Database) {
+    fun loadEvents(pluginType: PluginType, pluginId: String): List<PluginEvent> = db.transaction {
+        PluginEvents.selectAll()
+            .where { PluginEvents.pluginType eq pluginType and (PluginEvents.pluginId eq pluginId) }
+            .orderBy(PluginEvents.version)
+            .map { it.toPluginEvent() }
+    }
+
+    fun appendEvent(pluginEvent: PluginEvent): Unit = db.transaction {
+        PluginEvents.insert {
+            it[pluginType] = pluginEvent.pluginType
+            it[pluginId] = pluginEvent.pluginId
+            it[version] = pluginEvent.version
+            it[payload] = pluginEvent.payload
+            it[createdAt] = pluginEvent.createdAt
+            it[createdBy] = pluginEvent.createdBy
+        }
+    }
+
+    private fun ResultRow.toPluginEvent() = PluginEvent(
+        pluginType = this[PluginEvents.pluginType],
+        pluginId = this[PluginEvents.pluginId],
+        version = this[PluginEvents.version],
+        payload = this[PluginEvents.payload],
+        createdAt = this[PluginEvents.createdAt],
+        createdBy = this[PluginEvents.createdBy]
+    )
+}
+
+/**
+ * A table to store plugin events.
+ */
+internal object PluginEvents : Table("plugin_events") {
+    val pluginType = enumerationByName<PluginType>("plugin_type", 255)
+    val pluginId = text("plugin_id")
+    val version = long("version")
+    val payload = jsonb<PluginEventPayload>("payload")
+    val createdAt = timestamp("created_at")
+    val createdBy = text("created_by")
+
+    override val primaryKey = PrimaryKey(pluginType, pluginId, version)
+}

--- a/components/plugin-manager/implementation/src/main/kotlin/endpoints/DisablePlugin.kt
+++ b/components/plugin-manager/implementation/src/main/kotlin/endpoints/DisablePlugin.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.components.pluginmanager.endpoints
+
+import io.github.smiley4.ktoropenapi.post
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.auth.principal
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+
+import kotlinx.datetime.Clock
+
+import org.eclipse.apoapsis.ortserver.components.authorization.OrtPrincipal
+import org.eclipse.apoapsis.ortserver.components.authorization.getUserId
+import org.eclipse.apoapsis.ortserver.components.authorization.requireSuperuser
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.Plugin
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginDisabled
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginEvent
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginEventStore
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
+import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireParameter
+
+fun Route.disablePlugin(eventStore: PluginEventStore) = post("admin/plugins/{pluginType}/{pluginId}/disable", {
+    operationId = "DisablePlugin"
+    summary = "Disable an ORT plugin globally"
+    description = "Disable an ORT plugin globally to make it generally unavailable."
+    tags = listOf("Plugins")
+
+    request {
+        pathParameter<String>("pluginType") {
+            description = "The type of the plugin to disable."
+            required = true
+        }
+
+        pathParameter<String>("pluginId") {
+            description = "The ID of the plugin to disable."
+            required = true
+        }
+    }
+
+    response {
+        HttpStatusCode.Accepted to {
+            description = "The plugin was disabled successfully."
+        }
+
+        HttpStatusCode.NotModified to {
+            description = "The plugin is already disabled."
+        }
+    }
+}) {
+    requireSuperuser()
+
+    val pluginType = enumValueOf<PluginType>(call.requireParameter("pluginType"))
+    val pluginId = call.requireParameter("pluginId")
+
+    val userId = checkNotNull(call.principal<OrtPrincipal>()).getUserId()
+
+    val events = eventStore.loadEvents(pluginType, pluginId)
+    val plugin = Plugin().applyAll(events)
+
+    if (!plugin.isEnabled()) {
+        call.respond(HttpStatusCode.NotModified)
+    } else {
+        val nextVersion = events.maxOfOrNull { it.version }?.plus(1) ?: 1L
+        val newEvent = PluginEvent(pluginType, pluginId, nextVersion, PluginDisabled, Clock.System.now(), userId)
+        eventStore.appendEvent(newEvent)
+        call.respond(HttpStatusCode.Accepted)
+    }
+}

--- a/components/plugin-manager/implementation/src/main/kotlin/endpoints/EnablePlugin.kt
+++ b/components/plugin-manager/implementation/src/main/kotlin/endpoints/EnablePlugin.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.components.pluginmanager.endpoints
+
+import io.github.smiley4.ktoropenapi.post
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.auth.principal
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+
+import kotlinx.datetime.Clock
+
+import org.eclipse.apoapsis.ortserver.components.authorization.OrtPrincipal
+import org.eclipse.apoapsis.ortserver.components.authorization.getUserId
+import org.eclipse.apoapsis.ortserver.components.authorization.requireSuperuser
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.Plugin
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginEnabled
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginEvent
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginEventStore
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
+import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireParameter
+
+fun Route.enablePlugin(eventStore: PluginEventStore) = post("admin/plugins/{pluginType}/{pluginId}/enable", {
+    operationId = "EnablePlugin"
+    summary = "Enable an ORT plugin globally"
+    description = "Enable an ORT plugin globally to make it generally available to all organizations."
+    tags = listOf("Plugins")
+
+    request {
+        pathParameter<String>("pluginType") {
+            description = "The type of the plugin to enable."
+            required = true
+        }
+
+        pathParameter<String>("pluginId") {
+            description = "The ID of the plugin to enable."
+            required = true
+        }
+    }
+
+    response {
+        HttpStatusCode.OK to {
+            description = "The plugin was enabled successfully."
+        }
+
+        HttpStatusCode.NotModified to {
+            description = "The plugin is already enabled."
+        }
+    }
+}) {
+    requireSuperuser()
+
+    val pluginType = enumValueOf<PluginType>(call.requireParameter("pluginType"))
+    val pluginId = call.requireParameter("pluginId")
+
+    val userId = checkNotNull(call.principal<OrtPrincipal>()).getUserId()
+
+    val events = eventStore.loadEvents(pluginType, pluginId)
+    val plugin = Plugin().applyAll(events)
+
+    if (plugin.isEnabled()) {
+        call.respond(HttpStatusCode.NotModified)
+    } else {
+        val nextVersion = events.maxOfOrNull { it.version }?.plus(1) ?: 1L
+        val newEvent = PluginEvent(pluginType, pluginId, nextVersion, PluginEnabled, Clock.System.now(), userId)
+        eventStore.appendEvent(newEvent)
+        call.respond(HttpStatusCode.Accepted)
+    }
+}

--- a/components/plugin-manager/implementation/src/main/kotlin/endpoints/GetInstalledPlugins.kt
+++ b/components/plugin-manager/implementation/src/main/kotlin/endpoints/GetInstalledPlugins.kt
@@ -31,9 +31,14 @@ import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginDescriptor
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginOption
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginOptionType
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginsReadModel
+
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.and
 
 import org.ossreviewtoolkit.advisor.AdviceProviderFactory
 import org.ossreviewtoolkit.analyzer.PackageManagerFactory
+import org.ossreviewtoolkit.model.utils.DatabaseUtils.transaction
 import org.ossreviewtoolkit.plugins.advisors.vulnerablecode.VulnerableCodeFactory
 import org.ossreviewtoolkit.plugins.api.PluginDescriptor as OrtPluginDescriptor
 import org.ossreviewtoolkit.plugins.api.PluginOption as OrtPluginOption
@@ -44,7 +49,7 @@ import org.ossreviewtoolkit.plugins.packagemanagers.node.npm.NpmFactory
 import org.ossreviewtoolkit.reporter.ReporterFactory
 import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
 
-fun Route.getInstalledPlugins() = get("admin/plugins", {
+fun Route.getInstalledPlugins(db: Database) = get("admin/plugins", {
     operationId = "GetInstalledPlugins"
     summary = "Get installed ORT plugins"
     description = "Get a list with detailed information about all installed ORT plugins."
@@ -57,8 +62,8 @@ fun Route.getInstalledPlugins() = get("admin/plugins", {
                 mediaTypes = setOf(ContentType.Application.Json)
                 example("List of ORT plugins") {
                     value = listOf(
-                        VulnerableCodeFactory.descriptor.mapToApi(PluginType.ADVISOR),
-                        NpmFactory.descriptor.mapToApi(PluginType.PACKAGE_MANAGER)
+                        VulnerableCodeFactory.descriptor.mapToApi(PluginType.ADVISOR, true),
+                        NpmFactory.descriptor.mapToApi(PluginType.PACKAGE_MANAGER, false)
                     )
                 }
             }
@@ -67,23 +72,35 @@ fun Route.getInstalledPlugins() = get("admin/plugins", {
 }) {
     requireSuperuser()
 
+    fun isEnabled(pluginType: PluginType, pluginId: String) = db.transaction {
+        PluginsReadModel.select(PluginsReadModel.enabled)
+            .where { PluginsReadModel.pluginType eq pluginType and (PluginsReadModel.pluginId eq pluginId) }
+            .firstOrNull()?.get(PluginsReadModel.enabled) ?: true
+    }
+
     val advisors = AdviceProviderFactory.ALL.values.map {
-        it.descriptor.mapToApi(PluginType.ADVISOR)
+        it.descriptor.mapToApi(PluginType.ADVISOR, isEnabled(PluginType.ADVISOR, it.descriptor.id))
     }
     val packageConfigurationProviders = PackageConfigurationProviderFactory.ALL.values.map {
-        it.descriptor.mapToApi(PluginType.PACKAGE_CONFIGURATION_PROVIDER)
+        it.descriptor.mapToApi(
+            PluginType.PACKAGE_CONFIGURATION_PROVIDER,
+            isEnabled(PluginType.PACKAGE_CONFIGURATION_PROVIDER, it.descriptor.id)
+        )
     }
     val packageCurationProviders = PackageCurationProviderFactory.ALL.values.map {
-        it.descriptor.mapToApi(PluginType.PACKAGE_CURATION_PROVIDER)
+        it.descriptor.mapToApi(
+            PluginType.PACKAGE_CURATION_PROVIDER,
+            isEnabled(PluginType.PACKAGE_CURATION_PROVIDER, it.descriptor.id)
+        )
     }
     val packageManagers = PackageManagerFactory.ALL.values.map {
-        it.descriptor.mapToApi(PluginType.PACKAGE_MANAGER)
+        it.descriptor.mapToApi(PluginType.PACKAGE_MANAGER, isEnabled(PluginType.PACKAGE_MANAGER, it.descriptor.id))
     }
     val reporters = ReporterFactory.ALL.values.map {
-        it.descriptor.mapToApi(PluginType.REPORTER)
+        it.descriptor.mapToApi(PluginType.REPORTER, isEnabled(PluginType.REPORTER, it.descriptor.id))
     }
     val scanners = ScannerWrapperFactory.ALL.values.map {
-        it.descriptor.mapToApi(PluginType.SCANNER)
+        it.descriptor.mapToApi(PluginType.SCANNER, isEnabled(PluginType.SCANNER, it.descriptor.id))
     }
 
     val allPlugins = advisors +
@@ -96,12 +113,13 @@ fun Route.getInstalledPlugins() = get("admin/plugins", {
     call.respond(HttpStatusCode.OK, allPlugins)
 }
 
-internal fun OrtPluginDescriptor.mapToApi(type: PluginType) = PluginDescriptor(
+internal fun OrtPluginDescriptor.mapToApi(type: PluginType, enabled: Boolean) = PluginDescriptor(
     id = id,
     type = type,
     displayName = displayName,
     description = description,
-    options = options.map { it.mapToApi() }
+    options = options.map { it.mapToApi() },
+    enabled = enabled
 )
 
 internal fun OrtPluginOption.mapToApi() = PluginOption(

--- a/components/plugin-manager/implementation/src/test/kotlin/endpoints/DisablePluginIntegrationTest.kt
+++ b/components/plugin-manager/implementation/src/test/kotlin/endpoints/DisablePluginIntegrationTest.kt
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.components.pluginmanager.endpoints
+
+import io.kotest.assertions.ktor.client.shouldHaveStatus
+import io.kotest.core.spec.style.WordSpec
+
+import io.ktor.client.request.post
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.serialization
+import io.ktor.server.application.install
+import io.ktor.server.auth.Authentication
+import io.ktor.server.auth.authenticate
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.RoutingContext
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+
+import kotlinx.serialization.json.Json
+
+import org.eclipse.apoapsis.ortserver.components.authorization.OrtPrincipal
+import org.eclipse.apoapsis.ortserver.components.authorization.getUserId
+import org.eclipse.apoapsis.ortserver.components.authorization.hasRole
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginEventStore
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
+import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
+import org.eclipse.apoapsis.ortserver.utils.test.Integration
+
+import org.ossreviewtoolkit.plugins.advisors.vulnerablecode.VulnerableCodeFactory
+
+class DisablePluginIntegrationTest : WordSpec({
+    tags(Integration)
+
+    val dbExtension = extension(DatabaseTestExtension())
+
+    beforeSpec {
+        mockkStatic(RoutingContext::hasRole)
+    }
+
+    afterSpec { unmockkAll() }
+
+    "DisablePlugin" should {
+        "return Accepted if the plugin was disabled" {
+            val principal = mockk<OrtPrincipal> {
+                every { getUserId() } returns "userId"
+                every { hasRole(any()) } returns true
+            }
+
+            val eventStore = PluginEventStore(dbExtension.db)
+
+            testApplication {
+                application {
+                    install(ContentNegotiation) {
+                        serialization(ContentType.Application.Json, Json)
+                    }
+
+                    install(Authentication) {
+                        register(FakeAuthenticationProvider(DummyConfig(principal)))
+                    }
+
+                    routing {
+                        authenticate("test") {
+                            disablePlugin(eventStore)
+                            enablePlugin(eventStore)
+                        }
+                    }
+                }
+
+                val pluginType = PluginType.ADVISOR
+                val pluginId = VulnerableCodeFactory.descriptor.id
+
+                val client = createJsonClient()
+
+                // Disable the plugin first because it is enabled by default.
+                client.post("/admin/plugins/$pluginType/$pluginId/disable") shouldHaveStatus HttpStatusCode.Accepted
+
+                // Verify again that the plugin can be disabled after it was enabled.
+                client.post("/admin/plugins/$pluginType/$pluginId/enable")
+                client.post("/admin/plugins/$pluginType/$pluginId/disable") shouldHaveStatus HttpStatusCode.Accepted
+            }
+        }
+
+        "return NotModified if the plugin was already disabled" {
+            val principal = mockk<OrtPrincipal> {
+                every { getUserId() } returns "userId"
+                every { hasRole(any()) } returns true
+            }
+
+            val eventStore = PluginEventStore(dbExtension.db)
+
+            testApplication {
+                application {
+                    install(ContentNegotiation) {
+                        serialization(ContentType.Application.Json, Json)
+                    }
+
+                    install(Authentication) {
+                        register(FakeAuthenticationProvider(DummyConfig(principal)))
+                    }
+
+                    routing {
+                        authenticate("test") {
+                            disablePlugin(eventStore)
+                            enablePlugin(eventStore)
+                        }
+                    }
+                }
+
+                val pluginType = PluginType.ADVISOR
+                val pluginId = VulnerableCodeFactory.descriptor.id
+
+                val client = createJsonClient()
+
+                // Disable the plugin first because it is enabled by default.
+                client.post("/admin/plugins/$pluginType/$pluginId/disable")
+                client.post("/admin/plugins/$pluginType/$pluginId/disable") shouldHaveStatus HttpStatusCode.NotModified
+            }
+        }
+    }
+})

--- a/components/plugin-manager/implementation/src/test/kotlin/endpoints/EnablePluginIntegrationTest.kt
+++ b/components/plugin-manager/implementation/src/test/kotlin/endpoints/EnablePluginIntegrationTest.kt
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.components.pluginmanager.endpoints
+
+import io.kotest.assertions.ktor.client.shouldHaveStatus
+import io.kotest.core.spec.style.WordSpec
+
+import io.ktor.client.request.post
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.serialization.kotlinx.serialization
+import io.ktor.server.application.install
+import io.ktor.server.auth.Authentication
+import io.ktor.server.auth.authenticate
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.RoutingContext
+import io.ktor.server.routing.routing
+import io.ktor.server.testing.testApplication
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+
+import kotlinx.serialization.json.Json
+
+import org.eclipse.apoapsis.ortserver.components.authorization.OrtPrincipal
+import org.eclipse.apoapsis.ortserver.components.authorization.getUserId
+import org.eclipse.apoapsis.ortserver.components.authorization.hasRole
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginEventStore
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
+import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
+import org.eclipse.apoapsis.ortserver.utils.test.Integration
+
+import org.ossreviewtoolkit.plugins.advisors.vulnerablecode.VulnerableCodeFactory
+
+class EnablePluginIntegrationTest : WordSpec({
+    tags(Integration)
+
+    val dbExtension = extension(DatabaseTestExtension())
+
+    beforeSpec {
+        mockkStatic(RoutingContext::hasRole)
+    }
+
+    afterSpec { unmockkAll() }
+
+    "EnablePlugin" should {
+        "return Accepted if the plugin was enabled" {
+            val principal = mockk<OrtPrincipal> {
+                every { getUserId() } returns "userId"
+                every { hasRole(any()) } returns true
+            }
+
+            val eventStore = PluginEventStore(dbExtension.db)
+
+            testApplication {
+                application {
+                    install(ContentNegotiation) {
+                        serialization(ContentType.Application.Json, Json)
+                    }
+
+                    install(Authentication) {
+                        register(FakeAuthenticationProvider(DummyConfig(principal)))
+                    }
+
+                    routing {
+                        authenticate("test") {
+                            disablePlugin(eventStore)
+                            enablePlugin(eventStore)
+                        }
+                    }
+                }
+
+                val pluginType = PluginType.ADVISOR
+                val pluginId = VulnerableCodeFactory.descriptor.id
+
+                val client = createJsonClient()
+
+                // Disable the plugin first because it is enabled by default.
+                client.post("/admin/plugins/$pluginType/$pluginId/disable")
+                client.post("/admin/plugins/$pluginType/$pluginId/enable") shouldHaveStatus HttpStatusCode.Accepted
+
+                // Verify again that the plugin can be enabled after it was disabled.
+                client.post("/admin/plugins/$pluginType/$pluginId/disable")
+                client.post("/admin/plugins/$pluginType/$pluginId/enable") shouldHaveStatus HttpStatusCode.Accepted
+            }
+        }
+
+        "return NotModified if the plugin was already enabled" {
+            val principal = mockk<OrtPrincipal> {
+                every { getUserId() } returns "userId"
+                every { hasRole(any()) } returns true
+            }
+
+            val eventStore = PluginEventStore(dbExtension.db)
+
+            testApplication {
+                application {
+                    install(ContentNegotiation) {
+                        serialization(ContentType.Application.Json, Json)
+                    }
+
+                    install(Authentication) {
+                        register(FakeAuthenticationProvider(DummyConfig(principal)))
+                    }
+
+                    routing {
+                        authenticate("test") {
+                            disablePlugin(eventStore)
+                            enablePlugin(eventStore)
+                        }
+                    }
+                }
+
+                val pluginType = PluginType.ADVISOR
+                val pluginId = VulnerableCodeFactory.descriptor.id
+
+                val client = createJsonClient()
+
+                client.post("/admin/plugins/$pluginType/$pluginId/enable") shouldHaveStatus HttpStatusCode.NotModified
+
+                // Verify again after disabling and re-enabling the plugin.
+                client.post("/admin/plugins/$pluginType/$pluginId/disable")
+                client.post("/admin/plugins/$pluginType/$pluginId/enable")
+                client.post("/admin/plugins/$pluginType/$pluginId/enable") shouldHaveStatus HttpStatusCode.NotModified
+            }
+        }
+    }
+})

--- a/components/plugin-manager/implementation/src/test/kotlin/endpoints/GetInstalledPluginsIntegrationTest.kt
+++ b/components/plugin-manager/implementation/src/test/kotlin/endpoints/GetInstalledPluginsIntegrationTest.kt
@@ -22,11 +22,13 @@ package org.eclipse.apoapsis.ortserver.components.pluginmanager.endpoints
 import io.kotest.assertions.ktor.client.shouldHaveStatus
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
 
 import io.ktor.client.call.body
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
 import io.ktor.client.request.get
+import io.ktor.client.request.post
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.serialization.kotlinx.json.json
@@ -50,10 +52,16 @@ import io.mockk.unmockkAll
 import kotlinx.serialization.json.Json
 
 import org.eclipse.apoapsis.ortserver.components.authorization.OrtPrincipal
+import org.eclipse.apoapsis.ortserver.components.authorization.getUserId
 import org.eclipse.apoapsis.ortserver.components.authorization.hasRole
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginDescriptor
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginEventStore
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
+import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
 import org.eclipse.apoapsis.ortserver.utils.test.Integration
+
+import org.ossreviewtoolkit.plugins.advisors.vulnerablecode.VulnerableCodeFactory
+import org.ossreviewtoolkit.plugins.packagemanagers.node.npm.NpmFactory
 
 class DummyConfig(val principal: OrtPrincipal) : AuthenticationProvider.Config("test")
 
@@ -65,6 +73,8 @@ class FakeAuthenticationProvider(val config: DummyConfig) : AuthenticationProvid
 
 class GetInstalledPluginsIntegrationTest : WordSpec({
     tags(Integration)
+
+    val dbExtension = extension(DatabaseTestExtension())
 
     beforeSpec {
         mockkStatic(RoutingContext::hasRole)
@@ -90,7 +100,7 @@ class GetInstalledPluginsIntegrationTest : WordSpec({
 
                     routing {
                         authenticate("test") {
-                            getInstalledPlugins()
+                            getInstalledPlugins(dbExtension.db)
                         }
                     }
                 }
@@ -103,6 +113,49 @@ class GetInstalledPluginsIntegrationTest : WordSpec({
                 enumValues<PluginType>().forEach { pluginType ->
                     pluginDescriptors.filter { it.type == pluginType } shouldNot beEmpty()
                 }
+            }
+        }
+
+        "return if plugins are enabled or disabled" {
+            val principal = mockk<OrtPrincipal> {
+                every { getUserId() } returns "userId"
+                every { hasRole(any()) } returns true
+            }
+
+            val eventStore = PluginEventStore(dbExtension.db)
+
+            testApplication {
+                application {
+                    install(ContentNegotiation) {
+                        serialization(ContentType.Application.Json, Json)
+                    }
+
+                    install(Authentication) {
+                        register(FakeAuthenticationProvider(DummyConfig(principal)))
+                    }
+
+                    routing {
+                        authenticate("test") {
+                            disablePlugin(eventStore)
+                            getInstalledPlugins(dbExtension.db)
+                        }
+                    }
+                }
+
+                val npmType = PluginType.PACKAGE_MANAGER
+                val npmId = NpmFactory.descriptor.id
+                val vulnerableCodeType = PluginType.ADVISOR
+                val vulnerableCodeId = VulnerableCodeFactory.descriptor.id
+
+                val client = createJsonClient()
+                client.post("/admin/plugins/$npmType/$npmId/disable") shouldHaveStatus HttpStatusCode.Accepted
+                val response = client.get("/admin/plugins")
+
+                response shouldHaveStatus HttpStatusCode.OK
+                val descriptors = response.body<List<PluginDescriptor>>()
+
+                descriptors.find { it.type == npmType && it.id == npmId }?.enabled shouldBe false
+                descriptors.find { it.type == vulnerableCodeType && it.id == vulnerableCodeId }?.enabled shouldBe true
             }
         }
     }

--- a/components/plugin-manager/implementation/src/test/kotlin/endpoints/PluginManagerAuthorizationTest.kt
+++ b/components/plugin-manager/implementation/src/test/kotlin/endpoints/PluginManagerAuthorizationTest.kt
@@ -221,7 +221,7 @@ class PluginManagerAuthorizationTest : WordSpec({
 
                     routing {
                         authenticate(SecurityConfigurations.TOKEN) {
-                            getInstalledPlugins()
+                            getInstalledPlugins(dbExtension.db)
                         }
                     }
                 }

--- a/core/src/main/kotlin/di/Module.kt
+++ b/core/src/main/kotlin/di/Module.kt
@@ -91,10 +91,9 @@ import org.koin.dsl.module
 
 /**
  * Creates the Koin module for the ORT server. The [config] is used to configure the application and the database. For
- * integration tests, the [setupDatabase] flag can be set to `false` as the data source will be provided by the
- * testcontainer there.
+ * integration tests, the [database][db] from the testcontainer can be provided directly.
  */
-fun ortServerModule(config: ApplicationConfig, setupDatabase: Boolean = true) = module {
+fun ortServerModule(config: ApplicationConfig, db: Database?) = module {
     single { config }
     single { ConfigFactory.parseMap(config.toMap()) }
 
@@ -111,7 +110,9 @@ fun ortServerModule(config: ApplicationConfig, setupDatabase: Boolean = true) = 
         DefaultKeycloakClient.create(get<ConfigManager>().createKeycloakClientConfiguration(), get())
     }
 
-    if (setupDatabase) {
+    if (db != null) {
+        single<Database> { db }
+    } else {
         single<Database>(createdAtStart = true) {
             val configManager = get<ConfigManager>()
             val dataSourceConfig = DataSourceConfig.create(configManager)

--- a/core/src/main/kotlin/di/Module.kt
+++ b/core/src/main/kotlin/di/Module.kt
@@ -28,6 +28,7 @@ import kotlinx.serialization.json.Json
 
 import org.eclipse.apoapsis.ortserver.clients.keycloak.DefaultKeycloakClient
 import org.eclipse.apoapsis.ortserver.clients.keycloak.KeycloakClient
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginEventStore
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.core.plugins.customSerializersModule
 import org.eclipse.apoapsis.ortserver.core.services.OrchestratorService
@@ -164,4 +165,6 @@ fun ortServerModule(config: ApplicationConfig, db: Database?) = module {
     single { ContentManagementService(get()) }
     singleOf(::ReportStorageService)
     singleOf(::InfrastructureServiceService)
+
+    single { PluginEventStore(get()) }
 }

--- a/core/src/main/kotlin/plugins/Koin.kt
+++ b/core/src/main/kotlin/plugins/Koin.kt
@@ -24,12 +24,14 @@ import io.ktor.server.application.install
 
 import org.eclipse.apoapsis.ortserver.core.di.ortServerModule
 
+import org.jetbrains.exposed.sql.Database
+
 import org.koin.ktor.plugin.Koin
 
-fun Application.configureKoin(setupDatabase: Boolean = true) {
+fun Application.configureKoin(db: Database? = null) {
     install(Koin) {
         modules(
-            ortServerModule(environment.config, setupDatabase)
+            ortServerModule(environment.config, db)
         )
     }
 }

--- a/core/src/main/kotlin/plugins/Routing.kt
+++ b/core/src/main/kotlin/plugins/Routing.kt
@@ -25,6 +25,8 @@ import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 
 import org.eclipse.apoapsis.ortserver.components.authorization.SecurityConfigurations
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.endpoints.disablePlugin
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.endpoints.enablePlugin
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.endpoints.getInstalledPlugins
 import org.eclipse.apoapsis.ortserver.core.api.admin
 import org.eclipse.apoapsis.ortserver.core.api.authentication
@@ -36,6 +38,8 @@ import org.eclipse.apoapsis.ortserver.core.api.repositories
 import org.eclipse.apoapsis.ortserver.core.api.runs
 import org.eclipse.apoapsis.ortserver.core.api.versions
 
+import org.koin.ktor.ext.get
+
 fun Application.configureRouting() {
     routing {
         route("api/v1") {
@@ -44,6 +48,8 @@ fun Application.configureRouting() {
             downloads()
             authenticate(SecurityConfigurations.TOKEN) {
                 admin()
+                disablePlugin(get())
+                enablePlugin(get())
                 getInstalledPlugins()
                 organizations()
                 products()

--- a/core/src/main/kotlin/plugins/Routing.kt
+++ b/core/src/main/kotlin/plugins/Routing.kt
@@ -50,7 +50,7 @@ fun Application.configureRouting() {
                 admin()
                 disablePlugin(get())
                 enablePlugin(get())
-                getInstalledPlugins()
+                getInstalledPlugins(get())
                 organizations()
                 products()
                 repositories()

--- a/core/src/test/kotlin/ApplicationTest.kt
+++ b/core/src/test/kotlin/ApplicationTest.kt
@@ -26,6 +26,8 @@ import org.eclipse.apoapsis.ortserver.core.plugins.*
 import org.eclipse.apoapsis.ortserver.core.testutils.configureTestAuthentication
 import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
 
+import org.jetbrains.exposed.sql.Database
+
 import org.koin.ktor.ext.get
 
 fun main(args: Array<String>) = io.ktor.server.netty.EngineMain.main(args)
@@ -38,8 +40,8 @@ fun main(args: Array<String>) = io.ktor.server.netty.EngineMain.main(args)
  * * Authentication: This application does not use KeyCloak for authentication. Instead, it uses an
  *                   authentication which is always valid.
  */
-fun Application.testModule() {
-    configureKoin(setupDatabase = false)
+fun Application.testModule(db: Database) {
+    configureKoin(db)
     configureTestAuthentication()
     configureStatusPages()
     configureRouting()
@@ -52,8 +54,8 @@ fun Application.testModule() {
 /**
  * A test application configuration that requires Keycloak to be run in the integration test.
  */
-fun Application.testAuthModule() {
-    configureKoin(setupDatabase = false)
+fun Application.testAuthModule(db: Database) {
+    configureKoin(db)
     configureAuthentication(get(), get())
     configureStatusPages()
     configureRouting()

--- a/core/src/test/kotlin/api/AbstractIntegrationTest.kt
+++ b/core/src/test/kotlin/api/AbstractIntegrationTest.kt
@@ -47,7 +47,7 @@ import org.eclipse.apoapsis.ortserver.core.SUPERUSER_PASSWORD
 import org.eclipse.apoapsis.ortserver.core.TEST_USER
 import org.eclipse.apoapsis.ortserver.core.TEST_USER_PASSWORD
 import org.eclipse.apoapsis.ortserver.core.createJsonClient
-import org.eclipse.apoapsis.ortserver.core.testutils.authNoDbConfig
+import org.eclipse.apoapsis.ortserver.core.testutils.TestConfig
 import org.eclipse.apoapsis.ortserver.core.testutils.ortServerTestApplication
 import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
 import org.eclipse.apoapsis.ortserver.secrets.SecretStorage
@@ -115,7 +115,7 @@ abstract class AbstractIntegrationTest(body: AbstractIntegrationTest.() -> Unit)
     }
 
     fun integrationTestApplication(block: suspend ApplicationTestBuilder.() -> Unit) =
-        ortServerTestApplication(dbExtension.db, authNoDbConfig, additionalConfig, block)
+        ortServerTestApplication(dbExtension.db, TestConfig.TestAuth, additionalConfig, block)
 
     fun requestShouldRequireRole(
         role: String,

--- a/core/src/test/kotlin/api/ErrorsIntegrationTest.kt
+++ b/core/src/test/kotlin/api/ErrorsIntegrationTest.kt
@@ -43,7 +43,7 @@ import org.eclipse.apoapsis.ortserver.components.authorization.roles.Superuser
 import org.eclipse.apoapsis.ortserver.core.SUPERUSER
 import org.eclipse.apoapsis.ortserver.core.SUPERUSER_PASSWORD
 import org.eclipse.apoapsis.ortserver.core.createJsonClient
-import org.eclipse.apoapsis.ortserver.core.testutils.authNoDbConfig
+import org.eclipse.apoapsis.ortserver.core.testutils.TestConfig
 import org.eclipse.apoapsis.ortserver.core.testutils.ortServerTestApplication
 import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
 import org.eclipse.apoapsis.ortserver.utils.test.Integration
@@ -75,7 +75,7 @@ class ErrorsIntegrationTest : StringSpec() {
         tags(Integration)
 
         "An unauthorized call yields the correct status code" {
-            ortServerTestApplication(dbExtension.db, authNoDbConfig, additionalConfig) {
+            ortServerTestApplication(dbExtension.db, TestConfig.TestAuth, additionalConfig) {
                 val client = createJsonClient()
 
                 client.get("/api/v1/organizations") shouldHaveStatus HttpStatusCode.Unauthorized
@@ -83,7 +83,7 @@ class ErrorsIntegrationTest : StringSpec() {
         }
 
         "Sorting by an unsupported field should be handled" {
-            ortServerTestApplication(dbExtension.db, authNoDbConfig, additionalConfig) {
+            ortServerTestApplication(dbExtension.db, TestConfig.TestAuth, additionalConfig) {
                 val client = createJsonClient().configureAuthentication(superuserClientConfig, json)
 
                 val response = client.get("/api/v1/organizations?sort=color")
@@ -96,7 +96,7 @@ class ErrorsIntegrationTest : StringSpec() {
         "An invalid limit parameter should be handled" {
             val limitValue = "a-couple-of"
 
-            ortServerTestApplication(dbExtension.db, authNoDbConfig, additionalConfig) {
+            ortServerTestApplication(dbExtension.db, TestConfig.TestAuth, additionalConfig) {
                 val client = createJsonClient().configureAuthentication(superuserClientConfig, json)
 
                 val response = client.get("/api/v1/organizations?limit=$limitValue")
@@ -111,7 +111,7 @@ class ErrorsIntegrationTest : StringSpec() {
         "An invalid offset parameter should be handled" {
             val offsetValue = "a-quarter"
 
-            ortServerTestApplication(dbExtension.db, authNoDbConfig, additionalConfig) {
+            ortServerTestApplication(dbExtension.db, TestConfig.TestAuth, additionalConfig) {
                 val client = createJsonClient().configureAuthentication(superuserClientConfig, json)
 
                 val response = client.get("/api/v1/organizations?limit=25&offset=$offsetValue")
@@ -126,7 +126,7 @@ class ErrorsIntegrationTest : StringSpec() {
         "An invalid URL path should be handled" {
             val invalidOrgId = "not_a_number"
 
-            ortServerTestApplication(dbExtension.db, authNoDbConfig, additionalConfig) {
+            ortServerTestApplication(dbExtension.db, TestConfig.TestAuth, additionalConfig) {
                 val client = createJsonClient().configureAuthentication(superuserClientConfig, json)
 
                 val response = client.get("/api/v1/organizations/$invalidOrgId")

--- a/core/src/test/kotlin/api/HealthIntegrationTest.kt
+++ b/core/src/test/kotlin/api/HealthIntegrationTest.kt
@@ -26,7 +26,7 @@ import io.ktor.client.request.get
 
 import org.eclipse.apoapsis.ortserver.core.createJsonClient
 import org.eclipse.apoapsis.ortserver.core.shouldHaveBody
-import org.eclipse.apoapsis.ortserver.core.testutils.noDbConfig
+import org.eclipse.apoapsis.ortserver.core.testutils.TestConfig
 import org.eclipse.apoapsis.ortserver.core.testutils.ortServerTestApplication
 import org.eclipse.apoapsis.ortserver.utils.test.Integration
 
@@ -35,7 +35,7 @@ class HealthIntegrationTest : WordSpec({
 
     "/liveness" should {
         "respond with 200 if the server is running" {
-            ortServerTestApplication(config = noDbConfig) {
+            ortServerTestApplication(config = TestConfig.Test) {
                 val client = createJsonClient()
 
                 val response = client.get("/api/v1/liveness")

--- a/core/src/test/kotlin/api/OpenApiIntegrationTest.kt
+++ b/core/src/test/kotlin/api/OpenApiIntegrationTest.kt
@@ -34,7 +34,7 @@ import kotlinx.serialization.json.jsonObject
 
 import org.eclipse.apoapsis.ortserver.core.createJsonClient
 import org.eclipse.apoapsis.ortserver.core.plugins.configureOpenApi
-import org.eclipse.apoapsis.ortserver.core.testutils.noDbConfig
+import org.eclipse.apoapsis.ortserver.core.testutils.TestConfig
 import org.eclipse.apoapsis.ortserver.core.testutils.ortServerTestApplication
 import org.eclipse.apoapsis.ortserver.utils.system.ORT_SERVER_VERSION
 import org.eclipse.apoapsis.ortserver.utils.test.Integration
@@ -45,7 +45,7 @@ class OpenApiIntegrationTest : WordSpec({
     "/swagger-ui/api.json" should {
         "return the API specification" {
             ortServerTestApplication(
-                config = noDbConfig,
+                config = TestConfig.Test,
                 additionalConfigs = mapOf("jwt.issuer" to "https://example.org")
             ) {
                 application { configureOpenApi() }

--- a/core/src/test/kotlin/auth/AuthenticationIntegrationTest.kt
+++ b/core/src/test/kotlin/auth/AuthenticationIntegrationTest.kt
@@ -50,7 +50,7 @@ import org.eclipse.apoapsis.ortserver.clients.keycloak.test.setUpUser
 import org.eclipse.apoapsis.ortserver.clients.keycloak.test.setUpUserRoles
 import org.eclipse.apoapsis.ortserver.core.TEST_USER
 import org.eclipse.apoapsis.ortserver.core.TEST_USER_PASSWORD
-import org.eclipse.apoapsis.ortserver.core.testutils.authNoDbConfig
+import org.eclipse.apoapsis.ortserver.core.testutils.TestConfig
 import org.eclipse.apoapsis.ortserver.core.testutils.ortServerTestApplication
 import org.eclipse.apoapsis.ortserver.utils.test.Integration
 
@@ -76,7 +76,7 @@ class AuthenticationIntegrationTest : StringSpec({
         onCall: RoutingContext.() -> Unit = {},
         block: suspend ApplicationTestBuilder.() -> Unit
     ) =
-        ortServerTestApplication(config = authNoDbConfig, additionalConfigs = keycloakConfig + jwtConfig) {
+        ortServerTestApplication(config = TestConfig.TestAuth, additionalConfigs = keycloakConfig + jwtConfig) {
             routing {
                 route("api/v1") {
                     authenticate(SecurityConfigurations.TOKEN) {

--- a/core/src/test/kotlin/utils/ExtensionsTest.kt
+++ b/core/src/test/kotlin/utils/ExtensionsTest.kt
@@ -33,7 +33,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.PagingOptions
 import org.eclipse.apoapsis.ortserver.api.v1.model.SortDirection
 import org.eclipse.apoapsis.ortserver.api.v1.model.SortProperty
 import org.eclipse.apoapsis.ortserver.core.createJsonClient
-import org.eclipse.apoapsis.ortserver.core.testutils.noDbConfig
+import org.eclipse.apoapsis.ortserver.core.testutils.TestConfig
 import org.eclipse.apoapsis.ortserver.core.testutils.ortServerTestApplication
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters.Companion.DEFAULT_LIMIT
 import org.eclipse.apoapsis.ortserver.utils.test.Integration
@@ -111,7 +111,7 @@ class ExtensionsTest : WordSpec({
  * Execute a test for extracting the [PagingOptions] from the given [query] by applying the specified [check] function.
  */
 private fun testPagingOptionsExtraction(query: String?, check: PagingOptions.() -> Unit) {
-    ortServerTestApplication(config = noDbConfig) {
+    ortServerTestApplication(config = TestConfig.Test) {
         routing {
             get("/test") {
                 val pagingOptions = call.pagingOptions(SortProperty("name", SortDirection.ASCENDING))

--- a/core/src/test/kotlin/utils/GenerateOpenApiSpec.kt
+++ b/core/src/test/kotlin/utils/GenerateOpenApiSpec.kt
@@ -31,8 +31,9 @@ import java.io.File
 
 import org.eclipse.apoapsis.ortserver.core.createJsonClient
 import org.eclipse.apoapsis.ortserver.core.plugins.configureOpenApi
-import org.eclipse.apoapsis.ortserver.core.testutils.noDbConfig
+import org.eclipse.apoapsis.ortserver.core.testutils.TestConfig
 import org.eclipse.apoapsis.ortserver.core.testutils.ortServerTestApplication
+import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
 
 /**
  * This fake test starts the [ortServerTestApplication] to get the generated OpenAPI specification and writes it to
@@ -43,9 +44,12 @@ import org.eclipse.apoapsis.ortserver.core.testutils.ortServerTestApplication
  * set to `true`.
  */
 class GenerateOpenApiSpec : StringSpec({
+    val dbExtension = extension(DatabaseTestExtension())
+
     "generate the OpenAPI specification".config(enabled = System.getProperty("generateOpenApiSpec").toBoolean()) {
         ortServerTestApplication(
-            config = noDbConfig,
+            db = dbExtension.db,
+            config = TestConfig.Test,
             additionalConfigs = mapOf("jwt.issuer" to "http://localhost:8081/realms/master")
         ) {
             application { configureOpenApi() }

--- a/core/src/test/resources/application-test-auth.conf
+++ b/core/src/test/resources/application-test-auth.conf
@@ -28,10 +28,6 @@ ktor {
   cors {
     allowedHosts = "localhost:5173,localhost:8082"
   }
-  
-  application {
-    modules = [org.eclipse.apoapsis.ortserver.core.ApplicationTestKt.testAuthModule]
-  }
 }
 
 jwt {

--- a/core/src/test/resources/application-test.conf
+++ b/core/src/test/resources/application-test.conf
@@ -28,10 +28,6 @@ ktor {
   cors {
     allowedHosts = "localhost:5173,localhost:8082"
   }
-  
-  application {
-    modules = [org.eclipse.apoapsis.ortserver.core.ApplicationTestKt.testModule]
-  }
 }
 
 jwt {

--- a/dao/src/main/resources/db/migration/V102__pluginEvents.sql
+++ b/dao/src/main/resources/db/migration/V102__pluginEvents.sql
@@ -1,0 +1,11 @@
+CREATE TABLE plugin_events
+(
+    plugin_type text      NOT NULL,
+    plugin_id   text      NOT NULL,
+    version     bigint    NOT NULL,
+    payload     jsonb     NOT NULL,
+    created_at  timestamp NOT NULL DEFAULT now(),
+    created_by  text      NOT NULL,
+
+    PRIMARY KEY (plugin_type, plugin_id, version)
+);

--- a/dao/src/main/resources/db/migration/V103__pluginsReadModel.sql
+++ b/dao/src/main/resources/db/migration/V103__pluginsReadModel.sql
@@ -1,0 +1,8 @@
+CREATE TABLE plugins_read_model
+(
+    plugin_type text    NOT NULL,
+    plugin_id   text    NOT NULL,
+    enabled     boolean NOT NULL,
+
+    PRIMARY KEY (plugin_type, plugin_id)
+)

--- a/ui/src/routes/admin/plugins/index.tsx
+++ b/ui/src/routes/admin/plugins/index.tsx
@@ -19,10 +19,16 @@
 
 import { createFileRoute } from '@tanstack/react-router';
 
+import {
+  usePluginsServiceGetApiV1AdminPluginsKey,
+  usePluginsServicePostApiV1AdminPluginsByPluginTypeByPluginIdDisable,
+  usePluginsServicePostApiV1AdminPluginsByPluginTypeByPluginIdEnable,
+} from '@/api/queries';
 import { prefetchUsePluginsServiceGetApiV1AdminPlugins } from '@/api/queries/prefetch.ts';
 import { usePluginsServiceGetApiV1AdminPluginsSuspense } from '@/api/queries/suspense.ts';
-import { PluginDescriptor } from '@/api/requests';
+import { ApiError, PluginDescriptor } from '@/api/requests';
 import { LoadingIndicator } from '@/components/loading-indicator.tsx';
+import { ToastError } from '@/components/toast-error.tsx';
 import {
   Card,
   CardContent,
@@ -30,6 +36,9 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card.tsx';
+import { Switch } from '@/components/ui/switch.tsx';
+import { queryClient } from '@/lib/query-client.ts';
+import { toast } from '@/lib/toast.ts';
 
 type PluginListCardProps = {
   title: string;
@@ -41,24 +50,92 @@ const PluginListCard = ({
   title,
   description,
   plugins,
-}: PluginListCardProps) => (
-  <Card className='mb-4 h-fit'>
-    <CardHeader>
-      <CardTitle>{title}</CardTitle>
-      <CardDescription>{description}</CardDescription>
-    </CardHeader>
-    <CardContent>
-      {plugins.map((plugin) => (
-        <Card key={plugin.id} className='mb-2'>
-          <CardHeader>
-            <CardTitle>{plugin.displayName}</CardTitle>
-            <CardDescription>{plugin.description}</CardDescription>
-          </CardHeader>
-        </Card>
-      ))}
-    </CardContent>
-  </Card>
-);
+}: PluginListCardProps) => {
+  const enablePlugin =
+    usePluginsServicePostApiV1AdminPluginsByPluginTypeByPluginIdEnable();
+  const disablePlugin =
+    usePluginsServicePostApiV1AdminPluginsByPluginTypeByPluginIdDisable();
+
+  const handleToggle = (plugin: PluginDescriptor) => {
+    if (plugin.enabled) {
+      disablePlugin.mutate(
+        { pluginType: plugin.type, pluginId: plugin.id },
+        {
+          onSuccess: () => {
+            toast.info('Disable Plugin', {
+              description: `Plugin "${plugin.displayName}" disabled successfully.`,
+            });
+            queryClient.invalidateQueries({
+              queryKey: [usePluginsServiceGetApiV1AdminPluginsKey],
+            });
+          },
+          onError(error: unknown) {
+            const apiError = error as ApiError;
+            toast.error(apiError.message, {
+              description: <ToastError error={apiError} />,
+              duration: Infinity,
+              cancel: {
+                label: 'Dismiss',
+                onClick: () => {},
+              },
+            });
+          },
+        }
+      );
+    } else {
+      enablePlugin.mutate(
+        { pluginType: plugin.type, pluginId: plugin.id },
+        {
+          onSuccess: () => {
+            toast.info('Enable Plugin', {
+              description: `Plugin "${plugin.displayName}" enabled successfully.`,
+            });
+            queryClient.invalidateQueries({
+              queryKey: [usePluginsServiceGetApiV1AdminPluginsKey],
+            });
+          },
+          onError(error: unknown) {
+            const apiError = error as ApiError;
+            toast.error(apiError.message, {
+              description: <ToastError error={apiError} />,
+              duration: Infinity,
+              cancel: {
+                label: 'Dismiss',
+                onClick: () => {},
+              },
+            });
+          },
+        }
+      );
+    }
+  };
+
+  return (
+    <Card className='mb-4 h-fit'>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {plugins.map((plugin) => (
+          <Card key={plugin.id} className='mb-2'>
+            <CardHeader className='flex items-start justify-between'>
+              <div>
+                <CardTitle>{plugin.displayName}</CardTitle>
+                <CardDescription>{plugin.description}</CardDescription>
+              </div>
+              <Switch
+                className='data-[state=checked]:bg-green-500'
+                checked={plugin.enabled}
+                onCheckedChange={() => handleToggle(plugin)}
+              />
+            </CardHeader>
+          </Card>
+        ))}
+      </CardContent>
+    </Card>
+  );
+};
 
 const PluginsComponent = () => {
   const { data: plugins } = usePluginsServiceGetApiV1AdminPluginsSuspense();


### PR DESCRIPTION
Prepare for enabling and disabling ORT plugins globally by creating the required configuration and UI, see the commit messages for details. The workers still ignore those settings, this needs to be changed in a later PR.

This PR introduces some code duplication mainly in integration tests, this will be addressed in a follow-up.