### PR TITLE
fix(api): Move username to query param in Keycloak group removal

### DIFF
--- a/core/src/main/kotlin/api/OrganizationsRoute.kt
+++ b/core/src/main/kotlin/api/OrganizationsRoute.kt
@@ -359,11 +359,11 @@ fun Route.organizations() = route("organizations") {
                 delete(deleteUserFromOrganizationGroup) {
                     requirePermission(OrganizationPermission.MANAGE_GROUPS)
 
-                    val user = call.receive<Username>()
                     val organizationId = call.requireIdParameter("organizationId")
                     val groupId = call.requireParameter("groupId")
+                    val username = call.requireParameter("username")
 
-                    organizationService.removeUserFromGroup(user.username, organizationId, groupId)
+                    organizationService.removeUserFromGroup(username, organizationId, groupId)
                     call.respond(HttpStatusCode.NoContent)
                 }
             }

--- a/core/src/main/kotlin/api/ProductsRoute.kt
+++ b/core/src/main/kotlin/api/ProductsRoute.kt
@@ -267,11 +267,11 @@ fun Route.products() = route("products/{productId}") {
             delete(deleteUserFromProductGroup) {
                 requirePermission(ProductPermission.MANAGE_GROUPS)
 
-                val user = call.receive<Username>()
                 val productId = call.requireIdParameter("productId")
                 val groupId = call.requireParameter("groupId")
+                val username = call.requireParameter("username")
 
-                productService.removeUserFromGroup(user.username, productId, groupId)
+                productService.removeUserFromGroup(username, productId, groupId)
                 call.respond(HttpStatusCode.NoContent)
             }
         }

--- a/core/src/main/kotlin/api/RepositoriesRoute.kt
+++ b/core/src/main/kotlin/api/RepositoriesRoute.kt
@@ -301,11 +301,11 @@ fun Route.repositories() = route("repositories/{repositoryId}") {
             delete(deleteUserFromRepositoryGroup) {
                 requirePermission(RepositoryPermission.MANAGE_GROUPS)
 
-                val user = call.receive<Username>()
                 val repositoryId = call.requireIdParameter("repositoryId")
                 val groupId = call.requireParameter("groupId")
+                val username = call.requireParameter("username")
 
-                repositoryService.removeUserFromGroup(user.username, repositoryId, groupId)
+                repositoryService.removeUserFromGroup(username, repositoryId, groupId)
                 call.respond(HttpStatusCode.NoContent)
             }
         }

--- a/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
@@ -592,10 +592,8 @@ val deleteUserFromOrganizationGroup: RouteConfig.() -> Unit = {
             description = "One of 'readers', 'writers' or 'admins'."
         }
 
-        jsonBody<Username> {
-            example("Remove user identified by username 'abc123'.") {
-                value = Username(username = "abc123")
-            }
+        queryParameter<String>("username") {
+            description = "The username of the user to remove from the group on organization level."
         }
     }
 

--- a/core/src/main/kotlin/apiDocs/ProductsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/ProductsDocs.kt
@@ -410,10 +410,8 @@ val deleteUserFromProductGroup: RouteConfig.() -> Unit = {
             description = "One of 'readers', 'writers' or 'admins'."
         }
 
-        jsonBody<Username> {
-            example("Remove user identified by username 'abc123'.") {
-                value = Username(username = "abc123")
-            }
+        queryParameter<String>("username") {
+            description = "The username of the user to remove from the group on product level."
         }
     }
 

--- a/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
@@ -731,10 +731,8 @@ val deleteUserFromRepositoryGroup: RouteConfig.() -> Unit = {
             description = "One of 'readers', 'writers' or 'admins'."
         }
 
-        jsonBody<Username> {
-            example("Remove user identified by username 'abc123'.") {
-                value = Username(username = "abc123")
-            }
+        queryParameter<String>("username") {
+            description = "The username of the user to remove from the group on repository level."
         }
     }
 

--- a/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
@@ -1321,9 +1321,9 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                         HttpMethod.Put -> put("/api/v1/organizations/${createdOrg.id}/groups/readers") {
                             setBody(user)
                         }
