### PR TITLE
ui: Prevent the UI from breaking with Gateway Timeout

### DIFF
--- a/ui/src/components/error-component.tsx
+++ b/ui/src/components/error-component.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { ErrorComponentProps } from '@tanstack/react-router';
+import { TriangleAlert } from 'lucide-react';
+
+import {
+  Card,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+
+export const ErrorComponent = ({ error }: ErrorComponentProps) => {
+  return (
+    <Card className='flex h-full gap-4'>
+      <CardHeader>
+        <CardTitle className='flex gap-2 align-baseline'>
+          <TriangleAlert className='text-traffic-light-red size-5' />
+          <div>Oops, something went wrong...</div>
+        </CardTitle>
+        <CardDescription>{`Error: ${error.message}`}</CardDescription>
+      </CardHeader>
+    </Card>
+  );
+};

--- a/ui/src/routes/organizations/$orgId/index.tsx
+++ b/ui/src/routes/organizations/$orgId/index.tsx
@@ -17,12 +17,13 @@
  * License-Filename: LICENSE
  */
 
-import { createFileRoute, Link } from '@tanstack/react-router';
+import { CatchBoundary, createFileRoute, Link } from '@tanstack/react-router';
 import { Boxes, Bug, Scale, ShieldQuestion } from 'lucide-react';
 import { Suspense } from 'react';
 
 import { useOrganizationsServiceGetApiV1OrganizationsByOrganizationId } from '@/api/queries';
 import { prefetchUseOrganizationsServiceGetApiV1OrganizationsByOrganizationId } from '@/api/queries/prefetch';
+import { ErrorComponent } from '@/components/error-component';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { StatisticsCard } from '@/components/statistics-card';
 import { ToastError } from '@/components/toast-error';
@@ -84,77 +85,84 @@ const OrganizationComponent = () => {
           orgId={params.orgId}
         />
       </div>
-      <div className='grid grid-cols-4 gap-2'>
-        <Link
-          to='/organizations/$orgId/vulnerabilities'
-          params={{
-            orgId: params.orgId,
-          }}
-          search={{
-            sortBy: [
-              { id: 'rating', desc: true },
-              { id: 'repositoriesCount', desc: true },
-            ],
-          }}
-        >
+      <CatchBoundary
+        getResetKey={() => 'reset'}
+        errorComponent={ErrorComponent}
+      >
+        <div className='grid grid-cols-4 gap-2'>
+          <Link
+            to='/organizations/$orgId/vulnerabilities'
+            params={{
+              orgId: params.orgId,
+            }}
+            search={{
+              sortBy: [
+                { id: 'rating', desc: true },
+                { id: 'repositoriesCount', desc: true },
+              ],
+            }}
+          >
+            <Suspense
+              fallback={
+                <StatisticsCard
+                  title='Vulnerabilities'
+                  icon={() => (
+                    <ShieldQuestion className='h-4 w-4 text-orange-500' />
+                  )}
+                  value={<LoadingIndicator />}
+                  className='hover:bg-muted/50 h-full'
+                />
+              }
+            >
+              <OrganizationVulnerabilitiesStatisticsCard
+                organizationId={organization.id}
+              />
+            </Suspense>
+          </Link>
           <Suspense
             fallback={
               <StatisticsCard
-                title='Vulnerabilities'
-                icon={() => (
-                  <ShieldQuestion className='h-4 w-4 text-orange-500' />
-                )}
+                title='Issues'
+                icon={() => <Bug className='h-4 w-4 text-orange-500' />}
                 value={<LoadingIndicator />}
                 className='hover:bg-muted/50 h-full'
               />
             }
           >
-            <OrganizationVulnerabilitiesStatisticsCard
+            <OrganizationIssuesStatisticsCard
               organizationId={organization.id}
             />
           </Suspense>
-        </Link>
-        <Suspense
-          fallback={
-            <StatisticsCard
-              title='Issues'
-              icon={() => <Bug className='h-4 w-4 text-orange-500' />}
-              value={<LoadingIndicator />}
-              className='hover:bg-muted/50 h-full'
+          <Suspense
+            fallback={
+              <StatisticsCard
+                title='Rule Violations'
+                icon={() => <Scale className='h-4 w-4 text-orange-500' />}
+                value={<LoadingIndicator />}
+                className='hover:bg-muted/50 h-full'
+              />
+            }
+          >
+            <OrganizationViolationsStatisticsCard
+              organizationId={organization.id}
             />
-          }
-        >
-          <OrganizationIssuesStatisticsCard organizationId={organization.id} />
-        </Suspense>
-        <Suspense
-          fallback={
-            <StatisticsCard
-              title='Rule Violations'
-              icon={() => <Scale className='h-4 w-4 text-orange-500' />}
-              value={<LoadingIndicator />}
-              className='hover:bg-muted/50 h-full'
+          </Suspense>
+          <Suspense
+            fallback={
+              <StatisticsCard
+                title='Packages'
+                icon={() => <Boxes className='h-4 w-4 text-orange-500' />}
+                value={<LoadingIndicator />}
+                className='hover:bg-muted/50 h-full'
+              />
+            }
+          >
+            <OrganizationPackagesStatisticsCard
+              organizationId={organization.id}
             />
-          }
-        >
-          <OrganizationViolationsStatisticsCard
-            organizationId={organization.id}
-          />
-        </Suspense>
-        <Suspense
-          fallback={
-            <StatisticsCard
-              title='Packages'
-              icon={() => <Boxes className='h-4 w-4 text-orange-500' />}
-              value={<LoadingIndicator />}
-              className='hover:bg-muted/50 h-full'
-            />
-          }
-        >
-          <OrganizationPackagesStatisticsCard
-            organizationId={organization.id}
-          />
-        </Suspense>
-      </div>
+          </Suspense>
+        </div>
+      </CatchBoundary>
       <Card>
         <CardContent className='my-4'>
           <OrganizationProductTable />


### PR DESCRIPTION
This PR fixes a bug that was found for a huge organization (over thousand repositories). Moreover, it introduces a general error boundary pattern that can be used elsewhere in the UI whenever a query response breaks the whole UI.

The 504 error was simulated by setting the organization statistics endpoint to return a 504 after a delay instead of an OK.

Loading state when fetching data:

![Screenshot from 2025-04-28 13-46-44](https://github.com/user-attachments/assets/013a6a08-1b9a-418e-93a7-a1e1a99c9fd9)

Error fallback component when 504 happens:

![Screenshot from 2025-04-28 13-51-28](https://github.com/user-attachments/assets/fafe61a9-b917-4765-bc00-c592bd276a0c)


Please see the commits for details.

Yes, the error title is a bit cheeky. It could be made as a prop, to generalize the component a bit.