### PR TITLE
ui: Small tweaks for the header

### DIFF
--- a/ui/src/components/header.tsx
+++ b/ui/src/components/header.tsx
@@ -27,8 +27,14 @@ import { z } from 'zod';
 import { ModeToggle } from '@/components/mode-toggle';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Form, FormControl, FormField, FormItem } from '@/components/ui/form';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { extractInitials } from '@/helpers/extract-initials.ts';
 import { useUser } from '@/hooks/use-user';
+import favicon from '../../public/favicon.svg';
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -117,13 +123,18 @@ export const Header = () => {
     <header className='bg-background sticky top-0 z-50 flex h-16 justify-between gap-4 border-b px-4 md:px-6'>
       <div className='flex flex-row items-center gap-4'>
         <nav className='hidden flex-col gap-6 text-lg font-medium md:flex md:flex-row md:items-center md:gap-5 md:text-sm lg:gap-6'>
-          <Link
-            to='/'
-            className='flex items-center gap-2 text-lg font-semibold md:text-base'
-          >
-            <Home className='h-6 w-6' />
-            <span className='sr-only'>Home</span>
-          </Link>
+          <Tooltip>
+            <TooltipTrigger>
+              <Link
+                to='/'
+                className='flex items-center gap-2 text-lg font-semibold md:text-base'
+              >
+                <img src={favicon} alt='ORT Server' className='size-6' />
+                <span className='sr-only'>Home</span>
+              </Link>
+            </TooltipTrigger>
+            <TooltipContent>Home</TooltipContent>
+          </Tooltip>
         </nav>
         <Sheet>
           <SheetTrigger asChild>

--- a/ui/src/components/header.tsx
+++ b/ui/src/components/header.tsx
@@ -19,7 +19,7 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Link, useNavigate, useRouterState } from '@tanstack/react-router';
-import { CircleUser, Home, Menu } from 'lucide-react';
+import { Home, Menu } from 'lucide-react';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
@@ -247,7 +247,12 @@ export const Header = () => {
               size='icon'
               className='ml-auto rounded-full'
             >
-              <CircleUser className='h-5 w-5' />
+              <Avatar className='h-8 w-8'>
+                <AvatarFallback className='h-8 w-8 bg-red-400'>
+                  {extractInitials(user.fullName) ??
+                    user.username?.slice(0, 2).toUpperCase()}
+                </AvatarFallback>
+              </Avatar>
               <span className='sr-only'>Toggle user menu</span>
             </Button>
           </DropdownMenuTrigger>
@@ -255,7 +260,8 @@ export const Header = () => {
             <DropdownMenuItem className='flex gap-2' disabled>
               <Avatar className='h-8 w-8'>
                 <AvatarFallback className='h-8 w-8 bg-red-400'>
-                  {extractInitials(user.fullName) ?? '??'}
+                  {extractInitials(user.fullName) ??
+                    user.username?.slice(0, 2).toUpperCase()}
                 </AvatarFallback>
               </Avatar>
               <div>


### PR DESCRIPTION
Show ORT logo as a "Home" indicator":
![Screenshot from 2025-05-02 12-23-41](https://github.com/user-attachments/assets/01835173-0b09-4f51-bc19-9ff15c96634d)

Show the gravatar also as the menu indicator:
![Screenshot from 2025-05-02 12-49-26](https://github.com/user-attachments/assets/ef531db0-ec25-423b-814c-dda2225459e4)


Please see the commits for details.