### PR TITLE
ui: Fix removal of a user from an entity (org, prod, repo)

### DIFF
--- a/ui/src/components/delete-dialog.tsx
+++ b/ui/src/components/delete-dialog.tsx
@@ -51,6 +51,13 @@ interface DeleteDialogProps {
   thingId?: string;
 
   /**
+   * An optional item from which to delete. This is to generalise the delete dialog,
+   * as sometimes, for example a user is only deleted from an organization, not
+   * completely.
+   */
+  itemName?: string;
+
+  /**
    * The UI component to show as part of the delete dialog.
    */
   uiComponent: ReactNode;
@@ -59,13 +66,26 @@ interface DeleteDialogProps {
    * The action to perform on deletion.
    */
   onDelete: () => void | Promise<void>;
+
+  /**
+   * The tooltip for the delete button.
+   */
+  tooltip?: string;
+
+  /**
+   * The title of the delete dialog.
+   */
+  title?: string;
 }
 
 export const DeleteDialog = ({
   thingName,
   thingId,
+  itemName,
   uiComponent,
   onDelete,
+  tooltip,
+  title,
 }: DeleteDialogProps) => {
   const [input, setInput] = useState('');
   const [open, setOpen] = useState(false);
@@ -85,14 +105,14 @@ export const DeleteDialog = ({
         <TooltipTrigger asChild>
           <AlertDialogTrigger asChild>{uiComponent}</AlertDialogTrigger>
         </TooltipTrigger>
-        <TooltipContent>Delete</TooltipContent>
+        <TooltipContent>{tooltip || 'Delete'}</TooltipContent>
       </Tooltip>
       {/* Adding the preventDefault will prevent focusing on the trigger after closing the modal (which would cause the tooltip to show) */}
       <AlertDialogContent onCloseAutoFocus={(e) => e.preventDefault()}>
         <AlertDialogHeader>
           <div className='flex items-center'>
             <OctagonAlert className='h-8 w-8 pr-2 text-red-500' />
-            <AlertDialogTitle>Confirm deletion</AlertDialogTitle>
+            <AlertDialogTitle>{title || 'Confirm deletion'}</AlertDialogTitle>
           </div>
         </AlertDialogHeader>
         <div className='flex flex-col gap-2'>
@@ -104,8 +124,9 @@ export const DeleteDialog = ({
             <>
               <AlertDialogDescription>
                 If you are sure to delete the {thingName}{' '}
-                <span className='font-bold'>{thingId}</span>, enter the bold
-                text below for confirmation.
+                <span className='font-bold'>{thingId}</span>{' '}
+                {itemName ? `from the ${itemName}` : ''}, enter the bold text
+                below for confirmation.
               </AlertDialogDescription>
               <Input
                 autoFocus

--- a/ui/src/components/delete-icon-button.tsx
+++ b/ui/src/components/delete-icon-button.tsx
@@ -24,6 +24,8 @@ import { Button } from './ui/button';
 
 type DeleteIconButtonProps = {
   disabled?: boolean;
+  icon?: React.ReactNode;
+  srDescription?: string;
 };
 
 const DeleteIconButton = forwardRef<HTMLButtonElement, DeleteIconButtonProps>(
@@ -36,8 +38,8 @@ const DeleteIconButton = forwardRef<HTMLButtonElement, DeleteIconButtonProps>(
         className='h-8 px-2 text-red-500'
         ref={ref}
       >
-        <span className='sr-only'>Delete</span>
-        <TrashIcon size={16} />
+        <span className='sr-only'>{props.srDescription || 'Delete'}</span>
+        {props.icon || <TrashIcon size={16} />}
       </Button>
     );
   }


### PR DESCRIPTION
1. Tooltip indicates the consequence of the removal action. Also a different icon is used here:
![Screenshot from 2025-04-30 08-40-38](https://github.com/user-attachments/assets/85be8a6b-3619-44ab-b917-91c45d0f3c25)


2. Delete confirmation icon title indicates what is about to be deleted:
![Screenshot from 2025-04-30 13-21-53](https://github.com/user-attachments/assets/afb18cf0-472a-4bea-b25d-79ecd17d0c76)



3. Successful removal of a user from an organization -  the users table is immediately updated:
![Screenshot from 2025-04-30 08-42-21](https://github.com/user-attachments/assets/4e2b4e70-24ef-4b38-94c0-1d7c4ac4ca2d)


4.  The user still exists on the server:
![Screenshot from 2025-04-30 08-43-04](https://github.com/user-attachments/assets/b8670e44-6a9c-41a6-8800-bc0cda39af58)



Please see the commits for details.
