### PR TITLE
build: Allow the local maven repository for ORT dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/ort-server-base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-base-conventions.gradle.kts
@@ -20,6 +20,14 @@
 repositories {
     mavenCentral()
 
+    mavenLocal() {
+        name = "localOrt"
+
+        content {
+            includeGroupByRegex("org\\.ossreviewtoolkit(\\..*)?")
+        }
+    }
+
     exclusiveContent {
         forRepository {
             maven("https://jitpack.io")


### PR DESCRIPTION
ORT and the ORT Server are often developed in parallel. To allow using non-published versions, the local maven repository is added as a source for dependencies of the `org.ossreviewtoolkit` group.