### PR TITLE
fix(analyzer): Fix warning about undefined variables in Docker build

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -23,8 +23,11 @@ runs:
     run: |
       sudo rm -rf /usr/lib/dotnet
       sudo rm -rf /usr/lib/firefox
+      sudo rm -rf /usr/lib/google-cloud-sdk
+      sudo rm -rf /usr/lib/llvm*
       sudo rm -rf /usr/local/aws-cli
       sudo rm -rf /usr/local/aws-sam-cli
+      sudo rm -rf /usr/local/julia1.11.5
       sudo rm -rf /usr/local/lib/android
       sudo rm -rf /usr/local/lib/node_modules
       sudo rm -rf /usr/local/share/chromium

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -164,6 +164,12 @@ jobs:
           type=sha
           type=raw,value=latest,enable={{ is_default_branch }}
 
+    - name: Prepare Jib Cache Directories
+      if: ${{ matrix.docker.task != '' }}
+      run: |
+        sudo mkdir -p /mnt/jib-app-cache /mnt/jib-base-cache /mnt/tmp
+        sudo chown $USER /mnt/jib-app-cache /mnt/jib-base-cache /mnt/tmp
+
     - name: Build ${{ matrix.docker.jibImage }} Image
       if: ${{ matrix.docker.task != '' }}
       run: |
@@ -173,6 +179,9 @@ jobs:
           -PdockerImagePrefix=${{ env.REGISTRY }}/${{ github.repository_owner }}/ \
           -PdockerImageTag=${{ env.ORT_SERVER_VERSION }} \
           ${{ matrix.docker.task }} \
+          -Djib.applicationCache=/mnt/jib-app-cache \
+          -Djib.baseImageCache=/mnt/jib-base-cache \
+          -Djava.io.tmpdir=/mnt/tmp \
           -Djib.console=plain \
           -Djib.container.labels="$(echo "${{ steps.meta.outputs.labels }}" | tr '\n' ',' | sed 's/,$//')" \
           -Djib.to.tags="$(echo "${{ steps.meta.outputs.tags }}" | tr '\n' ',' | sed 's/,$//')"


### PR DESCRIPTION
The used environment variables are not defined in the stages where they are used, so replace them with the actual values.