### PR TITLE
fix(dao): Fix inefficient loading of shortest paths for packages

### DIFF
--- a/dao/src/main/kotlin/repositories/analyzerrun/ShortestDependencyPathsTable.kt
+++ b/dao/src/main/kotlin/repositories/analyzerrun/ShortestDependencyPathsTable.kt
@@ -19,7 +19,6 @@
 
 package org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun
 
-import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerjob.AnalyzerJobsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.ortrun.OrtRunsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
 import org.eclipse.apoapsis.ortserver.dao.utils.jsonb
@@ -52,10 +51,9 @@ object ShortestDependencyPathsTable : LongIdTable("shortest_dependency_paths") {
     fun getForOrtRunId(ortRunId: Long): Map<Identifier, List<ShortestDependencyPath>> {
         val projectIdentifiersTable = IdentifiersTable.alias("project_identifiers")
 
-        return innerJoin(AnalyzerRunsTable)
-            .innerJoin(AnalyzerJobsTable)
-            .innerJoin(OrtRunsTable)
-            .innerJoin(PackagesTable)
+        val analyzerRunId = OrtRunsTable.getAnalyzerRunIdById(ortRunId)
+
+        return innerJoin(PackagesTable)
             .innerJoin(ProjectsTable)
             .join(
                 IdentifiersTable,
@@ -70,7 +68,7 @@ object ShortestDependencyPathsTable : LongIdTable("shortest_dependency_paths") {
                 projectIdentifiersTable[IdentifiersTable.id]
             )
             .selectAll()
-            .where { OrtRunsTable.id eq ortRunId }
+            .where { ShortestDependencyPathsTable.analyzerRunId eq analyzerRunId }
             .map { resultRow ->
                 val packageIdentifier = Identifier(
                     type = resultRow[IdentifiersTable.type],

--- a/dao/src/main/kotlin/repositories/ortrun/OrtRunsTable.kt
+++ b/dao/src/main/kotlin/repositories/ortrun/OrtRunsTable.kt
@@ -23,6 +23,7 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.advisorjob.AdvisorJobDao
 import org.eclipse.apoapsis.ortserver.dao.repositories.advisorjob.AdvisorJobsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerjob.AnalyzerJobDao
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerjob.AnalyzerJobsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.AnalyzerRunsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.evaluatorjob.EvaluatorJobDao
 import org.eclipse.apoapsis.ortserver.dao.repositories.evaluatorjob.EvaluatorJobsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.notifierjob.NotifierJobDao
@@ -82,6 +83,14 @@ object OrtRunsTable : SortableTable("ort_runs") {
     val traceId = text("trace_id").nullable()
     val environmentConfigPath = text("environment_config_path").nullable()
     val userDisplayName = reference("user_id", UserDisplayNamesTable.id).nullable()
+
+    /** Get the id of the analyzer run for the given ORT run [id]. Returns `null` if no run is found. */
+    fun getAnalyzerRunIdById(id: Long): Long? =
+        innerJoin(AnalyzerJobsTable)
+            .innerJoin(AnalyzerRunsTable)
+            .select(AnalyzerRunsTable.id)
+            .where { OrtRunsTable.id eq id }
+            .singleOrNull()?.let { it[AnalyzerRunsTable.id].value }
 }
 
 class OrtRunDao(id: EntityID<Long>) : LongEntity(id) {

--- a/dao/src/main/resources/db/migration/V106_addShortestDependencyPathsAnalyzerRunIdIndex.sql
+++ b/dao/src/main/resources/db/migration/V106_addShortestDependencyPathsAnalyzerRunIdIndex.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS shortest_dependency_paths_analyzer_run_id ON shortest_dependency_paths (analyzer_run_id);


### PR DESCRIPTION
The query to load the shortest paths was inefficient because the joins exploded the number of rows PostgreSQL had to process. Fix this by getting the analyzer run ID separately and adding an index for the `analyzer_run_id` column in `shortest_dependency_paths`.