### PR TITLE
fix(cli): Enable path completion for `--parameters-file` option

### DIFF
--- a/cli/src/commonMain/kotlin/StartCommand.kt
+++ b/cli/src/commonMain/kotlin/StartCommand.kt
@@ -20,6 +20,7 @@
 package org.eclipse.apoapsis.ortserver.cli
 
 import com.github.ajalt.clikt.command.SuspendingCliktCommand
+import com.github.ajalt.clikt.completion.CompletionCandidates
 import com.github.ajalt.clikt.core.Context
 import com.github.ajalt.clikt.core.terminal
 import com.github.ajalt.clikt.parameters.groups.mutuallyExclusiveOptions
@@ -80,7 +81,8 @@ class StartCommand : SuspendingCliktCommand(name = "start") {
             "--parameters-file",
             envvar = "OSC_RUNS_START_PARAMETERS_FILE",
             help = "The path to a JSON file containing the run configuration " +
-                    "(see https://eclipse-apoapsis.github.io/ort-server/api/post-ort-run)."
+                    "(see https://eclipse-apoapsis.github.io/ort-server/api/post-ort-run).",
+            completionCandidates = CompletionCandidates.Path
         ).convert { it.expandTilde().toPath().read() },
         option(
             "--parameters",

--- a/integrations/completions/osc-completion.bash
+++ b/integrations/completions/osc-completion.bash
@@ -738,6 +738,7 @@ _osc_runs_start() {
     "--wait")
       ;;
     "--parameters-file")
+       __complete_files "${word}"
       ;;
     "--parameters")
       ;;

--- a/integrations/completions/osc-completion.fish
+++ b/integrations/completions/osc-completion.fish
@@ -96,7 +96,7 @@ complete -c osc -f -n "__fish_seen_subcommand_from runs; and not __fish_seen_sub
 ## Options for start
 complete -c osc -n "__fish_seen_subcommand_from start" -l repository-id -r -d 'The ID of the repository.'
 complete -c osc -n "__fish_seen_subcommand_from start" -l wait -d 'Wait for the run to finish.'
-complete -c osc -n "__fish_seen_subcommand_from start" -l parameters-file -r -d 'The path to a JSON file containing the run configuration (see https://eclipse-apoapsis.github.io/ort-server/api/post-ort-run).'
+complete -c osc -n "__fish_seen_subcommand_from start" -l parameters-file -r -F -d 'The path to a JSON file containing the run configuration (see https://eclipse-apoapsis.github.io/ort-server/api/post-ort-run).'
 complete -c osc -n "__fish_seen_subcommand_from start" -l parameters -r -d 'The run configuration as a JSON string (see https://eclipse-apoapsis.github.io/ort-server/api/post-ort-run).'
 complete -c osc -n "__fish_seen_subcommand_from start" -s h -l help -d 'Show this message and exit'
 

--- a/integrations/completions/osc-completion.zsh
+++ b/integrations/completions/osc-completion.zsh
@@ -743,6 +743,7 @@ _osc_runs_start() {
     "--wait")
       ;;
     "--parameters-file")
+       __complete_files "${word}"
       ;;
     "--parameters")
       ;;


### PR DESCRIPTION
Because Clikt doesn't support the `file` and `path` parameter types on
Kotlin native [1], we have to use a String parameter.
This means that the `--parameter-file` option doesn't offer any
tab-completion options.

Fix this by explicitly defining paths as completion candidates.

[1]: https://ajalt.github.io/clikt/advanced/#jvm