### PR TITLE
Introduce admin configuration

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
@@ -266,21 +266,13 @@ fun EvaluatorJob.mapToApiSummary() =
 
 fun EvaluatorJobConfiguration.mapToApi() =
     ApiEvaluatorJobConfiguration(
-        copyrightGarbageFile,
-        licenseClassificationsFile,
         packageConfigurationProviders.map { it.mapToApi() },
-        resolutionsFile,
-        ruleSet,
         keepAliveWorker
     )
 
 fun ApiEvaluatorJobConfiguration.mapToModel() =
     EvaluatorJobConfiguration(
-        copyrightGarbageFile,
-        licenseClassificationsFile,
         packageConfigurationProviders?.map { it.mapToModel() }.orEmpty(),
-        resolutionsFile,
-        ruleSet,
         keepAliveWorker
     )
 

--- a/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
@@ -314,7 +314,8 @@ fun JobConfigurations.mapToApi() =
         evaluator?.mapToApi(),
         reporter?.mapToApi(),
         notifier?.mapToApi(),
-        parameters
+        parameters,
+        ruleSet
     )
 
 fun ApiJobConfigurations.mapToModel() =
@@ -325,7 +326,8 @@ fun ApiJobConfigurations.mapToModel() =
         evaluator?.mapToModel(),
         reporter?.mapToModel(),
         notifier?.mapToModel(),
-        parameters.orEmpty()
+        parameters.orEmpty(),
+        ruleSet
     )
 
 fun Jobs.mapToApi() =

--- a/api/v1/model/src/commonMain/kotlin/JobConfigurations.kt
+++ b/api/v1/model/src/commonMain/kotlin/JobConfigurations.kt
@@ -37,7 +37,14 @@ data class JobConfigurations(
      * A map with custom parameters for the whole ORT run. The parameters can be evaluated by the validation script
      * executed by the Config worker. The script can convert these parameters to specific job configurations.
      */
-    val parameters: Options? = null
+    val parameters: Options? = null,
+
+    /**
+     * The name of the rule set to be used during the run. The rule set defines a number of files that are required by
+     * different worker jobs. Therefore, this is a top-level property. If this property is unspecified, the default
+     * rule set configured for this ORT Server instance is used.
+     */
+    val ruleSet: String? = null
 )
 
 /**

--- a/api/v1/model/src/commonMain/kotlin/JobConfigurations.kt
+++ b/api/v1/model/src/commonMain/kotlin/JobConfigurations.kt
@@ -210,32 +210,9 @@ data class ScannerJobConfiguration(
 @Serializable
 data class EvaluatorJobConfiguration(
     /**
-     * The path to the copyright garbage file which is resolved from the configured configuration source. If this is
-     * `null`, the default path from ORT will be used.
-     */
-    val copyrightGarbageFile: String? = null,
-
-    /**
-     * The path to the license classifications file which is resolved from the configured configuration source. If this
-     * is `null`, the default path from ORT will be used.
-     */
-    val licenseClassificationsFile: String? = null,
-
-    /**
      * The list of package configuration providers to use.
      */
     val packageConfigurationProviders: List<ProviderPluginConfiguration>? = null,
-
-    /**
-     * The path to the resolutions file which is resolved from the configured configuration source. If this is `null`,
-     * the default path from ORT will be used.
-     */
-    val resolutionsFile: String? = null,
-
-    /**
-     * The id of the rule set to use for the evaluation.
-     */
-    val ruleSet: String? = null,
 
     /**
      * Keep the worker alive after it has finished. This is useful for manual problem analysis directly

--- a/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
@@ -134,11 +134,7 @@ internal val fullJobConfigurations = JobConfigurations(
         sourceCodeOrigins = listOf(SourceCodeOrigin.ARTIFACT, SourceCodeOrigin.VCS)
     ),
     evaluator = EvaluatorJobConfiguration(
-        copyrightGarbageFile = "copyright-garbage.yml",
-        licenseClassificationsFile = "license-classifications.yml",
         packageConfigurationProviders = listOf(ProviderPluginConfiguration(type = "OrtConfig")),
-        resolutionsFile = "resolutions.yml",
-        ruleSet = "rules.evaluator.kts"
     ),
     reporter = ReporterJobConfiguration(formats = listOf("WebApp")),
     notifier = NotifierJobConfiguration(
@@ -162,7 +158,8 @@ internal val fullJobConfigurations = JobConfigurations(
                 password = "password"
             )
         )
-    )
+    ),
+    ruleSet = "default"
 )
 
 private val minimalJobConfigurations = JobConfigurations(

--- a/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
@@ -650,10 +650,16 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                     customLicenseTextDir = "LICENSE_TEXTS"
                 )
                 val parameters = mapOf("p1" to "v1", "p2" to "v2")
+                val ruleSet = "test"
                 val createRun = CreateOrtRun(
                     "main",
                     null,
-                    ApiJobConfigurations(analyzerJob, reporter = reporterJob, parameters = parameters),
+                    ApiJobConfigurations(
+                        analyzerJob,
+                        reporter = reporterJob,
+                        parameters = parameters,
+                        ruleSet = ruleSet
+                    ),
                     labelsMap
                 )
 
@@ -699,6 +705,7 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                 }
 
                 run.jobConfigs.parameters shouldBe parameters
+                run.jobConfigs.ruleSet shouldBe ruleSet
             }
         }
 

--- a/dao/src/testFixtures/kotlin/Fixtures.kt
+++ b/dao/src/testFixtures/kotlin/Fixtures.kt
@@ -120,9 +120,7 @@ class Fixtures(private val db: Database) {
             advisors = listOf("OSV")
         ),
         scanner = ScannerJobConfiguration(),
-        evaluator = EvaluatorJobConfiguration(
-            ruleSet = "default"
-        ),
+        evaluator = EvaluatorJobConfiguration(),
         reporter = ReporterJobConfiguration(
             formats = listOf("WebApp")
         ),

--- a/model/src/commonMain/kotlin/JobConfigurations.kt
+++ b/model/src/commonMain/kotlin/JobConfigurations.kt
@@ -44,7 +44,14 @@ data class JobConfigurations(
      * A map with custom parameters for the whole ORT run. The parameters can be evaluated by the validation script
      * executed by the Config worker. The script can convert these parameters to specific job configurations.
      */
