### PR TITLE
ui: Extend the error component

### DIFF
--- a/ui/src/components/error-component.tsx
+++ b/ui/src/components/error-component.tsx
@@ -26,16 +26,35 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import { cn } from '@/lib/utils';
 
-export const ErrorComponent = ({ error }: ErrorComponentProps) => {
+type Props = ErrorComponentProps & {
+  title?: string;
+  className?: string;
+  showStackTrace?: boolean;
+};
+
+export const ErrorComponent = ({
+  error,
+  title = 'Oops, something went wrong...',
+  className,
+  showStackTrace = false,
+}: Props) => {
   return (
-    <Card className='flex h-full gap-4'>
+    <Card className={cn('flex h-full', className)}>
       <CardHeader>
         <CardTitle className='flex gap-2 align-baseline'>
           <TriangleAlert className='text-traffic-light-red size-5' />
-          <div>Oops, something went wrong...</div>
+          <div>{title}</div>
         </CardTitle>
         <CardDescription>{`Error: ${error.message}`}</CardDescription>
+        {showStackTrace && (
+          <CardDescription className='text-xs'>
+            {error.stack
+              ?.split('\n')
+              .map((line, index) => <div key={index}>{line}</div>)}
+          </CardDescription>
+        )}
       </CardHeader>
     </Card>
   );

--- a/ui/src/routes/organizations/$orgId/index.tsx
+++ b/ui/src/routes/organizations/$orgId/index.tsx
@@ -87,7 +87,9 @@ const OrganizationComponent = () => {
       </div>
       <CatchBoundary
         getResetKey={() => 'reset'}
-        errorComponent={ErrorComponent}
+        errorComponent={(props) => (
+          <ErrorComponent {...props} title='Could not load statistics' />
+        )}
       >
         <div className='grid grid-cols-4 gap-2'>
           <Link


### PR DESCRIPTION
#2605 introduced a simple way to isolate UI errors in the DOM by setting error boundaries. If an error happens inside an error boundary, an error component is rendered in place of the erroring sub-DOM, instead of breaking the UI.

This PR extends the error component to provide both "user-friendly errors" (for production) and "technical errors" (mainly used for debugging purposes). Some examples:

1. Explicit user-friendly error title (this is now set for the organization overview page):
![Screenshot from 2025-04-29 13-08-52](https://github.com/user-attachments/assets/c0f8dc21-2034-4d60-8bbd-a44d7c9fc1e3)

2. Error message with default props:
![Screenshot from 2025-04-29 07-17-40](https://github.com/user-attachments/assets/32e415fa-5fa1-483d-bd0f-9b0fe0ed84e7)

3. The error component can even show the stack trace of the error:
![Screenshot from 2025-04-29 07-20-00](https://github.com/user-attachments/assets/b3d15147-fd1f-46f9-bb0b-240823ae4618)

Please see the commits for details.
