### PR TITLE
chore(reporters): Omit the plugin type from the display name

### DIFF
--- a/shared/reporters/src/main/kotlin/OrtResultReporter.kt
+++ b/shared/reporters/src/main/kotlin/OrtResultReporter.kt
@@ -41,7 +41,7 @@ data class OrtResultReporterConfig(
 
 @OrtPlugin(
     id = "OrtResult",
-    displayName = "ORT Result Reporter",
+    displayName = "ORT Result",
     description = "A reporter that creates an ORT result YAML file for the ORT run.",
     factory = ReporterFactory::class
 )

--- a/shared/reporters/src/main/kotlin/RunStatisticsReporter.kt
+++ b/shared/reporters/src/main/kotlin/RunStatisticsReporter.kt
@@ -35,7 +35,7 @@ import org.ossreviewtoolkit.reporter.ReporterInput
  */
 @OrtPlugin(
     id = "RunStatistics",
-    displayName = "Run Statistics Reporter",
+    displayName = "Run Statistics",
     description = "A reporter that creates a JSON file with the statistics of the ORT run.",
     factory = ReporterFactory::class
 )

--- a/shared/reporters/src/main/kotlin/SourceCodeBundleReporter.kt
+++ b/shared/reporters/src/main/kotlin/SourceCodeBundleReporter.kt
@@ -82,7 +82,7 @@ data class SourceCodeBundleReporterConfig(
  */
 @OrtPlugin(
     id = "SourceCodeBundle",
-    displayName = "Source Code Bundle Reporter",
+    displayName = "Source Code Bundle",
     description = "A reporter that creates a source code bundle for the given ORT result.",
     factory = ReporterFactory::class
 )


### PR DESCRIPTION
Follow an ORT change [1] and do not repeat the plugin type as part of the display name, which avoids duplication when listing plugins by type, like in the administration UI.

[1]: https://github.com/oss-review-toolkit/ort/pull/10190/commits/dc690ea12e0a229c52099772e8f00434eb457196