### PR TITLE
fix(cli): Properly configure the release build

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -19,6 +19,7 @@
 
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
+import org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType
 
 plugins {
     id("ort-server-kotlin-multiplatform-conventions")
@@ -47,10 +48,9 @@ kotlin {
 
     targets.withType<KotlinNativeTarget> {
         binaries {
-            executable {
+            executable(setOf(NativeBuildType.RELEASE)) {
                 entryPoint = "org.eclipse.apoapsis.ortserver.cli.main"
                 baseName = "osc"
-                optimized = true
             }
         }
     }


### PR DESCRIPTION
Just enabling `optimized` clashes with the default of `debuggable` also being enabled, resulting in a compiler warning saying

    Unsupported combination of flags: -opt and -g. Please pick one.

Instead of disabling `debuggable`, use the proper way to configure the build type(s) [1], which takes care of mutually setting these options.