### PR TITLE
refactor: Add `baseUrl` and `realm` to `KeycloakClientConfiguration`

### DIFF
--- a/clients/keycloak/src/main/kotlin/KeycloakClientConfiguration.kt
+++ b/clients/keycloak/src/main/kotlin/KeycloakClientConfiguration.kt
@@ -28,6 +28,8 @@ package org.eclipse.apoapsis.ortserver.clients.keycloak
  *   interpreted as the secret of a confidential client.
  */
 data class KeycloakClientConfiguration(
+    val baseUrl: String,
+    val realm: String,
     val apiUrl: String,
     val clientId: String,
     val accessTokenUrl: String,

--- a/clients/keycloak/src/testFixtures/kotlin/Extensions.kt
+++ b/clients/keycloak/src/testFixtures/kotlin/Extensions.kt
@@ -114,6 +114,8 @@ fun KeycloakContainer.createKeycloakClientConfigurationForTestRealm(
     dataGetChunkSize: Int = 9999
 ) =
     KeycloakClientConfiguration(
+        baseUrl = authServerUrl,
+        realm = TEST_REALM,
         apiUrl = "$authServerUrl/admin/realms/$TEST_REALM",
         clientId = clientId,
         accessTokenUrl = "$authServerUrl/realms/$TEST_REALM/protocol/openid-connect/token",
@@ -130,6 +132,8 @@ fun KeycloakContainer.createKeycloakClientConfigurationForTestRealm(
 fun KeycloakContainer.createKeycloakConfigMapForTestRealm() =
     createKeycloakClientConfigurationForTestRealm().let { config ->
         mapOf(
+            "keycloak.baseUrl" to config.baseUrl,
+            "keycloak.realm" to config.realm,
             "keycloak.apiUrl" to config.apiUrl,
             "keycloak.clientId" to config.clientId,
             "keycloak.accessTokenUrl" to config.accessTokenUrl,

--- a/core/src/main/kotlin/api/AuthenticationRoute.kt
+++ b/core/src/main/kotlin/api/AuthenticationRoute.kt
@@ -41,8 +41,15 @@ fun Route.authentication() = route("auth") {
 
     route("oidc-config/cli") {
         get(getCliOidcConfig) {
+            val accessTokenUrl = applicationConfig.propertyOrNull("keycloak.accessTokenUrl")?.getString() ?: run {
+                val baseUrl = applicationConfig.property("keycloak.baseUrl").getString()
+                val realm = applicationConfig.property("keycloak.realm").getString()
+
+                "$baseUrl/realms/$realm/protocol/openid-connect/token"
+            }
+
             val oidcConfig = OidcConfig(
-                accessTokenUrl = applicationConfig.property("keycloak.accessTokenUrl").getString(),
+                accessTokenUrl = accessTokenUrl,
                 clientId = applicationConfig.property("jwt.audience").getString(),
             )
 

--- a/core/src/main/kotlin/utils/Extensions.kt
+++ b/core/src/main/kotlin/utils/Extensions.kt
@@ -19,16 +19,27 @@
 
 package org.eclipse.apoapsis.ortserver.core.utils
 
+import io.ktor.server.config.tryGetString
+
 import org.eclipse.apoapsis.ortserver.clients.keycloak.KeycloakClientConfiguration
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.config.Path
 
-fun ConfigManager.createKeycloakClientConfiguration() =
-    KeycloakClientConfiguration(
-        apiUrl = getString("keycloak.apiUrl"),
+fun ConfigManager.createKeycloakClientConfiguration(): KeycloakClientConfiguration {
+    val baseUrl = getString("keycloak.baseUrl")
+    val realm = getString("keycloak.realm")
+
+    val defaultApiUrl = "$baseUrl/admin/realms/$realm"
+    val defaultAccessTokenUrl = "$baseUrl/realms/$realm/protocol/openid-connect/token"
+
+    return KeycloakClientConfiguration(
+        baseUrl = baseUrl,
+        realm = realm,
+        apiUrl = tryGetString("keycloak.apiUrl") ?: defaultApiUrl,
         clientId = getString("keycloak.clientId"),
-        accessTokenUrl = getString("keycloak.accessTokenUrl"),
+        accessTokenUrl = tryGetString("keycloak.accessTokenUrl") ?: defaultAccessTokenUrl,
         apiUser = getString("keycloak.apiUser"),
         apiSecret = getSecret(Path("keycloak.apiSecret")),
         subjectClientId = getString("keycloak.subjectClientId")
     )
+}

--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -58,10 +58,12 @@ jwt {
 }
 
 keycloak {
-  accessTokenUrl = "http://keycloak:8080/realms/master/protocol/openid-connect/token"
-  accessTokenUrl = ${?KEYCLOAK_ACCESS_TOKEN_URL}
-  apiUrl = "http://keycloak:8080/admin/realms/master"
+  baseUrl = "http://keycloak:8080"
+  baseUrl = ${?KEYCLOAK_BASE_URL}
+  realm = "master"
+  realm = ${?KEYCLOAK_REALM}
   apiUrl = ${?KEYCLOAK_API_URL}
+  accessTokenUrl = ${?KEYCLOAK_ACCESS_TOKEN_URL}
   clientId = "ort-server"
   clientId = ${?KEYCLOAK_CLIENT_ID}
   apiUser = "admin"


### PR DESCRIPTION
Introduce dedicated properties for the `baseUrl` and `realm`, which otherwise are only encoded in the `apiUrl` and `accessTokenUrl` properties.

Having `baseUrl` and `realm` available separately is a preparation for migrating to the official Keycloak client which needs these.