### PR TITLE
fix(core): Return `ErrorResponse` when disabled plugins are used

### DIFF
--- a/core/src/main/kotlin/api/ProductsRoute.kt
+++ b/core/src/main/kotlin/api/ProductsRoute.kt
@@ -414,8 +414,11 @@ fun Route.products() = route("products/{productId}") {
             if (disabledPlugins.isNotEmpty()) {
                 call.respond(
                     HttpStatusCode.BadRequest,
-                    "The following plugins are disabled in this ORT Server instance: " +
-                            disabledPlugins.joinToString { (type, id) -> "$id ($type)" }
+                    ErrorResponse(
+                        message = "Disabled plugins are used.",
+                        cause = "The following plugins are disabled in this ORT Server instance: " +
+                                disabledPlugins.joinToString { (type, id) -> "$id ($type)" }
+                    )
                 )
                 return@post
             }

--- a/core/src/main/kotlin/api/RepositoriesRoute.kt
+++ b/core/src/main/kotlin/api/RepositoriesRoute.kt
@@ -155,8 +155,11 @@ fun Route.repositories() = route("repositories/{repositoryId}") {
                 if (disabledPlugins.isNotEmpty()) {
                     call.respond(
                         HttpStatusCode.BadRequest,
-                        "The following plugins are disabled in this ORT Server instance: " +
-                                disabledPlugins.joinToString { (type, id) -> "$id ($type)" }
+                        ErrorResponse(
+                            message = "Disabled plugins are used.",
+                            cause = "The following plugins are disabled in this ORT Server instance: " +
+                                    disabledPlugins.joinToString { (type, id) -> "$id ($type)" }
+                        )
                     )
                     return@post
                 }


### PR DESCRIPTION
This aligns the error response with other endpoints.