### PR TITLE
feat(dao): Improve performance of loading analyzer runs

### DIFF
--- a/dao/src/main/kotlin/repositories/analyzerjob/AnalyzerJobsTable.kt
+++ b/dao/src/main/kotlin/repositories/analyzerjob/AnalyzerJobsTable.kt
@@ -48,6 +48,13 @@ object AnalyzerJobsTable : LongIdTable("analyzer_jobs") {
     val finishedAt = timestamp("finished_at").nullable()
     val configuration = jsonb<AnalyzerJobConfiguration>("configuration")
     val status = enumerationByName<JobStatus>("status", 128)
+
+    /** Get the ORT run ID for the given job [id]. Returns `null` if no job is found. */
+    fun getOrtRunIdById(id: Long): Long? =
+        select(ortRunId)
+            .where { AnalyzerJobsTable.id eq id }
+            .map { it[ortRunId].value }
+            .firstOrNull()
 }
 
 class AnalyzerJobDao(id: EntityID<Long>) : LongEntity(id) {

--- a/dao/src/main/kotlin/repositories/analyzerrun/AnalyzerConfigurationsPackageManagerConfigurationsTable.kt
+++ b/dao/src/main/kotlin/repositories/analyzerrun/AnalyzerConfigurationsPackageManagerConfigurationsTable.kt
@@ -19,7 +19,10 @@
 
 package org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun
 
+import org.eclipse.apoapsis.ortserver.model.runs.PackageManagerConfiguration
+
 import org.jetbrains.exposed.sql.Table
+import org.jetbrains.exposed.sql.selectAll
 
 /**
  * A junction table to store references from [AnalyzerConfigurationsTable] and [PackageManagerConfigurationsTable].
@@ -31,4 +34,44 @@ object AnalyzerConfigurationsPackageManagerConfigurationsTable :
 
     override val primaryKey: PrimaryKey
         get() = PrimaryKey(analyzerConfigurationId, packageManagerConfigurationId, name = "${tableName}_pkey")
+
+    /**
+     * Get the map of package manager IDs associated with their [PackageManagerConfiguration] for the given
+     * [analyzerConfigurationId]. Returns `null` if no configurations are found.
+     */
+    fun getPackageManagerConfigurationsByAnalyzerConfigurationId(
+        analyzerConfigurationId: Long
+    ): Map<String, PackageManagerConfiguration>? {
+        val resultRows = innerJoin(PackageManagerConfigurationsTable)
+            .leftJoin(PackageManagerConfigurationOptionsTable)
+            .selectAll()
+            .where {
+                AnalyzerConfigurationsPackageManagerConfigurationsTable.analyzerConfigurationId eq
+                        analyzerConfigurationId
+            }
+            .toList()
+
+        if (resultRows.isEmpty()) return null
+
+        return resultRows.groupBy { it[PackageManagerConfigurationsTable.name] }.mapValues { (_, rows) ->
+            @Suppress("UNCHECKED_CAST")
+            val options = if (rows[0][PackageManagerConfigurationsTable.hasOptions]) {
+                // The compiler wrongly assumes that the option keys cannot be null, but they can be if there are no
+                // entries in the joined tables, so they must be cast to nullable.
+                val nullableOptions = rows.associate {
+                    it[PackageManagerConfigurationOptionsTable.name] to
+                            it[PackageManagerConfigurationOptionsTable.value]
+                } as Map<String?, String>
+
+                nullableOptions.filterKeys { it != null } as Map<String, String>
+            } else {
+                null
+            }
+
+            PackageManagerConfiguration(
+                mustRunAfter = rows[0][PackageManagerConfigurationsTable.mustRunAfter]?.split(','),
+                options = options
+            )
+        }
+    }
 }

--- a/dao/src/main/kotlin/repositories/analyzerrun/AnalyzerConfigurationsTable.kt
+++ b/dao/src/main/kotlin/repositories/analyzerrun/AnalyzerConfigurationsTable.kt
@@ -25,6 +25,7 @@ import org.jetbrains.exposed.dao.LongEntity
 import org.jetbrains.exposed.dao.LongEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.LongIdTable
