### PR TITLE
feat(logs): Extend logging on generated files

### DIFF
--- a/workers/common/src/main/kotlin/common/env/ConfigFileBuilder.kt
+++ b/workers/common/src/main/kotlin/common/env/ConfigFileBuilder.kt
@@ -179,9 +179,7 @@ class ConfigFileBuilder(
      * given [block].
      */
     suspend fun buildInUserHome(name: String, block: suspend PrintWriter.() -> Unit) {
-        val file = File(System.getProperty("user.home"), name)
-
-        build(file, block)
+        build(File(System.getProperty("user.home"), name), block)
     }
 
     /**

--- a/workers/common/src/main/kotlin/common/env/GeneratorLogger.kt
+++ b/workers/common/src/main/kotlin/common/env/GeneratorLogger.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.common.env
+
+import org.eclipse.apoapsis.ortserver.model.InfrastructureService
+
+import org.slf4j.LoggerFactory
+
+/**
+ * Logger helper class for the environment configuration generators.
+ * It helps log messages related to the generation of environment configuration files.
+ */
+internal object GeneratorLogger {
+
+    private val logger = LoggerFactory.getLogger(GeneratorLogger::class.java)
+
+    internal fun entryAdded(entry: String, targetFile: String, service: InfrastructureService) {
+        logger.debug(
+            "Added entry '{}' to '{}' file for '{}', '{}', '{}'.",
+            entry,
+            targetFile,
+            service.name,
+            service.organization?.name.orEmpty(),
+            service.product?.name.orEmpty()
+        )
+    }
+
+    internal fun entryAdded(entry: String, targetFile: String) {
+        logger.debug("Added entry '{}' to '{}' file.", entry, targetFile)
+    }
+
+    internal fun proxySettingAdded(entry: String, targetFile: String) {
+        logger.debug("Added proxy setting '{}' to {} file.", entry, targetFile)
+    }
+
+    internal fun error(errorMsg: String, targetFile: String, exception: Throwable) {
+        logger.error("Error occurred while generating '{}': \n{}\n", targetFile, errorMsg, exception)
+    }
+}

--- a/workers/common/src/main/kotlin/common/env/GitConfigGenerator.kt
+++ b/workers/common/src/main/kotlin/common/env/GitConfigGenerator.kt
@@ -98,21 +98,21 @@ class GitConfigGenerator(private val gitConfigUrlInsteadOfPairs: Map<String, Str
                     if (hasCredentials) {
                         println("[credential]")
                         println("\thelper = store")
+                        GeneratorLogger.entryAdded("[credential]\n\thelper = store", GIT_CONFIG_FILE_NAME)
                     }
 
                     // Create `url.<base>.insteadOf` sections.
                     gitConfigUrlInsteadOfPairs.forEach {
                         println("[url \"${it.key}\"]")
                         println("\tinsteadOf = \"${it.value}\"")
+                        GeneratorLogger.entryAdded(
+                            "[url \"${it.key}\"]\n\tinsteadOf = \"${it.value}\"",
+                            GIT_CONFIG_FILE_NAME
+                        )
                     }
                 }
-                logger.debug(
-                    "Generated .gitconfig file hasCredentials={} insteadOf={}",
-                    hasCredentials,
-                    gitConfigUrlInsteadOfPairs
-                )
             } else {
-                logger.debug("Not generating .gitconfig file.")
+                logger.debug("Not generating {} file.", GIT_CONFIG_FILE_NAME)
             }
         }
     }

--- a/workers/common/src/main/kotlin/common/env/MavenSettingsGenerator.kt
+++ b/workers/common/src/main/kotlin/common/env/MavenSettingsGenerator.kt
@@ -76,6 +76,12 @@ class MavenSettingsGenerator : EnvironmentConfigGenerator<MavenDefinition> {
                 printTag("username", builder.secretRef(definition.service.usernameSecret))
                 printTag("password", builder.secretRef(definition.service.passwordSecret))
                 println("</server>".prependIndent(INDENT_8_SPACES))
+
+                GeneratorLogger.entryAdded(
+                    "server '${definition.id}': username/password",
+                    TARGET_NAME,
+                    definition.service
+                )
             }
 
             println("</servers>".prependIndent(INDENT_4_SPACES))
@@ -87,9 +93,18 @@ class MavenSettingsGenerator : EnvironmentConfigGenerator<MavenDefinition> {
                 println("<proxies>".prependIndent(INDENT_4_SPACES))
                 proxyConfig.httpProxy?.let {
                     printSingleProxy(it.host, it.port, "http", proxyConfig.nonProxyHosts)
+                    GeneratorLogger.proxySettingAdded(
+                        "http ${it.host}:${it.port} noproxy: ${proxyConfig.nonProxyHosts}",
+                        TARGET_NAME
+                    )
                 }
+
                 proxyConfig.httpsProxy?.let {
                     printSingleProxy(it.host, it.port, "https", proxyConfig.nonProxyHosts)
+                    GeneratorLogger.proxySettingAdded(
+                        "https ${it.host}:${it.port} noproxy: ${proxyConfig.nonProxyHosts}",
+                        TARGET_NAME
+                    )
                 }
                 println("</proxies>".prependIndent(INDENT_4_SPACES))
             }

--- a/workers/common/src/main/kotlin/common/env/NetRcGenerator.kt
+++ b/workers/common/src/main/kotlin/common/env/NetRcGenerator.kt
@@ -25,8 +25,6 @@ import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 import org.eclipse.apoapsis.ortserver.workers.common.env.definition.EnvironmentServiceDefinition
 
