### PR TITLE
chore(ui): Remove "ORT" from "Plugin Management"

### DIFF
--- a/ui/src/routes/admin/route.tsx
+++ b/ui/src/routes/admin/route.tsx
@@ -35,7 +35,7 @@ const Layout = () => {
       ],
     },
     {
-      label: 'ORT Plugin Management',
+      label: 'Plugin Management',
       items: [
         {
           title: 'Installed Plugins',


### PR DESCRIPTION
While technically correct, there probably will be no other plugins for the foreseeable future. So use a shorter name to better match "User Management".