### PR TITLE
feat(services): Add support for dynamic infrastructure services

### DIFF
--- a/dao/src/main/kotlin/repositories/infrastructureservice/DaoInfrastructureServiceDeclarationRepository.kt
+++ b/dao/src/main/kotlin/repositories/infrastructureservice/DaoInfrastructureServiceDeclarationRepository.kt
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.dao.repositories.infrastructureservice
+
+import org.eclipse.apoapsis.ortserver.dao.blockingQuery
+import org.eclipse.apoapsis.ortserver.model.InfrastructureServiceDeclaration
+import org.eclipse.apoapsis.ortserver.model.repositories.InfrastructureServiceDeclarationRepository
+
+import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.insert
+import org.jetbrains.exposed.sql.selectAll
+
+class DaoInfrastructureServiceDeclarationRepository(private val db: Database) :
+    InfrastructureServiceDeclarationRepository {
+    override fun getOrCreateForRun(
+        service: InfrastructureServiceDeclaration,
+        runId: Long
+    ): InfrastructureServiceDeclaration {
+        service.validate()
+        return db.blockingQuery {
+            val serviceDao = InfrastructureServiceDeclarationDao.Companion.getOrPut(service)
+            InfrastructureServiceDeclarationsRunsTable.insert {
+                it[infrastructureServiceDeclarationId] = serviceDao.id
+                it[ortRunId] = runId
+            }
+
+            serviceDao.mapToModel()
+        }
+    }
+
+    override fun listForRun(runId: Long): List<InfrastructureServiceDeclaration> =
+        db.blockingQuery {
+            val subQuery = InfrastructureServiceDeclarationsRunsTable
+                .select(InfrastructureServiceDeclarationsRunsTable.infrastructureServiceDeclarationId)
+                .where { InfrastructureServiceDeclarationsRunsTable.ortRunId eq runId }
+
+            InfrastructureServiceDeclarationsTable
+                .selectAll()
+                .where {
+                    InfrastructureServiceDeclarationsTable.id inSubQuery subQuery
+                }
+                .map { row ->
+                    InfrastructureServiceDeclaration(
+                        name = row[InfrastructureServiceDeclarationsTable.name],
+                        url = row[InfrastructureServiceDeclarationsTable.url],
+                        description = row[InfrastructureServiceDeclarationsTable.description],
+                        usernameSecret = row[InfrastructureServiceDeclarationsTable.usernameSecret],
+                        passwordSecret = row[InfrastructureServiceDeclarationsTable.passwordSecret],
+                        credentialsTypes = InfrastructureServiceDeclarationDao.fromCredentialsTypeString(
+                            row[InfrastructureServiceDeclarationsTable.credentialsType]
+                        )
+                    )
+                }
+        }
+}

--- a/dao/src/main/kotlin/repositories/infrastructureservice/InfrastructureServiceDeclarationsRunsTable.kt
+++ b/dao/src/main/kotlin/repositories/infrastructureservice/InfrastructureServiceDeclarationsRunsTable.kt
@@ -24,12 +24,15 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.ortrun.OrtRunsTable
 import org.jetbrains.exposed.sql.Table
 
 /**
- * An intermediate table to store references from [InfrastructureServicesTable] to [OrtRunsTable].
+ * An intermediate table to store references from [InfrastructureServiceDeclarationsTable] to [OrtRunsTable].
  */
