### PR TITLE
ui: Minor tweaks

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/runs/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/runs/index.tsx
@@ -84,7 +84,13 @@ const RepositoryRunsComponent = () => {
             <span className='font-normal'>
               {getRepositoryTypeLabel(repo.type)} repository
             </span>{' '}
-            {repo.url}
+            <Link
+              className='font-semibold break-all hover:text-blue-400 hover:underline'
+              to={repo.url}
+              target='_blank'
+            >
+              {repo.url}
+            </Link>
           </CardTitle>
           <CardDescription>{repo.description}</CardDescription>
         </CardHeader>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/run-details-bar.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/run-details-bar.tsx
@@ -123,7 +123,7 @@ export const RunDetailsBar = ({ className }: RunDetailsBarProps) => {
           <Label className='font-semibold'>Run ID:</Label>
           <div>{ortRun.id}</div>
         </div>
-        <div className='text-sm'>
+        <div className='flex gap-2 text-sm'>
           <Label className='font-semibold'>Revision:</Label> {ortRun.revision}
           {ortRun.resolvedRevision &&
             ortRun.revision !== ortRun.resolvedRevision &&

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/run-details-bar.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/run-details-bar.tsx
@@ -137,7 +137,8 @@ export const RunDetailsBar = ({ className }: RunDetailsBarProps) => {
             {ortRun.userDisplayName.username ? (
               <Tooltip>
                 <TooltipTrigger className='cursor-pointer'>
-                  {ortRun.userDisplayName.fullName}
+                  {ortRun.userDisplayName.fullName ||
+                    ortRun.userDisplayName.username}
                 </TooltipTrigger>
                 <TooltipContent>
                   {ortRun.userDisplayName.username}


### PR DESCRIPTION
This PR contains minor fixes and tweaks for the UI.

Repository URL in the title when not hovering over it:
![Screenshot from 2025-05-02 07-24-24](https://github.com/user-attachments/assets/4100101b-1782-4be4-9650-f661aee4057c)


Repository URL is rendered as blue when hovering over:
![Screenshot from 2025-05-02 07-24-42](https://github.com/user-attachments/assets/1a8c9e3f-98db-411b-b033-b7d2f78d6641)

"Revision:" and the revision rendered on the same line. Moreover, "Created by:" falls back to showing the username in case full name doesn't exist:
![Screenshot from 2025-05-02 07-25-30](https://github.com/user-attachments/assets/358d3702-7505-4b62-aacf-14f59b06922e)

Please see the commits for details.

For discussion: when changing the repository URL into a link, I decided to _not_ render it always as blue, to retain some consistency with the different titles in the UI. The link now turns blue only when hovering over with a mouse. This can easily be changed, however, if so decided.