-                        HttpMethod.Delete -> delete("/api/v1/organizations/${createdOrg.id}/groups/readers") {
-                            setBody(user)
-                        }
+                        HttpMethod.Delete -> delete(
+                            "/api/v1/organizations/${createdOrg.id}/groups/readers?username=${user.username}"
+                        )
                         else -> error("Unsupported method: $method")
                     }
                 }
@@ -1346,10 +1346,8 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                             setBody(user)
                         }
                         HttpMethod.Delete -> superuserClient.delete(
-                            "/api/v1/organizations/${createdOrg.id}/groups/readers"
-                        ) {
-                            setBody(user)
-                        }
+                            "/api/v1/organizations/${createdOrg.id}/groups/readers?username=${user.username}"
+                        )
                         else -> error("Unsupported method: $method")
                     }
 
@@ -1376,10 +1374,8 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                             setBody(user)
                         }
                         HttpMethod.Delete -> superuserClient.delete(
-                            "/api/v1/organizations/999999/groups/readers"
-                        ) {
-                            setBody(user)
-                        }
+                            "/api/v1/organizations/999999/groups/readers?username=${user.username}"
+                        )
                         else -> error("Unsupported method: $method")
                     }
 
@@ -1392,8 +1388,7 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
         }
 
         forAll(
-            row(HttpMethod.Put),
-            row(HttpMethod.Delete)
+            row(HttpMethod.Put)
         ) { method ->
             "respond with 'BadRequest' if the request body is invalid for method '${method.value}'" {
                 integrationTestApplication {
@@ -1402,11 +1397,6 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
 
                     val response = when (method) {
                         HttpMethod.Put -> superuserClient.put(
-                            "/api/v1/organizations/${createdOrg.id}/groups/readers"
-                        ) {
-                            setBody(org)
-                        }
-                        HttpMethod.Delete -> superuserClient.delete(
                             "/api/v1/organizations/${createdOrg.id}/groups/readers"
                         ) {
                             setBody(org)
@@ -1435,10 +1425,8 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                             setBody(user)
                         }
                         HttpMethod.Delete -> superuserClient.delete(
-                            "/api/v1/organizations/${createdOrg.id}/groups/non-existing-group"
-                        ) {
-                            setBody(user)
-                        }
+                            "/api/v1/organizations/${createdOrg.id}/groups/non-existing-group?username=${user.username}"
+                        )
                         else -> error("Unsupported method: $method")
                     }
 
@@ -1512,10 +1500,8 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                     membersBefore.map { it.username } shouldContain TEST_USER.username
 
                     val response = superuserClient.delete(
-                        "/api/v1/organizations/${createdOrg.id}/groups/$groupId"
-                    ) {
-                        setBody(user)
-                    }
+                        "/api/v1/organizations/${createdOrg.id}/groups/$groupId?username=${user.username}"
+                    )
 
                     response shouldHaveStatus HttpStatusCode.NoContent
 

--- a/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
@@ -783,9 +783,9 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                         HttpMethod.Put -> put("/api/v1/products/${createdProd.id}/groups/readers") {
                             setBody(user)
                         }
-                        HttpMethod.Delete -> delete("/api/v1/products/${createdProd.id}/groups/readers") {
-                            setBody(user)
-                        }
+                        HttpMethod.Delete -> delete(
+                            "/api/v1/products/${createdProd.id}/groups/readers?username=${user.username}"
+                        )
                         else -> error("Unsupported method: $method")
                     }
                 }
@@ -807,10 +807,8 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                             setBody(user)
                         }
                         HttpMethod.Delete -> superuserClient.delete(
-                            "/api/v1/products/${createdProd.id}/groups/readers"
-                        ) {
-                            setBody(user)
-                        }
+                            "/api/v1/products/${createdProd.id}/groups/readers?username=${user.username}"
+                        )
                         else -> error("Unsupported method: $method")
                     }
 
