### PR TITLE
feat(ui): Drop the border and background color from the footer

### DIFF
--- a/ui/src/components/footer.tsx
+++ b/ui/src/components/footer.tsx
@@ -53,7 +53,7 @@ export function Footer() {
   const columnsAlignedRight = extractColumns(markdown, 'right');
   return (
     enabled && (
-      <footer className='bg-muted text-muted-foreground w-full border-t text-sm'>
+      <footer className='text-muted-foreground w-full text-sm'>
         <div className='mx-auto flex max-w-screen-xl flex-col items-center justify-between gap-4 p-4 sm:flex-row md:gap-8 md:p-8'>
           <nav className='flex flex-col gap-4 sm:flex-row sm:items-start'>
             {columnsAlignedLeft.map((content, index) => (


### PR DESCRIPTION
This was a decision of today's alignment meeting.

![Screenshot from 2025-05-06 16-01-19](https://github.com/user-attachments/assets/046b252f-be02-4108-b0b1-de86b43a5ec4)

![Screenshot from 2025-05-06 16-01-26](https://github.com/user-attachments/assets/84250fa1-5590-485b-a6ac-5f82eda46e66)

Please see the commits for details.