### PR TITLE
fix(ui): Don't use 'Unmanaged' when no package manager is selected

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
@@ -255,9 +255,11 @@ export function defaultValues(
     if (ortRun) {
       return {
         enabled:
-          ortRun.jobConfigs.analyzer?.enabledPackageManagers?.includes(
-            packageManagerId
-          ) || false,
+          ortRun.jobConfigs.analyzer?.enabledPackageManagers === undefined
+            ? enabledByDefault
+            : ortRun.jobConfigs.analyzer?.enabledPackageManagers?.includes(
+                packageManagerId
+              ) || false,
         mustRunAfter:
           (ortRun.jobConfigs.analyzer?.packageManagerOptions?.[packageManagerId]
             ?.mustRunAfter as PackageManagerId[]) || [],


### PR DESCRIPTION
When rerunning a scan with **no** selected package managers selected, don't send 'Unmanaged' as the package manager, but instead don't send a list of enabled package managers at all to the backend. This allows ORT Server to fall back to its default behavior of using **all** installed package managers.

This solves issues where scans were rerun, but all of a sudden where no longer analyzed by some package managers.