### PR TITLE
feat(services): Mark secrets as deleted instead of removing them

### DIFF
--- a/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
@@ -1095,7 +1095,7 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
     }
 
     "DELETE /repositories/{repositoryId}/secrets/{secretName}" should {
-        "delete a secret" {
+        "mark a secret as deleted" {
             integrationTestApplication {
                 val repositoryId = createRepository().id
                 val secret = createSecret(repositoryId)
@@ -1104,6 +1104,12 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                     HttpStatusCode.NoContent
 
                 secretRepository.listForId(RepositoryId(repositoryId)).data shouldBe emptyList()
+
+                val allSecrets = secretRepository.listForId(RepositoryId(repositoryId), includeDeleted = true)
+                with(allSecrets.data) {
+                    shouldHaveSize(1)
+                    first().shouldBe(secret.copy(isDeleted = true))
+                }
 
                 val provider = SecretsProviderFactoryForTesting.instance()
                 provider.readSecret(Path(secret.path)) should beNull()

--- a/dao/src/main/kotlin/repositories/secret/SecretsTable.kt
+++ b/dao/src/main/kotlin/repositories/secret/SecretsTable.kt
@@ -27,11 +27,13 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.repository.RepositoriesTa
 import org.eclipse.apoapsis.ortserver.dao.repositories.repository.RepositoryDao
 import org.eclipse.apoapsis.ortserver.dao.utils.SortableEntityClass
 import org.eclipse.apoapsis.ortserver.dao.utils.SortableTable
+import org.eclipse.apoapsis.ortserver.dao.utils.transformToDatabasePrecision
 import org.eclipse.apoapsis.ortserver.dao.utils.transformToEntityId
 import org.eclipse.apoapsis.ortserver.model.Secret
 
 import org.jetbrains.exposed.dao.LongEntity
 import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.sql.kotlin.datetime.timestamp
 
 object SecretsTable : SortableTable("secrets") {
     val organizationId = reference("organization_id", OrganizationsTable).nullable()
@@ -41,6 +43,9 @@ object SecretsTable : SortableTable("secrets") {
     val path = text("path")
     val name = text("name").sortable()
     val description = text("description").nullable()
+
+    val isDeleted = bool("is_deleted").default(false)
+    val deletedAt = timestamp("deleted_at").nullable()
 }
 
 class SecretDao(id: EntityID<Long>) : LongEntity(id) {
@@ -57,6 +62,9 @@ class SecretDao(id: EntityID<Long>) : LongEntity(id) {
     var name by SecretsTable.name
     var description by SecretsTable.description
 
+    var isDeleted by SecretsTable.isDeleted
+    var deletedAt by SecretsTable.deletedAt.transformToDatabasePrecision()
+
     fun mapToModel() = Secret(
         id = id.value,
         path = path,
@@ -64,6 +72,7 @@ class SecretDao(id: EntityID<Long>) : LongEntity(id) {
         description = description,
         organization = organization?.mapToModel(),
         product = product?.mapToModel(),
-        repository = repository?.mapToModel()
+        repository = repository?.mapToModel(),
+        isDeleted = isDeleted
     )
 }

--- a/dao/src/main/resources/db/migration/V108__markSecretsAsDeleted.sql
+++ b/dao/src/main/resources/db/migration/V108__markSecretsAsDeleted.sql
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+-- Allow to mark secrets as deleted without removing them from the database table.
+ALTER TABLE secrets
+    ADD COLUMN is_deleted boolean DEFAULT FALSE NOT NULL;
+
+ALTER TABLE secrets
+    ADD COLUMN deleted_at timestamp;

--- a/dao/src/test/kotlin/repositories/secret/DaoSecretRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/secret/DaoSecretRepositoryTest.kt
@@ -141,13 +141,20 @@ class DaoSecretRepositoryTest : StringSpec() {
             )
         }
 
-        "delete should delete the database entry" {
+        "delete should mark the secret as deleted" {
             val name = "secret3"
             createSecret(name, repositoryId)
 
-            secretRepository.deleteForIdAndName(repositoryId, name)
+            secretRepository.markAsDeletedForIdAndName(repositoryId, name)
 
             secretRepository.listForId(repositoryId).data shouldBe emptyList()
+
+            val allSecrets = secretRepository.listForId(repositoryId, includeDeleted = true)
+            with(allSecrets.data) {
+                shouldNotBeNull()
+                size shouldBe 1
+                first().isDeleted shouldBe true
+            }
         }
 
         "Reading all secrets of specific type" should {

--- a/model/src/commonMain/kotlin/Secret.kt
+++ b/model/src/commonMain/kotlin/Secret.kt
@@ -57,5 +57,10 @@ data class Secret(
     /**
      * The [Repository] to which the secret belongs.
      */
-    val repository: Repository?
+    val repository: Repository?,
+
+    /**
+     *  If true, the secret is considered deleted and should not no longer be used.
+     */
+    val isDeleted: Boolean? = false
 )

--- a/model/src/commonMain/kotlin/repositories/SecretRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/SecretRepository.kt
@@ -41,10 +41,12 @@ interface SecretRepository {
 
     /**
      * List all secrets for an [id] according to the given [parameters].
+     * Only if [includeDeleted] is true, also includes secrets that are marked as deleted.
      */
     fun listForId(
         id: HierarchyId,
-        parameters: ListQueryParameters = ListQueryParameters.DEFAULT
+        parameters: ListQueryParameters = ListQueryParameters.DEFAULT,
+        includeDeleted: Boolean = false
     ): ListQueryResult<Secret>
 
     /**
@@ -53,7 +55,7 @@ interface SecretRepository {
     fun updateForIdAndName(id: HierarchyId, name: String, description: OptionalValue<String?>): Secret
 
     /**
-     * Delete a secret by [id] and secret's [name].
+     * Mark a secret as deleted by [id] and secret's [name].
      */
-    fun deleteForIdAndName(id: HierarchyId, name: String)
+    fun markAsDeletedForIdAndName(id: HierarchyId, name: String): Secret?
 }


### PR DESCRIPTION
Secrets are now soft-deleted by setting a deletion flag instead of being physically removed from the database. This preserves foreign key references from InfrastructureService entities while preventing deleted secrets from being used via the ORT Server UI.

Before this change, it was not possible to delete secrets when they were at least used once by one scan.