-object InfrastructureServicesRunsTable : Table("infrastructure_services_ort_runs") {
-    val infrastructureServiceId = reference("infrastructure_service_id", InfrastructureServicesTable)
+object InfrastructureServiceDeclarationsRunsTable : Table("infrastructure_service_declarations_ort_runs") {
+    val infrastructureServiceDeclarationId = reference(
+        "infrastructure_service_declaration_id",
+        InfrastructureServiceDeclarationsTable
+    )
     val ortRunId = reference("ort_run_id", OrtRunsTable)
 
     override val primaryKey: PrimaryKey
-        get() = PrimaryKey(infrastructureServiceId, ortRunId, name = "${tableName}_pkey")
+        get() = PrimaryKey(infrastructureServiceDeclarationId, ortRunId, name = "${tableName}_pkey")
 }

--- a/dao/src/main/kotlin/repositories/infrastructureservice/InfrastructureServiceDeclarationsTable.kt
+++ b/dao/src/main/kotlin/repositories/infrastructureservice/InfrastructureServiceDeclarationsTable.kt
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2023 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.dao.repositories.infrastructureservice
+
+import java.util.EnumSet
+
+import org.eclipse.apoapsis.ortserver.dao.utils.SortableEntityClass
+import org.eclipse.apoapsis.ortserver.dao.utils.SortableTable
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
+import org.eclipse.apoapsis.ortserver.model.InfrastructureServiceDeclaration
+
+import org.jetbrains.exposed.dao.LongEntity
+import org.jetbrains.exposed.dao.id.EntityID
+import org.jetbrains.exposed.sql.and
+
+/**
+ * A table to store dynamic infrastructure services that are defined by environment file .ort.env.yml for each new
+ * ORT run on a repository.
+ */
+object InfrastructureServiceDeclarationsTable : SortableTable("infrastructure_service_declarations") {
+    val name = text("name").sortable()
+    val url = text("url")
+    val description = text("description").nullable()
+    val credentialsType = text("credentials_type").nullable()
+
+    val usernameSecret = text("username_secret")
+    val passwordSecret = text("password_secret")
+}
+
+class InfrastructureServiceDeclarationDao(id: EntityID<Long>) : LongEntity(id) {
+    companion object : SortableEntityClass<InfrastructureServiceDeclarationDao>(
+        InfrastructureServiceDeclarationsTable
+    ) {
+        /**
+         * Try to find an entity with properties matching the ones of the given [service].
+         */
+        fun findByInfrastructureServiceDeclaration(service: InfrastructureServiceDeclaration):
+                InfrastructureServiceDeclarationDao? =
+            find {
+                InfrastructureServiceDeclarationsTable.name eq service.name and
+                        (InfrastructureServiceDeclarationsTable.url eq service.url) and
+                        (InfrastructureServiceDeclarationsTable.description eq service.description) and
+                        (InfrastructureServiceDeclarationsTable.usernameSecret eq service.usernameSecret) and
+                        (InfrastructureServiceDeclarationsTable.passwordSecret eq service.passwordSecret) and
+                        (
+                                InfrastructureServiceDeclarationsTable.credentialsType eq
+                                        toCredentialsTypeString(service.credentialsTypes)
+                                )
+            }.firstOrNull()
+
+        /**
+         * Return an entity with properties matching the ones of the given [service]. If no such entity exists yet, a
+         * new one is created now.
+         */
+        fun getOrPut(service: InfrastructureServiceDeclaration): InfrastructureServiceDeclarationDao =
+            findByInfrastructureServiceDeclaration(service) ?: new {
+                name = service.name
+                url = service.url
+                description = service.description
+                credentialsTypes = service.credentialsTypes
+                usernameSecret = service.usernameSecret
+                passwordSecret = service.passwordSecret
+            }
+
+        /**
+         * Convert a set of [CredentialsType]s to a string representation.
+         */
+        private fun toCredentialsTypeString(types: Set<CredentialsType>): String? =
+            types.takeUnless { it.isEmpty() }?.toSortedSet()?.joinToString(",") { it.name }
+
+        /**
+         * Return a set of [CredentialsType]s from a string representation.
+         */
+        fun fromCredentialsTypeString(typeString: String?): Set<CredentialsType> =
+            typeString?.split(",")
+                ?.mapTo(EnumSet.noneOf(CredentialsType::class.java)) { CredentialsType.valueOf(it) }.orEmpty()
+    }
+
+    var name by InfrastructureServiceDeclarationsTable.name
+    var url by InfrastructureServiceDeclarationsTable.url
+    var description by InfrastructureServiceDeclarationsTable.description
+
+    var credentialsTypes by InfrastructureServiceDeclarationsTable.credentialsType.transform(
+        { toCredentialsTypeString(it) },
+        { fromCredentialsTypeString(it) }
+    )
+
+    var usernameSecret by InfrastructureServiceDeclarationsTable.usernameSecret
+    var passwordSecret by InfrastructureServiceDeclarationsTable.passwordSecret
+
+    fun mapToModel() = InfrastructureServiceDeclaration(
+        name,
+        url,
+        description,
+        usernameSecret,
+        passwordSecret,
+        credentialsTypes
+    )
+}

--- a/dao/src/main/resources/db/migration/V110__addInfrastructureServiceDeclarations.sql
+++ b/dao/src/main/resources/db/migration/V110__addInfrastructureServiceDeclarations.sql
@@ -1,0 +1,39 @@
+-- Table storing infrastructure service declarations that are created from .ort.env.yml in the source code repository.
+CREATE TABLE infrastructure_service_declarations
+(
+     id bigserial PRIMARY KEY,
+     name text NOT NULL,
+     url text NOT NULL,
+     description text,
+     credentials_type text,
+     username_secret text NOT NULL,
+     password_secret text NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS infrastructure_service_declarations_name ON infrastructure_service_declarations (name);
+
+CREATE INDEX infrastructure_service_declarations_all_value_columns
+    ON infrastructure_service_declarations (name, url, description, credentials_type, username_secret, password_secret);
+
+-- Delete any infrastructure services that are already associated with an ORT run.
+-- This does not matter, because they will be re-created from the .ort.env.yml on any new ORT run.
+DROP TABLE IF EXISTS infrastructure_services_to_delete;
+CREATE TEMP TABLE infrastructure_services_to_delete AS
+    SELECT DISTINCT infrastructure_service_id
+    FROM infrastructure_services_ort_runs;
+
+DELETE FROM infrastructure_services_ort_runs
+    WHERE infrastructure_service_id IN (SELECT infrastructure_service_id FROM infrastructure_services_to_delete);
+
+DELETE FROM infrastructure_services
+    WHERE id IN (SELECT infrastructure_service_id FROM infrastructure_services_to_delete);
+
+DROP TABLE infrastructure_services_ort_runs;
+
+CREATE TABLE infrastructure_service_declarations_ort_runs
+(
+    infrastructure_service_declaration_id bigint REFERENCES infrastructure_service_declarations NOT NULL,
+    ort_run_id bigint REFERENCES ort_runs NOT NULL,
+
+    PRIMARY KEY (infrastructure_service_declaration_id, ort_run_id)
+);

--- a/dao/src/test/kotlin/repositories/infrastructureservice/InfrastructureServiceDeclarationRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/infrastructureservice/InfrastructureServiceDeclarationRepositoryTest.kt
@@ -1,0 +1,215 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.dao.repositories.infrastructureservice
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldContainOnly
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldInclude
+
+import org.eclipse.apoapsis.ortserver.dao.repositories.ortrun.DaoOrtRunRepository
+import org.eclipse.apoapsis.ortserver.dao.repositories.secret.DaoSecretRepository
+import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
+import org.eclipse.apoapsis.ortserver.dao.test.Fixtures
+import org.eclipse.apoapsis.ortserver.model.CredentialsType
+import org.eclipse.apoapsis.ortserver.model.InfrastructureService
+import org.eclipse.apoapsis.ortserver.model.InfrastructureServiceDeclaration
+import org.eclipse.apoapsis.ortserver.model.Organization
+import org.eclipse.apoapsis.ortserver.model.OrganizationId
+import org.eclipse.apoapsis.ortserver.model.Product
+import org.eclipse.apoapsis.ortserver.model.Secret
+import org.eclipse.apoapsis.ortserver.model.validation.ValidationException
+
+class InfrastructureServiceDeclarationRepositoryTest : WordSpec() {
+    private val dbExtension = extension(DatabaseTestExtension())
+
+    private lateinit var infrastructureServicesRepository: DaoInfrastructureServiceRepository
+    private lateinit var infrastructureServiceDeclarationRepository: DaoInfrastructureServiceDeclarationRepository
+    private lateinit var secretRepository: DaoSecretRepository
+    private lateinit var ortRunRepository: DaoOrtRunRepository
+    private lateinit var fixtures: Fixtures
+    private lateinit var usernameSecret: Secret
+    private lateinit var passwordSecret: Secret
+
+    init {
+        beforeEach {
+            infrastructureServicesRepository = dbExtension.fixtures.infrastructureServiceRepository
+            infrastructureServiceDeclarationRepository = dbExtension.fixtures.infrastructureServiceDeclarationRepository
+            secretRepository = dbExtension.fixtures.secretRepository
+            ortRunRepository = dbExtension.fixtures.ortRunRepository
+            fixtures = dbExtension.fixtures
+
+            usernameSecret = secretRepository.create("p1", "user", null, OrganizationId(fixtures.organization.id))
+            passwordSecret = secretRepository.create("p2", "pass", null, OrganizationId(fixtures.organization.id))
+        }
+
+        "getOrCreateForRun" should {
+            "create a new entity in the database" {
+                val expectedService = createInfrastructureServiceDeclaration()
+
+                val service = infrastructureServiceDeclarationRepository.getOrCreateForRun(
+                    expectedService,
+                    fixtures.ortRun.id
+                )
+
+                service shouldBe expectedService
+
+                val runServices = infrastructureServiceDeclarationRepository.listForRun(fixtures.ortRun.id)
+                runServices shouldContainOnly listOf(service)
+            }
+
+            "reuse an already existing entity" {
+                val otherRun = fixtures.createOrtRun()
+                val expectedService = createInfrastructureServiceDeclaration()
+                val serviceForOtherRun =
+                    infrastructureServiceDeclarationRepository.getOrCreateForRun(expectedService, otherRun.id)
+
+                val serviceForRun =
+                    infrastructureServiceDeclarationRepository.getOrCreateForRun(expectedService, fixtures.ortRun.id)
+
+                serviceForRun shouldBe expectedService
+                serviceForRun shouldBe serviceForOtherRun
+
+                val runServices = infrastructureServiceDeclarationRepository.listForRun(fixtures.ortRun.id)
+                runServices shouldContainOnly listOf(serviceForRun)
+            }
+
+            "not reuse a service assigned to an organization" {
+                val orgService = createInfrastructureService(organization = fixtures.organization)
+                infrastructureServicesRepository.create(orgService)
+
+                val runService = createInfrastructureServiceDeclaration()
+                val dbRunService = infrastructureServiceDeclarationRepository.getOrCreateForRun(
+                    runService,
+                    fixtures.ortRun.id
+                )
+
+                dbRunService shouldNotBe orgService
+            }
+
+            "not reuse a service assigned to a product" {
+                val prodService = createInfrastructureService(product = fixtures.product)
+                infrastructureServicesRepository.create(prodService)
+
+                val runService = createInfrastructureServiceDeclaration()
+                val dbRunService = infrastructureServiceDeclarationRepository.getOrCreateForRun(
+                    runService,
+                    fixtures.ortRun.id
+                )
+
+                dbRunService shouldNotBe prodService
+            }
+
+            "throw exception if the entity name is invalid" {
+                val serviceName = " #servicename! "
+                val newService = createInfrastructureServiceDeclaration(name = serviceName)
+
+                val exception = shouldThrow<ValidationException> {
+                    infrastructureServiceDeclarationRepository.getOrCreateForRun(newService, fixtures.ortRun.id)
+                }
+
+                exception.message shouldInclude serviceName
+
+                infrastructureServiceDeclarationRepository.listForRun(fixtures.ortRun.id) shouldBe emptyList()
+            }
+        }
+
+        "listForRun" should {
+            "return all services assigned to a run" {
+                val runService1 = createInfrastructureServiceDeclaration(name = "run1")
+                val runService2 = createInfrastructureServiceDeclaration(name = "run2")
+                val orgService = createInfrastructureService(name = "org", organization = fixtures.organization)
+                val prodService = createInfrastructureService(name = "prod", product = fixtures.product)
+
+                infrastructureServicesRepository.create(orgService)
+                infrastructureServicesRepository.create(prodService)
+                infrastructureServiceDeclarationRepository.getOrCreateForRun(runService1, fixtures.ortRun.id)
+                infrastructureServiceDeclarationRepository.getOrCreateForRun(runService2, fixtures.ortRun.id)
+
+                val runServices = infrastructureServiceDeclarationRepository.listForRun(fixtures.ortRun.id)
+
+                runServices shouldContainExactlyInAnyOrder listOf(runService1, runService2)
+            }
+        }
+    }
+
+    /**
+     * Convenience function to create a test [InfrastructureService] with default properties.
+     */
+    private fun createInfrastructureService(
+        name: String = SERVICE_NAME,
+        url: String = SERVICE_URL,
+        description: String? = SERVICE_DESCRIPTION,
+        usernameSecret: Secret = this.usernameSecret,
+        passwordSecret: Secret = this.passwordSecret,
+        organization: Organization? = null,
+        product: Product? = null,
+        credentialsTypes: Set<CredentialsType> = setOf(CredentialsType.NETRC_FILE),
+    ): InfrastructureService =
+        InfrastructureService(
+            name,
+            url,
+            description,
+            usernameSecret,
+            passwordSecret,
+            organization,
+            product,
+            credentialsTypes
+        )
+
+    private fun createInfrastructureServiceDeclaration(
+        name: String = SERVICE_NAME,
+        url: String = SERVICE_URL,
+        description: String = SERVICE_DESCRIPTION,
+        usernameSecret: Secret = this.usernameSecret,
+        passwordSecret: Secret = this.passwordSecret,
+        credentialsTypes: Set<CredentialsType> = setOf(CredentialsType.NETRC_FILE),
+    ): InfrastructureServiceDeclaration =
+        InfrastructureServiceDeclaration(
+            name,
+            url,
+            description,
+            usernameSecret.name,
+            passwordSecret.name,
+            credentialsTypes
+        )
+}
+
+private const val SERVICE_NAME = "MyRepositoryService"
+private const val SERVICE_URL = "https://repo.example.org/artifacts"
+private const val SERVICE_DESCRIPTION = "This infrastructure service..."
+
+/**
+ * Create an infrastructure service in the database based on the given [service].
+ */
+private fun DaoInfrastructureServiceRepository.create(service: InfrastructureService): InfrastructureService =
+    create(
+        service.name,
+        service.url,
+        service.description,
+        service.usernameSecret,
+        service.passwordSecret,
+        service.credentialsTypes,
+        service.organization?.id,
+        service.product?.id
+    )

--- a/dao/src/testFixtures/kotlin/Fixtures.kt
+++ b/dao/src/testFixtures/kotlin/Fixtures.kt
@@ -28,6 +28,7 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerjob.DaoAnalyzerJo
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.DaoAnalyzerRunRepository
 import org.eclipse.apoapsis.ortserver.dao.repositories.evaluatorjob.DaoEvaluatorJobRepository
 import org.eclipse.apoapsis.ortserver.dao.repositories.evaluatorrun.DaoEvaluatorRunRepository
+import org.eclipse.apoapsis.ortserver.dao.repositories.infrastructureservice.DaoInfrastructureServiceDeclarationRepository
 import org.eclipse.apoapsis.ortserver.dao.repositories.infrastructureservice.DaoInfrastructureServiceRepository
 import org.eclipse.apoapsis.ortserver.dao.repositories.notifierjob.DaoNotifierJobRepository
 import org.eclipse.apoapsis.ortserver.dao.repositories.notifierrun.DaoNotifierRunRepository
@@ -83,6 +84,7 @@ class Fixtures(private val db: Database) {
     val analyzerJobRepository = DaoAnalyzerJobRepository(db)
     val analyzerRunRepository = DaoAnalyzerRunRepository(db)
     val evaluatorJobRepository = DaoEvaluatorJobRepository(db)
+    val infrastructureServiceDeclarationRepository = DaoInfrastructureServiceDeclarationRepository(db)
     val evaluatorRunRepository = DaoEvaluatorRunRepository(db)
     val infrastructureServiceRepository = DaoInfrastructureServiceRepository(db)
     val organizationRepository = DaoOrganizationRepository(db)

--- a/model/src/commonMain/kotlin/InfrastructureService.kt
+++ b/model/src/commonMain/kotlin/InfrastructureService.kt
@@ -84,4 +84,18 @@ data class InfrastructureService(
             )
         }
     }
+
+    /**
+     * Map this [InfrastructureService] to a [InfrastructureServiceDeclaration]. This can be useful when both types
+     * of Infrastructure Service information are processed by the same code.
+     */
+    fun toInfrastructureServiceDeclaration() =
+        InfrastructureServiceDeclaration(
+            name = name,
+            url = url,
+            description = description,
+            usernameSecret = usernameSecret.name,
+            passwordSecret = passwordSecret.name,
+            credentialsTypes = credentialsTypes
+        )
 }

