### PR TITLE
refactor: Add helper functions to group routes in components

### DIFF
--- a/components/admin-config/backend/src/main/kotlin/Routing.kt
+++ b/components/admin-config/backend/src/main/kotlin/Routing.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.components.adminconfig
+
+import io.ktor.server.routing.Route
+
+import org.eclipse.apoapsis.ortserver.components.adminconfig.endpoints.getConfigByKey
+import org.eclipse.apoapsis.ortserver.components.adminconfig.endpoints.insertOrUpdateConfig
+
+import org.jetbrains.exposed.sql.Database
+
+/** Add routes for all admin-config endpoints. */
+fun Route.adminConfigRoutes(db: Database) {
+    getConfigByKey(db)
+    insertOrUpdateConfig(db)
+}

--- a/components/admin-config/backend/src/main/kotlin/endpoints/GetConfigByKey.kt
+++ b/components/admin-config/backend/src/main/kotlin/endpoints/GetConfigByKey.kt
@@ -35,7 +35,7 @@ import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireParameter
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.transactions.transaction
 
-fun Route.getConfigByKey(db: Database) = get("admin/config/{key}", {
+internal fun Route.getConfigByKey(db: Database) = get("admin/config/{key}", {
     operationId = "GetConfigByKey"
     summary = "Get the value of a configuration key"
     description = "Get the value and isEnabled properties of a configuration key. " +

--- a/components/admin-config/backend/src/main/kotlin/endpoints/InsertOrUpdateConfig.kt
+++ b/components/admin-config/backend/src/main/kotlin/endpoints/InsertOrUpdateConfig.kt
@@ -36,7 +36,7 @@ import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireParameter
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.transactions.transaction
 
-fun Route.insertOrUpdateConfig(db: Database) = post("admin/config/{key}", {
+internal fun Route.insertOrUpdateConfig(db: Database) = post("admin/config/{key}", {
     operationId = "InsertOrUpdateConfig"
     summary = "Insert or update a configuration key"
     description = "For an existing key, update the value and isEnabled of the key. " +

--- a/components/plugin-manager/implementation/src/main/kotlin/Routing.kt
+++ b/components/plugin-manager/implementation/src/main/kotlin/Routing.kt
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.components.pluginmanager
+
+import io.ktor.server.routing.Route
+
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.endpoints.disablePlugin
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.endpoints.enablePlugin
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.endpoints.getInstalledPlugins
+
+/** Add routes for all plugin-manager endpoints. */
+fun Route.pluginManagerRoutes(eventStore: PluginEventStore, pluginService: PluginService) {
+    disablePlugin(eventStore)
+    enablePlugin(eventStore)
+    getInstalledPlugins(pluginService)
+}

--- a/components/plugin-manager/implementation/src/main/kotlin/endpoints/DisablePlugin.kt
+++ b/components/plugin-manager/implementation/src/main/kotlin/endpoints/DisablePlugin.kt
@@ -36,7 +36,7 @@ import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.normalizePluginId
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireParameter
 
-fun Route.disablePlugin(eventStore: PluginEventStore) = post("admin/plugins/{pluginType}/{pluginId}/disable", {
+internal fun Route.disablePlugin(eventStore: PluginEventStore) = post("admin/plugins/{pluginType}/{pluginId}/disable", {
     operationId = "DisablePlugin"
     summary = "Disable an ORT plugin globally"
     description = "Disable an ORT plugin globally to make it generally unavailable."

--- a/components/plugin-manager/implementation/src/main/kotlin/endpoints/EnablePlugin.kt
+++ b/components/plugin-manager/implementation/src/main/kotlin/endpoints/EnablePlugin.kt
@@ -36,7 +36,7 @@ import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.normalizePluginId
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireParameter
 
-fun Route.enablePlugin(eventStore: PluginEventStore) = post("admin/plugins/{pluginType}/{pluginId}/enable", {
+internal fun Route.enablePlugin(eventStore: PluginEventStore) = post("admin/plugins/{pluginType}/{pluginId}/enable", {
     operationId = "EnablePlugin"
     summary = "Enable an ORT plugin globally"
     description = "Enable an ORT plugin globally to make it generally available to all organizations."

--- a/components/plugin-manager/implementation/src/main/kotlin/endpoints/GetInstalledPlugins.kt
+++ b/components/plugin-manager/implementation/src/main/kotlin/endpoints/GetInstalledPlugins.kt
@@ -37,7 +37,7 @@ import org.ossreviewtoolkit.plugins.api.PluginDescriptor as OrtPluginDescriptor
 import org.ossreviewtoolkit.plugins.api.PluginOption as OrtPluginOption
 import org.ossreviewtoolkit.plugins.api.PluginOptionType as OrtPluginOptionType
 
-fun Route.getInstalledPlugins(pluginService: PluginService) = get("admin/plugins", {
+internal fun Route.getInstalledPlugins(pluginService: PluginService) = get("admin/plugins", {
     operationId = "GetInstalledPlugins"
     summary = "Get installed ORT plugins"
     description = "Get a list with detailed information about all installed ORT plugins."

--- a/core/src/main/kotlin/plugins/Routing.kt
+++ b/core/src/main/kotlin/plugins/Routing.kt
@@ -24,12 +24,9 @@ import io.ktor.server.auth.authenticate
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 
-import org.eclipse.apoapsis.ortserver.components.adminconfig.endpoints.getConfigByKey
-import org.eclipse.apoapsis.ortserver.components.adminconfig.endpoints.insertOrUpdateConfig
+import org.eclipse.apoapsis.ortserver.components.adminconfig.adminConfigRoutes
 import org.eclipse.apoapsis.ortserver.components.authorization.SecurityConfigurations
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.endpoints.disablePlugin
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.endpoints.enablePlugin
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.endpoints.getInstalledPlugins
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.pluginManagerRoutes
 import org.eclipse.apoapsis.ortserver.core.api.admin
 import org.eclipse.apoapsis.ortserver.core.api.authentication
 import org.eclipse.apoapsis.ortserver.core.api.downloads
@@ -50,12 +47,9 @@ fun Application.configureRouting() {
             downloads()
             authenticate(SecurityConfigurations.TOKEN) {
                 admin()
-                disablePlugin(get())
-                enablePlugin(get())
-                getConfigByKey(get())
-                getInstalledPlugins(get())
-                insertOrUpdateConfig(get())
+                adminConfigRoutes(get())
                 organizations()
+                pluginManagerRoutes(get(), get())
                 products()
                 repositories()
                 runs()


### PR DESCRIPTION
Add helper functions that add all routes for a component to simplify the routing in `core`. This also allows to make the actual route functions internal.