### PR TITLE
fix(services): Respect group prefix when querying Keycloak members

### DIFF
--- a/clients/keycloak/src/main/kotlin/DefaultKeycloakClient.kt
+++ b/clients/keycloak/src/main/kotlin/DefaultKeycloakClient.kt
@@ -209,11 +209,11 @@ class DefaultKeycloakClient(
         }.body<List<Group>>().find { it.name == name }
             ?: throw KeycloakClientException("Could not find group with name '${name.value}'.")
 
-    override suspend fun searchGroups(name: GroupName): Set<Group> =
+    override suspend fun searchGroups(partialName: GroupName): Set<Group> =
         runCatching {
             httpClient.get("$apiUrl/groups") {
                 url {
-                    parameters.append("search", name.value)
+                    parameters.append("search", partialName.value)
                     parameters.append("exact", "false")
                 }
             }

--- a/clients/keycloak/src/main/kotlin/KeycloakClient.kt
+++ b/clients/keycloak/src/main/kotlin/KeycloakClient.kt
@@ -42,9 +42,9 @@ interface KeycloakClient {
     suspend fun getGroup(name: GroupName): Group
 
     /**
-     * Searches the [group][Group] that group name contains [name].
+     * Get all [groups][Group] that partially match the given [partialName][GroupName].
      */
-    suspend fun searchGroups(name: GroupName): Set<Group>
+    suspend fun searchGroups(partialName: GroupName): Set<Group>
 
     /**
      * Add a new [group][Group] to the Keycloak realm with the given [name].

--- a/clients/keycloak/src/testFixtures/kotlin/KeycloakTestClient.kt
+++ b/clients/keycloak/src/testFixtures/kotlin/KeycloakTestClient.kt
@@ -63,8 +63,8 @@ class KeycloakTestClient(
     override suspend fun getGroup(name: GroupName) =
         groups.find { it.name == name } ?: throw KeycloakClientException("")
 
-    override suspend fun searchGroups(name: GroupName) =
-        groups.filter { it.name.value.contains(name.value) }.toSet()
+    override suspend fun searchGroups(partialName: GroupName) =
+        groups.filter { it.name.value.contains(partialName.value) }.toSet()
 
     override suspend fun createGroup(name: GroupName) {
         if (groups.any { it.name == name }) throw KeycloakClientException("")

--- a/core/src/main/kotlin/di/Module.kt
+++ b/core/src/main/kotlin/di/Module.kt
@@ -190,12 +190,16 @@ fun ortServerModule(config: ApplicationConfig, db: Database?) = module {
     singleOf(::RepositoryService)
     singleOf(::RuleViolationService)
     singleOf(::SecretService)
-    singleOf(::UserService)
     singleOf(::VulnerabilityService)
 
     single<AuthorizationService> {
         val keycloakGroupPrefix = get<ApplicationConfig>().tryGetString("keycloak.groupPrefix").orEmpty()
         DefaultAuthorizationService(get(), get(), get(), get(), get(), keycloakGroupPrefix)
+    }
+
+    single<UserService> {
+        val keycloakGroupPrefix = get<ApplicationConfig>().tryGetString("keycloak.groupPrefix").orEmpty()
+        UserService(get(), keycloakGroupPrefix)
     }
 
     single {

--- a/services/authorization/src/main/kotlin/UserService.kt
+++ b/services/authorization/src/main/kotlin/UserService.kt
@@ -33,7 +33,13 @@ import org.eclipse.apoapsis.ortserver.model.UserGroup
  * A service providing functions for working with [users][User].
  */
 class UserService(
-    private val keycloakClient: KeycloakClient
+    private val keycloakClient: KeycloakClient,
+
+    /**
+     * A prefix for Keycloak group names, to be used when multiple instances of ORT Server share the same Keycloak
+     * realm.
+     */
+    private val keycloakGroupPrefix: String
 ) {
     /**
      * Create a user. If "password" is null, then "temporary" is ignored.
@@ -85,21 +91,33 @@ class UserService(
      * organization with this [organizationId].
      */
     suspend fun getUsersHavingRightsForOrganization(organizationId: Long): Map<User, Set<UserGroup>> =
-        getUsersForGroups(keycloakClient.searchGroups(GroupName(OrganizationRole.groupPrefix(organizationId))))
+        getUsersForGroups(
+            keycloakClient.searchGroups(
+                GroupName(keycloakGroupPrefix + OrganizationRole.groupPrefix(organizationId))
+            )
+        )
 
     /**
      * Get [User]s with all the [UserGroup]s assigned to them (ADMINS, WRITERS, READERS), that have access to the
      * product with this [productId].
      */
     suspend fun getUsersHavingRightForProduct(productId: Long): Map<User, Set<UserGroup>> =
-        getUsersForGroups(keycloakClient.searchGroups(GroupName(ProductRole.groupPrefix(productId))))
+        getUsersForGroups(
+            keycloakClient.searchGroups(
+                GroupName(keycloakGroupPrefix + ProductRole.groupPrefix(productId))
+            )
+        )
 
     /**
      * Get [User]s with all  the [UserGroup]s assigned to them (ADMINS, WRITERS, READERS), that have rights to the
      * repository with this [repositoryId].
      */
     suspend fun getUsersHavingRightsForRepository(repositoryId: Long): Map<User, Set<UserGroup>> =
-        getUsersForGroups(keycloakClient.searchGroups(GroupName(RepositoryRole.groupPrefix(repositoryId))))
+        getUsersForGroups(
+            keycloakClient.searchGroups(
+                GroupName(keycloakGroupPrefix + RepositoryRole.groupPrefix(repositoryId))
+            )
+        )
 
     private suspend fun getUsersForGroups(groups: Set<Group>): Map<User, Set<UserGroup>> {
         val users = mutableMapOf<User, Set<UserGroup>>()

--- a/services/authorization/src/test/kotlin/UserServiceTest.kt
+++ b/services/authorization/src/test/kotlin/UserServiceTest.kt
@@ -36,7 +36,9 @@ import org.eclipse.apoapsis.ortserver.model.UserGroup
 
 class UserServiceTest : WordSpec({
     val keycloakClient = mockk<KeycloakClient>()
-    val service = UserService(keycloakClient)
+
+    val keycloakGroupPrefix = "my_prefix_"
+    val service = UserService(keycloakClient, keycloakGroupPrefix)
 
     fun mockGroupsListForEntity(entityName: String, entityId: Long) {
         coEvery {
@@ -58,7 +60,7 @@ class UserServiceTest : WordSpec({
         } returns emptySet()
 
         coEvery {
-            keycloakClient.searchGroups(GroupName("${entityName}_${entityId}_"))
+            keycloakClient.searchGroups(GroupName("${keycloakGroupPrefix}${entityName}_${entityId}_"))
         } returns setOf(
             Group(GroupId("gr1-wri"), GroupName("${entityName}_${entityId}_WRITERS")),
             Group(GroupId("gr2-adm"), GroupName("${entityName}_${entityId}_ADMINS")),
@@ -72,7 +74,7 @@ class UserServiceTest : WordSpec({
             val orgId = 7L
 
             coEvery {
-                keycloakClient.searchGroups(GroupName("ORGANIZATION_${orgId}_"))
+                keycloakClient.searchGroups(GroupName("${keycloakGroupPrefix}ORGANIZATION_${orgId}_"))
             } returns emptySet()
 
             // When
@@ -105,7 +107,7 @@ class UserServiceTest : WordSpec({
             val prodId = 4L
 
             coEvery {
-                keycloakClient.searchGroups(GroupName("PRODUCT_${prodId}_"))
+                keycloakClient.searchGroups(GroupName("${keycloakGroupPrefix}PRODUCT_${prodId}_"))
             } returns emptySet()
 
             // When
@@ -115,7 +117,7 @@ class UserServiceTest : WordSpec({
             result shouldBe emptyMap()
         }
 
-        "return map of users with corresponding set of roles within organization" {
+        "return map of users with corresponding set of roles within product" {
             // Given
             val prodId = 4L
             mockGroupsListForEntity("PRODUCT", prodId)
@@ -138,7 +140,7 @@ class UserServiceTest : WordSpec({
             val repoId = 2L
 
             coEvery {
-                keycloakClient.searchGroups(GroupName("REPOSITORY_${repoId}_"))
+                keycloakClient.searchGroups(GroupName("${keycloakGroupPrefix}REPOSITORY_${repoId}_"))
             } returns emptySet()
 
             // When


### PR DESCRIPTION
Fix user membership queries to include the Keycloak group prefix when listing users in _Organization_, _Product_, or _Repository_ groups. This prevents incorrect results when multiple ORT Server instances share the same Keycloak realm.

This bug came up in an environment where a productive ORT Server instance and a development ORT Server instance shared the same Keycloak realm. In the ORT Server UI's User page, users showed up in the list that actually did not have an group membership on the production environment. 