### PR TITLE
feat(core): Improve error message for unavailable plugins

### DIFF
--- a/core/src/main/kotlin/api/ProductsRoute.kt
+++ b/core/src/main/kotlin/api/ProductsRoute.kt
@@ -71,7 +71,7 @@ import org.eclipse.apoapsis.ortserver.core.apiDocs.postRepository
 import org.eclipse.apoapsis.ortserver.core.apiDocs.postSecretForProduct
 import org.eclipse.apoapsis.ortserver.core.apiDocs.putUserToProductGroup
 import org.eclipse.apoapsis.ortserver.core.services.OrchestratorService
-import org.eclipse.apoapsis.ortserver.core.utils.getDisabledPlugins
+import org.eclipse.apoapsis.ortserver.core.utils.getUnavailablePlugins
 import org.eclipse.apoapsis.ortserver.core.utils.pagingOptions
 import org.eclipse.apoapsis.ortserver.model.Repository
 import org.eclipse.apoapsis.ortserver.model.Secret
@@ -410,15 +410,14 @@ fun Route.products() = route("products/{productId}") {
                 UserDisplayName(principal.getUserId(), principal.getUsername(), principal.getFullName())
             }
 
-            // Check if disabled plugins are used.
-            val disabledPlugins = createOrtRun.getDisabledPlugins(pluginService)
-            if (disabledPlugins.isNotEmpty()) {
+            // Check if unavailable plugins are used.
+            val unavailablePlugins = createOrtRun.getUnavailablePlugins(pluginService)
+            if (unavailablePlugins.isNotEmpty()) {
                 call.respond(
                     HttpStatusCode.BadRequest,
                     ErrorResponse(
-                        message = "Disabled plugins are used.",
-                        cause = "The following plugins are disabled in this ORT Server instance: " +
-                                disabledPlugins.joinToString { (type, id) -> "$id ($type)" }
+                        message = "Unavailable plugins are used.",
+                        cause = unavailablePlugins.errorMessage()
                     )
                 )
                 return@post

--- a/core/src/main/kotlin/api/RepositoriesRoute.kt
+++ b/core/src/main/kotlin/api/RepositoriesRoute.kt
@@ -68,7 +68,7 @@ import org.eclipse.apoapsis.ortserver.core.apiDocs.postOrtRun
 import org.eclipse.apoapsis.ortserver.core.apiDocs.postSecretForRepository
 import org.eclipse.apoapsis.ortserver.core.apiDocs.putUserToRepositoryGroup
 import org.eclipse.apoapsis.ortserver.core.services.OrchestratorService
-import org.eclipse.apoapsis.ortserver.core.utils.getDisabledPlugins
+import org.eclipse.apoapsis.ortserver.core.utils.getUnavailablePlugins
 import org.eclipse.apoapsis.ortserver.core.utils.pagingOptions
 import org.eclipse.apoapsis.ortserver.model.Secret
 import org.eclipse.apoapsis.ortserver.model.UserDisplayName
@@ -151,15 +151,14 @@ fun Route.repositories() = route("repositories/{repositoryId}") {
                     UserDisplayName(principal.getUserId(), principal.getUsername(), principal.getFullName())
                 }
 
-                // Check if disabled plugins are used.
-                val disabledPlugins = createOrtRun.getDisabledPlugins(pluginService)
-                if (disabledPlugins.isNotEmpty()) {
+                // Check if unavailable plugins are used.
+                val unavailablePlugins = createOrtRun.getUnavailablePlugins(pluginService)
+                if (unavailablePlugins.isNotEmpty()) {
                     call.respond(
                         HttpStatusCode.BadRequest,
                         ErrorResponse(
-                            message = "Disabled plugins are used.",
-                            cause = "The following plugins are disabled in this ORT Server instance: " +
-                                    disabledPlugins.joinToString { (type, id) -> "$id ($type)" }
+                            message = "Unavailable plugins are used.",
+                            cause = unavailablePlugins.errorMessage()
                         )
                     )
                     return@post


### PR DESCRIPTION
Differentiate between plugins which are not installed and plugins which are disabled when checking if the plugins used in an ORT run are available. Previously, also not installed plugins were reported as disabled.