+import org.jetbrains.exposed.sql.selectAll
 
 /**
  * A table to represent an analyzer configuration.
@@ -36,6 +37,27 @@ object AnalyzerConfigurationsTable : LongIdTable("analyzer_configurations") {
     val enabledPackageManagers = text("enabled_package_managers").nullable()
     val disabledPackageManagers = text("disabled_package_managers").nullable()
     val skipExcluded = bool("skip_excluded")
+
+    /**
+     * Get the [AnalyzerConfiguration] for the given [analyzerRunId]. Returns `null` if no configuration is found.
+     */
+    fun getByAnalyzerRunId(analyzerRunId: Long): AnalyzerConfiguration? {
+        val resultRow = selectAll().where { AnalyzerConfigurationsTable.analyzerRunId eq analyzerRunId }.singleOrNull()
+
+        if (resultRow == null) return null
+
+        val packageManagers = AnalyzerConfigurationsPackageManagerConfigurationsTable
+            .getPackageManagerConfigurationsByAnalyzerConfigurationId(resultRow[id].value)
+
+        return AnalyzerConfiguration(
+            allowDynamicVersions = resultRow[allowDynamicVersions],
+            enabledPackageManagers =
+                resultRow[enabledPackageManagers]?.takeIf { it.isNotEmpty() }?.split(",").orEmpty(),
+            disabledPackageManagers = resultRow[disabledPackageManagers]?.takeIf { it.isNotEmpty() }?.split(","),
+            packageManagers = packageManagers,
+            skipExcluded = resultRow[skipExcluded]
+        )
+    }
 }
 
 class AnalyzerConfigurationDao(id: EntityID<Long>) : LongEntity(id) {

--- a/dao/src/main/kotlin/repositories/analyzerrun/AnalyzerRunsTable.kt
+++ b/dao/src/main/kotlin/repositories/analyzerrun/AnalyzerRunsTable.kt
@@ -23,6 +23,7 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerjob.AnalyzerJobDa
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerjob.AnalyzerJobsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.EnvironmentDao
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.EnvironmentsTable
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.OrtRunsIssuesTable
 import org.eclipse.apoapsis.ortserver.dao.utils.jsonb
 import org.eclipse.apoapsis.ortserver.dao.utils.transformToDatabasePrecision
 import org.eclipse.apoapsis.ortserver.model.runs.AnalyzerRun
@@ -32,7 +33,9 @@ import org.jetbrains.exposed.dao.LongEntity
 import org.jetbrains.exposed.dao.LongEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.LongIdTable
+import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
+import org.jetbrains.exposed.sql.selectAll
 
 /**
  * A table to represent an analyzer run.
@@ -44,6 +47,42 @@ object AnalyzerRunsTable : LongIdTable("analyzer_runs") {
     val startTime = timestamp("start_time")
     val endTime = timestamp("end_time")
     val dependencyGraphs = jsonb<DependencyGraphsWrapper>("dependency_graphs")
+
+    /** Get the [AnalyzerRun] for the given [id]. Returns `null` if no run is found. */
+    fun getById(id: Long): AnalyzerRun? =
+        selectAll().where { AnalyzerRunsTable.id eq id }.singleOrNull()?.let {
+            loadAnalyzerRun(it)
+        }
+
+    /** Get the [AnalyzerRun] for the given [analyzerJobId]. Returns `null` if no run is found. */
+    fun getByAnalyzerJobId(analyzerJobId: Long): AnalyzerRun? =
+        selectAll().where { AnalyzerRunsTable.analyzerJobId eq analyzerJobId }.singleOrNull()?.let {
+            loadAnalyzerRun(it)
+        }
+
+    private fun loadAnalyzerRun(resultRow: ResultRow): AnalyzerRun {
+        val analyzerRunId = resultRow[id].value
+        val analyzerJobId = resultRow[analyzerJobId].value
+        val environment = checkNotNull(EnvironmentsTable.getById(resultRow[environmentId].value))
+        val config = checkNotNull(AnalyzerConfigurationsTable.getByAnalyzerRunId(analyzerRunId))
+        val projects = ProjectsAnalyzerRunsTable.getProjectsByAnalyzerRunId(analyzerRunId)
+        val packages = PackagesAnalyzerRunsTable.getPackagesByAnalyzerRunId(analyzerRunId)
+        val ortRunId = checkNotNull(AnalyzerJobsTable.getOrtRunIdById(analyzerJobId))
+        val issues = OrtRunsIssuesTable.getIssuesByOrtRunId(ortRunId, AnalyzerRunDao.ISSUE_WORKER_TYPE)
+
+        return AnalyzerRun(
+            id = analyzerRunId,
+            analyzerJobId = analyzerJobId,
+            startTime = resultRow[startTime],
+            endTime = resultRow[endTime],
+            environment = environment,
+            config = config,
+            projects = projects,
+            packages = packages,
+            issues = issues,
+            dependencyGraphs = resultRow[dependencyGraphs].dependencyGraphs
+        )
+    }
 }
 
 class AnalyzerRunDao(id: EntityID<Long>) : LongEntity(id) {

--- a/dao/src/main/kotlin/repositories/analyzerrun/DaoAnalyzerRunRepository.kt
+++ b/dao/src/main/kotlin/repositories/analyzerrun/DaoAnalyzerRunRepository.kt
@@ -24,7 +24,6 @@ package org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun
 import kotlinx.datetime.Instant
 
 import org.eclipse.apoapsis.ortserver.dao.blockingQuery
-import org.eclipse.apoapsis.ortserver.dao.entityQuery
 import org.eclipse.apoapsis.ortserver.dao.mapAndDeduplicate
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerjob.AnalyzerJobDao
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.DeclaredLicenseDao
@@ -102,15 +101,14 @@ class DaoAnalyzerRunRepository(private val db: Database) : AnalyzerRunRepository
                 OrtRunIssueDao.createByIssue(jobDao.ortRun.id.value, analyzerIssue)
             }
 
