### PR TITLE
refactor(worker): Make createContext public again

### DIFF
--- a/workers/common/src/main/kotlin/common/context/WorkerContextFactory.kt
+++ b/workers/common/src/main/kotlin/common/context/WorkerContextFactory.kt
@@ -58,7 +58,7 @@ class WorkerContextFactory(
      * Return a [WorkerContext] for the given [ID of an ORT run][ortRunId]. The context is lazily initialized; so the
      * instance creation is not an expensive operation. When functionality is used, data may be loaded dynamically.
      */
-    internal fun createContext(ortRunId: Long): WorkerContext {
+    fun createContext(ortRunId: Long): WorkerContext {
         val ortConfig = WorkerOrtConfig.create(configManager)
         ortConfig.setUpOrtEnvironment()
 


### PR DESCRIPTION
Change the visibility of `WorkerContextFactory.createContext` back to public again, because the ORT Server Config script test must be able to call it to validate the parameter script.