### PR TITLE
UI: Set and show repository description

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repository-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repository-table.tsx
@@ -63,6 +63,7 @@ const columns = [
           </Link>
           <div className='text-muted-foreground text-sm md:inline'>
             {row.original.type}
+            {row.original.description ? ` | ${row.original.description}` : ''}
           </div>
         </>
       ),

--- a/ui/src/routes/organizations/$orgId/products/$productId/create-repository/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/create-repository/index.tsx
@@ -25,6 +25,8 @@ import { z } from 'zod';
 
 import { useProductsServicePostApiV1ProductsByProductIdRepositories } from '@/api/queries';
 import { $RepositoryType, ApiError } from '@/api/requests';
+import { asOptionalField } from '@/components/form/as-optional-field.ts';
+import { OptionalInput } from '@/components/form/optional-input.tsx';
 import { ToastError } from '@/components/toast-error';
 import { Button } from '@/components/ui/button';
 import {
@@ -56,6 +58,7 @@ import { getRepositoryTypeLabel } from '@/lib/types';
 
 const formSchema = z.object({
   url: z.string().url(),
+  description: asOptionalField(z.string().min(1)),
   type: z.enum($RepositoryType.enum),
 });
 
@@ -107,6 +110,7 @@ const CreateRepositoryPage = () => {
       productId: Number.parseInt(params.productId),
       requestBody: {
         url: values.url,
+        description: values.description,
         type: values.type,
       },
     });
@@ -128,6 +132,19 @@ const CreateRepositoryPage = () => {
                   <FormLabel>URL</FormLabel>
                   <FormControl autoFocus>
                     <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name='description'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Description</FormLabel>
+                  <FormControl>
+                    <OptionalInput {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/runs/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/runs/index.tsx
@@ -77,6 +77,14 @@ const RepositoryRunsComponent = () => {
 
   return (
     <div className='flex flex-col gap-4'>
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            {repo.type}: {repo.url}
+          </CardTitle>
+          <CardDescription>{repo.description}</CardDescription>
+        </CardHeader>
+      </Card>
       <JobDurations
         repoId={params.repoId}
         pageIndex={pageIndex}
@@ -85,7 +93,6 @@ const RepositoryRunsComponent = () => {
       <Card>
         <CardHeader>
           <CardTitle>Runs</CardTitle>
-          <CardDescription>All runs for {repo.url}</CardDescription>
           <div className='py-2'>
             <Button asChild size='sm' className='ml-auto gap-1'>
               <Link

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/settings/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/settings/index.tsx
@@ -60,6 +60,7 @@ import { toast } from '@/lib/toast';
 
 const formSchema = z.object({
   url: z.string(),
+  description: z.string().optional(),
   type: z.enum($RepositoryType.enum),
 });
 
@@ -105,6 +106,7 @@ const RepositorySettingsPage = () => {
     resolver: zodResolver(formSchema),
     defaultValues: {
       url: repository.url,
+      description: repository.description || '',
       type: repository.type,
     },
   });
@@ -114,6 +116,7 @@ const RepositorySettingsPage = () => {
       repositoryId: repository.id,
       requestBody: {
         url: values.url,
+        description: values.description,
         type: values.type,
       },
     });
@@ -164,6 +167,19 @@ const RepositorySettingsPage = () => {
                   <FormItem>
                     <FormLabel>URL</FormLabel>
                     <FormControl autoFocus>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name='description'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Description</FormLabel>
+                    <FormControl>
                       <Input {...field} />
                     </FormControl>
                     <FormMessage />


### PR DESCRIPTION
Extend the UI to:

Add inputs for the description to the forms for creating and editing repositories:
![image](https://github.com/user-attachments/assets/b55c728a-6eb6-41b0-a0a2-7a77fee84b53)

Show the description in the repository table:
![image](https://github.com/user-attachments/assets/d952ec82-e8f9-4a7d-b0f1-6e223e8ff93a)

Show the description in the repository overview:
![image](https://github.com/user-attachments/assets/83fc692d-5cfd-4820-869b-b1e68238dd1b)