--- a/model/src/commonMain/kotlin/InfrastructureServiceDeclaration.kt
+++ b/model/src/commonMain/kotlin/InfrastructureServiceDeclaration.kt
@@ -19,7 +19,13 @@
 
 package org.eclipse.apoapsis.ortserver.model
 
+import io.konform.validation.Invalid
+import io.konform.validation.Validation
+import io.konform.validation.constraints.pattern
+
 import kotlinx.serialization.Serializable
+
+import org.eclipse.apoapsis.ortserver.model.validation.ValidationException
 
 /**
  * A data class describing the declaration of an infrastructure service.
@@ -52,4 +58,24 @@ data class InfrastructureServiceDeclaration(
 
     /** The set of [CredentialsType]s for this infrastructure service. */
     val credentialsTypes: Set<CredentialsType> = emptySet()
-)
+) {
+    companion object {
+        val NAME_PATTERN_REGEX = """^(?!\s)[A-Za-z0-9- ]*(?<!\s)$""".toRegex()
+        const val NAME_PATTERN_MESSAGE = "The entity name may only contain letters, numbers, hyphen marks and " +
+                "spaces. Leading and trailing whitespaces are not allowed."
+    }
+
+    fun validate() {
+        val validationResult = Validation {
+            InfrastructureServiceDeclaration::name {
+                pattern(NAME_PATTERN_REGEX) hint NAME_PATTERN_MESSAGE
+            }
+        }.validate(this)
+
+        if (validationResult is Invalid) {
+            throw ValidationException(
+                validationResult.errors.joinToString("; ") { error -> "'$name': ${error.message}" }
+            )
+        }
+    }
+}

