### PR TITLE
chore: Ignore `.kotlin` directories not only in root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
-/.kotlin/
 .gradle/
+.kotlin/
 build/
 out/
 /*.iml


### PR DESCRIPTION
The directory can also temporarily exist in subdirectories.