-            analyzerRun.mapToModel()
+            checkNotNull(get(analyzerRun.id.value))
         }
     }
 
-    override fun get(id: Long): AnalyzerRun? = db.entityQuery { AnalyzerRunDao[id].mapToModel() }
+    override fun get(id: Long): AnalyzerRun? = db.blockingQuery { AnalyzerRunsTable.getById(id) }
 
-    override fun getByJobId(analyzerJobId: Long): AnalyzerRun? = db.blockingQuery {
-        AnalyzerRunDao.find { AnalyzerRunsTable.analyzerJobId eq analyzerJobId }.firstOrNull()?.mapToModel()
-    }
+    override fun getByJobId(analyzerJobId: Long): AnalyzerRun? =
+        db.blockingQuery { AnalyzerRunsTable.getByAnalyzerJobId(analyzerJobId) }
 }
 
 private fun createAnalyzerConfiguration(

--- a/dao/src/main/kotlin/repositories/analyzerrun/PackagesAnalyzerRunsTable.kt
+++ b/dao/src/main/kotlin/repositories/analyzerrun/PackagesAnalyzerRunsTable.kt
@@ -19,6 +19,8 @@
 
 package org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun
 
+import org.eclipse.apoapsis.ortserver.model.runs.Package
+
 import org.jetbrains.exposed.sql.Table
 
 /**
@@ -30,4 +32,13 @@ object PackagesAnalyzerRunsTable : Table("packages_analyzer_runs") {
 
     override val primaryKey: PrimaryKey
         get() = PrimaryKey(packageId, analyzerRunId, name = "${tableName}_pkey")
+
+    /** Get the [Package]s for the given [analyzerRunId]. */
+    fun getPackagesByAnalyzerRunId(analyzerRunId: Long): Set<Package> {
+        val packageIds = select(packageId)
+            .where { PackagesAnalyzerRunsTable.analyzerRunId eq analyzerRunId }
+            .mapTo(mutableSetOf()) { it[packageId].value }
+
+        return PackagesTable.getByIds(packageIds)
+    }
 }

--- a/dao/src/main/kotlin/repositories/analyzerrun/PackagesAuthorsTable.kt
+++ b/dao/src/main/kotlin/repositories/analyzerrun/PackagesAuthorsTable.kt
@@ -30,4 +30,13 @@ object PackagesAuthorsTable : Table("packages_authors") {
 
     override val primaryKey: PrimaryKey
         get() = PrimaryKey(authorId, packageId, name = "${tableName}_pkey")
+
+    /** Get the authors for the provided [packageIds]. */
+    fun getAuthorsByPackageIds(packageIds: Set<Long>): Map<Long, Set<String>> =
+        innerJoin(AuthorsTable)
+            .select(packageId, AuthorsTable.name)
+            .where { packageId inList packageIds }
+            .groupBy({ it[packageId] }) { it[AuthorsTable.name] }
+            .mapKeys { it.key.value }
+            .mapValues { it.value.toSet() }
 }

--- a/dao/src/main/kotlin/repositories/analyzerrun/PackagesDeclaredLicensesTable.kt
+++ b/dao/src/main/kotlin/repositories/analyzerrun/PackagesDeclaredLicensesTable.kt
@@ -32,4 +32,13 @@ object PackagesDeclaredLicensesTable : Table("packages_declared_licenses") {
 
     override val primaryKey: PrimaryKey
         get() = PrimaryKey(packageId, declaredLicenseId, name = "${tableName}_pkey")
+
+    /** Get the declared licenses for the provided [packageIds]. */
+    fun getDeclaredLicensesByPackageIds(packageIds: Set<Long>): Map<Long, Set<String>> =
+        innerJoin(DeclaredLicensesTable)
+            .select(packageId, DeclaredLicensesTable.name)
+            .where { packageId inList packageIds }
+            .groupBy({ it[packageId] }) { it[DeclaredLicensesTable.name] }
+            .mapKeys { it.key.value }
+            .mapValues { it.value.toSet() }
 }

