### PR TITLE
feat(scanner): Add submodule fetch strategy for nested repositories

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
@@ -578,7 +578,8 @@ fun ScannerJobConfiguration.mapToApi() = ApiScannerJobConfiguration(
     skipExcluded,
     sourceCodeOrigins?.map { it.mapToApi() },
     config?.mapValues { it.value.mapToApi() },
-    keepAliveWorker
+    keepAliveWorker,
+    submoduleFetchStrategy.mapToApi()
 )
 
 fun ApiScannerJobConfiguration.mapToModel() = ScannerJobConfiguration(
@@ -590,7 +591,8 @@ fun ApiScannerJobConfiguration.mapToModel() = ScannerJobConfiguration(
     skipExcluded,
     sourceCodeOrigins?.map { it.mapToModel() },
     config?.mapValues { it.value.mapToModel() },
-    keepAliveWorker
+    keepAliveWorker,
+    submoduleFetchStrategy.mapToModel()
 )
 
 fun Secret.mapToApi() = ApiSecret(name, description)

--- a/api/v1/model/src/commonMain/kotlin/JobConfigurations.kt
+++ b/api/v1/model/src/commonMain/kotlin/JobConfigurations.kt
@@ -187,7 +187,14 @@ data class ScannerJobConfiguration(
      * Keep the worker alive after it has finished. This is useful for manual problem analysis directly
      * within the pod's execution environment.
      */
-    val keepAliveWorker: Boolean = false
+    val keepAliveWorker: Boolean = false,
+
+    /**
+     * Specifies how submodules are fetched when resolving provenances. Currently supported only for Git repositories.
+     * If set to [SubmoduleFetchStrategy.FULLY_RECURSIVE] (default), all submodules are fetched recursively. If set
+     * to [SubmoduleFetchStrategy.TOP_LEVEL_ONLY], only the top-level submodules are fetched.
+     */
+    val submoduleFetchStrategy: SubmoduleFetchStrategy = SubmoduleFetchStrategy.FULLY_RECURSIVE
 )
 
 /**

--- a/dao/src/main/kotlin/tables/NestedProvenancesTable.kt
+++ b/dao/src/main/kotlin/tables/NestedProvenancesTable.kt
@@ -35,6 +35,11 @@ object NestedProvenancesTable : LongIdTable("nested_provenances") {
 
     val rootResolvedRevision = text("root_resolved_revision")
     val hasOnlyFixedRevisions = bool("has_only_fixed_revisions")
+
+    // If specific VCS plugin configurations are used, store a canonical string representation of these configuration
+    // options in this column. This ensures that results are only reused for scans with identical VCS plugin
+    // configurations.
+    val vcsPluginConfigs = text("vcs_plugin_configs").nullable()
 }
 
 class NestedProvenanceDao(id: EntityID<Long>) : LongEntity(id) {
@@ -44,6 +49,7 @@ class NestedProvenanceDao(id: EntityID<Long>) : LongEntity(id) {
 
     var rootResolvedRevision by NestedProvenancesTable.rootResolvedRevision
     var hasOnlyFixedRevisions by NestedProvenancesTable.hasOnlyFixedRevisions
+    var vcsPluginConfigs by NestedProvenancesTable.vcsPluginConfigs
 
     val packageProvenances by PackageProvenanceDao optionalReferrersOn PackageProvenancesTable.nestedProvenanceId
     val subRepositories by NestedProvenanceSubRepositoryDao referrersOn

--- a/dao/src/main/resources/db/migration/V105__addNestedProvenancesConfiguration.sql
+++ b/dao/src/main/resources/db/migration/V105__addNestedProvenancesConfiguration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE nested_provenances
+    ADD COLUMN vcs_plugin_configs text DEFAULT NULL;

--- a/model/src/commonMain/kotlin/JobConfigurations.kt
+++ b/model/src/commonMain/kotlin/JobConfigurations.kt
@@ -196,7 +196,14 @@ data class ScannerJobConfiguration(
      * Keep the worker alive after it has finished. This is useful for manual problem analysis directly
      * within the pod's execution environment.
      */
-    val keepAliveWorker: Boolean = false
+    val keepAliveWorker: Boolean = false,
+
+    /**
+     * Specifies how submodules are fetched when resolving provenances. Currently supported only for Git repositories.
+     * If set to [SubmoduleFetchStrategy.FULLY_RECURSIVE] (default), all submodules are fetched recursively. If set
+     * to [SubmoduleFetchStrategy.TOP_LEVEL_ONLY], only the top-level submodules are fetched.
+     */
+    val submoduleFetchStrategy: SubmoduleFetchStrategy = SubmoduleFetchStrategy.FULLY_RECURSIVE
 )
 
 /**

--- a/workers/scanner/src/test/kotlin/OrtServerNestedProvenanceStorageTest.kt
+++ b/workers/scanner/src/test/kotlin/OrtServerNestedProvenanceStorageTest.kt
@@ -64,7 +64,11 @@ class OrtServerNestedProvenanceStorageTest : WordSpec() {
             packageProvenanceCache = PackageProvenanceCache()
             packageProvenanceStorage =
                 OrtServerPackageProvenanceStorage(dbExtension.db, scannerRun.id, packageProvenanceCache)
-            nestedProvenanceStorage = OrtServerNestedProvenanceStorage(dbExtension.db, packageProvenanceCache)
+            nestedProvenanceStorage = OrtServerNestedProvenanceStorage(
+                dbExtension.db,
+                packageProvenanceCache,
+                ""
+            )
 
             packageProvenanceStorage.writeProvenance(id, vcsInfo, packageProvenance)
         }
@@ -209,7 +213,11 @@ class OrtServerNestedProvenanceStorageTest : WordSpec() {
                 packageProvenanceCache = PackageProvenanceCache()
                 packageProvenanceStorage =
                     OrtServerPackageProvenanceStorage(dbExtension.db, scannerRun.id, packageProvenanceCache)
-                nestedProvenanceStorage = OrtServerNestedProvenanceStorage(dbExtension.db, packageProvenanceCache)
+                nestedProvenanceStorage = OrtServerNestedProvenanceStorage(
+                    dbExtension.db,
+                    packageProvenanceCache,
+                    ""
+                )
 
                 val subInfo1 = vcsInfo.copy(path = "sub1")
                 val subProvenance1 = RepositoryProvenance(subInfo1, subInfo1.revision)

--- a/workers/scanner/src/test/kotlin/ScannerRunnerTest.kt
+++ b/workers/scanner/src/test/kotlin/ScannerRunnerTest.kt
@@ -44,6 +44,7 @@ import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.RepositoryProvenance
 import org.ossreviewtoolkit.model.config.ScannerConfiguration
+import org.ossreviewtoolkit.plugins.api.PluginConfig as OrtPluginConfig
 import org.ossreviewtoolkit.scanner.LocalPathScannerWrapper
 import org.ossreviewtoolkit.scanner.Scanner
 import org.ossreviewtoolkit.scanner.ScannerWrapperFactory
@@ -182,6 +183,43 @@ class ScannerRunnerTest : WordSpec({
             val result = runner.run(mockContext(), OrtResult.EMPTY, ScannerJobConfiguration(), 0L)
 
             result.issues shouldBe issuesMap
+        }
+    }
+
+    "createCanonicalVcsPluginConfigs" should {
+        "return null if no VCS config plugins are used at all." {
+            val vcsPluginConfigs = emptyMap<String, OrtPluginConfig>()
+
+            val result = ScannerRunner.createCanonicalVcsPluginConfigs(vcsPluginConfigs)
+
+            result shouldBe null
+        }
+
+        "return a canonical string of VCS plugin configs." {
+            val vcsPluginConfigs = mapOf(
+                "VCS-Z" to OrtPluginConfig(
+                    options = mapOf(
+                        "option-z" to "1",
+                        "option-a" to "2"
+                    ),
+                    secrets = mapOf(
+                        "some-secret" to "my-secret"
+                    )
+                ),
+                "VCS-A" to OrtPluginConfig(
+                    options = mapOf(
+                        "option-x" to "3",
+                        "option-b" to "4"
+                    ),
+                    secrets = mapOf(
+                        "some-secret" to "my-secret"
+                    )
+                )
+            )
+
+            val result = ScannerRunner.createCanonicalVcsPluginConfigs(vcsPluginConfigs)
+
+            result shouldBe "VCS-A/option-b/4&VCS-A/option-x/3&VCS-Z/option-a/2&VCS-Z/option-z/1"
         }
     }
 })


### PR DESCRIPTION
Introduce `submoduleFetchStrategy` config to control how the Scanner fetches Git submodules. When set to `TOP_LEVEL_ONLY`, only top-level submodules are fetched, avoiding timeouts on deeply nested repos.

This mirrors the behavior already available in the Analyzer and allows to resolve nested provenances even in this kind of repositories with a vast amount of nested submodules.

If activated, in the logs you will no longer see the `--recursive` flag in the `gib submodule update` command then:
````
Running 'git submodule update --init --depth 50' in '/tmp/ort-DefaultWorkingTreeCache13286267791034354700'..."
````

If particular VCS plugin configurations are active during a scan (like `submoduleFetchStrategy=TOP_LEVEL_ONLY`),
ensure that VCS plugin configurations are stored alongside nested provenance data. This prevents reuse of cache entries across scans with differing VCS plugin settings, ensuring correctness and reliability of scan results.

For storing the VCS plugin configuration, a canonical string like `Git/updateNestedSubmodules/false` is created and stored alogside with the nested provenance data.