### PR TITLE
ui: Show PURL for vulnerabilities if so configured

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
@@ -64,7 +64,10 @@ import {
 } from '@/components/ui/table';
 import { getVulnerabilityRatingBackgroundColor } from '@/helpers/get-status-class';
 import { updateColumnSorting } from '@/helpers/handle-multisort';
-import { identifierToString } from '@/helpers/identifier-conversion';
+import {
+  identifierToPurl,
+  identifierToString,
+} from '@/helpers/identifier-conversion';
 import { compareVulnerabilityRating } from '@/helpers/sorting-functions';
 import { ALL_ITEMS } from '@/lib/constants';
 import { toast } from '@/lib/toast';
@@ -76,6 +79,7 @@ import {
   vulnerabilityRatingSchema,
   vulnerabilityRatingSearchParameterSchema,
 } from '@/schemas';
+import { useUserSettingsStore } from '@/store/user-settings.store';
 
 const defaultPageSize = 10;
 
@@ -140,6 +144,7 @@ const VulnerabilitiesComponent = () => {
   const params = Route.useParams();
   const search = Route.useSearch();
   const navigate = Route.useNavigate();
+  const packageIdType = useUserSettingsStore((state) => state.packageIdType);
 
   const columns = [
     columnHelper.display({
@@ -226,7 +231,15 @@ const VulnerabilitiesComponent = () => {
     }),
     columnHelper.accessor(
       (vuln) => {
-        return identifierToString(vuln.identifier);
+        // TODO: This is a temporary front-end only solution to support PURL
+        //       identifiers. The backend endpoints should be updated to return
+        //       PURL identifiers natively so this will need to be removed
+        //       in the future.
+        if (packageIdType === 'PURL') {
+          return identifierToPurl(vuln.identifier);
+        } else {
+          return identifierToString(vuln.identifier);
+        }
       },
       {
         id: 'packageIdentifier',

--- a/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
@@ -60,7 +60,10 @@ import {
 } from '@/components/ui/table';
 import { getVulnerabilityRatingBackgroundColor } from '@/helpers/get-status-class';
 import { updateColumnSorting } from '@/helpers/handle-multisort';
-import { identifierToString } from '@/helpers/identifier-conversion';
+import {
+  identifierToPurl,
+  identifierToString,
+} from '@/helpers/identifier-conversion';
 import { compareVulnerabilityRating } from '@/helpers/sorting-functions';
 import { ALL_ITEMS } from '@/lib/constants';
 import { toast } from '@/lib/toast';
@@ -72,6 +75,7 @@ import {
   vulnerabilityRatingSchema,
   vulnerabilityRatingSearchParameterSchema,
 } from '@/schemas';
+import { useUserSettingsStore } from '@/store/user-settings.store';
 
 const defaultPageSize = 10;
 
@@ -132,6 +136,7 @@ const ProductVulnerabilitiesComponent = () => {
   const params = Route.useParams();
   const search = Route.useSearch();
   const navigate = Route.useNavigate();
+  const packageIdType = useUserSettingsStore((state) => state.packageIdType);
 
   const {
     data: vulnerabilities,
@@ -240,7 +245,11 @@ const ProductVulnerabilitiesComponent = () => {
       }),
       columnHelper.accessor(
         (vuln) => {
-          return identifierToString(vuln.identifier);
+          if (packageIdType === 'PURL') {
+            return identifierToPurl(vuln.identifier);
+          } else {
+            return identifierToString(vuln.identifier);
+          }
         },
         {
           id: 'packageIdentifier',
@@ -284,7 +293,7 @@ const ProductVulnerabilitiesComponent = () => {
         enableColumnFilter: false,
       }),
     ],
-    [navigate, search]
+    [navigate, packageIdType, search]
   );
 
   const pageIndex = useMemo(

--- a/ui/src/routes/organizations/$orgId/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/vulnerabilities/index.tsx
@@ -60,7 +60,10 @@ import {
   convertToBackendSorting,
   updateColumnSorting,
 } from '@/helpers/handle-multisort';
-import { identifierToString } from '@/helpers/identifier-conversion';
+import {
+  identifierToPurl,
+  identifierToString,
+} from '@/helpers/identifier-conversion';
 import { compareVulnerabilityRating } from '@/helpers/sorting-functions';
 import { toast } from '@/lib/toast';
 import {
@@ -68,6 +71,7 @@ import {
   paginationSearchParameterSchema,
   sortingSearchParameterSchema,
 } from '@/schemas';
+import { useUserSettingsStore } from '@/store/user-settings.store';
 
 const defaultPageSize = 10;
 
@@ -133,6 +137,7 @@ const OrganizationVulnerabilitiesComponent = () => {
   const search = Route.useSearch();
   const pageIndex = search.page ? search.page - 1 : 0;
   const pageSize = search.pageSize ? search.pageSize : defaultPageSize;
+  const packageIdType = useUserSettingsStore((state) => state.packageIdType);
 
   const {
     data: vulnerabilities,
@@ -225,7 +230,11 @@ const OrganizationVulnerabilitiesComponent = () => {
       }),
       columnHelper.accessor(
         (vuln) => {
-          return identifierToString(vuln.identifier);
+          if (packageIdType === 'PURL') {
+            return identifierToPurl(vuln.identifier);
+          } else {
+            return identifierToString(vuln.identifier);
+          }
         },
         {
           id: 'identifier',
@@ -262,7 +271,7 @@ const OrganizationVulnerabilitiesComponent = () => {
         enableColumnFilter: false,
       }),
     ],
-    [search]
+    [packageIdType, search]
   );
 
   const [expanded, setExpanded] = useState<ExpandedState>(


### PR DESCRIPTION
This PR is a temporary means to advance towards the goal of showing either PURLs or ORT IDs everywhere throughout the UI. Once the endpoints return PURLs (and possibly, whether the item was triggered by a project or package), we will follow-up with a proper implementation in the UI.

Relates to #2176, #2340, #2878.

![Screenshot from 2025-06-03 12-30-41](https://github.com/user-attachments/assets/2ba07645-0898-48a2-a7ea-c60ab51d6f0c)

![Screenshot from 2025-06-03 12-30-55](https://github.com/user-attachments/assets/07092c00-6363-483a-92b0-cd0428fa7a77)

Please see the commits for details.