-    val parameters: Options = emptyMap()
+    val parameters: Options = emptyMap(),
+
+    /**
+     * The name of the rule set to be used during the run. The rule set defines a number of files that are required by
+     * different worker jobs. Therefore, this is a top-level property. If this property is unspecified, the default
+     * rule set configured for this ORT Server instance is used.
+     */
+    val ruleSet: String? = null
 )
 
 /**

--- a/model/src/commonMain/kotlin/JobConfigurations.kt
+++ b/model/src/commonMain/kotlin/JobConfigurations.kt
@@ -219,32 +219,9 @@ data class ScannerJobConfiguration(
 @Serializable
 data class EvaluatorJobConfiguration(
     /**
-     * The path to the copyright garbage file which is resolved from the configured configuration source. If this is
-     * `null`, the default path from ORT will be used.
-     */
-    val copyrightGarbageFile: String? = null,
-
-    /**
-     * The path to the license classifications file which is resolved from the configured configuration source. If this
-     * is `null`, the default path from ORT will be used.
-     */
-    val licenseClassificationsFile: String? = null,
-
-    /**
      * The list of package configuration providers to use.
      */
     val packageConfigurationProviders: List<ProviderPluginConfiguration> = emptyList(),
-
-    /**
-     * The path to the resolutions file which is resolved from the configured configuration source. If this is `null`,
-     * the default path from ORT will be used.
-     */
-    val resolutionsFile: String? = null,
-
-    /**
-     * The id of the rule set to use for the evaluation.
-     */
-    val ruleSet: String? = null,
 
     /**
      * Keep the worker alive after it has finished. This is useful for manual problem analysis directly

--- a/services/admin-config/build.gradle.kts
+++ b/services/admin-config/build.gradle.kts
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+plugins {
+    // Apply precompiled plugins.
+    id("ort-server-kotlin-jvm-conventions")
+    id("ort-server-publication-conventions")
+}
+
+group = "org.eclipse.apoapsis.ortserver.services"
+
+dependencies {
+    api(projects.config.configSpi)
+
+    implementation(projects.utils.config)
+    implementation(projects.utils.logging)
+
+    implementation(libs.slf4j)
+    implementation(libs.ortUtils)
+
+    testImplementation(libs.kotestRunnerJunit5)
+    testImplementation(libs.mockk)
+}

--- a/services/admin-config/src/main/kotlin/AdminConfig.kt
+++ b/services/admin-config/src/main/kotlin/AdminConfig.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.services.config
+
+import org.ossreviewtoolkit.utils.ort.ORT_COPYRIGHT_GARBAGE_FILENAME
+import org.ossreviewtoolkit.utils.ort.ORT_EVALUATOR_RULES_FILENAME
+import org.ossreviewtoolkit.utils.ort.ORT_LICENSE_CLASSIFICATIONS_FILENAME
+import org.ossreviewtoolkit.utils.ort.ORT_RESOLUTIONS_FILENAME
+
+/**
+ * A class representing the admin configuration for the ORT server. It defines an object model for the configuration
+ * file loaded from the config file provider.
+ */
+class AdminConfig(
+    /** The default rule set. */
+    private val defaultRuleSet: RuleSet = DEFAULT_RULE_SET,
+
+    /** A map containing named rule sets. */
+    private val ruleSets: Map<String, RuleSet> = emptyMap()
+) {
+    companion object {
+        /**
+         * A default [RuleSet] instance that uses the standard names from ORT for the referenced files.
+         */
+        val DEFAULT_RULE_SET = RuleSet(
+            copyrightGarbageFile = ORT_COPYRIGHT_GARBAGE_FILENAME,
+            licenseClassificationsFile = ORT_LICENSE_CLASSIFICATIONS_FILENAME,
+            resolutionsFile = ORT_RESOLUTIONS_FILENAME,
+            evaluatorRules = ORT_EVALUATOR_RULES_FILENAME
+        )
+
+        /**
+         * An empty default configuration. This is going to be used if no path to a configuration file is specified,
+         * and the default path does not exist.
+         */
+        val DEFAULT = AdminConfig()
+    }
+
+    /**
+     * Return a set with the names of all defined rule sets. These names can be passed to the [getRuleSet] function to
+     * obtain the corresponding [RuleSet] instance. In addition, the name *null* can be used to obtain the default
+     * rule set.
+     */
+    val ruleSetNames: Set<String>
+        get() = ruleSets.keys
+
+    /**
+     * Return the [RuleSet] with the given [name]. A *null* name returns the default rule set. All other names refer
+     * to a named rule set which must be defined in the configuration file; otherwise, this function throws an
+     * exception.
+     */
+    fun getRuleSet(name: String?): RuleSet =
+        if (name == null) {
+            defaultRuleSet
+        } else {
+            ruleSets[name] ?: throw NoSuchElementException("No rule set defined with the name '$name'.")
+        }
+}