@@ -837,10 +835,8 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                             setBody(user)
                         }
                         HttpMethod.Delete -> superuserClient.delete(
-                            "/api/v1/products/999999/groups/readers"
-                        ) {
-                            setBody(user)
-                        }
+                            "/api/v1/products/999999/groups/readers?username=${user.username}"
+                        )
                         else -> error("Unsupported method: $method")
                     }
 
@@ -853,8 +849,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
         }
 
         forAll(
-            row(HttpMethod.Put),
-            row(HttpMethod.Delete)
+            row(HttpMethod.Put)
         ) { method ->
             "respond with 'BadRequest' if the request body is invalid for method '${method.value}'" {
                 integrationTestApplication {
@@ -863,11 +858,6 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
 
                     val response = when (method) {
                         HttpMethod.Put -> superuserClient.put(
-                            "/api/v1/products/${createdProd.id}/groups/readers"
-                        ) {
-                            setBody(org)
-                        }
-                        HttpMethod.Delete -> superuserClient.delete(
                             "/api/v1/products/${createdProd.id}/groups/readers"
                         ) {
                             setBody(org)
@@ -896,10 +886,8 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                             setBody(user)
                         }
                         HttpMethod.Delete -> superuserClient.delete(
-                            "/api/v1/products/${createdProd.id}/groups/non-existing-group"
-                        ) {
-                            setBody(user)
-                        }
+                            "/api/v1/products/${createdProd.id}/groups/non-existing-group?username=${user.username}"
+                        )
                         else -> error("Unsupported method: $method")
                     }
 
@@ -973,10 +961,8 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                     membersBefore.map { it.username } shouldContain TEST_USER.username
 
                     val response = superuserClient.delete(
-                        "/api/v1/products/${createdProd.id}/groups/$groupId"
-                    ) {
-                        setBody(user)
-                    }
+                        "/api/v1/products/${createdProd.id}/groups/$groupId?username=${user.username}"
+                    )
 
                     response shouldHaveStatus HttpStatusCode.NoContent
 

--- a/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
@@ -1151,9 +1151,9 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                         HttpMethod.Put -> put("/api/v1/repositories/${createdRepo.id}/groups/readers") {
                             setBody(user)
                         }
-                        HttpMethod.Delete -> delete("/api/v1/repositories/${createdRepo.id}/groups/readers") {
-                            setBody(user)
-                        }
+                        HttpMethod.Delete -> delete(
+                            "/api/v1/repositories/${createdRepo.id}/groups/readers?username=${user.username}"
+                        )
                         else -> error("Unsupported method: $method")
                     }
                 }
@@ -1175,10 +1175,8 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                             setBody(user)
                         }
                         HttpMethod.Delete -> superuserClient.delete(
-                            "/api/v1/repositories/${createdRepo.id}/groups/readers"
-                        ) {
-                            setBody(user)
-                        }
+                            "/api/v1/repositories/${createdRepo.id}/groups/readers?username=${user.username}"
+                        )
                         else -> error("Unsupported method: $method")
                     }
 
@@ -1205,10 +1203,8 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                             setBody(user)
                         }
                         HttpMethod.Delete -> superuserClient.delete(
-                            "/api/v1/repositories/999999/groups/readers"
-                        ) {
-                            setBody(user)
-                        }
+                            "/api/v1/repositories/999999/groups/readers?username=${user.username}"
+                        )
                         else -> error("Unsupported method: $method")
                     }
 
