### PR TITLE
fix(ui): Do not show a space before a comma

### DIFF
--- a/ui/src/components/delete-dialog.tsx
+++ b/ui/src/components/delete-dialog.tsx
@@ -124,8 +124,8 @@ export const DeleteDialog = ({
             <>
               <AlertDialogDescription>
                 If you are sure to delete the {thingName}{' '}
-                <span className='font-bold'>{thingId}</span>{' '}
-                {itemName ? `from the ${itemName}` : ''}, enter the bold text
+                <span className='font-bold'>{thingId}</span>
+                {itemName ? ` from the ${itemName}` : ''}, enter the bold text
                 below for confirmation.
               </AlertDialogDescription>
               <Input


### PR DESCRIPTION
If there is no `itemName`, do not show a space before a comma.