-import org.slf4j.LoggerFactory
-
 /**
  * A specialized generator class to generate the content of the .netrc file.
  *
@@ -47,8 +45,6 @@ class NetRcGenerator : EnvironmentConfigGenerator<EnvironmentServiceDefinition> 
         /** The name of the file to be generated. */
         private const val TARGET_NAME = ".netrc"
 
-        private val logger = LoggerFactory.getLogger(NetRcGenerator::class.java)
-
         /**
          * Obtain the host name of this [InfrastructureService] from its URL or *null* if the URL is not valid.
          */
@@ -56,7 +52,7 @@ class NetRcGenerator : EnvironmentConfigGenerator<EnvironmentServiceDefinition> 
             runCatching {
                 URI.create(url).host
             }.onFailure {
-                logger.error("Could not extract host for service '{}'. Ignoring it.", this, it)
+                GeneratorLogger.error("Could not extract host for service '$this'. Ignoring it.", TARGET_NAME, it)
             }.getOrNull()
     }
 
@@ -79,6 +75,8 @@ class NetRcGenerator : EnvironmentConfigGenerator<EnvironmentServiceDefinition> 
                 val password = builder.secretRef(service.passwordSecret)
 
                 println("machine $host login $username password $password")
+
+                GeneratorLogger.entryAdded("'$host:username/password'", TARGET_NAME, service)
             }
         }
     }

--- a/workers/common/src/main/kotlin/common/env/NuGetGenerator.kt
+++ b/workers/common/src/main/kotlin/common/env/NuGetGenerator.kt
@@ -48,6 +48,13 @@ class NuGetGenerator : EnvironmentConfigGenerator<NuGetDefinition> {
                     print("protocolVersion=\"${definition.sourceProtocolVersion}\" ")
                 }
                 println("/>")
+
+                GeneratorLogger.entryAdded(
+                    "package source ${definition.sourceName}:${definition.sourcePath} " +
+                        "protocol version: ${definition.sourceProtocolVersion.orEmpty()}",
+                    TARGET,
+                    definition.service
+                )
             }
             println("</packageSources>".prependIndent(INDENT_2_SPACES))
             println()
@@ -58,6 +65,12 @@ class NuGetGenerator : EnvironmentConfigGenerator<NuGetDefinition> {
                 println(generateUsernameBlock(builder, definition))
                 println(generatePasswordBlock(builder, definition))
                 println("</${definition.sourceName}>".prependIndent(INDENT_4_SPACES))
+
+                GeneratorLogger.entryAdded(
+                    "package credentials ${definition.sourceName}:username/password",
+                    TARGET,
+                    definition.service
+                )
             }
             println("</packageSourceCredentials>".prependIndent(INDENT_2_SPACES))
             println()
@@ -65,6 +78,12 @@ class NuGetGenerator : EnvironmentConfigGenerator<NuGetDefinition> {
             println("<apikeys>".prependIndent(INDENT_2_SPACES))
             definitions.filter { it.authMode == NuGetAuthMode.API_KEY }.forEach { definition ->
                 println(generateApiKeyBlock(definition, builder))
+
+                GeneratorLogger.entryAdded(
+                    "auth api key ${definition.sourcePath}:apiKey",
+                    TARGET,
+                    definition.service
+                )
             }
             println("</apikeys>".prependIndent(INDENT_2_SPACES))
 

--- a/workers/common/src/main/kotlin/common/env/YarnRcGenerator.kt
+++ b/workers/common/src/main/kotlin/common/env/YarnRcGenerator.kt
@@ -39,7 +39,10 @@ class YarnRcGenerator : EnvironmentConfigGenerator<YarnDefinition> {
          * Print a line for the given [key] and [value] if the value is not null.
          */
         private fun PrintWriter.printOptionalSetting(key: String, value: String?) {
-            value?.let { println("$key: \"$value\"") }
+            value?.let {
+                println("$key: \"${value}\"")
+                GeneratorLogger.entryAdded("$key: \"$value\"", TARGET)
+            }
         }
     }
 
@@ -60,21 +63,33 @@ class YarnRcGenerator : EnvironmentConfigGenerator<YarnDefinition> {
                     println()
                 }
 
-                println("\"${definition.service.url}\":".prependIndent(INDENT_2_SPACES))
+                val logEntry = StringBuilder()
 
-                if (definition.alwaysAuth) { println("npmAlwaysAuth: true".prependIndent(INDENT_4_SPACES)) }
+                println("\"${definition.service.url}\":".prependIndent(INDENT_2_SPACES))
+                logEntry.append("url: \"${definition.service.url}\":")
+
+                if (definition.alwaysAuth) {
+                    println("npmAlwaysAuth: true".prependIndent(INDENT_4_SPACES))
+                    logEntry.append("npmAlwaysAuth: true")
+                }
 
                 when (definition.authMode) {
-                    YarnAuthMode.AUTH_IDENT ->
+                    YarnAuthMode.AUTH_IDENT -> {
                         println(
                             generateUsernamePasswordAuthentication(builder, definition)
                         )
+                        logEntry.append("npmAuthIdent: [username:password]")
+                    }
 
-                    YarnAuthMode.AUTH_TOKEN ->
+                    YarnAuthMode.AUTH_TOKEN -> {
                         println(
                             generateTokenAuthentication(builder, definition)
                         )
+                        logEntry.append("npmAuthToken:[token]")
+                    }
                 }
+
+                GeneratorLogger.entryAdded(logEntry.toString(), TARGET, definition.service)
             }
         }
     }


### PR DESCRIPTION
This commit extends logging on generated configuration files:
- .gitconfig
- .git-credentials
- .netrc
- .npmrc
- .yarnrc.yml
- NuGet.Config
- settings.xml (Maven) 

It helps on debug / troubleshooting when it's uncertain if file was generated, and what settings it contains.