--- a/services/admin-config/src/main/kotlin/AdminConfigService.kt
+++ b/services/admin-config/src/main/kotlin/AdminConfigService.kt
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.services.config
+
+import com.typesafe.config.Config
+import com.typesafe.config.ConfigFactory
+import com.typesafe.config.ConfigObject
+
+import java.io.InputStreamReader
+
+import org.eclipse.apoapsis.ortserver.config.ConfigManager
+import org.eclipse.apoapsis.ortserver.config.Context
+import org.eclipse.apoapsis.ortserver.config.Path
+import org.eclipse.apoapsis.ortserver.utils.config.getConfigOrEmpty
+import org.eclipse.apoapsis.ortserver.utils.config.getStringOrDefault
+
+import org.slf4j.LoggerFactory
+
+/**
+ * A service providing access to the ORT Server Admin configuration.
+ *
+ * The Admin configuration is obtained from the `ConfigFileProvider` managed by the [ConfigManager]. The path to this
+ * configuration file is defined by the [PATH_PROPERTY] property in the current configuration. If this property
+ * is not defined, the [DEFAULT_PATH] is used instead. It is possible to run ORT Server without an Admin configuration,
+ * although this will hardly be useful in practice. To enable this mode, the [PATH_PROPERTY] property must be
+ * unspecified, and the [DEFAULT_PATH] must not exist. In all other cases, a missing configuration file causes an
+ * exception to be thrown.
+ */
+class AdminConfigService(
+    private val configManager: ConfigManager
+) {
+    companion object {
+        /**
+         * The name of the property defining the path to the Admin configuration file. If this is undefined, a
+         * default path is assumed.
+         */
+        const val PATH_PROPERTY = "adminConfigPath"
+
+        /** The default path to the Admin configuration file. */
+        const val DEFAULT_PATH = "ort-server.conf"
+
+        private val logger = LoggerFactory.getLogger(AdminConfigService::class.java)
+
+        /**
+         * Create an [AdminConfig] instance from the properties defined in the given [config].
+         */
+        private fun createAdminConfig(config: Config): AdminConfig {
+            val defaultRuleSetConfig = config.getConfigOrEmpty("defaultRuleSet")
+            val defaultRuleSet = parseRuleSet(defaultRuleSetConfig, AdminConfig.DEFAULT_RULE_SET)
+            val ruleSets = parseRuleSets(config, defaultRuleSet)
+
+            return AdminConfig(
+                defaultRuleSet = defaultRuleSet,
+                ruleSets = ruleSets
+            )
+        }
+
+        /**
+         * Parse all named rule sets defined in the given [config] and return a [Map] with the names as keys. For
+         * rule sets that are only partially defined, set the values of missing properties from the given
+         * [defaultRuleSet].
+         */
+        private fun parseRuleSets(config: Config, defaultRuleSet: RuleSet): Map<String, RuleSet> {
+            if (!config.hasPath("ruleSets")) return emptyMap()
+
+            return config.getObject("ruleSets").mapNotNull { entry ->
+                (entry.value as? ConfigObject)?.let { obj ->
+                    entry.key to parseRuleSet(obj.toConfig(), defaultRuleSet)
+                }
+            }.toMap()
+        }
+
+        /**
+         * Create a [RuleSet] based on the properties in the given [config]. Use the values from the given [default]
+         * instance for undefined properties.
+         */
+        private fun parseRuleSet(config: Config, default: RuleSet): RuleSet =
+            RuleSet(
+                copyrightGarbageFile = config.getStringOrDefault("copyrightGarbageFile", default.copyrightGarbageFile),
+                licenseClassificationsFile = config.getStringOrDefault(
+                    "licenseClassificationsFile",
+                    default.licenseClassificationsFile
+                ),
+                resolutionsFile = config.getStringOrDefault("resolutionsFile", default.resolutionsFile),
+                evaluatorRules = config.getStringOrDefault("evaluatorRules", default.evaluatorRules)
+            )
+    }
+
+    /**
+     * Load the [AdminConfig] from the configured path in the given [context] for the given [organizationId].
+     * TODO: The organization ID is currently not evaluated. In the future, it should be supported to have different
+     *       configurations for different organizations.
+     */
+    fun loadAdminConfig(context: Context?, organizationId: Long): AdminConfig {
+        val configPath = Path(configManager.getStringOrDefault(PATH_PROPERTY, DEFAULT_PATH))
+        if (configPath.path == DEFAULT_PATH && !configManager.containsFile(context, configPath)) {
+            logger.warn(
+                "No configuration path configured, and the default path '{}' does not exist. " +
+                        "Using the default admin configuration.",
+                DEFAULT_PATH
+            )
+            return AdminConfig.DEFAULT
+        }
+
+        logger.info("Loading admin configuration from path '{}' for organization {}.", configPath.path, organizationId)
+        val config = InputStreamReader(configManager.getFile(context, configPath)).use { reader ->
+            ConfigFactory.parseReader(reader)
+        }
+
+        return createAdminConfig(config)
+    }
+}

--- a/services/admin-config/src/main/kotlin/RuleSet.kt
+++ b/services/admin-config/src/main/kotlin/RuleSet.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.services.config
+
+/**
+ * A data class that represents the configuration of a rule set.
+ *
+ * A rule set consists of a number of paths to files that are used by the Evaluator and partly by the Reporter. The
+ * paths are passed to the _config file provider_ to obtain the actual configuration files.
+ */
+data class RuleSet(
+    /** The path to the copyright garbage file. */
+    val copyrightGarbageFile: String,
+
+    /** The path to the license classifications file. */
+    val licenseClassificationsFile: String,
+
+    /** The path to the resolutions file. */
+    val resolutionsFile: String,
+
+    /** The path to the files with rules to use for the evaluation. */
+    val evaluatorRules: String
+)