@@ -1221,8 +1217,7 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
         }
 
         forAll(
-            row(HttpMethod.Put),
-            row(HttpMethod.Delete)
+            row(HttpMethod.Put)
         ) { method ->
             "respond with 'BadRequest' if the request body is invalid for method '${method.value}'" {
                 integrationTestApplication {
@@ -1231,11 +1226,6 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
 
                     val response = when (method) {
                         HttpMethod.Put -> superuserClient.put(
-                            "/api/v1/repositories/${createdRepo.id}/groups/readers"
-                        ) {
-                            setBody(org)
-                        }
-                        HttpMethod.Delete -> superuserClient.delete(
                             "/api/v1/repositories/${createdRepo.id}/groups/readers"
                         ) {
                             setBody(org)
@@ -1264,10 +1254,8 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                             setBody(user)
                         }
                         HttpMethod.Delete -> superuserClient.delete(
-                            "/api/v1/repositories/${createdRepo.id}/groups/non-existing-group"
-                        ) {
-                            setBody(user)
-                        }
+                            "/api/v1/repositories/${createdRepo.id}/groups/non-existing-group?username=${user.username}"
+                        )
                         else -> error("Unsupported method: $method")
                     }
 
@@ -1341,10 +1329,8 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                     membersBefore.map { it.username } shouldContain TEST_USER.username
 
                     val response = superuserClient.delete(
-                        "/api/v1/repositories/${createdRepo.id}/groups/$groupId"
-                    ) {
-                        setBody(user)
-                    }
+                        "/api/v1/repositories/${createdRepo.id}/groups/$groupId?username=${user.username}"
+                    )
 
                     response shouldHaveStatus HttpStatusCode.NoContent
 

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/-components/repository-users-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/-components/repository-users-table.tsx
@@ -160,9 +160,7 @@ const columns = [
           await leaveGroup({
             repositoryId: repoId,
             groupId: group,
-            requestBody: {
-              username: row.original.user.username,
-            },
+            username: row.original.user.username,
           });
         }
       }
@@ -209,9 +207,7 @@ const columns = [
               leaveGroup({
                 repositoryId: repoId,
                 groupId: group,
-                requestBody: {
-                  username: row.original.user.username,
-                },
+                username: row.original.user.username,
               })
             )
           );

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/index.tsx
@@ -136,9 +136,7 @@ const ManageUsers = () => {
       await leaveGroup({
         repositoryId: repositoryId,
         groupId: group,
-        requestBody: {
-          username: username,
-        },
+        username: username,
       });
     }
   }

--- a/ui/src/routes/organizations/$orgId/products/$productId/users/-components/product-users-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/users/-components/product-users-table.tsx
@@ -154,9 +154,7 @@ const columns = [
           await leaveGroup({
             productId: productId,
             groupId: group,
-            requestBody: {
-              username: row.original.user.username,
-            },
+            username: row.original.user.username,
           });
         }
       }
@@ -203,9 +201,7 @@ const columns = [
               leaveGroup({
                 productId: productId,
                 groupId: group,
-                requestBody: {
-                  username: row.original.user.username,
-                },
+                username: row.original.user.username,
               })
             )
           );

--- a/ui/src/routes/organizations/$orgId/products/$productId/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/users/index.tsx
@@ -134,9 +134,7 @@ const ManageUsers = () => {
       await leaveGroup({
         productId: productId,
         groupId: group,
-        requestBody: {
-          username: username,
-        },
+        username: username,
       });
     }
   }

--- a/ui/src/routes/organizations/$orgId/users/-components/organization-users-table.tsx
+++ b/ui/src/routes/organizations/$orgId/users/-components/organization-users-table.tsx
@@ -160,9 +160,7 @@ const columns = [
           await leaveGroup({
             organizationId: organizationId,
             groupId: group,
-            requestBody: {
-              username: row.original.user.username,
-            },
+            username: row.original.user.username,
           });
         }
       }
@@ -209,9 +207,7 @@ const columns = [
               leaveGroup({
                 organizationId: organizationId,
                 groupId: group,
-                requestBody: {
-                  username: row.original.user.username,
-                },
+                username: row.original.user.username,
               })
             )
           );

--- a/ui/src/routes/organizations/$orgId/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/users/index.tsx
@@ -140,9 +140,7 @@ const ManageUsers = () => {
       await leaveGroup({
         organizationId: organizationId,
         groupId: group,
-        requestBody: {
-          username: username,
-        },
+        username: username,
       });
     }
   }


### PR DESCRIPTION
Update user removal from Keycloak groups to pass the username as a request parameter rather than placing it in the DELETE request body. Bodies in DELETE requests are discouraged and cause issues in our company cloud infrastructure with intermediate API proxies.