### PR TITLE
refactor: Do not add storages to the Koin context

### DIFF
--- a/core/src/main/kotlin/di/Module.kt
+++ b/core/src/main/kotlin/di/Module.kt
@@ -143,7 +143,6 @@ fun ortServerModule(config: ApplicationConfig, db: Database?) = module {
     single<InfrastructureServiceRepository> { DaoInfrastructureServiceRepository(get()) }
 
     single { SecretStorage.createStorage(get()) }
-    single { Storage.create("reportStorage", get()) }
     single { ConfigManager.create(get()) }
     single { LogFileService.create(get()) }
 
@@ -164,7 +163,10 @@ fun ortServerModule(config: ApplicationConfig, db: Database?) = module {
     single { UserService(get()) }
     single { OrtRunService(get(), get(), get(), get()) }
     single { ContentManagementService(get()) }
-    singleOf(::ReportStorageService)
+    single {
+        val storage = Storage.create("reportStorage", get())
+        ReportStorageService(storage, get())
+    }
     singleOf(::InfrastructureServiceService)
 
     single { PluginEventStore(get()) }

--- a/tasks/src/main/kotlin/TaskRunner.kt
+++ b/tasks/src/main/kotlin/TaskRunner.kt
@@ -182,10 +182,11 @@ private fun tasksModule(): Module =
         single<OrtRunRepository> { DaoOrtRunRepository(get()) }
         single<ReporterJobRepository> { DaoReporterJobRepository(get()) }
 
-        single { Storage.create("reportStorage", get()) }
-
         singleOf(::OrtRunService)
-        singleOf(::ReportStorageService)
+        single {
+            val storage = Storage.create("reportStorage", get())
+            ReportStorageService(storage, get())
+        }
         singleOf(::OrphanRemovalService)
 
         single<Task>(named("delete-old-ort-runs")) { DeleteOldOrtRunsTask.create(get(), get()) }

--- a/workers/reporter/src/main/kotlin/reporter/ReporterComponent.kt
+++ b/workers/reporter/src/main/kotlin/reporter/ReporterComponent.kt
@@ -136,11 +136,14 @@ class ReporterComponent : EndpointComponent<ReporterRequest>(ReporterEndpoint) {
         )
 
     private fun reporterModule(): Module = module {
-        single { Storage.create(ReportStorage.STORAGE_TYPE, get()) }
-
         single {
             val storage = Storage.create(OrtServerFileArchiveStorage.STORAGE_TYPE, get())
             FileArchiver(LicenseFilePatterns.DEFAULT.allLicenseFilenames, OrtServerFileArchiveStorage(storage))
+        }
+
+        single {
+            val storage = Storage.create(ReportStorage.STORAGE_TYPE, get())
+            ReportStorage(storage)
         }
 
         single {
@@ -153,7 +156,6 @@ class ReporterComponent : EndpointComponent<ReporterRequest>(ReporterEndpoint) {
             }
         }
 
-        singleOf(::ReportStorage)
         singleOf(::ReporterRunner)
         singleOf(::ReporterWorker)
     }


### PR DESCRIPTION
Different `Storage`s could be use by different services, so do not add them to the Koin context to avoid that a service accidentally uses the wrong `Storage`. This also is more consistent because in modules that define multiple `Storage`s only one of them was added to the context.