--- a/dao/src/main/kotlin/repositories/analyzerrun/PackagesTable.kt
+++ b/dao/src/main/kotlin/repositories/analyzerrun/PackagesTable.kt
@@ -31,7 +31,12 @@ import org.eclipse.apoapsis.ortserver.dao.utils.ArrayAggColumnEquals
 import org.eclipse.apoapsis.ortserver.dao.utils.ArrayAggTwoColumnsEquals
 import org.eclipse.apoapsis.ortserver.dao.utils.SortableEntityClass
 import org.eclipse.apoapsis.ortserver.dao.utils.SortableTable
+import org.eclipse.apoapsis.ortserver.model.RepositoryType
+import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.Package
+import org.eclipse.apoapsis.ortserver.model.runs.ProcessedDeclaredLicense
+import org.eclipse.apoapsis.ortserver.model.runs.RemoteArtifact
+import org.eclipse.apoapsis.ortserver.model.runs.VcsInfo
 
 import org.jetbrains.exposed.dao.LongEntity
 import org.jetbrains.exposed.dao.id.EntityID
@@ -39,6 +44,7 @@ import org.jetbrains.exposed.sql.JoinType
 import org.jetbrains.exposed.sql.alias
 import org.jetbrains.exposed.sql.andHaving
 import org.jetbrains.exposed.sql.andWhere
