### PR TITLE
Improve authentication logic

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ azureMessagingServicebus = "7.17.11"
 azureSecurityKeyvaultSecrets = "4.9.4"
 azureStorageBlob = "12.30.0"
 clikt = "5.0.3"
+commonsText = "1.13.1"
 exposed = "0.61.0"
 flyway = "11.9.1"
 hikari = "6.3.0"
@@ -98,6 +99,7 @@ azureMessagingServicebus = { module = "com.azure:azure-messaging-servicebus", ve
 azureSecurityKeyvaultSecrets = { module = "com.azure:azure-security-keyvault-secrets", version.ref = "azureSecurityKeyvaultSecrets" }
 azureStorageBlob = { module = "com.azure:azure-storage-blob", version.ref = "azureStorageBlob" }
 clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
+commonsText = { module = "org.apache.commons:commons-text", version.ref = "commonsText" }
 exposedCore = { module = "org.jetbrains.exposed:exposed-core", version.ref = "exposed" }
 exposedDao = { module = "org.jetbrains.exposed:exposed-dao", version.ref = "exposed" }
 exposedJdbc = { module = "org.jetbrains.exposed:exposed-jdbc", version.ref = "exposed" }

--- a/workers/common/build.gradle.kts
+++ b/workers/common/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     implementation(projects.utils.config)
     implementation(projects.utils.logging)
 
+    implementation(libs.commonsText)
     implementation(libs.kaml)
     implementation(libs.kotlinxCoroutines)
     implementation(libs.kotlinxSerializationJson)


### PR DESCRIPTION
This PR extends `OrtServerAuthenticator` to better handle corner cases when authenticating URLs for which no uniquely matching infrastructure service is available.