### PR TITLE
chore(ui): Tweak profile menu items a bit

### DIFF
--- a/ui/src/components/header.tsx
+++ b/ui/src/components/header.tsx
@@ -270,17 +270,20 @@ export const Header = () => {
                 <span>{user.username}</span>
               </div>
             </DropdownMenuItem>
+            {user.hasRole(['superuser']) && (
+              <>
+                <DropdownMenuSeparator />
+                <Link to='/admin'>
+                  <DropdownMenuItem>Administration</DropdownMenuItem>
+                </Link>
+              </>
+            )}
             <DropdownMenuSeparator />
+            <Link to='/settings'>
+              <DropdownMenuItem>User Settings</DropdownMenuItem>
+            </Link>
             <Link to='/about'>
               <DropdownMenuItem>About</DropdownMenuItem>
-            </Link>
-            {user.hasRole(['superuser']) && (
-              <Link to='/admin'>
-                <DropdownMenuItem>Admin</DropdownMenuItem>
-              </Link>
-            )}
-            <Link to='/settings'>
-              <DropdownMenuItem>Settings</DropdownMenuItem>
             </Link>
             <DropdownMenuSeparator />
             <DropdownMenuItem


### PR DESCRIPTION
Make the conditionally shown administration item go frist and rename it to make clear it is not about an "admin" user but server "administration".

Similarly, make clear that "settings" are about the user, not the server.