--- a/model/src/commonMain/kotlin/repositories/InfrastructureServiceDeclarationRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/InfrastructureServiceDeclarationRepository.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.model.repositories
+
+import org.eclipse.apoapsis.ortserver.model.InfrastructureServiceDeclaration
+
+/**
+ * Repository interface to manage [InfrastructureServiceDeclaration] entities.
+ */
+interface InfrastructureServiceDeclarationRepository {
+    /**
+     * Return an [InfrastructureServiceDeclaration] with properties matching the ones
+     * of the given [service] that is associated with the given [ORT Run][runId]. Try to find an already existing
+     * [service] with the given properties first and return this. If not found, create a new
+     * [InfrastructureServiceDeclaration]. In both cases, associate the [service] with the given [ORT Run][runId].
+     */
+    fun getOrCreateForRun(service: InfrastructureServiceDeclaration, runId: Long): InfrastructureServiceDeclaration
+
+    /**
+     * Return the [InfrastructureServiceDeclaration]s associated to the given [ORT Run][runId].
+     */
+    fun listForRun(runId: Long): List<InfrastructureServiceDeclaration>
+}

--- a/model/src/commonMain/kotlin/repositories/InfrastructureServiceRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/InfrastructureServiceRepository.kt
@@ -47,14 +47,6 @@ interface InfrastructureServiceRepository {
     ): InfrastructureService
 
     /**
-     * Return an [InfrastructureService] with properties matching the ones of the given [service] that is associated
-     * with the given [ORT Run][runId]. Based on the provided [service], an already existing entity is searched.
-     * If there is no match, a new one is created. Note that existing services associated with an organization or a
-     * product will not be matched. This is because such services can be changed by users at any time.
-     */
-    fun getOrCreateForRun(service: InfrastructureService, runId: Long): InfrastructureService
-
-    /**
      * Return a list with the [InfrastructureService]s that belong to the given [organization][organizationId]
      * according to the given [parameters].
      */
