### PR TITLE
ui: CVSS 4.0 radar charts

### DIFF
--- a/ui/src/components/charts/cvss23-radar-chart.tsx
+++ b/ui/src/components/charts/cvss23-radar-chart.tsx
@@ -151,7 +151,7 @@ export const Cvss23RadarChart = ({ cvssScore }: Cvss23RadarChartProps) => {
             <Radar
               dataKey='score'
               fill='hsl(var(--chart-1))'
-              fillOpacity={0}
+              fillOpacity={0.2}
               stroke='hsl(var(--chart-1))'
               strokeWidth={2}
               dot={(props) => {
@@ -159,7 +159,12 @@ export const Cvss23RadarChart = ({ cvssScore }: Cvss23RadarChartProps) => {
                 return payload.payload.dot ? (
                   <circle cx={payload.x} cy={payload.y} r='6' fill='orange' />
                 ) : (
-                  <g />
+                  <circle
+                    cx={payload.x}
+                    cy={payload.y}
+                    r='4'
+                    fill='hsl(var(--chart-1))'
+                  />
                 );
               }}
             />

--- a/ui/src/components/charts/cvss4-radar-chart.tsx
+++ b/ui/src/components/charts/cvss4-radar-chart.tsx
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import {
+  PolarAngleAxis,
+  PolarGrid,
+  PolarRadiusAxis,
+  Radar,
+  RadarChart,
+} from 'recharts';
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '@/components/ui/chart';
+import { Cvss4Result } from '@/helpers/vulnerability-statistics';
+
+type Cvss4RadarChartProps = {
+  cvssScore: Cvss4Result;
+};
+
+export const Cvss4RadarChart = ({ cvssScore }: Cvss4RadarChartProps) => {
+  const { base, overall, environmental, threat } = cvssScore.scores;
+  const version = `4.0`;
+  const nomenclature = cvssScore.nomenclature;
+  const url = 'https://www.first.org/cvss/v4-0/specification-document';
+
+  // In the absence of reported Temporal and Environmental metrics, default these unspecified metrics to values
+  // that do not alter the Base Score. This ensures that the overall severity assessment reflects the inherent
+  // qualities of the vulnerability without additional modifiers.
+  //
+  // The CVSS v3.1 specification indicates that when Temporal and Environmental metrics are not defined,
+  // they are treated in a way that the Base Score remains unaffected. Therefore, for the purpose of rendering
+  // the radar chart, use the Base Score for these metrics, and indicate true data points with a dot.
+  //
+  // See: https://www.first.org/cvss/v3-1/specification-document
+  const chartData = [
+    { component: 'Base', score: base, dot: true },
+    {
+      component: 'Modified Impact',
+      score: overall,
+      dot: false,
+    },
+    { component: 'Impact', score: overall, dot: false },
+    { component: 'Temporal', score: threat || base, dot: !!threat },
+    { component: 'Exploitability', score: overall, dot: false },
+    {
+      component: 'Environmental',
+      score: environmental || overall,
+      dot: !!environmental,
+    },
+  ];
+
+  const chartConfig = {
+    score: {
+      label: 'Score',
+      color: 'hsl(var(--chart-1))',
+    },
+  } satisfies ChartConfig;
+
+  return (
+    <Card>
+      <CardHeader className='items-center'>
+        <CardTitle>
+          {nomenclature} {version} Severity Radar (
+          <a
+            className='font-normal break-all text-blue-400 hover:underline'
+            href={url}
+            target='_blank'
+          >
+            details
+          </a>
+          )
+        </CardTitle>
+        <CardDescription>
+          Severity scores from CVSS assessing impact and exploitability of the
+          vulnerability.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer
+          config={chartConfig}
+          className='mx-auto aspect-square max-h-[250px] w-full'
+        >
+          <RadarChart
+            data={chartData}
+            margin={{
+              top: 10,
+              right: 10,
+              bottom: 10,
+              left: 10,
+            }}
+          >
+            <ChartTooltip
+              cursor={false}
+              content={<ChartTooltipContent indicator='line' />}
+            />
+            <PolarAngleAxis
+              dataKey='component'
+              tickFormatter={(value) => {
+                return value === 'Base'
+                  ? 'Base'
+                  : value === 'Temporal'
+                    ? 'Temp'
+                    : value.slice(0, 3);
+              }}
+            />
+            <PolarRadiusAxis
+              style={{ visibility: 'hidden' }}
+              angle={60}
+              tickCount={6}
+              domain={[0, 10]}
+            />
+            <PolarGrid radialLines={false} />
+            <Radar
+              dataKey='score'
+              fill='hsl(var(--chart-1))'
+              fillOpacity={0.2}
+              stroke='hsl(var(--chart-1))'
+              strokeWidth={2}
+              dot={(props) => {
+                const { payload } = props;
+                return payload.payload.dot ? (
+                  <circle cx={payload.x} cy={payload.y} r='6' fill='orange' />
+                ) : (
+                  <circle
+                    cx={payload.x}
+                    cy={payload.y}
+                    r='4'
+                    fill='hsl(var(--chart-1))'
+                  />
+                );
+              }}
+            />
+          </RadarChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  );
+};

--- a/ui/src/components/charts/vulnerability-metrics.tsx
+++ b/ui/src/components/charts/vulnerability-metrics.tsx
@@ -18,10 +18,12 @@
  */
 
 import { Vulnerability } from '@/api/requests';
+import { Cvss4RadarChart } from '@/components/charts/cvss4-radar-chart';
 import { Cvss4VectorCard } from '@/components/charts/cvss4-vector-card';
 import { Cvss23RadarChart } from '@/components/charts/cvss23-radar-chart';
 import { EpssChart } from '@/components/charts/epss-chart';
 import { Card, CardContent } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import {
   findHighestCvssScore,
   findHighestEpssScore,
@@ -42,7 +44,18 @@ export const VulnerabilityMetrics = ({
       <div className='col-span-2'>
         {highestCvssScore ? (
           highestCvssScore.version === 'CVSS:4.0' ? (
-            <Cvss4VectorCard macroVector={highestCvssScore.macroVector} />
+            <Tabs defaultValue='radar' className='w-full'>
+              <TabsList className='grid w-full grid-cols-2'>
+                <TabsTrigger value='radar'>Radar</TabsTrigger>
+                <TabsTrigger value='macrovector'>Macrovector</TabsTrigger>
+              </TabsList>
+              <TabsContent value='radar'>
+                <Cvss4RadarChart cvssScore={highestCvssScore} />
+              </TabsContent>
+              <TabsContent value='macrovector'>
+                <Cvss4VectorCard macroVector={highestCvssScore.macroVector} />
+              </TabsContent>
+            </Tabs>
           ) : (
             <Cvss23RadarChart cvssScore={highestCvssScore} />
           )

--- a/ui/src/helpers/vulnerability-statistics.ts
+++ b/ui/src/helpers/vulnerability-statistics.ts
@@ -26,7 +26,7 @@ import {
 } from 'ae-cvss-calculator';
 import {
   MultiScoreResult,
-  SingleScoreResult,
+  V4ScoreResult,
 } from 'ae-cvss-calculator/dist/types/src/CvssVector';
 
 import { Vulnerability } from '@/api/requests/types.gen';
@@ -51,9 +51,10 @@ export type Cvss2to3Result = CvssResultBase & {
   scores: MultiScoreResult;
 };
 
-type Cvss4Result = CvssResultBase & {
+export type Cvss4Result = CvssResultBase & {
   version: 'CVSS:4.0';
-  scores: SingleScoreResult;
+  nomenclature: string;
+  scores: V4ScoreResult;
   macroVector: Cvss4MacroVector;
 };
 
@@ -147,6 +148,7 @@ export function findHighestCvssScore(
       const cvss = new Cvss4P0(highestCvss.vector);
       return {
         version: 'CVSS:4.0',
+        nomenclature: cvss.getNomenclature(),
         scores: cvss.calculateScores(true),
         macroVector: {
           name: cvss.getMacroVector().toString(),


### PR DESCRIPTION
More scores are now available from the `metaeffect CVSS calculator` for CVSS 4.0 vectors, so take them into use.

1. Tweak the general look and feel of the radar charts by providing a slight opaque shadowing to the spanned area, and marking all data points (not only those with true data) with dots:

![Screenshot from 2025-05-19 12-44-50](https://github.com/user-attachments/assets/1fc50e4e-f73e-4e04-a3d6-3a6a0b3fad48)

(Note for @sschuberth: I tried numerous ways of showing the numerical tick labels for the radial axis, but sadly couldn't make it work without the numbers overlapping/crowding the view, so I left the feature to future investigation.)

2. Show the radar chart and macrovector corresponding to a CVSS 4.0 vulnerability vector in tabs:

![Screenshot from 2025-05-19 13-09-14](https://github.com/user-attachments/assets/1763a74d-d343-4ce1-ab92-edb4d2957c23)

![Screenshot from 2025-05-19 13-09-28](https://github.com/user-attachments/assets/3411fc27-e03b-43ac-95b6-4757a1dc46ee)

This is a hard-coded example which is also presented by the author of the `metaeffect CVSS calculator` [here](https://metaeffekt.com/security/cvss/calculator/?vector=%5B%5B%22CVSS%3A4.0%22%2Ctrue%2C%22CVSS%3A4.0%2FAV%3AN%2FAC%3AH%2FAT%3AN%2FPR%3AN%2FUI%3AP%2FVC%3AH%2FVI%3AL%2FVA%3AH%2FSC%3AN%2FSI%3AL%2FSA%3AH%2FE%3AU%2FMAV%3AA%2FMAC%3AX%2FMAT%3AN%2FMPR%3AL%2FMUI%3AX%2FMVC%3AX%2FMVI%3AX%2FMVA%3AX%2FMSC%3AX%2FMSI%3AX%2FMSA%3AX%2FS%3AX%2FAU%3AX%2FR%3AA%2FV%3AX%2FRE%3AM%2FU%3ARed%22%2C%22CVSS%3A4.0%22%2C%22CVSS%3A4.0%2FAV%3AN%2FAC%3AH%2FAT%3AN%2FPR%3AN%2FUI%3AP%2FVC%3AH%2FVI%3AL%2FVA%3AH%2FSC%3AN%2FSI%3AL%2FSA%3AH%22%5D%5D&open=environmental-base%2Cthreat&selected=CVSS%3A4.0).

Please see the commits for details.