### PR TITLE
Tune Graphite's retention policies

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -130,6 +130,12 @@ services:
     - type: bind
       source: ./scripts/compose/graphite/storage
       target: /opt/graphite/storage
+    - type: bind
+      source: ./scripts/compose/graphite/conf/storage-schemas.conf
+      target: /opt/graphite/conf/storage-schemas.conf
+    - type: bind
+      source: ./scripts/compose/graphite/conf/storage-aggregation.conf
+      target: /opt/graphite/conf/storage-aggregation.conf
     logging:
       driver: gelf
       options:

--- a/scripts/compose/graphite/conf/storage-aggregation.conf
+++ b/scripts/compose/graphite/conf/storage-aggregation.conf
@@ -1,0 +1,42 @@
+# Aggregation methods for whisper files. Entries are scanned in order,
+# and first match wins. This file is scanned for changes every 60 seconds
+#
+#  [name]
+#  pattern = <regex>
+#  xFilesFactor = <float between 0 and 1>
+#  aggregationMethod = <average|sum|last|max|min>
+#
+#  name: Arbitrary unique name for the rule
+#  pattern: Regex pattern to match against the metric name
+#  xFilesFactor: Ratio of valid data points required for aggregation to the next retention to occur
+#  aggregationMethod: function to apply to data points for aggregation
+#
+[min]
+pattern = \.lower$
+xFilesFactor = 0.1
+aggregationMethod = min
+
+[max]
+pattern = \.upper(_\d+)?$
+xFilesFactor = 0.1
+aggregationMethod = max
+
+[sum]
+pattern = \.sum$
+xFilesFactor = 0
+aggregationMethod = sum
+
+[count]
+pattern = \.count$
+xFilesFactor = 0
+aggregationMethod = sum
+
+[count_legacy]
+pattern = ^stats_counts.*
+xFilesFactor = 0
+aggregationMethod = sum
+
+[default_average]
+pattern = .*
+xFilesFactor = 0.3
+aggregationMethod = average

--- a/scripts/compose/graphite/conf/storage-schemas.conf
+++ b/scripts/compose/graphite/conf/storage-schemas.conf
@@ -1,0 +1,26 @@
+# Schema definitions for Whisper files. Entries are scanned in order,
+# and first match wins. This file is scanned for changes every 60 seconds.
+#
+# Definition Syntax:
+#
+#    [name]
+#    pattern = regex
+#    retentions = timePerPoint:timeToStore, timePerPoint:timeToStore, ...
+#
+# Remember: To support accurate aggregation from higher to lower resolution
+#           archives, the precision of a longer retention archive must be
+#           cleanly divisible by precision of next lower retention archive.
+#
+#           Valid:    60s:7d,300s:30d (300/60 = 5)
+#           Invalid:  180s:7d,300s:30d (300/180 = 3.333)
+#
+
+# Carbon's internal metrics. This entry should match what is specified in
+# CARBON_METRIC_PREFIX and CARBON_METRIC_INTERVAL settings
+[carbon]
+pattern = ^carbon\.
+retentions = 10s:6h,1m:7d,5m:30d,1h:90d
+
+[default]
+pattern = .*
+retentions = 10s:6h,1m:7d,5m:30d,1h:90d


### PR DESCRIPTION
The commit message explains what is done in this PR, as per advice from @mnonnenmacher, but a sanity check is needed. 

I did verify that the changes to the files mounted from `scripts/compose/graphite/conf` are mirrored properly to the container, and the local Docker Compose environment starts properly and seems to be working. Some verification of the new retention policies would need to be done.