+import org.jetbrains.exposed.sql.selectAll
 
 /**
  * A table to represent all metadata for a software package.
@@ -56,6 +62,96 @@ object PackagesTable : SortableTable("packages") {
     val homepageUrl = text("homepage_url")
     val isMetadataOnly = bool("is_metadata_only").default(false)
     val isModified = bool("is_modified").default(false)
+
+    /** Get the [Package]s for the provided [packageIds]. */
+    fun getByIds(packageIds: Set<Long>): Set<Package> {
+        val vcsProcessedTable = VcsInfoTable.alias("vcs_processed_info")
+        val binaryArtifacts = RemoteArtifactsTable.alias("binary_artifacts")
+        val sourceArtifacts = RemoteArtifactsTable.alias("source_artifacts")
+
+        val resultRows = innerJoin(IdentifiersTable)
+            .join(VcsInfoTable, JoinType.LEFT, vcsId, VcsInfoTable.id)
+            .join(vcsProcessedTable, JoinType.LEFT, vcsProcessedId, vcsProcessedTable[VcsInfoTable.id])
+            .join(
+                binaryArtifacts,
+                JoinType.LEFT,
+                binaryArtifactId,
+                binaryArtifacts[RemoteArtifactsTable.id]
+            )
+            .join(
+                sourceArtifacts,
+                JoinType.LEFT,
+                sourceArtifactId,
+                sourceArtifacts[RemoteArtifactsTable.id]
+            )
+            .selectAll()
+            .where { id inList packageIds }
+            .toList()
+
+        val authorsByPackageId = PackagesAuthorsTable.getAuthorsByPackageIds(packageIds)
+        val declaredLicensesByPackageId = PackagesDeclaredLicensesTable.getDeclaredLicensesByPackageIds(packageIds)
+        val processedDeclaredLicenseByPackageId = ProcessedDeclaredLicensesTable.getByPackageIds(packageIds)
+
+        return resultRows.mapTo(mutableSetOf()) { resultRow ->
+            val pkgId = resultRow[id].value
+
+            val identifier = Identifier(
+                type = resultRow[IdentifiersTable.type],
+                namespace = resultRow[IdentifiersTable.namespace],
+                name = resultRow[IdentifiersTable.name],
+                version = resultRow[IdentifiersTable.version]
+            )
+
+            val processedDeclaredLicense = processedDeclaredLicenseByPackageId[pkgId] ?: ProcessedDeclaredLicense(
+                spdxExpression = null,
+                mappedLicenses = emptyMap(),
+                unmappedLicenses = emptySet()
+            )
+
+            val binaryArtifact = RemoteArtifact(
+                url = resultRow[binaryArtifacts[RemoteArtifactsTable.url]],
+                hashValue = resultRow[binaryArtifacts[RemoteArtifactsTable.hashValue]],
+                hashAlgorithm = resultRow[binaryArtifacts[RemoteArtifactsTable.hashAlgorithm]]
+            )
+
+            val sourceArtifact = RemoteArtifact(
+                url = resultRow[sourceArtifacts[RemoteArtifactsTable.url]],
+                hashValue = resultRow[sourceArtifacts[RemoteArtifactsTable.hashValue]],
+                hashAlgorithm = resultRow[sourceArtifacts[RemoteArtifactsTable.hashAlgorithm]]
+            )
+
+            val vcs = VcsInfo(
+                type = RepositoryType.forName(resultRow[VcsInfoTable.type]),
+                url = resultRow[VcsInfoTable.url],
+                revision = resultRow[VcsInfoTable.revision],
+                path = resultRow[VcsInfoTable.path]
+            )
+
+            val vcsProcessed = VcsInfo(
+                type = RepositoryType.forName(resultRow[vcsProcessedTable[VcsInfoTable.type]]),
+                url = resultRow[vcsProcessedTable[VcsInfoTable.url]],
+                revision = resultRow[vcsProcessedTable[VcsInfoTable.revision]],
+                path = resultRow[vcsProcessedTable[VcsInfoTable.path]]
+            )
+
+            Package(
+                identifier = identifier,
+                purl = resultRow[purl],
+                cpe = resultRow[cpe],
+                authors = authorsByPackageId[pkgId].orEmpty(),
+                declaredLicenses = declaredLicensesByPackageId[pkgId].orEmpty(),
+                processedDeclaredLicense = processedDeclaredLicense,
+                description = resultRow[description],
+                homepageUrl = resultRow[homepageUrl],
+                binaryArtifact = binaryArtifact,
+                sourceArtifact = sourceArtifact,
+                vcs = vcs,
+                vcsProcessed = vcsProcessed,
+                isMetadataOnly = resultRow[isMetadataOnly],
+                isModified = resultRow[isModified]
+            )
+        }
+    }
 }
 
 class PackageDao(id: EntityID<Long>) : LongEntity(id) {

--- a/dao/src/main/kotlin/repositories/analyzerrun/ProjectScopesTable.kt
+++ b/dao/src/main/kotlin/repositories/analyzerrun/ProjectScopesTable.kt
@@ -23,6 +23,7 @@ import org.jetbrains.exposed.dao.LongEntity
 import org.jetbrains.exposed.dao.LongEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.LongIdTable
+import org.jetbrains.exposed.sql.selectAll
 
 /**
  * A table to represent project scopes.
@@ -30,6 +31,13 @@ import org.jetbrains.exposed.dao.id.LongIdTable
 object ProjectScopesTable : LongIdTable("project_scopes") {
     var projectId = reference("project_id", ProjectsTable)
     var name = text("name")
+
+    fun getScopesByProjectIds(projectIds: Set<Long>): Map<Long, Set<String>> =
+        selectAll()
+            .where { projectId inList projectIds }
+            .groupBy({ it[projectId] }) { it[name] }
+            .mapKeys { it.key.value }
+            .mapValues { it.value.toSet() }
 }
 
 class ProjectScopeDao(id: EntityID<Long>) : LongEntity(id) {

--- a/dao/src/main/kotlin/repositories/analyzerrun/ProjectsAnalyzerRunsTable.kt
+++ b/dao/src/main/kotlin/repositories/analyzerrun/ProjectsAnalyzerRunsTable.kt
@@ -19,6 +19,8 @@
 
 package org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun
 
+import org.eclipse.apoapsis.ortserver.model.runs.Project
+
 import org.jetbrains.exposed.sql.Table
 
 /**
@@ -30,4 +32,13 @@ object ProjectsAnalyzerRunsTable : Table("projects_analyzer_runs") {
 
     override val primaryKey: PrimaryKey
         get() = PrimaryKey(projectId, analyzerRunId, name = "${tableName}_pkey")
+
+    /** Get the [Project]s for the given [analyzerRunId]. */
+    fun getProjectsByAnalyzerRunId(analyzerRunId: Long): Set<Project> {
+        val projectIds = select(projectId)
+            .where { ProjectsAnalyzerRunsTable.analyzerRunId eq analyzerRunId }
+            .mapTo(mutableSetOf()) { it[projectId].value }
+
+        return ProjectsTable.getByIds(projectIds)
+    }
 }

