### PR TITLE
Show only relevant issues in ORT Server run view

### DIFF
--- a/services/hierarchy/src/main/kotlin/IssueService.kt
+++ b/services/hierarchy/src/main/kotlin/IssueService.kt
@@ -48,7 +48,6 @@ import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.Query
 import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.alias
-import org.jetbrains.exposed.sql.count
 import org.jetbrains.exposed.sql.innerJoin
 
 /**

--- a/services/hierarchy/src/main/kotlin/IssueService.kt
+++ b/services/hierarchy/src/main/kotlin/IssueService.kt
@@ -26,6 +26,7 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsSca
 import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.ScanResultsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.ScanSummariesIssuesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.ScanSummariesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IssueDao
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IssuesTable
@@ -176,7 +177,8 @@ class IssueService(private val db: Database) {
             .innerJoin(ScannerRunsTable, { ScannerJobsTable.id }, { scannerJobId })
             .innerJoin(ScannerRunsScanResultsTable, { ScannerRunsTable.id }, { scannerRunId })
             .innerJoin(ScanResultsTable, { ScannerRunsScanResultsTable.scanResultId }, { ScanResultsTable.id })
-            .innerJoin(ScanSummariesIssuesTable, { ScanResultsTable.id }, { scanSummaryId })
+            .innerJoin(ScanSummariesTable, { ScanResultsTable.scanSummaryId }, { ScanSummariesTable.id })
+            .innerJoin(ScanSummariesIssuesTable, { ScanSummariesTable.id }, { scanSummaryId })
             .innerJoin(IssuesTable, { ScanSummariesIssuesTable.issueId }, { IssuesTable.id })
 
     /**


### PR DESCRIPTION
Previously, the ORT Server UI **could** display issues unrelated to the current run. This fix in the backend REST endpoint implementation for _issues_ ensures that only issues belonging to the actual run are shown.
