### PR TITLE
test: Add `:utils:logging` as test dependency to all JVM modules

### DIFF
--- a/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-conventions.gradle.kts
@@ -37,6 +37,7 @@ plugins {
 }
 
 dependencies {
+    testImplementation(project(":utils:logging"))
     testImplementation(project(":utils:test"))
 }
 


### PR DESCRIPTION
This fixes the issue that the custom `MdcConverter` was not on the classpath when running tests in several modules resulting in an exception from Logback.