--- a/dao/src/main/kotlin/repositories/analyzerrun/ProjectsAuthorsTable.kt
+++ b/dao/src/main/kotlin/repositories/analyzerrun/ProjectsAuthorsTable.kt
@@ -30,4 +30,13 @@ object ProjectsAuthorsTable : Table("projects_authors") {
 
     override val primaryKey: PrimaryKey
         get() = PrimaryKey(authorId, projectId, name = "${tableName}_pkey")
+
+    /** Get the authors for the provided [projectIds]. */
+    fun getAuthorsByProjectIds(projectIds: Set<Long>): Map<Long, Set<String>> =
+        innerJoin(AuthorsTable)
+            .select(projectId, AuthorsTable.name)
+            .where { projectId inList projectIds }
+            .groupBy({ it[projectId] }) { it[AuthorsTable.name] }
+            .mapKeys { it.key.value }
+            .mapValues { it.value.toSet() }
 }

--- a/dao/src/main/kotlin/repositories/analyzerrun/ProjectsDeclaredLicensesTable.kt
+++ b/dao/src/main/kotlin/repositories/analyzerrun/ProjectsDeclaredLicensesTable.kt
@@ -32,4 +32,13 @@ object ProjectsDeclaredLicensesTable : Table("projects_declared_licenses") {
 
     override val primaryKey: PrimaryKey
         get() = PrimaryKey(projectId, declaredLicenseId, name = "${tableName}_pkey")
+
+    /** Get the declared licenses for the provided [projectIds]. */
+    fun getDeclaredLicensesByProjectIds(projectIds: Set<Long>): Map<Long, Set<String>> =
+        innerJoin(DeclaredLicensesTable)
+            .select(projectId, DeclaredLicensesTable.name)
+            .where { projectId inList projectIds }
+            .groupBy({ it[projectId] }) { it[DeclaredLicensesTable.name] }
+            .mapKeys { it.key.value }
+            .mapValues { it.value.toSet() }
 }

--- a/dao/src/main/kotlin/repositories/analyzerrun/ProjectsTable.kt
+++ b/dao/src/main/kotlin/repositories/analyzerrun/ProjectsTable.kt
@@ -29,7 +29,11 @@ import org.eclipse.apoapsis.ortserver.dao.utils.ArrayAggColumnEquals
 import org.eclipse.apoapsis.ortserver.dao.utils.ArrayAggTwoColumnsEquals
 import org.eclipse.apoapsis.ortserver.dao.utils.SortableEntityClass
 import org.eclipse.apoapsis.ortserver.dao.utils.SortableTable
+import org.eclipse.apoapsis.ortserver.model.RepositoryType
+import org.eclipse.apoapsis.ortserver.model.runs.Identifier
+import org.eclipse.apoapsis.ortserver.model.runs.ProcessedDeclaredLicense
 import org.eclipse.apoapsis.ortserver.model.runs.Project
+import org.eclipse.apoapsis.ortserver.model.runs.VcsInfo
 
 import org.jetbrains.exposed.dao.LongEntity
 import org.jetbrains.exposed.dao.id.EntityID
@@ -37,6 +41,7 @@ import org.jetbrains.exposed.sql.JoinType
 import org.jetbrains.exposed.sql.alias
 import org.jetbrains.exposed.sql.andHaving
 import org.jetbrains.exposed.sql.andWhere
