### PR TITLE
Docs user guide

### DIFF
--- a/website/docs/user-guide/_category_.yml
+++ b/website/docs/user-guide/_category_.yml
@@ -1,0 +1,2 @@
+position: 3
+label: User Guide

--- a/website/docs/user-guide/concepts/_category_.yml
+++ b/website/docs/user-guide/concepts/_category_.yml
@@ -1,0 +1,2 @@
+position: 1
+label: Concepts

--- a/website/docs/user-guide/concepts/external-services.md
+++ b/website/docs/user-guide/concepts/external-services.md
@@ -1,0 +1,111 @@
+# External Services
+
+This document describes how to configure credentials for external services, like source code or artifact repositories.
+
+## Infrastructure Services
+
+External services are always accessed via _Infrastructure Services_.
+An Infrastructure Service can be created via API/UI or defined in a project's `.ort.env.yml`. It has the following properties:
+
+- An identifying `name`
+- An `url` to the external service
+- An optional `description`
+- A `username secret reference`
+- A `password secret reference`
+- Optional `credentials types`
+
+Please note, that you have to set a username secret reference, even if it is not needed for your service because you e.g. use a PAT.
+
+### Credential Types
+
+- `Git credentials` should be used, if a service is a Git repository; the credentials are then listed in the `.git-credentials` file.
+- `Netrc` should only be used in exceptional cases in which an external tool requires the credentials in the `.netrc` file. The only example
+- For services representing artifact repositories, it is typically not necessary to set any credential type. They are handled automatically by the standard authentication mechanism implemented in ORT Server.
+  we have seen for this so far are some Git repositories that use Git LFS.
+- The type No credentials is to be used for public repositories that do not require authentication, such as Maven Central or Conan Central. Here, the credentials of the service are ignored.
+
+The credentials of an Infrastructure Service can be added to the `Netrc` file and the `Git credentials` files. Adding credentials to the `Netrc` file allows access to most external services.
+
+If Git should not be able to obtain the credentials from the `Netrc` file, one can choose to add the credentials to the `Git credentials` file.
+
+In some cases, there could be conflicting services; for instance, if multiple repositories with different credentials are defined on the same repository server.
+Therefore, it is also possible to choose not to include the credentials in any files.
+
+### `.ort.env.yml` Example
+
+```yaml
+infrastructureServices:
+  - name: 'RepositoryService'
+    url: 'https://repo.example.org/test/repository.git'
+    usernameSecret: 'testUser'
+    passwordSecret: 'testPassword1'
+```
+
+## Secrets
+
+ORT stores confidential values&mdash;like usernames, passwords, and tokens&mdash;for Infrastructure Services as _Secrets_.
+A Secret has three properties:
+
+- An identifying `name`
+- A secret `value`
+- An optional `description`
+
+A secret value cannot be retrieved after the Secret has been created, only replaced.
+
+## Environment Definitions
+
+For artifact repositories you often need to generate configuration files for package managers&mdash;such as Maven's `settings.xml` or NPM's `.npmrc`.
+ORT Server creates these files from _Environment Definitions_ specified in your `.ort.env.yml`-file.
+
+Depending on the package manager, the environment definitions have different properties.
+
+### `.ort.env.yml` Examples
+
+#### Conan
+
+```yaml
+environmentDefinitions:
+  conan:
+    - service: 'RepositoryService'
+      name: 'conancenter'
+      url: 'https://center.conan.io'
+      verifySsl: 'true'
+```
+
+#### Maven
+
+```yaml
+maven:
+  - service: 'RepositoryService'
+    id: 'mainRepo'
+```
+
+#### NPM
+
+```yaml
+npm:
+  - service: 'RepositoryService'
+    scope: 'external'
+    email: 'test@example.org'
+    authMode: 'USERNAME_PASSWORD_AUTH'
+```
+
+#### NuGet
+
+```yaml
+nuget:
+  - service: 'RepositoryService'
+    sourceName: 'nuget.org'
+    sourcePath: 'https://api.nuget.org/v3/index.json'
+    sourceProtocolVersion: '3'
+    authMode: 'PASSWORD'
+```
+
+#### Yarn
+
+```yaml
+yarn:
+  - service: 'RepositoryService'
+    alwaysAuth: 'true'
+    authMode: 'AUTH_IDENT'
+```

--- a/website/docs/user-guide/concepts/structure.md
+++ b/website/docs/user-guide/concepts/structure.md
@@ -1,0 +1,58 @@
+# Structure
+
+This document describes how ORT Server is structured.
+
+## Entities
+
+ORT Server groups runs by repository, product, and organization.
+Each organization can have multiple products, and each product can have multiple repositories, and each repository can have multiple runs.
+
+### Organizations
+
+Organizations are a root entity. Admins of an organization can manage:
+
+- products
+- repositories
+- users
+- secrets
+- infrastructure services
+
+### Products
+
+Products are an entity to group repositories within an organization. Admins of a product can manage:
+
+- repositories
+- users
+- secrets
+
+### Repositories
+
+A repository represents a VCS repository, for example, a Git repository on GitHub. Admins of a repository can manage:
+
+- users
+- secrets
+- runs
+
+## Users
+
+To manage user rights, they can be assigned roles directly (see also [Authorization](../../admin-guide/architecture/authorization.md)) or indirectly by being members of a group.
+
+### Groups
+
+Groups have assigned roles. Users in the group inherit all roles from the group.
+Each group contains the roles of its child entity, e.g. the _readers_ group on product level also contains the _readers_ group for the child repositories.
+
+#### Readers
+
+Users in the _readers_ group can see the details of an entity and the child entities.
+On repository level, they can see ORT run results.
+
+#### Writers
+
+Users in the _writers_ group have the roles of the _readers_ group.
+Additionally, they can create child entities. On repository level, they can trigger new ORT runs.
+
+#### Admins
+
+Users in the _admins_ group have the roles of the _writers_ group.
+Additionally, they can manage secrets, infrastructure services and user groups.


### PR DESCRIPTION
This commit separated "Admin Guide" vs. "User Guide". It adds the documentation of two concepts to the "User Guide": "Structure" and "External Services".
