### PR TITLE
feat(dao): Retain at least one ORT run per repository

### DIFF
--- a/dao/src/test/kotlin/repositories/ortrun/DaoOrtRunRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/ortrun/DaoOrtRunRepositoryTest.kt
@@ -19,7 +19,7 @@
 
 package org.eclipse.apoapsis.ortserver.dao.repositories.ortrun
 
-import io.kotest.core.spec.style.StringSpec
+import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.longs.shouldBeGreaterThan
@@ -63,7 +63,7 @@ import org.eclipse.apoapsis.ortserver.model.util.OrderField
 import org.eclipse.apoapsis.ortserver.model.util.asPresent
 
 @Suppress("LargeClass")
-class DaoOrtRunRepositoryTest : StringSpec({
+class DaoOrtRunRepositoryTest : WordSpec({
     val dbExtension = extension(DatabaseTestExtension())
 
     lateinit var ortRunRepository: DaoOrtRunRepository
@@ -98,393 +98,57 @@ class DaoOrtRunRepositoryTest : StringSpec({
         unmockkAll()
     }
 
-    "create should create an entry in the database" {
-        val revision = "revision"
-        val path = "somePath"
-        val jobConfigContext = "someConfigContext"
-        val traceId = "trace-1234"
-        val environmentConfigPath = "path/to/env.yml"
+    "create" should {
+        "create an entry in the database" {
+            val revision = "revision"
+            val path = "somePath"
+            val jobConfigContext = "someConfigContext"
+            val traceId = "trace-1234"
+            val environmentConfigPath = "path/to/env.yml"
 
-        val createdOrtRun = ortRunRepository.create(
-            repositoryId,
-            revision,
-            path,
-            jobConfigurations,
-            jobConfigContext,
-            labelsMap,
-            traceId = traceId,
-            environmentConfigPath
-        )
-
-        val dbEntry = ortRunRepository.get(createdOrtRun.id)
-
-        dbEntry.shouldNotBeNull()
-        dbEntry shouldBe OrtRun(
-            id = createdOrtRun.id,
-            index = createdOrtRun.id,
-            organizationId = organizationId,
-            productId = productId,
-            repositoryId = repositoryId,
-            revision = revision,
-            path = path,
-            createdAt = createdOrtRun.createdAt,
-            jobConfigs = jobConfigurations,
-            resolvedJobConfigs = null,
-            jobConfigContext = jobConfigContext,
-            resolvedJobConfigContext = null,
-            status = OrtRunStatus.CREATED,
-            finishedAt = null,
-            labels = labelsMap,
-            vcsId = null,
-            vcsProcessedId = null,
-            nestedRepositoryIds = emptyMap(),
-            repositoryConfigId = null,
-            issues = emptyList(),
-            traceId = traceId,
-            environmentConfigPath = environmentConfigPath
-        )
-    }
-
-    "create should create sequential indexes for different repositories" {
-        val otherRepository = dbExtension.fixtures.createRepository(url = "https://example.com/repo2.git")
-
-        ortRunRepository.create(
-            repositoryId,
-            "revision",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            traceId = null,
-            null
-        ).index shouldBe 1
-        ortRunRepository.create(
-            otherRepository.id,
-            "revision",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            traceId = null,
-            null
-        ).index shouldBe 1
-        ortRunRepository.create(
-            otherRepository.id,
-            "revision",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            traceId = "some-trace-id",
-            null
-        ).index shouldBe 2
-        ortRunRepository.create(
-            repositoryId,
-            "revision",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            traceId = null,
-            null
-        ).index shouldBe 2
-    }
-
-    "getByIndex should return the correct run" {
-        val ortRun = ortRunRepository.create(
-            repositoryId,
-            "revision",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            traceId = "some-trace-id",
-            null
-        )
-
-        ortRunRepository.getByIndex(repositoryId, ortRun.index) shouldBe ortRun
-    }
-
-    "get should return null" {
-        ortRunRepository.get(1L).shouldBeNull()
-    }
-
-    "get should return the run" {
-        val ortRun = ortRunRepository.create(
-            repositoryId,
-            "revision",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            traceId = "some-trace-id",
-            null
-        )
-
-        ortRunRepository.get(ortRun.id) shouldBe ortRun
-    }
-
-    "list should return all runs" {
-        val ortRun1 = ortRunRepository.create(
-            repositoryId,
-            "revision1",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            traceId = "the-first-trace-id",
-            null
-        )
-
-        val ortRun2 = ortRunRepository.create(
-            repositoryId,
-            "revision2",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            traceId = "the-second-trace-id",
-            null
-        )
-
-        ortRunRepository.list() shouldBe ListQueryResult(listOf(ortRun1, ortRun2), ListQueryParameters.DEFAULT, 2)
-    }
-
-    "list should apply query parameters" {
-        ortRunRepository.create(
-            repositoryId,
-            "revision1",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            traceId = "t",
-            null
-        )
-
-        val ortRun2 = ortRunRepository.create(
-            repositoryId,
-            "revision2",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            traceId = "trace-id",
-            null
-        )
-
-        val parameters = ListQueryParameters(
-            sortFields = listOf(OrderField("revision", OrderDirection.DESCENDING)),
-            limit = 1
-        )
-
-        ortRunRepository.list(parameters) shouldBe ListQueryResult(listOf(ortRun2), parameters, 2)
-    }
-
-    "list should apply filters" {
-        ortRunRepository.create(
-            repositoryId,
-            "revision1",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            traceId = "t",
-            null
-        )
-
-        val ortRun2 = ortRunRepository.create(
-            repositoryId,
-            "revision2",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            traceId = "trace-id",
-            null
-        )
-
-        val failedRun = ortRunRepository.update(ortRun2.id, status = OrtRunStatus.FAILED.asPresent())
-
-        val filters = OrtRunFilters(
-            status = FilterOperatorAndValue(
-                ComparisonOperator.IN,
-                setOf(OrtRunStatus.FAILED)
-            )
-        )
-
-        ortRunRepository.list(
-            ListQueryParameters.DEFAULT,
-            filters
-        ) shouldBe ListQueryResult(listOf(failedRun), ListQueryParameters.DEFAULT, 1)
-    }
-
-    "list should apply filters based on operator" {
-        val ortRun1 = ortRunRepository.create(
-            repositoryId,
-            "revision1",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            traceId = "t",
-            null
-        )
-
-        val ortRun2 = ortRunRepository.create(
-            repositoryId,
-            "revision2",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            traceId = "trace-id",
-            null
-        )
-
-        ortRunRepository.update(ortRun2.id, status = OrtRunStatus.FAILED.asPresent())
-
-        val filters = OrtRunFilters(
-            status = FilterOperatorAndValue(
-                ComparisonOperator.NOT_IN,
-                setOf(OrtRunStatus.FAILED)
-            )
-        )
-
-        ortRunRepository.list(
-            ListQueryParameters.DEFAULT,
-            filters
-        ) shouldBe ListQueryResult(listOf(ortRun1), ListQueryParameters.DEFAULT, 1)
-    }
-
-    "listForRepositories should return all runs for a repository" {
-        val ortRun1 = ortRunRepository.create(
-            repositoryId,
-            "revision1",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            traceId = "the-first-trace-id",
-            null
-        )
-        val ortRun2 = ortRunRepository.create(
-            repositoryId,
-            "revision2",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            traceId = "the-second-trace-id",
-            null
-        )
-
-        ortRunRepository.listForRepository(repositoryId) shouldBe
-                ListQueryResult(listOf(ortRun1, ortRun2), ListQueryParameters.DEFAULT, 2)
-    }
-
-    "listForRepositories should apply query parameters" {
-        ortRunRepository.create(
-            repositoryId,
-            "revision1",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            traceId = "t",
-            null
-        )
-        val ortRun2 = ortRunRepository.create(
-            repositoryId,
-            "revision2",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            traceId = "trace-id",
-            null
-        )
-
-        val parameters = ListQueryParameters(
-            sortFields = listOf(OrderField("revision", OrderDirection.DESCENDING)),
-            limit = 1
-        )
-
-        ortRunRepository.listForRepository(repositoryId, parameters) shouldBe
-                ListQueryResult(listOf(ortRun2), parameters, 2)
-    }
-
-    "listActiveRuns should return all active runs" {
-        val createdRun = ortRunRepository.create(
-            repositoryId,
-            "revision1",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            traceId = "t",
-            null
-        )
-        val activeRun = ortRunRepository.create(
-            repositoryId,
-            "revision2",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            traceId = "trace-id",
-            null
-        )
-        ortRunRepository.update(
-            id = activeRun.id,
-            status = OrtRunStatus.ACTIVE.asPresent()
-        )
-
-        setOf(OrtRunStatus.FAILED, OrtRunStatus.FINISHED, OrtRunStatus.FINISHED_WITH_ISSUES).forEach { status ->
-            val run = ortRunRepository.create(
+            val createdOrtRun = ortRunRepository.create(
                 repositoryId,
-                "revision${status.name}",
-                null,
+                revision,
+                path,
                 jobConfigurations,
-                null,
+                jobConfigContext,
                 labelsMap,
-                traceId = "irrelevant",
-                null
+                traceId = traceId,
+                environmentConfigPath
             )
-            ortRunRepository.update(run.id, status = status.asPresent())
+
+            val dbEntry = ortRunRepository.get(createdOrtRun.id)
+
+            dbEntry.shouldNotBeNull()
+            dbEntry shouldBe OrtRun(
+                id = createdOrtRun.id,
+                index = createdOrtRun.id,
+                organizationId = organizationId,
+                productId = productId,
+                repositoryId = repositoryId,
+                revision = revision,
+                path = path,
+                createdAt = createdOrtRun.createdAt,
+                jobConfigs = jobConfigurations,
+                resolvedJobConfigs = null,
+                jobConfigContext = jobConfigContext,
+                resolvedJobConfigContext = null,
+                status = OrtRunStatus.CREATED,
+                finishedAt = null,
+                labels = labelsMap,
+                vcsId = null,
+                vcsProcessedId = null,
+                nestedRepositoryIds = emptyMap(),
+                repositoryConfigId = null,
+                issues = emptyList(),
+                traceId = traceId,
+                environmentConfigPath = environmentConfigPath
+            )
         }
 
-        val activeRuns = ortRunRepository.listActiveRuns()
+        "create sequential indexes for different repositories" {
+            val otherRepository = dbExtension.fixtures.createRepository(url = "https://example.com/repo2.git")
 
-        activeRuns shouldContainExactlyInAnyOrder listOf(
-            ActiveOrtRun(createdRun.id, createdRun.createdAt, createdRun.traceId),
-            ActiveOrtRun(activeRun.id, activeRun.createdAt, activeRun.traceId)
-        )
-    }
-
-    "findRunsBefore should return all runs before a given time" {
-        val refTime = Instant.parse("2025-01-15T08:34:48Z")
-        val finishedTimes = listOf(
-            refTime - 10.seconds,
-            refTime - 1.seconds,
-            refTime,
-            refTime + 1.seconds
-        )
-
-        // Mock the clock to have defined finishedAt times for the test ORT runs.
-        // For each run, the repository queries the clock twice: for the creation and the completion time.
-        val mockTimes = buildList {
-            finishedTimes.forEach {
-                add(it - 30.seconds)
-                add(it)
-            }
-        }
-        mockkObject(Clock.System)
-        every {
-            Clock.System.now()
-        } returnsMany mockTimes
-
-        fun createFinishedRun(): OrtRun =
             ortRunRepository.create(
                 repositoryId,
                 "revision",
@@ -492,307 +156,665 @@ class DaoOrtRunRepositoryTest : StringSpec({
                 jobConfigurations,
                 null,
                 labelsMap,
-                traceId = "irrelevant",
+                traceId = null,
                 null
-            ).run { ortRunRepository.update(id, status = OrtRunStatus.FINISHED.asPresent()) }
-
-        val runs = List(4) { createFinishedRun() }
-        ortRunRepository.create(
-            repositoryId,
-            "revision_active",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            traceId = "irrelevant",
-            null
-        )
-
-        val runsBefore = ortRunRepository.findRunsBefore(refTime)
-
-        val expectedIds = runs.take(2).map(OrtRun::id)
-        runsBefore shouldContainExactlyInAnyOrder expectedIds
+            ).index shouldBe 1
+            ortRunRepository.create(
+                otherRepository.id,
+                "revision",
+                null,
+                jobConfigurations,
+                null,
+                labelsMap,
+                traceId = null,
+                null
+            ).index shouldBe 1
+            ortRunRepository.create(
+                otherRepository.id,
+                "revision",
+                null,
+                jobConfigurations,
+                null,
+                labelsMap,
+                traceId = "some-trace-id",
+                null
+            ).index shouldBe 2
+            ortRunRepository.create(
+                repositoryId,
+                "revision",
+                null,
+                jobConfigurations,
+                null,
+                labelsMap,
+                traceId = null,
+                null
+            ).index shouldBe 2
+        }
     }
 
-    "update should update an entry in the database" {
-        val identifier = dbExtension.db.dbQuery {
-            IdentifierDao.getOrPut(Identifier("test", "ns", "name", "1.0"))
-        }
+    "getByIndex" should {
+            "return the correct run" {
+                val ortRun = ortRunRepository.create(
+                    repositoryId,
+                    "revision",
+                    null,
+                    jobConfigurations,
+                    null,
+                    labelsMap,
+                    traceId = "some-trace-id",
+                    null
+                )
 
-        val issue1 = Issue(
-            Instant.parse("2023-08-02T06:16:10Z"),
-            "existing",
-            "An initial issue",
-            Severity.WARNING,
-            "some/path",
-            identifier.mapToModel(),
-            "Analyzer"
-        )
-        val issue2 = Issue(
-            Instant.parse("2023-08-02T06:17:16Z"),
-            "new1",
-            "An new issue",
-            Severity.HINT,
-            identifier = identifier.mapToModel()
-        )
-        val issue3 = Issue(
-            Instant.parse("2023-08-02T06:17:36Z"),
-            "new2",
-            "Another new issue",
-            Severity.ERROR,
-            worker = "Reporter"
-        )
-
-        val label2Value = "new value for label2"
-        val label3Value = "a newly added label"
-
-        val ortRun = ortRunRepository.create(
-            repositoryId,
-            "revision",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            "theTraceId",
-            null
-        )
-
-        val resolvedContext = "theResolvedConfigContext"
-        val revision = "main"
-        val resolvedRevision = "0123456789abcdef0123456789abcdef01234567"
-        val updateStatus = OrtRunStatus.ACTIVE.asPresent()
-
-        val updateResult = ortRunRepository.update(
-            ortRun.id,
-            updateStatus,
-            jobConfigurations.asPresent(),
-            resolvedJobConfigurations.asPresent(),
-            resolvedContext.asPresent(),
-            revision.asPresent(),
-            resolvedRevision.asPresent(),
-            listOf(issue1, issue2, issue3).asPresent(),
-            mapOf("label2" to label2Value, "label3" to label3Value).asPresent()
-        )
-
-        val expectedResult = ortRun.copy(
-            status = updateStatus.value,
-            resolvedJobConfigs = resolvedJobConfigurations,
-            resolvedJobConfigContext = resolvedContext,
-            revision = revision,
-            resolvedRevision = resolvedRevision,
-            issues = listOf(issue1, issue2, issue3),
-            labels = mapOf("label1" to labelsMap.getValue("label1"), "label2" to label2Value, "label3" to label3Value)
-        )
-        updateResult shouldBe expectedResult
-        ortRunRepository.get(ortRun.id) shouldBe expectedResult
+                ortRunRepository.getByIndex(repositoryId, ortRun.index) shouldBe ortRun
+            }
     }
 
-    "update should add new issues to a run" {
-        val identifier = dbExtension.db.dbQuery {
-            IdentifierDao.getOrPut(Identifier("test", "ns", "name", "1.0"))
+    "get" should {
+        "return null" {
+            ortRunRepository.get(1L).shouldBeNull()
         }
 
-        val issue1 = Issue(
-            Instant.parse("2023-08-02T06:16:10Z"),
-            "existing",
-            "An initial issue",
-            Severity.WARNING,
-            "some/path",
-            identifier.mapToModel(),
-            "Analyzer"
-        )
-        val issue2 = Issue(
-            Instant.parse("2023-08-02T06:17:16Z"),
-            "new1",
-            "An new issue",
-            Severity.HINT,
-            identifier = identifier.mapToModel()
-        )
-        val issue3 = Issue(
-            Instant.parse("2023-08-02T06:17:36Z"),
-            "new2",
-            "Another new issue",
-            Severity.ERROR,
-            worker = "Reporter"
-        )
-
-        val ortRun = ortRunRepository.create(
-            repositoryId,
-            "revision",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            "theTraceId",
-            null
-        )
-
-        ortRunRepository.update(
-            ortRun.id,
-            issues = listOf(issue1).asPresent()
-        )
-        val updateResult = ortRunRepository.update(
-            ortRun.id,
-            issues = listOf(issue2, issue3).asPresent()
-        )
-        val expectedResult = ortRun.copy(
-            issues = listOf(issue1, issue2, issue3),
-        )
-        updateResult shouldBe expectedResult
-        ortRunRepository.get(ortRun.id) shouldBe expectedResult
-    }
-
-    "issues added to a run should be deduplicated" {
-        val identifier1 = dbExtension.db.dbQuery {
-            IdentifierDao.getOrPut(Identifier("test", "ns", "name", "1.0"))
-        }
-        val identifier2 = dbExtension.db.dbQuery {
-            IdentifierDao.getOrPut(Identifier("test", "ns", "name2", "2.0"))
-        }
-
-        val issue1 = Issue(
-            Instant.parse("2024-10-18T09:35:41Z"),
-            "test",
-            "A test issue",
-            Severity.WARNING,
-            "test/path",
-            identifier1.mapToModel(),
-            "Analyzer"
-        )
-        val issue2 = Issue(
-            Instant.parse("2024-10-18T09:36:02Z"),
-            "test",
-            "One more test issue",
-            Severity.HINT,
-            identifier = identifier1.mapToModel(),
-            worker = "Analyzer"
-        )
-        val issue3 = issue1.copy(
-            timestamp = Instant.parse("2024-10-18T09:36:22Z"),
-            identifier = identifier2.mapToModel(),
-            worker = "Test worker"
-        )
-
-        val ortRun1 = ortRunRepository.create(
-            repositoryId,
-            "revision",
-            null,
-            jobConfigurations,
-            null,
-            labelsMap,
-            "theTraceId",
-            null
-        )
-        val ortRun2 = ortRunRepository.create(
-            repositoryId,
-            "other_revision",
-            null,
-            jobConfigurations,
-            null,
-            emptyMap(),
-            "otherTraceId",
-            null
-        )
-
-        ortRunRepository.update(
-            ortRun1.id,
-            issues = listOf(issue1, issue2).asPresent()
-        )
-        ortRunRepository.update(
-            ortRun2.id,
-            issues = listOf(issue3).asPresent()
-        )
-
-        dbExtension.db.dbQuery {
-            val issueTime = Instant.parse("2024-10-18T09:42:31Z")
-            val expectedIssues = listOf(
-                issue1.copy(timestamp = issueTime, worker = null, identifier = null),
-                issue2.copy(timestamp = issueTime, worker = null, identifier = null)
+        "return the run" {
+            val ortRun = ortRunRepository.create(
+                repositoryId,
+                "revision",
+                null,
+                jobConfigurations,
+                null,
+                labelsMap,
+                traceId = "some-trace-id",
+                null
             )
 
-            val issues = IssueDao.all().map { it.mapToModel(issueTime, null, null) }
-            issues shouldContainExactlyInAnyOrder expectedIssues
+            ortRunRepository.get(ortRun.id) shouldBe ortRun
         }
     }
 
-    "update should mark a finished run as completed" {
-        val ortRun = ortRunRepository.create(
-            repositoryId,
-            "revision",
-            null,
-            jobConfigurations,
-            null,
-            emptyMap(),
-            "theTraceId",
-            null
-        )
+    "list" should {
+        "return all runs" {
+            val ortRun1 = ortRunRepository.create(
+                repositoryId,
+                "revision1",
+                null,
+                jobConfigurations,
+                null,
+                labelsMap,
+                traceId = "the-first-trace-id",
+                null
+            )
 
-        val updateResult = ortRunRepository.update(ortRun.id, status = OrtRunStatus.FINISHED.asPresent())
+            val ortRun2 = ortRunRepository.create(
+                repositoryId,
+                "revision2",
+                null,
+                jobConfigurations,
+                null,
+                labelsMap,
+                traceId = "the-second-trace-id",
+                null
+            )
 
-        assertCurrentTime(updateResult.finishedAt)
-        ortRunRepository.get(ortRun.id) shouldBe updateResult
+            ortRunRepository.list() shouldBe ListQueryResult(listOf(ortRun1, ortRun2), ListQueryParameters.DEFAULT, 2)
+        }
+
+        "apply query parameters" {
+            ortRunRepository.create(
+                repositoryId,
+                "revision1",
+                null,
+                jobConfigurations,
+                null,
+                labelsMap,
+                traceId = "t",
+                null
+            )
+
+            val ortRun2 = ortRunRepository.create(
+                repositoryId,
+                "revision2",
+                null,
+                jobConfigurations,
+                null,
+                labelsMap,
+                traceId = "trace-id",
+                null
+            )
+
+            val parameters = ListQueryParameters(
+                sortFields = listOf(OrderField("revision", OrderDirection.DESCENDING)),
+                limit = 1
+            )
+
+            ortRunRepository.list(parameters) shouldBe ListQueryResult(listOf(ortRun2), parameters, 2)
+        }
+
+        "apply filters" {
+            ortRunRepository.create(
+                repositoryId,
+                "revision1",
+                null,
+                jobConfigurations,
+                null,
+                labelsMap,
+                traceId = "t",
+                null
+            )
+
+            val ortRun2 = ortRunRepository.create(
+                repositoryId,
+                "revision2",
+                null,
+                jobConfigurations,
+                null,
+                labelsMap,
+                traceId = "trace-id",
+                null
+            )
+
+            val failedRun = ortRunRepository.update(ortRun2.id, status = OrtRunStatus.FAILED.asPresent())
+
+            val filters = OrtRunFilters(
+                status = FilterOperatorAndValue(
+                    ComparisonOperator.IN,
+                    setOf(OrtRunStatus.FAILED)
+                )
+            )
+
+            ortRunRepository.list(
+                ListQueryParameters.DEFAULT,
+                filters
+            ) shouldBe ListQueryResult(listOf(failedRun), ListQueryParameters.DEFAULT, 1)
+        }
+
+        "apply filters based on operator" {
+            val ortRun1 = ortRunRepository.create(
+                repositoryId,
+                "revision1",
+                null,
+                jobConfigurations,
+                null,
+                labelsMap,
+                traceId = "t",
+                null
+            )
+
+            val ortRun2 = ortRunRepository.create(
+                repositoryId,
+                "revision2",
+                null,
+                jobConfigurations,
+                null,
+                labelsMap,
+                traceId = "trace-id",
+                null
+            )
+
+            ortRunRepository.update(ortRun2.id, status = OrtRunStatus.FAILED.asPresent())
+
+            val filters = OrtRunFilters(
+                status = FilterOperatorAndValue(
+                    ComparisonOperator.NOT_IN,
+                    setOf(OrtRunStatus.FAILED)
+                )
+            )
+
+            ortRunRepository.list(
+                ListQueryParameters.DEFAULT,
+                filters
+            ) shouldBe ListQueryResult(listOf(ortRun1), ListQueryParameters.DEFAULT, 1)
+        }
     }
 
-    "update should mark a failed run as completed" {
-        val ortRun = ortRunRepository.create(
-            repositoryId,
-            "revision",
-            null,
-            jobConfigurations,
-            null,
-            emptyMap(),
-            "traceIT",
-            null
-        )
+    "listForRepositories" should {
+        "return all runs for a repository" {
+            val ortRun1 = ortRunRepository.create(
+                repositoryId,
+                "revision1",
+                null,
+                jobConfigurations,
+                null,
+                labelsMap,
+                traceId = "the-first-trace-id",
+                null
+            )
+            val ortRun2 = ortRunRepository.create(
+                repositoryId,
+                "revision2",
+                null,
+                jobConfigurations,
+                null,
+                labelsMap,
+                traceId = "the-second-trace-id",
+                null
+            )
 
-        val updateResult = ortRunRepository.update(ortRun.id, status = OrtRunStatus.FAILED.asPresent())
+            ortRunRepository.listForRepository(repositoryId) shouldBe
+                    ListQueryResult(listOf(ortRun1, ortRun2), ListQueryParameters.DEFAULT, 2)
+        }
 
-        assertCurrentTime(updateResult.finishedAt)
-        ortRunRepository.get(ortRun.id) shouldBe updateResult
+        "apply query parameters" {
+            ortRunRepository.create(
+                repositoryId,
+                "revision1",
+                null,
+                jobConfigurations,
+                null,
+                labelsMap,
+                traceId = "t",
+                null
+            )
+            val ortRun2 = ortRunRepository.create(
+                repositoryId,
+                "revision2",
+                null,
+                jobConfigurations,
+                null,
+                labelsMap,
+                traceId = "trace-id",
+                null
+            )
+
+            val parameters = ListQueryParameters(
+                sortFields = listOf(OrderField("revision", OrderDirection.DESCENDING)),
+                limit = 1
+            )
+
+            ortRunRepository.listForRepository(repositoryId, parameters) shouldBe
+                    ListQueryResult(listOf(ortRun2), parameters, 2)
+        }
     }
 
-    "delete should delete the database entries" {
-        with(dbExtension.fixtures) {
-            createAnalyzerJob()
-            createAdvisorJob()
-            createScannerJob()
-            createEvaluatorJob()
-            createReporterJob()
-            createNotifierJob()
+    "listActiveRuns" should {
+        "return all active runs" {
+            val createdRun = ortRunRepository.create(
+                repositoryId,
+                "revision1",
+                null,
+                jobConfigurations,
+                null,
+                labelsMap,
+                traceId = "t",
+                null
+            )
+            val activeRun = ortRunRepository.create(
+                repositoryId,
+                "revision2",
+                null,
+                jobConfigurations,
+                null,
+                labelsMap,
+                traceId = "trace-id",
+                null
+            )
+            ortRunRepository.update(
+                id = activeRun.id,
+                status = OrtRunStatus.ACTIVE.asPresent()
+            )
 
-            val issue = Issue(
-                Instant.parse("2024-11-12T14:49:35Z"),
+            setOf(OrtRunStatus.FAILED, OrtRunStatus.FINISHED, OrtRunStatus.FINISHED_WITH_ISSUES).forEach { status ->
+                val run = ortRunRepository.create(
+                    repositoryId,
+                    "revision${status.name}",
+                    null,
+                    jobConfigurations,
+                    null,
+                    labelsMap,
+                    traceId = "irrelevant",
+                    null
+                )
+                ortRunRepository.update(run.id, status = status.asPresent())
+            }
+
+            val activeRuns = ortRunRepository.listActiveRuns()
+
+            activeRuns shouldContainExactlyInAnyOrder listOf(
+                ActiveOrtRun(createdRun.id, createdRun.createdAt, createdRun.traceId),
+                ActiveOrtRun(activeRun.id, activeRun.createdAt, activeRun.traceId)
+            )
+        }
+    }
+
+    "findRunsBefore" should {
+        "return all runs before a given time" {
+            val refTime = Instant.parse("2025-01-15T08:34:48Z")
+            val finishedTimes = listOf(
+                refTime - 10.seconds,
+                refTime - 1.seconds,
+                refTime,
+                refTime + 1.seconds
+            )
+
+            // Mock the clock to have defined finishedAt times for the test ORT runs.
+            // For each run, the repository queries the clock twice: for the creation and the completion time.
+            val mockTimes = buildList {
+                finishedTimes.forEach {
+                    add(it - 30.seconds)
+                    add(it)
+                }
+            }
+            mockkObject(Clock.System)
+            every {
+                Clock.System.now()
+            } returnsMany mockTimes
+
+            fun createFinishedRun(): OrtRun =
+                ortRunRepository.create(
+                    repositoryId,
+                    "revision",
+                    null,
+                    jobConfigurations,
+                    null,
+                    labelsMap,
+                    traceId = "irrelevant",
+                    null
+                ).run { ortRunRepository.update(id, status = OrtRunStatus.FINISHED.asPresent()) }
+
+            val runs = List(4) { createFinishedRun() }
+            ortRunRepository.create(
+                repositoryId,
+                "revision_active",
+                null,
+                jobConfigurations,
+                null,
+                labelsMap,
+                traceId = "irrelevant",
+                null
+            )
+
+            val runsBefore = ortRunRepository.findRunsBefore(refTime)
+
+            val expectedIds = runs.take(2).map(OrtRun::id)
+            runsBefore shouldContainExactlyInAnyOrder expectedIds
+        }
+    }
+
+    "update" should {
+        "update an entry in the database" {
+            val identifier = dbExtension.db.dbQuery {
+                IdentifierDao.getOrPut(Identifier("test", "ns", "name", "1.0"))
+            }
+
+            val issue1 = Issue(
+                Instant.parse("2023-08-02T06:16:10Z"),
+                "existing",
+                "An initial issue",
+                Severity.WARNING,
+                "some/path",
+                identifier.mapToModel(),
+                "Analyzer"
+            )
+            val issue2 = Issue(
+                Instant.parse("2023-08-02T06:17:16Z"),
+                "new1",
+                "An new issue",
+                Severity.HINT,
+                identifier = identifier.mapToModel()
+            )
+            val issue3 = Issue(
+                Instant.parse("2023-08-02T06:17:36Z"),
+                "new2",
+                "Another new issue",
+                Severity.ERROR,
+                worker = "Reporter"
+            )
+
+            val label2Value = "new value for label2"
+            val label3Value = "a newly added label"
+
+            val ortRun = ortRunRepository.create(
+                repositoryId,
+                "revision",
+                null,
+                jobConfigurations,
+                null,
+                labelsMap,
+                "theTraceId",
+                null
+            )
+
+            val resolvedContext = "theResolvedConfigContext"
+            val revision = "main"
+            val resolvedRevision = "0123456789abcdef0123456789abcdef01234567"
+            val updateStatus = OrtRunStatus.ACTIVE.asPresent()
+
+            val updateResult = ortRunRepository.update(
+                ortRun.id,
+                updateStatus,
+                jobConfigurations.asPresent(),
+                resolvedJobConfigurations.asPresent(),
+                resolvedContext.asPresent(),
+                revision.asPresent(),
+                resolvedRevision.asPresent(),
+                listOf(issue1, issue2, issue3).asPresent(),
+                mapOf("label2" to label2Value, "label3" to label3Value).asPresent()
+            )
+
+            val expectedResult = ortRun.copy(
+                status = updateStatus.value,
+                resolvedJobConfigs = resolvedJobConfigurations,
+                resolvedJobConfigContext = resolvedContext,
+                revision = revision,
+                resolvedRevision = resolvedRevision,
+                issues = listOf(issue1, issue2, issue3),
+                labels = mapOf(
+                    "label1" to labelsMap.getValue("label1"),
+                    "label2" to label2Value,
+                    "label3" to label3Value
+                )
+            )
+            updateResult shouldBe expectedResult
+            ortRunRepository.get(ortRun.id) shouldBe expectedResult
+        }
+
+        "add new issues to a run" {
+            val identifier = dbExtension.db.dbQuery {
+                IdentifierDao.getOrPut(Identifier("test", "ns", "name", "1.0"))
+            }
+
+            val issue1 = Issue(
+                Instant.parse("2023-08-02T06:16:10Z"),
+                "existing",
+                "An initial issue",
+                Severity.WARNING,
+                "some/path",
+                identifier.mapToModel(),
+                "Analyzer"
+            )
+            val issue2 = Issue(
+                Instant.parse("2023-08-02T06:17:16Z"),
+                "new1",
+                "An new issue",
+                Severity.HINT,
+                identifier = identifier.mapToModel()
+            )
+            val issue3 = Issue(
+                Instant.parse("2023-08-02T06:17:36Z"),
+                "new2",
+                "Another new issue",
+                Severity.ERROR,
+                worker = "Reporter"
+            )
+
+            val ortRun = ortRunRepository.create(
+                repositoryId,
+                "revision",
+                null,
+                jobConfigurations,
+                null,
+                labelsMap,
+                "theTraceId",
+                null
+            )
+
+            ortRunRepository.update(
+                ortRun.id,
+                issues = listOf(issue1).asPresent()
+            )
+            val updateResult = ortRunRepository.update(
+                ortRun.id,
+                issues = listOf(issue2, issue3).asPresent()
+            )
+            val expectedResult = ortRun.copy(
+                issues = listOf(issue1, issue2, issue3),
+            )
+            updateResult shouldBe expectedResult
+            ortRunRepository.get(ortRun.id) shouldBe expectedResult
+        }
+
+        "deduplicate issues added to a run" {
+            val identifier1 = dbExtension.db.dbQuery {
+                IdentifierDao.getOrPut(Identifier("test", "ns", "name", "1.0"))
+            }
+            val identifier2 = dbExtension.db.dbQuery {
+                IdentifierDao.getOrPut(Identifier("test", "ns", "name2", "2.0"))
+            }
+
+            val issue1 = Issue(
+                Instant.parse("2024-10-18T09:35:41Z"),
                 "test",
                 "A test issue",
                 Severity.WARNING,
                 "test/path",
-                null,
+                identifier1.mapToModel(),
                 "Analyzer"
             )
-            ortRunRepository.update(ortRun.id, issues = listOf(issue).asPresent())
+            val issue2 = Issue(
+                Instant.parse("2024-10-18T09:36:02Z"),
+                "test",
+                "One more test issue",
+                Severity.HINT,
+                identifier = identifier1.mapToModel(),
+                worker = "Analyzer"
+            )
+            val issue3 = issue1.copy(
+                timestamp = Instant.parse("2024-10-18T09:36:22Z"),
+                identifier = identifier2.mapToModel(),
+                worker = "Test worker"
+            )
 
-            ortRunRepository.delete(ortRun.id)
+            val ortRun1 = ortRunRepository.create(
+                repositoryId,
+                "revision",
+                null,
+                jobConfigurations,
+                null,
+                labelsMap,
+                "theTraceId",
+                null
+            )
+            val ortRun2 = ortRunRepository.create(
+                repositoryId,
+                "other_revision",
+                null,
+                jobConfigurations,
+                null,
+                emptyMap(),
+                "otherTraceId",
+                null
+            )
 
-            ortRunRepository.listForRepository(repository.id).data shouldBe emptyList()
+            ortRunRepository.update(
+                ortRun1.id,
+                issues = listOf(issue1, issue2).asPresent()
+            )
+            ortRunRepository.update(
+                ortRun2.id,
+                issues = listOf(issue3).asPresent()
+            )
 
-            analyzerJobRepository.getForOrtRun(ortRun.id) should beNull()
-            advisorJobRepository.getForOrtRun(ortRun.id) should beNull()
-            scannerJobRepository.getForOrtRun(ortRun.id) should beNull()
-            evaluatorJobRepository.getForOrtRun(ortRun.id) should beNull()
-            reporterJobRepository.getForOrtRun(ortRun.id) should beNull()
-            notifierJobRepository.getForOrtRun(ortRun.id) should beNull()
+            dbExtension.db.dbQuery {
+                val issueTime = Instant.parse("2024-10-18T09:42:31Z")
+                val expectedIssues = listOf(
+                    issue1.copy(timestamp = issueTime, worker = null, identifier = null),
+                    issue2.copy(timestamp = issueTime, worker = null, identifier = null)
+                )
+
+                val issues = IssueDao.all().map { it.mapToModel(issueTime, null, null) }
+                issues shouldContainExactlyInAnyOrder expectedIssues
+            }
         }
 
-        dbExtension.db.dbQuery {
-            val runIssues = OrtRunIssueDao.find {
-                OrtRunsIssuesTable.ortRunId eq dbExtension.fixtures.ortRun.id
-            }.toList()
-            runIssues should beEmpty()
+        "mark a finished run as completed" {
+            val ortRun = ortRunRepository.create(
+                repositoryId,
+                "revision",
+                null,
+                jobConfigurations,
+                null,
+                emptyMap(),
+                "theTraceId",
+                null
+            )
 
-            val runLabels = OrtRunsLabelsTable.select(OrtRunsLabelsTable.labelId)
-                .where { OrtRunsLabelsTable.ortRunId eq dbExtension.fixtures.ortRun.id }
-                .toList()
-            runLabels should beEmpty()
+            val updateResult = ortRunRepository.update(ortRun.id, status = OrtRunStatus.FINISHED.asPresent())
+
+            assertCurrentTime(updateResult.finishedAt)
+            ortRunRepository.get(ortRun.id) shouldBe updateResult
+        }
+
+        "mark a failed run as completed" {
+            val ortRun = ortRunRepository.create(
+                repositoryId,
+                "revision",
+                null,
+                jobConfigurations,
+                null,
+                emptyMap(),
+                "traceIT",
+                null
+            )
+
+            val updateResult = ortRunRepository.update(ortRun.id, status = OrtRunStatus.FAILED.asPresent())
+
+            assertCurrentTime(updateResult.finishedAt)
+            ortRunRepository.get(ortRun.id) shouldBe updateResult
+        }
+    }
+
+    "delete" should {
+        "delete the database entries" {
+            with(dbExtension.fixtures) {
+                createAnalyzerJob()
+                createAdvisorJob()
+                createScannerJob()
+                createEvaluatorJob()
+                createReporterJob()
+                createNotifierJob()
+
+                val issue = Issue(
+                    Instant.parse("2024-11-12T14:49:35Z"),
+                    "test",
+                    "A test issue",
+                    Severity.WARNING,
+                    "test/path",
+                    null,
+                    "Analyzer"
+                )
+                ortRunRepository.update(ortRun.id, issues = listOf(issue).asPresent())
+
+                ortRunRepository.delete(ortRun.id)
+
+                ortRunRepository.listForRepository(repository.id).data shouldBe emptyList()
+
+                analyzerJobRepository.getForOrtRun(ortRun.id) should beNull()
+                advisorJobRepository.getForOrtRun(ortRun.id) should beNull()
+                scannerJobRepository.getForOrtRun(ortRun.id) should beNull()
+                evaluatorJobRepository.getForOrtRun(ortRun.id) should beNull()
+                reporterJobRepository.getForOrtRun(ortRun.id) should beNull()
+                notifierJobRepository.getForOrtRun(ortRun.id) should beNull()
+            }
+
+            dbExtension.db.dbQuery {
+                val runIssues = OrtRunIssueDao.find {
+                    OrtRunsIssuesTable.ortRunId eq dbExtension.fixtures.ortRun.id
+                }.toList()
+                runIssues should beEmpty()
+
+                val runLabels = OrtRunsLabelsTable.select(OrtRunsLabelsTable.labelId)
+                    .where { OrtRunsLabelsTable.ortRunId eq dbExtension.fixtures.ortRun.id }
+                    .toList()
+                runLabels should beEmpty()
+            }
         }
     }
 })

--- a/services/hierarchy/src/test/kotlin/OrtRunServiceTest.kt
+++ b/services/hierarchy/src/test/kotlin/OrtRunServiceTest.kt
@@ -208,11 +208,12 @@ class OrtRunServiceTest : WordSpec() {
                 }
 
                 fixtures.ortRunRepository.get(ortRunId1) shouldBe null
-                fixtures.ortRunRepository.get(ortRunId2) shouldBe null
+                // Run 2 is the latest run in the repository and is intentionally retained.
+                fixtures.ortRunRepository.get(ortRunId2) shouldNotBe null
                 fixtures.ortRunRepository.get(ortRunId3) shouldNotBe null
 
                 fixtures.reporterRunRepository.getByJobId(reporterjobId1) shouldBe null
-                fixtures.reporterRunRepository.getByJobId(reporterjobId2) shouldBe null
+                fixtures.reporterRunRepository.getByJobId(reporterjobId2) shouldNotBe null
                 fixtures.reporterRunRepository.getByJobId(reporterjobId3) shouldNotBe null
             }
 
@@ -230,12 +231,13 @@ class OrtRunServiceTest : WordSpec() {
                 service.deleteRunsCreatedBefore(Clock.System.now())
 
                 fixtures.ortRunRepository.get(ortRunId1) shouldBe null
-                fixtures.ortRunRepository.get(ortRunId2) shouldBe null
+                // Run 2 is the latest run in the repository and is intentionally retained.
+                fixtures.ortRunRepository.get(ortRunId2) shouldNotBe null
                 // Run 3 is active and should not be deleted
                 fixtures.ortRunRepository.get(ortRunId3) shouldNotBe null
 
                 fixtures.reporterRunRepository.getByJobId(reporterjobId1) shouldBe null
-                fixtures.reporterRunRepository.getByJobId(reporterjobId2) shouldBe null
+                fixtures.reporterRunRepository.getByJobId(reporterjobId2) shouldNotBe null
                 fixtures.reporterRunRepository.getByJobId(reporterjobId3) shouldNotBe null
             }
         }


### PR DESCRIPTION
Ensure the housekeeping logic keeps at least one ORT run for each repository, even if it is older than the defined retention period. This improves continuity of scanning activities after long pauses.

Please check the respective commits for details.