@@ -123,15 +115,6 @@ interface InfrastructureServiceRepository {
      * Throw an exception if the service cannot be found.
      */
     fun deleteForProductAndName(productId: Long, name: String)
-
-    /**
-     * Return a list with the [InfrastructureService]s that are associated with the given [ORT Run][runId]
-     * according to the given [parameters].
-     */
-    fun listForRun(
-        runId: Long,
-        parameters: ListQueryParameters = ListQueryParameters.DEFAULT
-    ): List<InfrastructureService>
 
     /**
      * Return a list with [InfrastructureService]s that are associated with the given [organizationId], or

--- a/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
@@ -62,7 +62,7 @@ import org.eclipse.apoapsis.ortserver.model.Secret
 import org.eclipse.apoapsis.ortserver.model.orchestrator.AnalyzerRequest
 import org.eclipse.apoapsis.ortserver.model.orchestrator.AnalyzerWorkerError
 import org.eclipse.apoapsis.ortserver.model.orchestrator.AnalyzerWorkerResult
-import org.eclipse.apoapsis.ortserver.model.repositories.InfrastructureServiceRepository
+import org.eclipse.apoapsis.ortserver.model.repositories.InfrastructureServiceDeclarationRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.SecretRepository
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
@@ -313,7 +313,7 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
                         ListQueryResult(listOf(usernameSecret, passwordSecret), ListQueryParameters.DEFAULT, 2)
             }
 
-            declareMock<InfrastructureServiceRepository> {
+            declareMock<InfrastructureServiceDeclarationRepository> {
                 every { getOrCreateForRun(any(), any()) } answers { firstArg() }
             }
 

--- a/workers/common/src/main/kotlin/common/env/EnvironmentModule.kt
+++ b/workers/common/src/main/kotlin/common/env/EnvironmentModule.kt
@@ -19,8 +19,10 @@
 
 package org.eclipse.apoapsis.ortserver.workers.common.env
 
+import org.eclipse.apoapsis.ortserver.dao.repositories.infrastructureservice.DaoInfrastructureServiceDeclarationRepository
 import org.eclipse.apoapsis.ortserver.dao.repositories.infrastructureservice.DaoInfrastructureServiceRepository
 import org.eclipse.apoapsis.ortserver.dao.repositories.secret.DaoSecretRepository
+import org.eclipse.apoapsis.ortserver.model.repositories.InfrastructureServiceDeclarationRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.InfrastructureServiceRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.SecretRepository
 import org.eclipse.apoapsis.ortserver.workers.common.env.config.EnvironmentConfigLoader
@@ -36,6 +38,7 @@ import org.koin.dsl.module
  */
 fun buildEnvironmentModule(): Module = module {
     single<InfrastructureServiceRepository> { DaoInfrastructureServiceRepository(get()) }
+    single<InfrastructureServiceDeclarationRepository> { DaoInfrastructureServiceDeclarationRepository(get()) }
     single<SecretRepository> { DaoSecretRepository(get()) }
 
     singleOf(::EnvironmentDefinitionFactory)
@@ -43,6 +46,8 @@ fun buildEnvironmentModule(): Module = module {
 
     single {
         EnvironmentService(
+            get(),
+            get(),
             get(),
             listOf(
                 ConanGenerator(),

--- a/workers/common/src/test/kotlin/common/env/MockConfigFileBuilder.kt
+++ b/workers/common/src/test/kotlin/common/env/MockConfigFileBuilder.kt
@@ -60,14 +60,18 @@ class MockConfigFileBuilder {
          */
         fun createInfrastructureService(
             url: String = REPOSITORY_URL,
-            userSecret: Secret = mockk(relaxed = true),
-            passwordSecret: Secret = mockk(relaxed = true),
+            usernameSecret: Secret = mockk(relaxed = true) {
+                every { name } returns "some-user-secret-name"
+            },
+            passwordSecret: Secret = mockk(relaxed = true) {
+                every { name } returns "some-password-secret-name"
+            },
             credentialsTypes: Set<CredentialsType> = EnumSet.of(CredentialsType.NETRC_FILE)
         ): InfrastructureService =
             InfrastructureService(
                 name = url,
                 url = url,
-                usernameSecret = userSecret,
+                usernameSecret = usernameSecret,
                 passwordSecret = passwordSecret,
                 organization = null,
                 product = null,


### PR DESCRIPTION
Persist **Infrastructure Service Declarations**. These are
* created dynamically on the fly from _.ort.env.yml_ files in the source repository and associated
directly to the current ORT run. 
* referencing secrets **by name** (unlike existing infrastructure services which have a foreign key relationship to secrets). This allows that Secrets can be deleted, even when referenced. An ORT Run will fail if Secrets cannot be resolved by name at runtime.
* using some logic to look up the Secrets by name, searching on levels Repository --> Product --> Organization and writing warnings to the log if there is ambiguity detected
* not having attributes _organization_ or _product_, because the related ORT run specifies to which Organization or Product they belong to.

In contract to this, the existing (static) Infrastructure Services
* are managed by the user using the REST API or the ORT Server UI, 
* are assigned to a hierarchy level
* have strong references to their Secrets (database foreign key contraint). Not possible to delete a Secret as long it is still references in a (static) Infrastructure Service
