### PR TITLE
test: Add an abstract integration test class to ktor-utils

### DIFF
--- a/components/plugin-manager/implementation/build.gradle.kts
+++ b/components/plugin-manager/implementation/build.gradle.kts
@@ -68,15 +68,14 @@ dependencies {
 
     testImplementation(testFixtures(projects.clients.keycloak))
     testImplementation(testFixtures(projects.dao))
+    testImplementation(testFixtures(projects.shared.ktorUtils))
 
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestAssertionsKtor)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.kotlinxSerializationJson)
-    testImplementation(libs.ktorClientContentNegotiation)
     testImplementation(libs.ktorKotlinxSerialization)
     testImplementation(libs.ktorServerAuth)
-    testImplementation(libs.ktorServerAuthJwt)
     testImplementation(libs.ktorServerContentNegotiation)
     testImplementation(libs.ktorServerStatusPages)
     testImplementation(libs.ktorServerTestHost)

--- a/components/plugin-manager/implementation/src/test/kotlin/endpoints/EnablePluginIntegrationTest.kt
+++ b/components/plugin-manager/implementation/src/test/kotlin/endpoints/EnablePluginIntegrationTest.kt
@@ -20,67 +20,25 @@
 package org.eclipse.apoapsis.ortserver.components.pluginmanager.endpoints
 
 import io.kotest.assertions.ktor.client.shouldHaveStatus
-import io.kotest.core.spec.style.WordSpec
 
 import io.ktor.client.request.post
-import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
-import io.ktor.serialization.kotlinx.serialization
-import io.ktor.server.application.install
-import io.ktor.server.auth.Authentication
 import io.ktor.server.auth.authenticate
-import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
-import io.ktor.server.routing.RoutingContext
 import io.ktor.server.routing.routing
-import io.ktor.server.testing.testApplication
 
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.mockkStatic
-import io.mockk.unmockkAll
-
-import kotlinx.serialization.json.Json
-
-import org.eclipse.apoapsis.ortserver.components.authorization.OrtPrincipal
-import org.eclipse.apoapsis.ortserver.components.authorization.getUserId
-import org.eclipse.apoapsis.ortserver.components.authorization.hasRole
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginEventStore
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
-import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
-import org.eclipse.apoapsis.ortserver.utils.test.Integration
+import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
 
 import org.ossreviewtoolkit.plugins.advisors.vulnerablecode.VulnerableCodeFactory
 
