### PR TITLE
build(Gradle): Fix group names to refer to the module parent

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -28,7 +28,7 @@ plugins {
     alias(libs.plugins.kotlinSerialization)
 }
 
-group = "org.eclipse.apoapsis.ortserver.cli"
+group = "org.eclipse.apoapsis.ortserver"
 
 kotlin {
     jvm {

--- a/shared/ktor-utils/build.gradle.kts
+++ b/shared/ktor-utils/build.gradle.kts
@@ -22,7 +22,7 @@ plugins {
     id("ort-server-publication-conventions")
 }
 
-group = "org.eclipse.apoapsis.ortserver.shared.ktor-utils"
+group = "org.eclipse.apoapsis.ortserver.shared"
 
 dependencies {
     implementation(libs.ktorServerCore)

--- a/tasks/build.gradle.kts
+++ b/tasks/build.gradle.kts
@@ -31,7 +31,7 @@ plugins {
     alias(libs.plugins.jib)
 }
 
-group = "org.eclipse.apoapsis.ortserver.tasks"
+group = "org.eclipse.apoapsis.ortserver"
 
 tasks.withType<JibTask> {
     notCompatibleWithConfigurationCache("https://github.com/GoogleContainerTools/jib/issues/3132")


### PR DESCRIPTION
Group names that are used for Maven coordinates should refer to the parent directory of a module to avoid having groups that contain only a single module. This provides better overview when browsing artifacts.