### PR TITLE
ui: Sibling navigation in breadcrumb

### DIFF
--- a/ui/src/components/header.tsx
+++ b/ui/src/components/header.tsx
@@ -27,6 +27,7 @@ import { z } from 'zod';
 import { useAdminServiceGetApiV1AdminConfigByKey } from '@/api/queries';
 import homeIcon from '@/assets/home-icon.svg';
 import { ModeToggle } from '@/components/mode-toggle';
+import { Siblings } from '@/components/siblings';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Form, FormControl, FormField, FormItem } from '@/components/ui/form';
 import {
@@ -41,8 +42,6 @@ import { LoadingIndicator } from './loading-indicator';
 import { ToastError } from './toast-error';
 import {
   Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
   BreadcrumbList,
   BreadcrumbSeparator,
 } from './ui/breadcrumb';
@@ -232,27 +231,18 @@ export const Header = () => {
             {organizationMatch?.context &&
               organizationMatch.context.breadcrumbs.organization !==
                 undefined && (
-                <BreadcrumbItem>
-                  <BreadcrumbLink asChild>
-                    <Link to={organizationMatch.pathname}>
-                      {organizationMatch.context.breadcrumbs.organization}
-                    </Link>
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
+                <Siblings
+                  entity='organization'
+                  pathName={organizationMatch.pathname}
+                />
               )}
-            {productMatch?.context &&
-              productMatch.context.breadcrumbs.product !== undefined && (
-                <>
-                  <BreadcrumbSeparator />
-                  <BreadcrumbItem>
-                    <BreadcrumbLink asChild>
-                      <Link to={productMatch.pathname}>
-                        {productMatch.context.breadcrumbs.product}
-                      </Link>
-                    </BreadcrumbLink>
-                  </BreadcrumbItem>
-                </>
-              )}
+            {productMatch?.context && (
+              <>
+                {organizationMatch?.context.breadcrumbs.organization !==
+                  undefined && <BreadcrumbSeparator />}
+                <Siblings entity='product' pathName={productMatch.pathname} />
+              </>
+            )}
             {repoMatch?.context && (
               <>
                 {(organizationMatch?.context.breadcrumbs.organization !==
@@ -260,32 +250,18 @@ export const Header = () => {
                   productMatch?.context.breadcrumbs.product !== undefined) && (
                   <BreadcrumbSeparator />
                 )}
-                <BreadcrumbItem>
-                  <BreadcrumbLink asChild>
-                    <Link
-                      to='/organizations/$orgId/products/$productId/repositories/$repoId/runs'
-                      params={{
-                        orgId: repoMatch.params.orgId,
-                        productId: repoMatch.params.productId,
-                        repoId: repoMatch.params.repoId,
-                      }}
-                    >
-                      {repoMatch.context.breadcrumbs.repo}
-                    </Link>
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
+                <Siblings
+                  entity='repository'
+                  pathName={
+                    '/organizations/$orgId/products/$productId/repositories/$repoId/runs'
+                  }
+                />
               </>
             )}
             {runMatch?.context && (
               <>
                 <BreadcrumbSeparator />
-                <BreadcrumbItem>
-                  <BreadcrumbLink asChild>
-                    <Link to={runMatch.pathname}>
-                      {runMatch.context.breadcrumbs.run}
-                    </Link>
-                  </BreadcrumbLink>
-                </BreadcrumbItem>
+                <Siblings entity='run' pathName={runMatch.pathname} />
               </>
             )}
           </BreadcrumbList>

--- a/ui/src/components/siblings.tsx
+++ b/ui/src/components/siblings.tsx
@@ -1,0 +1,281 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { Link, useParams, useRouter } from '@tanstack/react-router';
+import { ChevronDown } from 'lucide-react';
+
+import {
+  useOrganizationsServiceGetApiV1Organizations,
+  useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdProducts,
+  useProductsServiceGetApiV1ProductsByProductIdRepositories,
+  useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdRuns,
+} from '@/api/queries';
+import { ApiError } from '@/api/requests';
+import { BreadcrumbItem, BreadcrumbLink } from '@/components/ui/breadcrumb';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { ALL_ITEMS } from '@/lib/constants';
+
+type SiblingsProps = {
+  entity: 'organization' | 'product' | 'repository' | 'run';
+  pathName?: string;
+};
+
+export const Siblings = ({ entity, pathName }: SiblingsProps) => {
+  const router = useRouter();
+  const breadcrumbs = router.options.context.breadcrumbs;
+  const params = useParams({ strict: false });
+
+  // To improve the performance of the siblings component, set a stale time of
+  // 2 hours for all queries. This is because the entities (organizations, products,
+  // repositories, runs) are not expected to change frequently, and when changes do
+  // occur, cache invalidation will ensure that the latest data is fetched.
+  const staleTime = 2 * 60 * 60 * 1000;
+
+  // By using the `enabled` option in the query hooks, unnecessary API calls can be prevented.
+  // Now, only the single query relevant to the clicked dropdown will be executed. Also ensure
+  // that queries that depend on a path parameter (like orgId) do not run until that parameter
+  // is actually present.
+  const {
+    data: organizations,
+    isPending: isOrgPending,
+    isError: isOrgError,
+    error: orgError,
+  } = useOrganizationsServiceGetApiV1Organizations(
+    {
+      limit: ALL_ITEMS,
+    },
+    undefined,
+    {
+      staleTime: staleTime,
+      enabled: entity === 'organization',
+    }
+  );
+
+  const {
+    data: products,
+    isPending: isProductsPending,
+    isError: isProductsError,
+    error: productsError,
+  } = useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdProducts(
+    {
+      organizationId: Number(params.orgId) ?? '',
+    },
+    undefined,
+    {
+      staleTime: staleTime,
+      enabled: entity === 'product' || !!params.orgId,
+    }
+  );
+
+  const {
+    data: repositories,
+    isPending: isRepositoriesPending,
+    isError: isRepositoriesError,
+    error: repositoriesError,
+  } = useProductsServiceGetApiV1ProductsByProductIdRepositories(
+    {
+      productId: Number(params.productId) ?? '',
+    },
+    undefined,
+    {
+      staleTime: staleTime,
+      enabled: entity === 'repository' || !!params.productId,
+    }
+  );
+
+  const {
+    data: runs,
+    isPending: isRunsPending,
+    isError: isRunsError,
+    error: runsError,
+  } = useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdRuns(
+    {
+      repositoryId: Number(params.repoId) ?? '',
+    },
+    undefined,
+    {
+      staleTime: staleTime,
+      enabled: entity === 'run' || !!params.repoId,
+    }
+  );
+
+  const name =
+    entity === 'organization'
+      ? breadcrumbs.organization
+      : entity === 'product'
+        ? breadcrumbs.product
+        : entity === 'repository'
+          ? breadcrumbs.repo
+          : breadcrumbs.run;
+
+  const orgSiblings = organizations?.data.filter(
+    (org) => org.id !== Number(params.orgId)
+  );
+
+  const prodSiblings = products?.data.filter(
+    (prod) => prod.id !== Number(params.productId)
+  );
+  const repoSiblings = repositories?.data.filter(
+    (repo) => repo.id !== Number(params.repoId)
+  );
+  const runSiblings = runs?.data
+    .sort((a, b) => b.index - a.index)
+    .filter((run) => run.index !== Number(params.runIndex));
+
+  return (
+    <BreadcrumbItem>
+      {entity === 'organization' && orgSiblings && orgSiblings.length > 0 && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <ChevronDown className='ml-1 size-4 cursor-pointer' />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className='max-h-96' align='start'>
+            <>
+              {isOrgPending && <DropdownMenuItem>Loading...</DropdownMenuItem>}
+              {isOrgError && (
+                <DropdownMenuItem className='text-red-500'>
+                  Error:{' '}
+                  {`Failed to load organizations: ${(orgError as ApiError).message}`}
+                </DropdownMenuItem>
+              )}
+              {orgSiblings.map((org) => (
+                <DropdownMenuItem key={org.id} className='ml-2'>
+                  <Link
+                    to='/organizations/$orgId'
+                    params={{ orgId: org.id.toString() ?? '' }}
+                  >
+                    {org.name}
+                  </Link>
+                </DropdownMenuItem>
+              ))}
+            </>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+      {entity === 'product' && prodSiblings && prodSiblings.length > 0 && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <ChevronDown className='ml-1 size-4 cursor-pointer' />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className='max-h-96' align='start'>
+            <>
+              {isProductsPending && (
+                <DropdownMenuItem>Loading...</DropdownMenuItem>
+              )}
+              {isProductsError && (
+                <DropdownMenuItem className='text-red-500'>
+                  Error:{' '}
+                  {`Failed to load products: ${(productsError as ApiError).message}`}
+                </DropdownMenuItem>
+              )}
+              {prodSiblings.map((prod) => (
+                <DropdownMenuItem key={prod.id} className='ml-2'>
+                  <Link
+                    to='/organizations/$orgId/products/$productId'
+                    params={{
+                      orgId: params.orgId ?? '',
+                      productId: prod.id.toString() ?? '',
+                    }}
+                  >
+                    {prod.name}
+                  </Link>
+                </DropdownMenuItem>
+              ))}
+            </>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+      {entity === 'repository' && repoSiblings && repoSiblings.length > 0 && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <ChevronDown className='ml-1 size-4 cursor-pointer' />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className='max-h-96' align='start'>
+            <>
+              {isRepositoriesPending && (
+                <DropdownMenuItem>Loading...</DropdownMenuItem>
+              )}
+              {isRepositoriesError && (
+                <DropdownMenuItem className='text-red-500'>
+                  Error:{' '}
+                  {`Failed to load repositories: ${(repositoriesError as ApiError).message}`}
+                </DropdownMenuItem>
+              )}
+              {repoSiblings?.map((repo) => (
+                <DropdownMenuItem key={repo.id} className='ml-2'>
+                  <Link
+                    to='/organizations/$orgId/products/$productId/repositories/$repoId'
+                    params={{
+                      orgId: params.orgId ?? '',
+                      productId: params.productId ?? '',
+                      repoId: repo.id.toString() ?? '',
+                    }}
+                  >
+                    {repo.url}
+                  </Link>
+                </DropdownMenuItem>
+              ))}
+            </>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+      {entity === 'run' && runSiblings && runSiblings.length > 0 && (
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <ChevronDown className='ml-1 size-4 cursor-pointer' />
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className='max-h-96' align='start'>
+            <>
+              {isRunsPending && <DropdownMenuItem>Loading...</DropdownMenuItem>}
+              {isRunsError && (
+                <DropdownMenuItem className='text-red-500'>
+                  Error:{' '}
+                  {`Failed to load runs: ${(runsError as ApiError).message}`}
+                </DropdownMenuItem>
+              )}
+              {runSiblings?.map((run) => (
+                <DropdownMenuItem key={run.index} className='ml-2'>
+                  <Link
+                    to='/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex'
+                    params={{
+                      orgId: params.orgId ?? '',
+                      productId: params.productId ?? '',
+                      repoId: params.repoId ?? '',
+                      runIndex: run.index.toString() ?? '',
+                    }}
+                  >
+                    {run.index}
+                  </Link>
+                </DropdownMenuItem>
+              ))}
+            </>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+      <BreadcrumbLink asChild>
+        <Link to={pathName}>{name}</Link>
+      </BreadcrumbLink>
+    </BreadcrumbItem>
+  );
+};


### PR DESCRIPTION
This PR introduces a "shortcut" navigation to sibling organizations, products, repositories and runs to the breadcrumb. 


![Screenshot from 2025-06-26 11-22-39](https://github.com/user-attachments/assets/e0f32328-79c8-489e-b992-93be2beb9f65)

![Screenshot from 2025-06-26 11-22-51](https://github.com/user-attachments/assets/782b695c-1e0a-4673-a026-2925486d7cc1)

![Screenshot from 2025-06-26 11-23-05](https://github.com/user-attachments/assets/36c577e0-d6a2-4d44-8eaa-a97644c70e5d)



@sschuberth I decided to keep the down carets in the breadcrumb in case there are siblings available on server, to simplify the logic of this feature combined with the earlier feature of not showing upper-level entities in breadcrumb for technical users that do not have access rights to upper-level entities.

I also tested that the breadcrumb works as intended also for the said technical users, which only have access to some lower-level entities such as product/repository.

1. This user only has access rights to one particular product (Semver).  No sibling products are shown in the breadcrumb, as intended.

![Screenshot from 2025-06-26 11-30-40](https://github.com/user-attachments/assets/81647f46-9cd9-4e7c-b09f-24a8ddb46dbf)

2. This user only has access rights to one particular repository (harmony-access-point).  No sibling repositories are shown in the breadcrumb, as intended.

![Screenshot from 2025-06-24 12-20-57](https://github.com/user-attachments/assets/788a297b-9d28-4dc2-bddd-fe3cdc0a3dcb)

Note on performance: extra care has been taken to not introduce a visible degradation into navigation performance:
- stale time of 2 hours to all "entity" queries, to retrieve the entities (org, prod, repo) efficiently from cache instead of an endpoint
- clicking open a "sibling" item which opens up a dropdown only runs the query for getting the list of that particular entity (and only if stale time is passed)