+import org.jetbrains.exposed.sql.selectAll
 
 /**
  * A table to represent a software package as a project.
@@ -51,6 +56,67 @@ object ProjectsTable : SortableTable("projects") {
     val definitionFilePath = text("definition_file_path")
     val description = text("description")
     val homepageUrl = text("homepage_url")
+
+    fun getByIds(projectIds: Set<Long>): Set<Project> {
+        val vcsProcessedTable = VcsInfoTable.alias("vcs_processed_info")
+
+        val resultRows = innerJoin(IdentifiersTable)
+            .join(VcsInfoTable, JoinType.LEFT, vcsId, VcsInfoTable.id)
+            .join(vcsProcessedTable, JoinType.LEFT, vcsProcessedId, vcsProcessedTable[VcsInfoTable.id])
+            .selectAll()
+            .where { id inList projectIds }
+            .toList()
+
+        val authorsByProjectId = ProjectsAuthorsTable.getAuthorsByProjectIds(projectIds)
+        val declaredLicensesByProjectId = ProjectsDeclaredLicensesTable.getDeclaredLicensesByProjectIds(projectIds)
+        val processedDeclaredLicenseByProjectId = ProcessedDeclaredLicensesTable.getByProjectIds(projectIds)
+        val scopeNamesByProjectId = ProjectScopesTable.getScopesByProjectIds(projectIds)
+
+        return resultRows.mapTo(mutableSetOf()) { resultRow ->
+            val projectId = resultRow[id].value
+
+            val identifier = Identifier(
+                type = resultRow[IdentifiersTable.type],
+                namespace = resultRow[IdentifiersTable.namespace],
+                name = resultRow[IdentifiersTable.name],
+                version = resultRow[IdentifiersTable.version]
+            )
+
+            val processedDeclaredLicense = processedDeclaredLicenseByProjectId[projectId] ?: ProcessedDeclaredLicense(
+                spdxExpression = null,
+                mappedLicenses = emptyMap(),
+                unmappedLicenses = emptySet()
+            )
+
+            val vcs = VcsInfo(
+                type = RepositoryType.forName(resultRow[VcsInfoTable.type]),
+                url = resultRow[VcsInfoTable.url],
+                revision = resultRow[VcsInfoTable.revision],
+                path = resultRow[VcsInfoTable.path]
+            )
+
+            val vcsProcessed = VcsInfo(
+                type = RepositoryType.forName(resultRow[vcsProcessedTable[VcsInfoTable.type]]),
+                url = resultRow[vcsProcessedTable[VcsInfoTable.url]],
+                revision = resultRow[vcsProcessedTable[VcsInfoTable.revision]],
+                path = resultRow[vcsProcessedTable[VcsInfoTable.path]]
+            )
+
+            Project(
+                identifier = identifier,
+                cpe = resultRow[cpe],
+                definitionFilePath = resultRow[definitionFilePath],
+                authors = authorsByProjectId[projectId].orEmpty(),
+                declaredLicenses = declaredLicensesByProjectId[projectId].orEmpty(),
+                processedDeclaredLicense = processedDeclaredLicense,
+                vcs = vcs,
+                vcsProcessed = vcsProcessed,
+                description = resultRow[description],
+                homepageUrl = resultRow[homepageUrl],
+                scopeNames = scopeNamesByProjectId[projectId].orEmpty()
+            )
+        }
+    }
 }
 
 class ProjectDao(id: EntityID<Long>) : LongEntity(id) {

--- a/dao/src/main/kotlin/tables/shared/EnvironmentsTable.kt
+++ b/dao/src/main/kotlin/tables/shared/EnvironmentsTable.kt
@@ -27,6 +27,7 @@ import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.LongIdTable
 import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
 
 /**
  * A table to represent the environment settings.
@@ -37,6 +38,26 @@ object EnvironmentsTable : LongIdTable("environments") {
     val os = text("os")
     val processors = integer("processors")
     val maxMemory = long("max_memory")
+
+    /** Get the [Environment] for the given [id]. Returns `null` if no environment is found. */
+    fun getById(id: Long): Environment? {
+        val resultRow = selectAll().where { EnvironmentsTable.id eq id }.singleOrNull()
+
+        if (resultRow == null) return null
+
+        val variables = EnvironmentsVariablesTable.getVariablesByEnvironmentId(id)
+        val toolVersions = EnvironmentsToolVersionsTable.getToolVersionsByEnvironmentId(id)
+
+        return Environment(
+            ortVersion = resultRow[ortVersion],
+            javaVersion = resultRow[javaVersion],
+            os = resultRow[os],
+            processors = resultRow[processors],
+            maxMemory = resultRow[maxMemory],
+            variables = variables,
+            toolVersions = toolVersions
+        )
+    }
 }
 
 class EnvironmentDao(id: EntityID<Long>) : LongEntity(id) {

--- a/dao/src/main/kotlin/tables/shared/EnvironmentsToolVersionsTable.kt
+++ b/dao/src/main/kotlin/tables/shared/EnvironmentsToolVersionsTable.kt
@@ -30,4 +30,12 @@ object EnvironmentsToolVersionsTable : Table("environments_tool_versions") {
 
     override val primaryKey: PrimaryKey
         get() = PrimaryKey(environmentId, toolVersionId, name = "${tableName}_pkey")
+
+    /** Get the tool versions for a given [environmentId]. */
+    fun getToolVersionsByEnvironmentId(environmentId: Long): Map<String, String> =
+        innerJoin(ToolVersionsTable)
+            .select(ToolVersionsTable.name, ToolVersionsTable.version)
+            .where { EnvironmentsToolVersionsTable.environmentId eq environmentId }.associate { resultRow ->
+                resultRow[ToolVersionsTable.name] to resultRow[ToolVersionsTable.version]
+            }
 }

--- a/dao/src/main/kotlin/tables/shared/EnvironmentsVariablesTable.kt
+++ b/dao/src/main/kotlin/tables/shared/EnvironmentsVariablesTable.kt
@@ -30,4 +30,12 @@ object EnvironmentsVariablesTable : Table("environments_variables") {
 
     override val primaryKey: PrimaryKey
         get() = PrimaryKey(environmentId, variableId, name = "${tableName}_pkey")
+
+    /** Get the variables for a given [environmentId]. */
+    fun getVariablesByEnvironmentId(environmentId: Long): Map<String, String> =
+        innerJoin(VariablesTable)
+            .select(VariablesTable.name, VariablesTable.value)
+            .where { EnvironmentsVariablesTable.environmentId eq environmentId }.associate { resultRow ->
+                resultRow[VariablesTable.name] to resultRow[VariablesTable.value]
+            }
 }

--- a/dao/src/main/kotlin/tables/shared/OrtRunsIssuesTable.kt
+++ b/dao/src/main/kotlin/tables/shared/OrtRunsIssuesTable.kt
@@ -22,13 +22,16 @@ package org.eclipse.apoapsis.ortserver.dao.tables.shared
 import org.eclipse.apoapsis.ortserver.dao.repositories.ortrun.OrtRunDao
 import org.eclipse.apoapsis.ortserver.dao.repositories.ortrun.OrtRunsTable
 import org.eclipse.apoapsis.ortserver.dao.utils.transformToDatabasePrecision
+import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
 
 import org.jetbrains.exposed.dao.LongEntity
 import org.jetbrains.exposed.dao.LongEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.LongIdTable
+import org.jetbrains.exposed.sql.andWhere
 import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
+import org.jetbrains.exposed.sql.selectAll
 
 /**
  * An intermediate table to store references from [OrtRunsTable] and [IssuesTable] together with some additional
@@ -40,6 +43,35 @@ object OrtRunsIssuesTable : LongIdTable("ort_runs_issues") {
     val identifierId = reference("identifier_id", IdentifiersTable).nullable()
     val worker = text("worker").nullable()
     val timestamp = timestamp("timestamp")
+
+    /** Get the [Issue]s for the given [ortRunId] and [issueWorkerType]. */
+    fun getIssuesByOrtRunId(ortRunId: Long, issueWorkerType: String): List<Issue> {
+        return innerJoin(IssuesTable)
+            .leftJoin(IdentifiersTable)
+            .selectAll()
+            .where { OrtRunsIssuesTable.ortRunId eq ortRunId }
+            .andWhere { worker eq issueWorkerType }
+            .mapNotNull {
+                val identifier = it[identifierId]?.let { id ->
+                    Identifier(
+                        type = it[IdentifiersTable.type],
+                        namespace = it[IdentifiersTable.namespace],
+                        name = it[IdentifiersTable.name],
+                        version = it[IdentifiersTable.version]
+                    )
+                }
+
+                Issue(
+                    timestamp = it[timestamp],
+                    source = it[IssuesTable.issueSource],
+                    message = it[IssuesTable.message],
+                    severity = it[IssuesTable.severity],
+                    affectedPath = it[IssuesTable.affectedPath],
+                    identifier = identifier,
+                    worker = it[worker]
+                )
+            }
+    }
 }
 
 class OrtRunIssueDao(id: EntityID<Long>) : LongEntity(id) {

--- a/workers/common/src/test/kotlin/common/OrtRunServiceTest.kt
+++ b/workers/common/src/test/kotlin/common/OrtRunServiceTest.kt
@@ -789,7 +789,7 @@ class OrtRunServiceTest : WordSpec({
                     allowDynamicVersions = true,
                     enabledPackageManagers = emptyList(),
                     disabledPackageManagers = null,
-                    packageManagers = emptyMap(),
+                    packageManagers = null,
                     skipExcluded = true
                 ),
                 projects = emptySet(),


### PR DESCRIPTION
Add queries to bulk load the contents of an `AnalyzerRun` and use that instead of the `AnalyzerRunDao` in the `DaoAnalyzerRunRepository`.

The DAO suffers from the N + 1 problem because an `AnalyzerRun` contains several nested objects and the Exposed DAO API creates lots of separate queries to load them. Depending on the amount of projects and packages in an `AnalyzerRun` this can easily result in several thousand executed queries.

The new approach solves the N + 1 problem by bulk loading the data from the one-to-many relations: For example, the authors for all packages are loaded in a single query and then associated to the packages in memory. This results in a constant amount of executed queries, independent of the number of projects or packages in the `AnalyzerRun`.

Loading all data in a single query would not have been feasible, because SQL builds a cross product when multiple one-to-many relations are involved in a joined query, exploding the number of result rows.

Tests have shown that this change reduces the duration for loading an `AnalyzerRun` by a factor of 50-100, for example, a run with ~1,000 packages now loads in ~200ms instead of ~10s. This affects all workers that run after the analyzer, because all of them have to build an `OrtResult` object from the database.

Similar changes should also be made for loading the other parts of the ORT result.