### PR TITLE
ci(github): Cache Kotlin/Native build tools

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -70,6 +70,17 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@8379f6a1328ee0e06e2bb424dadb7b159856a326 # v4
 
+    - name: Get the Kotlin version
+      id: get-kotlin-plugin-info
+      shell: bash
+      run: echo "info=$(./gradlew -q :cli:properties | grep kotlin.plugin.loaded.in.projects)" >> $GITHUB_OUTPUT
+
+    - name: Cache the .konan directory
+      uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+      with:
+        path: ~/.konan
+        key: ${{ steps.get-kotlin-plugin-info.outputs.info }}
+
     - name: Build CLI - ${{ matrix.target.name }}
       run: ./gradlew --stacktrace cli:${{ matrix.target.task }}
 


### PR DESCRIPTION
Avoid re-downloading of Kotlin/Native build tools by caching them based on the Kotlin version used in the project. This is supposed to avoid output like seen at [1].

[1]: https://github.com/eclipse-apoapsis/ort-server/actions/runs/15385899915/job/43284366074#step:5:38