### PR TITLE
fix(git-config): Do not swallow exceptions

### DIFF
--- a/config/git/src/main/kotlin/GitConfigFileProvider.kt
+++ b/config/git/src/main/kotlin/GitConfigFileProvider.kt
@@ -144,7 +144,7 @@ class GitConfigFileProvider internal constructor(
 
             // Update the working tree to the requested revision.
             withAuthenticator(username, token) {
-                measureTime { git.updateWorkingTree(workingTree, revision, recursive = true) }.also {
+                measureTime { git.updateWorkingTree(workingTree, revision, recursive = true).getOrThrow() }.also {
                     logger.debug("Updated Git working tree to revision '$revision' in $it.")
                 }
             }

--- a/config/git/src/test/kotlin/GitConfigFileProviderTest.kt
+++ b/config/git/src/test/kotlin/GitConfigFileProviderTest.kt
@@ -25,6 +25,8 @@ import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 
+import java.io.IOException
+
 import org.eclipse.apoapsis.ortserver.config.ConfigException
 import org.eclipse.apoapsis.ortserver.config.Context
 import org.eclipse.apoapsis.ortserver.config.Path
@@ -60,6 +62,14 @@ class GitConfigFileProviderTest : WordSpec({
             val context = provider.resolveContext(Context(GIT_BRANCH_DEV))
 
             context.name shouldBe GIT_REVISION_DEV
+        }
+
+        "throw an exception for a non-resolvable context" {
+            val provider = GitConfigFileProvider(GIT_URL, tempdir())
+
+            shouldThrow<IOException> {
+                provider.resolveContext(Context("non-existent-branch"))
+            }
         }
     }
 


### PR DESCRIPTION
When updating the working tree, `GitConfigFileProvider` silently ignored exceptions that may be caused for instance by invalid credentials or a non-existing branch. This made it hard to diagnose such problems. So, throw corresponding exceptions to produce meaningful error logs.