--- a/services/admin-config/src/test/kotlin/AdminConfigServiceTest.kt
+++ b/services/admin-config/src/test/kotlin/AdminConfigServiceTest.kt
@@ -1,0 +1,260 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.services.config
+
+import com.typesafe.config.ConfigFactory
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+
+import io.mockk.every
+import io.mockk.spyk
+
+import org.eclipse.apoapsis.ortserver.config.ConfigManager
+import org.eclipse.apoapsis.ortserver.config.Context
+import org.eclipse.apoapsis.ortserver.config.Path
+
+import org.ossreviewtoolkit.utils.ort.ORT_COPYRIGHT_GARBAGE_FILENAME
+import org.ossreviewtoolkit.utils.ort.ORT_EVALUATOR_RULES_FILENAME
+import org.ossreviewtoolkit.utils.ort.ORT_LICENSE_CLASSIFICATIONS_FILENAME
+import org.ossreviewtoolkit.utils.ort.ORT_RESOLUTIONS_FILENAME
+
+class AdminConfigServiceTest : WordSpec({
+    "loadAdminConfig()" should {
+        "return the default configuration if there is no config file" {
+            val service = createService(null) {
+                every { containsFile(context, Path(AdminConfigService.DEFAULT_PATH)) } returns false
+            }
+
+            service.loadAdminConfig(context, ORGANIZATION_ID) shouldBe AdminConfig.DEFAULT
+        }
+
+        "throw for an unresolvable non-default config file" {
+            val exception = IllegalArgumentException("Test exception: unresolvable config file")
+            val service = createService {
+                every { getFile(context, Path(ADMIN_CONFIG_PATH)) } throws exception
+            }
+
+            shouldThrow<IllegalArgumentException> {
+                service.loadAdminConfig(context, ORGANIZATION_ID)
+            } shouldBe exception
+        }
+    }
+
+    "getRuleSet()" should {
+        "return the a default rule set with the standard names from ORT" {
+            val service = createServiceWithConfig("")
+
+            val ruleSet = service.loadAdminConfig(context, ORGANIZATION_ID).getRuleSet(null)
+
+            ruleSet.copyrightGarbageFile shouldBe ORT_COPYRIGHT_GARBAGE_FILENAME
+            ruleSet.licenseClassificationsFile shouldBe ORT_LICENSE_CLASSIFICATIONS_FILENAME
+            ruleSet.resolutionsFile shouldBe ORT_RESOLUTIONS_FILENAME
+            ruleSet.evaluatorRules shouldBe ORT_EVALUATOR_RULES_FILENAME
+        }
+
+        "parse the default rule set from the config file" {
+            val config = """
+                    defaultRuleSet {
+                      copyrightGarbageFile = "testCopyrightGarbageFile"
+                      licenseClassificationsFile = "testLicenseClassificationsFile"
+                      resolutionsFile = "testResolutionsFile"
+                      evaluatorRules = "testEvaluatorRules"
+                    }
+                """.trimIndent()
+            val service = createServiceWithConfig(config)
+
+            val ruleSet = service.loadAdminConfig(context, ORGANIZATION_ID).getRuleSet(null)
+
+            ruleSet.copyrightGarbageFile shouldBe "testCopyrightGarbageFile"
+            ruleSet.licenseClassificationsFile shouldBe "testLicenseClassificationsFile"
+            ruleSet.resolutionsFile shouldBe "testResolutionsFile"
+            ruleSet.evaluatorRules shouldBe "testEvaluatorRules"
+        }
+
+        "return a named rule set" {
+            val config = """
+                    ruleSets {
+                      customRuleSet1 {
+                        copyrightGarbageFile = "testCopyrightGarbageFile1"
+                        licenseClassificationsFile = "testLicenseClassificationsFile1"
+                        resolutionsFile = "testResolutionsFile1"
+                        evaluatorRules = "testEvaluatorRules1"
+                      }  
+                      customRuleSet2 {
+                        copyrightGarbageFile = "testCopyrightGarbageFile2"
+                        licenseClassificationsFile = "testLicenseClassificationsFile2"
+                        resolutionsFile = "testResolutionsFile2"
+                        evaluatorRules = "testEvaluatorRules2"
+                      }  
+                    }
+                """.trimIndent()
+            val service = createServiceWithConfig(config)
+
+            val ruleSet = service.loadAdminConfig(context, ORGANIZATION_ID).getRuleSet("customRuleSet1")
+
+            ruleSet.copyrightGarbageFile shouldBe "testCopyrightGarbageFile1"
+            ruleSet.licenseClassificationsFile shouldBe "testLicenseClassificationsFile1"
+            ruleSet.resolutionsFile shouldBe "testResolutionsFile1"
+            ruleSet.evaluatorRules shouldBe "testEvaluatorRules1"
+        }
+
+        "throw an exception for an unknown rule set name" {
+            val config = """
+                    ruleSets {
+                      someRuleSet {
+                        copyrightGarbageFile = "testCopyrightGarbageFile1"
+                        licenseClassificationsFile = "testLicenseClassificationsFile1"
+                        resolutionsFile = "testResolutionsFile1"
+                        evaluatorRules = "testEvaluatorRules1"
+                      }  
+                    }
+                """.trimIndent()
+            val service = createServiceWithConfig(config)
+
+            val nonExistentRuleSetName = "nonExistentRuleSet"
+            val exception = shouldThrow<NoSuchElementException> {
+                service.loadAdminConfig(context, ORGANIZATION_ID).getRuleSet(nonExistentRuleSetName)
+            }
+
+            exception.message shouldContain nonExistentRuleSetName
+            exception.message shouldContain "No rule set"
+        }
+
+        "set undefined properties in rule sets from the default rule set" {
+            val config = """
+                    defaultRuleSet {
+                      copyrightGarbageFile = "defaultCopyrightGarbageFile"
+                      licenseClassificationsFile = "defaultLicenseClassificationsFile"
+                      resolutionsFile = "defaultResolutionsFile"
+                      evaluatorRules = "defaultEvaluatorRules"
+                    }
+                    ruleSets {
+                      customRuleSet1 {
+                        copyrightGarbageFile = "testCopyrightGarbageFile1"
+                      }  
+                      customRuleSet2 {
+                        licenseClassificationsFile = "testLicenseClassificationsFile2"
+                        resolutionsFile = "testResolutionsFile2"
+                        evaluatorRules = "testEvaluatorRules2"
+                      }  
+                    }
+                """.trimIndent()
+            val service = createServiceWithConfig(config)
+            val adminConfig = service.loadAdminConfig(context, ORGANIZATION_ID)
+
+            val ruleSet1 = adminConfig.getRuleSet("customRuleSet1")
+            ruleSet1.copyrightGarbageFile shouldBe "testCopyrightGarbageFile1"
+            ruleSet1.licenseClassificationsFile shouldBe "defaultLicenseClassificationsFile"
+            ruleSet1.resolutionsFile shouldBe "defaultResolutionsFile"
+            ruleSet1.evaluatorRules shouldBe "defaultEvaluatorRules"
+
+            val ruleSet2 = adminConfig.getRuleSet("customRuleSet2")
+            ruleSet2.copyrightGarbageFile shouldBe "defaultCopyrightGarbageFile"
+            ruleSet2.licenseClassificationsFile shouldBe "testLicenseClassificationsFile2"
+            ruleSet2.resolutionsFile shouldBe "testResolutionsFile2"
+            ruleSet2.evaluatorRules shouldBe "testEvaluatorRules2"
+        }
+    }
+
+    "ruleSetNames" should {
+        "be empty for the default configuration" {
+            AdminConfig.DEFAULT.ruleSetNames should beEmpty()
+        }
+
+        "be empty for a configuration containing only the default rule set" {
+            val config = """
+                    defaultRuleSet {
+                      copyrightGarbageFile = "testCopyrightGarbageFile"
+                      licenseClassificationsFile = "testLicenseClassificationsFile"
+                      resolutionsFile = "testResolutionsFile"
+                      evaluatorRules = "testEvaluatorRules"
+                    }
+                """.trimIndent()
+            val service = createServiceWithConfig(config)
+            val adminConfig = service.loadAdminConfig(context, ORGANIZATION_ID)
+
+            adminConfig.ruleSetNames should beEmpty()
+        }
+
+        "contain the names of all defined rule sets" {
+            val config = """
+                    ruleSets {
+                      customRuleSet1 {
+                        copyrightGarbageFile = "testCopyrightGarbageFile1"
+                      }  
+                      customRuleSet2 {
+                        licenseClassificationsFile = "testLicenseClassificationsFile2"
+                      }  
+                    }
+                """.trimIndent()
+            val service = createServiceWithConfig(config)
+            val adminConfig = service.loadAdminConfig(context, ORGANIZATION_ID)
+
+            adminConfig.ruleSetNames shouldContainExactlyInAnyOrder listOf("customRuleSet1", "customRuleSet2")
+        }
+    }
+})
+
+/** The context used by tests when querying the admin configuration. */
+private val context = Context("testContext")
+
+/** A path to the admin config used by tests per default. */
+private const val ADMIN_CONFIG_PATH = "test-ort-server.conf"
+
+/** A test organization ID. */
+private const val ORGANIZATION_ID = 20250617160321L
+
+/**
+ * Return an [AdminConfigService] instance for testing that uses a [ConfigManager] spy with the given
+ * [adminConfigPath]. The given [block] can be used to further configure the [ConfigManager] spy.
+ */
+private fun createService(
+    adminConfigPath: String? = ADMIN_CONFIG_PATH,
+    block: ConfigManager.() -> Unit = {}
+): AdminConfigService {
+    val config = adminConfigPath?.let { ConfigFactory.parseMap(mapOf("adminConfigPath" to it)) }
+        ?: ConfigFactory.empty()
+    val configManager = spyk(ConfigManager.create(config)) {
+        block()
+    }
+
+    return AdminConfigService(configManager)
+}
+
+/**
+ * Return an [AdminConfigService] instance for testing that yields an [AdminConfig] that is parsed from the given
+ * [config] string.
+ */
+private fun createServiceWithConfig(config: String): AdminConfigService =
+    createService { initAdminConfig(config) }
+
+/**
+ * Prepare this [ConfigManager] spy to return configuration data with the given [content] when asked for the
+ * default admin configuration file.
+ */
+private fun ConfigManager.initAdminConfig(content: String) {
+    every { getFile(context, Path(ADMIN_CONFIG_PATH)) } returns content.byteInputStream()
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -52,6 +52,7 @@ include(":secrets:file")
 include(":secrets:spi")
 include(":secrets:scaleway")
 include(":secrets:vault")
+include(":services:admin-config")
 include(":services:authorization")
 include(":services:content-management")
 include(":services:hierarchy")
@@ -96,6 +97,7 @@ project(":api:v1:model").name = "api-v1-model"
 project(":config:spi").name = "config-spi"
 project(":logaccess:spi").name = "logaccess-spi"
 project(":secrets:spi").name = "secrets-spi"
+project(":services:admin-config").name = "admin-config-service"
 project(":services:authorization").name = "authorization-service"
 project(":services:content-management").name = "content-management-service"
 project(":services:hierarchy").name = "hierarchy-service"

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/evaluator-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/evaluator-fields.tsx
@@ -19,34 +19,15 @@
 
 import { UseFormReturn } from 'react-hook-form';
 
-import {
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from '@/components/ui/accordion';
-import {
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@/components/ui/form';
-import { Input } from '@/components/ui/input';
+import { FormControl, FormField } from '@/components/ui/form';
 import { Switch } from '@/components/ui/switch';
 import { CreateRunFormValues } from '../_repo-layout/create-run/-create-run-utils';
 
 type EvaluatorFieldsProps = {
   form: UseFormReturn<CreateRunFormValues>;
-  value: string;
-  onToggle: () => void;
 };
 
-export const EvaluatorFields = ({
-  form,
-  value,
-  onToggle,
-}: EvaluatorFieldsProps) => {
+export const EvaluatorFields = ({ form }: EvaluatorFieldsProps) => {
   return (
     <div className='flex flex-row align-middle'>
       <FormField
@@ -62,83 +43,6 @@ export const EvaluatorFields = ({
           </FormControl>
         )}
       />
-      <AccordionItem value={value} className='flex-1'>
-        <AccordionTrigger onClick={onToggle}>Evaluator</AccordionTrigger>
-        <AccordionContent>
-          <div className='text-sm text-gray-500'>
-            In case any input field is left empty, the default path from the
-            config file provider will be used for the corresponding file.
-          </div>
-          <FormField
-            control={form.control}
-            name='jobConfigs.evaluator.ruleSet'
-            render={({ field }) => (
-              <FormItem className='pt-4'>
-                <FormLabel>Evaluator rules</FormLabel>
-                <FormControl>
-                  <Input {...field} />
-                </FormControl>
-                <FormDescription>
-                  The path to the rules file to get from the configuration
-                  provider.
-                </FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name='jobConfigs.evaluator.licenseClassificationsFile'
-            render={({ field }) => (
-              <FormItem className='pt-4'>
-                <FormLabel>License classifications</FormLabel>
-                <FormControl>
-                  <Input {...field} />
-                </FormControl>
-                <FormDescription>
-                  The path to the license classifications file to get from the
-                  configuration provider.
-                </FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name='jobConfigs.evaluator.copyrightGarbageFile'
-            render={({ field }) => (
-              <FormItem className='pt-4'>
-                <FormLabel>Copyright garbage</FormLabel>
-                <FormControl>
-                  <Input {...field} />
-                </FormControl>
-                <FormDescription>
-                  The path to the copyright garbage file to get from the
-                  configuration provider.
-                </FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name='jobConfigs.evaluator.resolutionsFile'
-            render={({ field }) => (
-              <FormItem className='pt-4'>
-                <FormLabel>Resolutions</FormLabel>
-                <FormControl>
-                  <Input {...field} />
-                </FormControl>
-                <FormDescription>
-                  The path to the resolutions file to get from the configuration
-                  provider.
-                </FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-        </AccordionContent>
-      </AccordionItem>
     </div>
   );
 };

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
@@ -146,6 +146,7 @@ export const createRunFormSchema = z.object({
       }),
     }),
     parameters: z.array(keyValueSchema).optional(),
+    ruleSet: z.string().optional(),
   }),
   labels: z.array(keyValueSchema).optional(),
   jobConfigContext: z.string().optional(),
@@ -426,18 +427,6 @@ export function defaultValues(
             enabled:
               ortRun.jobConfigs.evaluator !== undefined &&
               ortRun.jobConfigs.evaluator !== null,
-            ruleSet:
-              ortRun.jobConfigs.evaluator?.ruleSet ||
-              baseDefaults.jobConfigs.evaluator.ruleSet,
-            licenseClassificationsFile:
-              ortRun.jobConfigs.evaluator?.licenseClassificationsFile ||
-              baseDefaults.jobConfigs.evaluator.licenseClassificationsFile,
-            copyrightGarbageFile:
-              ortRun.jobConfigs.evaluator?.copyrightGarbageFile ||
-              baseDefaults.jobConfigs.evaluator.copyrightGarbageFile,
-            resolutionsFile:
-              ortRun.jobConfigs.evaluator?.resolutionsFile ||
-              baseDefaults.jobConfigs.evaluator.resolutionsFile,
           },
           reporter: {
             enabled:
@@ -663,20 +652,7 @@ export function formValuesToPayload(
   // Evaluator configuration
   //
 
-  const evaluatorConfig = values.jobConfigs.evaluator.enabled
-    ? {
-        // Only include the config parameter structures if the corresponding form fields are not empty.
-        // In case they are empty, the default path from the config file provider will be used to
-        // resolve the corresponding files.
-        ruleSet: values.jobConfigs.evaluator.ruleSet || undefined,
-        licenseClassificationsFile:
-          values.jobConfigs.evaluator.licenseClassificationsFile || undefined,
-        copyrightGarbageFile:
-          values.jobConfigs.evaluator.copyrightGarbageFile || undefined,
-        resolutionsFile:
-          values.jobConfigs.evaluator.resolutionsFile || undefined,
-      }
-    : undefined;
+  const evaluatorConfig = values.jobConfigs.evaluator.enabled ? {} : undefined;
 
   //
   // Reporter configuration

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -252,6 +252,25 @@ const CreateRunPage = () => {
                 </FormItem>
               )}
             />
+            <FormField
+              control={form.control}
+              name='jobConfigs.ruleSet'
+              render={({ field }) => (
+                <FormItem className='pt-4'>
+                  <FormLabel>Rule set</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder='(optional)' />
+                  </FormControl>
+                  <FormDescription>
+                    The rule set to use for the run. This selects a set of
+                    configuration files used by the Evaluator and the Reporter,
+                    such as rules for the Evaluator or license classifications.
+                    If left empty, the default rule set is used.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
 
             <h3 className='mt-4'>Configuration parameters</h3>
             <div className='text-sm text-gray-500'>
@@ -411,11 +430,7 @@ const CreateRunPage = () => {
                 value='scanner'
                 onToggle={() => toggleAccordionOpen('scanner')}
               />
-              <EvaluatorFields
-                form={form}
-                value='evaluator'
-                onToggle={() => toggleAccordionOpen('evaluator')}
-              />
+              <EvaluatorFields form={form} />
               <ReporterFields
                 form={form}
                 value='reporter'

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/evaluator-job-details.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/-components/evaluator-job-details.tsx
@@ -40,30 +40,10 @@ export const EvaluatorJobDetails = ({ run }: EvaluatorJobDetailsProps) => {
       <CardContent>
         {jobConfigs && (
           <div className='space-y-2 text-sm'>
-            {jobConfigs?.ruleSet && (
+            {run.resolvedJobConfigs?.ruleSet && (
               <div>
                 <Label className='font-semibold'>Ruleset:</Label>{' '}
-                {jobConfigs.ruleSet}
-              </div>
-            )}
-            {jobConfigs?.licenseClassificationsFile && (
-              <div>
-                <Label className='font-semibold'>
-                  License classifications:
-                </Label>{' '}
-                {jobConfigs.licenseClassificationsFile}
-              </div>
-            )}
-            {jobConfigs?.copyrightGarbageFile && (
-              <div>
-                <Label className='font-semibold'>Copyright garbage:</Label>{' '}
-                {jobConfigs.copyrightGarbageFile}
-              </div>
-            )}
-            {jobConfigs?.resolutionsFile && (
-              <div>
-                <Label className='font-semibold'>Resolutions:</Label>{' '}
-                {jobConfigs.resolutionsFile}
+                {run.resolvedJobConfigs?.ruleSet}
               </div>
             )}
             {jobConfigs?.packageConfigurationProviders && (

--- a/workers/common/build.gradle.kts
+++ b/workers/common/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     implementation(projects.model)
     implementation(projects.secrets.secretsSpi)
     implementation(projects.utils.config)
+    implementation(projects.services.adminConfigService)
     implementation(projects.utils.logging)
 
     implementation(libs.commonsText)

--- a/workers/common/src/main/kotlin/common/Extensions.kt
+++ b/workers/common/src/main/kotlin/common/Extensions.kt
@@ -46,9 +46,10 @@ fun Map<String, PluginConfig>.mapOptions(
     mapValues { (_, pluginConfig) -> pluginConfig.copy(options = pluginConfig.options.mapValues(transform)) }
 
 /**
- * If [path] is not `null`, read the YAML configuration file using the provided [context] and deserialize its value. If
- * a [ConfigException] occurs while reading the file it is rethrown. If [path] is `null`, the file at [defaultPath] is
- * read instead. If the file cannot be read, the [fallbackValue] is returned.
+ * If [path] is not `null` and does not equal the [defaultPath], read the YAML configuration file using the provided
+ * [context] and deserialize its value. If a [ConfigException] occurs while reading the file it is rethrown. If [path]
+ * is `null` or equals the [defaultPath], the file at [defaultPath] is read instead. If the file cannot be read, the
+ * [fallbackValue] is returned.
  *
  * This function realizes the contract that if a specific config file is requested, not being able to read it leads to
  * an exception, but the default file is allowed to not exist. Not being able to deserialize the file to the return type
@@ -62,9 +63,9 @@ inline fun <reified T> ConfigManager.readConfigFileValueWithDefault(
 ): T = getConfigFileWithDefault<T>(path, defaultPath, fallbackValue, context, ::readConfigFileValue)
 
 /**
- * If [path] is not `null`, read the file using the provided [context]. If a [ConfigException] occurs while reading the
- * file it is rethrown. If [path] is `null`, the file at [defaultPath] is read instead. If the file cannot be read, the
- * [fallbackValue] is returned.
+ * If [path] is not `null` and does not equal the [defaultPath], read the file using the provided [context]. If a
+ * [ConfigException] occurs while reading the file it is rethrown. If [path] is `null` or equals the [defaultPath], the
+ * file at [defaultPath] is read instead. If the file cannot be read, the [fallbackValue] is returned.
  *
  * This function realizes the contract that if a specific config file is requested, not being able to read it leads to
  * an exception, but the default file is allowed to not exist.
@@ -77,9 +78,10 @@ fun ConfigManager.readConfigFileWithDefault(
 ): String = getConfigFileWithDefault(path, defaultPath, fallbackValue, context, ::readConfigFile)
 
 /**
- * If [path] is not `null`, get the file using the provided [context] and [getConfigFile] function. If a
- * [ConfigException] occurs while reading the file it is rethrown. If [path] is `null`, the file at [defaultPath] is
- * read instead. If the file cannot be read, the [fallbackValue] is returned.
+ * If [path] is not `null` and does not equal the [defaultPath], get the file using the provided [context] and
+ * [getConfigFile] function. If a [ConfigException] occurs while reading the file it is rethrown. If [path] is `null`
+ * or equals the [defaultPath], the file at [defaultPath] is read instead. If the file cannot be read, the
+ * [fallbackValue] is returned.
  *
  * This function realizes the contract that if a specific config file is requested, not being able to read it leads to
  * an exception, but the default file is allowed to not exist.
@@ -91,7 +93,7 @@ internal inline fun <reified T> getConfigFileWithDefault(
     fallbackValue: T,
     context: Context?,
     getConfigFile: (path: String, context: Context?, exceptionHandler: (ConfigException) -> T) -> T
-): T = if (path != null) {
+): T = if (path != null && path != defaultPath) {
     getConfigFile(path, context) {
         logger.error("Could not get config file from path '$path'.")
         throw it

--- a/workers/common/src/main/kotlin/common/context/WorkerContextModule.kt
+++ b/workers/common/src/main/kotlin/common/context/WorkerContextModule.kt
@@ -23,18 +23,21 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.ortrun.DaoOrtRunRepositor
 import org.eclipse.apoapsis.ortserver.dao.repositories.repository.DaoRepositoryRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.RepositoryRepository
+import org.eclipse.apoapsis.ortserver.services.config.AdminConfigService
 
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
 import org.koin.dsl.module
 
 /**
- * Return a [Module] with bean definitions required to obtain a [WorkerContextFactory]. Workers requiring a
- * [WorkerContext] can integrate this module and then obtain a factory via injection.
+ * Return a [Module] with bean definitions required to obtain a [WorkerContextFactory] and other functionality that is
+ * typically needed by workers. Workers requiring a [WorkerContext] can integrate this module and then obtain a
+ * factory via injection.
  */
 fun workerContextModule(): Module = module {
     single<OrtRunRepository> { DaoOrtRunRepository(get()) }
     single<RepositoryRepository> { DaoRepositoryRepository(get()) }
 
     singleOf(::WorkerContextFactory)
+    singleOf(::AdminConfigService)
 }

--- a/workers/config/build.gradle.kts
+++ b/workers/config/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation(projects.config.configSpi)
     implementation(projects.dao)
     implementation(projects.model)
+    implementation(projects.services.adminConfigService)
     implementation(projects.transport.transportSpi)
     implementation(projects.utils.logging)
     implementation(projects.workers.common)

--- a/workers/config/src/main/kotlin/ConfigWorker.kt
+++ b/workers/config/src/main/kotlin/ConfigWorker.kt
@@ -27,6 +27,7 @@ import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
 import org.eclipse.apoapsis.ortserver.model.util.OptionalValue
 import org.eclipse.apoapsis.ortserver.model.util.asPresent
+import org.eclipse.apoapsis.ortserver.services.config.AdminConfigService
 import org.eclipse.apoapsis.ortserver.workers.common.RunResult
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContextFactory
@@ -49,7 +50,10 @@ class ConfigWorker(
     private val contextFactory: WorkerContextFactory,
 
     /** The object for accessing configuration data. */
-    private val configManager: ConfigManager
+    private val configManager: ConfigManager,
+
+    /** The service to access the admin configuration. */
+    private val adminConfigService: AdminConfigService
 ) {
     companion object {
         /** Constant for the path to the script that validates and transforms parameters. */
@@ -88,7 +92,10 @@ class ConfigWorker(
                 logger.info("Running validation script.")
 
                 val validationScript = configManager.getFileAsString(resolvedJobConfigContext, VALIDATION_SCRIPT_PATH)
-                val validator = ConfigValidator.create(createValidationWorkerContext(context, resolvedJobConfigContext))
+                val validator = ConfigValidator.create(
+                    createValidationWorkerContext(context, resolvedJobConfigContext),
+                    adminConfigService
+                )
                 val validationResult = validator.validate(validationScript)
 
                 logger.debug("Issues returned by validation script: {}.", validationResult.issues)

--- a/workers/config/src/test/kotlin/ConfigWorkerTest.kt
+++ b/workers/config/src/test/kotlin/ConfigWorkerTest.kt
@@ -76,7 +76,7 @@ class ConfigWorkerTest : StringSpec({
         }
 
         mockkTransaction {
-            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, configManager)
+            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, configManager, mockk())
             worker.testRun() shouldBe RunResult.Success
 
             verify {
@@ -107,7 +107,7 @@ class ConfigWorkerTest : StringSpec({
         }
 
         mockkTransaction {
-            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, configManager)
+            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, configManager, mockk())
             worker.testRun() shouldBe RunResult.Success
 
             verify {
@@ -137,7 +137,7 @@ class ConfigWorkerTest : StringSpec({
         }
 
         mockkTransaction {
-            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, configManager)
+            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, configManager, mockk())
             when (val result = worker.testRun()) {
                 is RunResult.Failed -> result.error should beInstanceOf<IllegalArgumentException>()
                 else -> fail("Unexpected result: $result")
@@ -160,7 +160,7 @@ class ConfigWorkerTest : StringSpec({
         val configManager = mockConfigManager()
         every { configManager.getFileAsString(any(), any()) } throws configException
 
-        val worker = ConfigWorker(mockk(), mockk(), contextFactory, configManager)
+        val worker = ConfigWorker(mockk(), mockk(), contextFactory, configManager, mockk())
         when (val result = worker.testRun()) {
             is RunResult.Failed -> result.error shouldBe configException
             else -> fail("Unexpected result: $result")
@@ -181,12 +181,12 @@ class ConfigWorkerTest : StringSpec({
         }
 
         mockkTransaction {
-            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, configManager)
+            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, configManager, mockk())
             worker.testRun() shouldBe RunResult.Success
 
             val slotContext = mutableListOf<WorkerContext>()
             verify {
-                ConfigValidator.create(capture(slotContext))
+                ConfigValidator.create(capture(slotContext), any())
             }
             val capturedContext = slotContext.last()
 
@@ -214,7 +214,7 @@ class ConfigWorkerTest : StringSpec({
         }
 
         mockkTransaction {
-            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, configManager)
+            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, configManager, mockk())
             worker.testRun() shouldBe RunResult.Success
 
             val expectedJobConfigs = context.ortRun.jobConfigs
@@ -304,7 +304,7 @@ private fun mockValidator(result: ConfigValidationResult): ConfigValidator {
         every { validate(PARAMETERS_SCRIPT) } returns result
     }
 
-    every { ConfigValidator.create(any()) } returns validator
+    every { ConfigValidator.create(any(), any()) } returns validator
 
     return validator
 }

--- a/workers/evaluator/build.gradle.kts
+++ b/workers/evaluator/build.gradle.kts
@@ -46,6 +46,7 @@ dependencies {
     implementation(projects.config.configSpi)
     implementation(projects.dao)
     implementation(projects.model)
+    implementation(projects.services.adminConfigService)
     implementation(projects.transport.transportSpi)
     implementation(projects.utils.logging)
     implementation(projects.workers.common)

--- a/workers/evaluator/src/test/kotlin/EvaluatorWorkerTest.kt
+++ b/workers/evaluator/src/test/kotlin/EvaluatorWorkerTest.kt
@@ -81,7 +81,7 @@ private val evaluatorJob = EvaluatorJob(
     createdAt = Clock.System.now(),
     startedAt = Clock.System.now(),
     finishedAt = null,
-    configuration = EvaluatorJobConfiguration(ruleSet = SCRIPT_FILE),
+    configuration = EvaluatorJobConfiguration(),
     status = JobStatus.CREATED
 )
 

--- a/workers/reporter/src/main/kotlin/reporter/ReporterRunner.kt
+++ b/workers/reporter/src/main/kotlin/reporter/ReporterRunner.kt
@@ -96,8 +96,7 @@ class ReporterRunner(
         evaluatorConfig: EvaluatorJobConfiguration?,
         context: WorkerContext
     ): ReporterRunnerResult {
-        val copyrightGarbageFile =
-            if (evaluatorConfig != null) evaluatorConfig.copyrightGarbageFile else config.copyrightGarbageFile
+        val copyrightGarbageFile = config.copyrightGarbageFile
         val copyrightGarbage = configManager.readConfigFileValueWithDefault(
             path = copyrightGarbageFile,
             defaultPath = ORT_COPYRIGHT_GARBAGE_FILENAME,
@@ -105,11 +104,7 @@ class ReporterRunner(
             context = context.resolvedConfigurationContext
         )
 
-        val licenseClassificationsFile = if (evaluatorConfig != null) {
-            evaluatorConfig.licenseClassificationsFile
-        } else {
-            config.licenseClassificationsFile
-        }
+        val licenseClassificationsFile = config.licenseClassificationsFile
         val licenseClassifications = configManager.readConfigFileValueWithDefault(
             path = licenseClassificationsFile,
             defaultPath = ORT_LICENSE_CLASSIFICATIONS_FILENAME,


### PR DESCRIPTION
This PR starts with moving properties from job configurations to a new admin configuration as described in https://github.com/eclipse-apoapsis/ort-server/issues/2901. It does this on all layers for the Evaluator configuration to have an initial admin configuration available and a proof of concept for this approach. Similar exercises then need to be done for the other workers.