### PR TITLE
build(gradle): Switch publishing to new Maven Central portal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,8 +61,8 @@ jobs:
     - name: Publish to OSSRH
       env:
         GITHUB_DEPENDENCY_GRAPH_REF: refs/heads/main
-        ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.ORG_OSSRH_USERNAME }}
-        ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.ORG_OSSRH_PASSWORD }}
+        ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.CENTRAL_SONATYPE_TOKEN_USERNAME }}
+        ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.CENTRAL_SONATYPE_TOKEN_PASSWORD }}
         ORG_GRADLE_PROJECT_RELEASE_SIGNING_ENABLED: true
         ORG_GRADLE_PROJECT_signingInMemoryKey: ${{ secrets.ORG_GPG_PRIVATE_KEY }}
         ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.ORG_GPG_SUBKEY_ID }}

--- a/buildSrc/src/main/kotlin/ort-server-publication-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-publication-conventions.gradle.kts
@@ -17,6 +17,8 @@
  * License-Filename: LICENSE
  */
 
+import com.vanniktech.maven.publish.SonatypeHost
+
 plugins {
     // Apply third-party plugins.
     id("com.vanniktech.maven.publish")
@@ -51,5 +53,5 @@ mavenPublishing {
         }
     }
 
-    publishToMavenCentral()
+    publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL)
 }


### PR DESCRIPTION
The Eclipse Foundation has migrated the accounts to the new portal [1].

[1]: https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/5854#note_4174244

~Currently a draft because the GitHub secrets are not yet updated:
https://otterdog.eclipse.org/projects/technology.apoapsis#secrets~