-class EnablePluginIntegrationTest : WordSpec({
-    tags(Integration)
-
-    val dbExtension = extension(DatabaseTestExtension())
-
-    beforeSpec {
-        mockkStatic(RoutingContext::hasRole)
-    }
-
-    afterSpec { unmockkAll() }
-
+class EnablePluginIntegrationTest : AbstractIntegrationTest({
     "EnablePlugin" should {
         "return Accepted if the plugin was enabled" {
-            val principal = mockk<OrtPrincipal> {
-                every { getUserId() } returns "userId"
-                every { hasRole(any()) } returns true
-            }
-
             val eventStore = PluginEventStore(dbExtension.db)
 
-            testApplication {
+            integrationTestApplication { client ->
                 application {
-                    install(ContentNegotiation) {
-                        serialization(ContentType.Application.Json, Json)
-                    }
-
-                    install(Authentication) {
-                        register(FakeAuthenticationProvider(DummyConfig(principal)))
-                    }
-
                     routing {
                         authenticate("test") {
                             disablePlugin(eventStore)
@@ -91,8 +49,6 @@ class EnablePluginIntegrationTest : WordSpec({
 
                 val pluginType = PluginType.ADVISOR
                 val pluginId = VulnerableCodeFactory.descriptor.id
-
-                val client = createJsonClient()
 
                 // Disable the plugin first because it is enabled by default.
                 client.post("/admin/plugins/$pluginType/$pluginId/disable")
@@ -105,23 +61,10 @@ class EnablePluginIntegrationTest : WordSpec({
         }
 
         "return NotFound if the plugin is not installed" {
-            val principal = mockk<OrtPrincipal> {
-                every { getUserId() } returns "userId"
-                every { hasRole(any()) } returns true
-            }
-
             val eventStore = PluginEventStore(dbExtension.db)
 
-            testApplication {
+            integrationTestApplication { client ->
                 application {
-                    install(ContentNegotiation) {
-                        serialization(ContentType.Application.Json, Json)
-                    }
-
-                    install(Authentication) {
-                        register(FakeAuthenticationProvider(DummyConfig(principal)))
-                    }
-
                     routing {
                         authenticate("test") {
                             enablePlugin(eventStore)
@@ -131,30 +74,15 @@ class EnablePluginIntegrationTest : WordSpec({
 
                 val pluginType = PluginType.ADVISOR
 
-                val client = createJsonClient()
-
                 client.post("/admin/plugins/$pluginType/unknown/enable") shouldHaveStatus HttpStatusCode.NotFound
             }
         }
 
         "return NotModified if the plugin was already enabled" {
-            val principal = mockk<OrtPrincipal> {
-                every { getUserId() } returns "userId"
-                every { hasRole(any()) } returns true
-            }
-
             val eventStore = PluginEventStore(dbExtension.db)
 
-            testApplication {
+            integrationTestApplication { client ->
                 application {
-                    install(ContentNegotiation) {
-                        serialization(ContentType.Application.Json, Json)
-                    }
-
-                    install(Authentication) {
-                        register(FakeAuthenticationProvider(DummyConfig(principal)))
-                    }
-
                     routing {
                         authenticate("test") {
                             disablePlugin(eventStore)
@@ -165,8 +93,6 @@ class EnablePluginIntegrationTest : WordSpec({
 
                 val pluginType = PluginType.ADVISOR
                 val pluginId = VulnerableCodeFactory.descriptor.id
-
-                val client = createJsonClient()
 
                 client.post("/admin/plugins/$pluginType/$pluginId/enable") shouldHaveStatus HttpStatusCode.NotModified
 

--- a/components/plugin-manager/implementation/src/test/kotlin/endpoints/PluginManagerAuthorizationTest.kt
+++ b/components/plugin-manager/implementation/src/test/kotlin/endpoints/PluginManagerAuthorizationTest.kt
@@ -62,6 +62,7 @@ import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginEventStore
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginService
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
 import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
+import org.eclipse.apoapsis.ortserver.shared.ktorutils.createJsonClient
 import org.eclipse.apoapsis.ortserver.utils.test.Integration
 
 import org.ossreviewtoolkit.plugins.advisors.vulnerablecode.VulnerableCodeFactory

--- a/shared/ktor-utils/build.gradle.kts
+++ b/shared/ktor-utils/build.gradle.kts
@@ -18,6 +18,10 @@
  */
 
 plugins {
+    // Apply core plugins.
+    `java-test-fixtures`
+
+    // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
     id("ort-server-publication-conventions")
 }
@@ -26,4 +30,19 @@ group = "org.eclipse.apoapsis.ortserver.shared.ktor-utils"
 
 dependencies {
     implementation(libs.ktorServerCore)
+
+    testFixturesApi(projects.components.authorization.implementation)
+    testFixturesApi(projects.utils.test)
+    testFixturesApi(testFixtures(projects.dao))
+
+    testFixturesImplementation(libs.kotestFrameworkApi)
+    testFixturesImplementation(libs.kotlinxSerializationJson)
+    testFixturesImplementation(libs.ktorServerCore)
+    testFixturesImplementation(libs.ktorClientContentNegotiation)
+    testFixturesImplementation(libs.ktorKotlinxSerialization)
+    testFixturesImplementation(libs.ktorServerAuth)
+    testFixturesImplementation(libs.ktorServerAuthJwt)
+    testFixturesImplementation(libs.ktorServerContentNegotiation)
+    testFixturesImplementation(libs.ktorServerTestHost)
+    testFixturesImplementation(libs.mockk)
 }

--- a/shared/ktor-utils/src/testFixtures/kotlin/AbstractIntegrationTest.kt
+++ b/shared/ktor-utils/src/testFixtures/kotlin/AbstractIntegrationTest.kt
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.shared.ktorutils
+
+import io.kotest.core.spec.Spec
+import io.kotest.core.spec.style.WordSpec
+
+import io.ktor.client.HttpClient
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation as ClientContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.serialization.kotlinx.json.json
+import io.ktor.serialization.kotlinx.serialization
+import io.ktor.server.application.install
+import io.ktor.server.auth.Authentication
+import io.ktor.server.auth.AuthenticationContext
+import io.ktor.server.auth.AuthenticationProvider
+import io.ktor.server.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.server.routing.RoutingContext
+import io.ktor.server.testing.ApplicationTestBuilder
+import io.ktor.server.testing.testApplication
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+
+import kotlinx.serialization.json.Json
+
+import org.eclipse.apoapsis.ortserver.components.authorization.OrtPrincipal
+import org.eclipse.apoapsis.ortserver.components.authorization.getUserId
+import org.eclipse.apoapsis.ortserver.components.authorization.hasRole
+import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
+import org.eclipse.apoapsis.ortserver.utils.test.Integration
+
+/**
+ * A base class for integration tests that provides a database connection and a mock authentication provider.
+ */
+@Suppress("UnnecessaryAbstractClass")
+abstract class AbstractIntegrationTest(body: AbstractIntegrationTest.() -> Unit) : WordSpec() {
+    val dbExtension = extension(DatabaseTestExtension())
+
+    val principal = mockk<OrtPrincipal> {
+        every { getUserId() } returns "userId"
+        every { hasRole(any()) } returns true
+    }
+
+    init {
+        tags(Integration)
+        body()
+    }
+
+    override suspend fun beforeSpec(spec: Spec) {
+        mockkStatic(RoutingContext::hasRole)
+    }
+
+    override fun afterSpec(f: suspend (Spec) -> Unit) {
+        unmockkAll()
+    }
+
+    fun integrationTestApplication(block: suspend ApplicationTestBuilder.(client: HttpClient) -> Unit) {
+        testApplication {
+            application {
+                install(ContentNegotiation) {
+                    serialization(ContentType.Application.Json, Json)
+                }
+
+                install(Authentication) {
+                    register(FakeAuthenticationProvider(DummyConfig(principal)))
+                }
+            }
+
+            block(createJsonClient())
+        }
+    }
+}
+
+fun ApplicationTestBuilder.createJsonClient() = createClient {
+    install(ClientContentNegotiation) {
+        json(Json)
+    }
+}
+
+class DummyConfig(val principal: OrtPrincipal) : AuthenticationProvider.Config("test")
+
+class FakeAuthenticationProvider(val config: DummyConfig) : AuthenticationProvider(config) {
+    override suspend fun onAuthenticate(context: AuthenticationContext) {
+        context.principal(config.principal)
+    }
+}


### PR DESCRIPTION
Reduce code duplication in the integration tests of the plugin manager by extracting common code into an abstract class. The `AbstractIntegrationTest` is added as a test fixture to the ktor-utils so that it can be used in all components.