### PR TITLE
feat(services): Add a handler for orphaned snippets

### DIFF
--- a/services/hierarchy/src/main/kotlin/OrphanRemovalService.kt
+++ b/services/hierarchy/src/main/kotlin/OrphanRemovalService.kt
@@ -37,6 +37,7 @@ import org.eclipse.apoapsis.ortserver.dao.tables.NestedProvenanceSubRepositories
 import org.eclipse.apoapsis.ortserver.dao.tables.NestedProvenancesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.NestedRepositoriesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.PackageProvenancesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.SnippetFindingsSnippetsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.SnippetsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.DeclaredLicensesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.RemoteArtifactsTable
@@ -55,6 +56,7 @@ import org.jetbrains.exposed.sql.SqlExpressionBuilder.inSubQuery
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.alias
 import org.jetbrains.exposed.sql.deleteWhere
+import org.jetbrains.exposed.sql.intLiteral
 import org.jetbrains.exposed.sql.notExists
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.union
@@ -261,6 +263,14 @@ private enum class OrphanEntityHandler(
                 )
 
             unionCondition(subQuery, table.id)
+        }
+    },
+
+    SNIPPETS(SnippetsTable, "snippets") {
+        override fun filterOrphanedEntities(): SqlExpressionBuilder.() -> AbstractQuery<*> = {
+            SnippetFindingsSnippetsTable
+                .select(intLiteral(1))
+                .where(SnippetFindingsSnippetsTable.snippetId eq table.id)
         }
     };
 

--- a/tasks/src/main/resources/application.conf
+++ b/tasks/src/main/resources/application.conf
@@ -56,6 +56,10 @@ orphanHandlers {
   remoteArtifacts.limit = ${?ORPHANED_REMOTE_ARTIFACTS_LIMIT}
   remoteArtifacts.chunkSize = 64
   remoteArtifacts.chunkSize = ${?ORPHANED_REMOTE_ARTIFACTS_CHUNK_SIZE}
+  snippets.limit = 1048576
+  snippets.limit = ${?ORPHANED_SNIPPETS_LIMIT}
+  snippets.chunkSize = 1024
+  snippets.chunkSize = ${?ORPHANED_SNIPPETS_CHUNK_SIZE}
 }
 
 jobMonitor {


### PR DESCRIPTION
Introduce a periodic cleanup mechanism to remove Snippets that are no longer associated with any SnippetFindings. This helps prevent unnecessary data accumulation and keeps the database clean. Being able to define a `limit` and a `chunkSize` allows to make sure that there is only little risk that the memory blows up when orphan snippets are looked up and that database limits are reached in the delete statement concerning the maximal allowed length of a SQL statement and the maximum number of operations allowed in a single database transaction.

Looking at the tests, Exposed creates the following SQL statements to find Snippet orphans (tests have a limit setting of 10):

````
SELECT snippets.id FROM snippets WHERE NOT EXISTS (
   SELECT 1 FROM snippet_findings_snippets WHERE snippet_findings_snippets.snippet_id = snippets.id
) LIMIT 10"

````

and for deletion (in a chunked way):

````

DELETE FROM snippets WHERE snippets.id IN (101, 102, 103, 104, 105)
````