### PR TITLE
refactor(services): Unify Infrastructure Service logic using Hierarchy concept

### DIFF
--- a/components/secrets/backend/src/test/kotlin/routes/organization/DeleteSecretByOrganizationIdAndNameIntegrationTest.kt
+++ b/components/secrets/backend/src/test/kotlin/routes/organization/DeleteSecretByOrganizationIdAndNameIntegrationTest.kt
@@ -101,8 +101,7 @@ class DeleteSecretByOrganizationIdAndNameIntegrationTest : AbstractIntegrationTe
                     usernameSecret = userSecret,
                     passwordSecret = passSecret,
                     credentialsTypes = EnumSet.of(CredentialsType.NETRC_FILE),
-                    organizationId = orgId,
-                    productId = null
+                    OrganizationId(orgId)
                 )
 
                 val response = client.delete("/organizations/$orgId/secrets/${userSecret.name}")

--- a/components/secrets/backend/src/test/kotlin/routes/product/DeleteSecretByProductIdAndNameIntegrationTest.kt
+++ b/components/secrets/backend/src/test/kotlin/routes/product/DeleteSecretByProductIdAndNameIntegrationTest.kt
@@ -101,8 +101,7 @@ class DeleteSecretByProductIdAndNameIntegrationTest : AbstractIntegrationTest({
                     usernameSecret = userSecret,
                     passwordSecret = passSecret,
                     credentialsTypes = EnumSet.of(CredentialsType.NETRC_FILE),
-                    organizationId = null,
-                    productId = prodId
+                    ProductId(prodId)
                 )
 
                 val response = client.delete("/products/$prodId/secrets/${userSecret.name}")

--- a/core/src/main/kotlin/api/OrganizationsRoute.kt
+++ b/core/src/main/kotlin/api/OrganizationsRoute.kt
@@ -63,6 +63,7 @@ import org.eclipse.apoapsis.ortserver.core.apiDocs.postOrganizations
 import org.eclipse.apoapsis.ortserver.core.apiDocs.postProduct
 import org.eclipse.apoapsis.ortserver.core.apiDocs.putUserToOrganizationGroup
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
+import org.eclipse.apoapsis.ortserver.model.OrganizationId
 import org.eclipse.apoapsis.ortserver.model.Product
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityWithAccumulatedData
 import org.eclipse.apoapsis.ortserver.services.InfrastructureServiceService
@@ -198,7 +199,7 @@ fun Route.organizations() = route("organizations") {
                 val pagingOptions = call.pagingOptions(SortProperty("name", SortDirection.ASCENDING))
 
                 val infrastructureServicesForOrganization =
-                    infrastructureServiceService.listForOrganization(orgId, pagingOptions.mapToModel())
+                    infrastructureServiceService.listForId(OrganizationId(orgId), pagingOptions.mapToModel())
 
                 val pagedResponse = infrastructureServicesForOrganization.mapToApi(InfrastructureService::mapToApi)
 
@@ -211,8 +212,8 @@ fun Route.organizations() = route("organizations") {
                 val organizationId = call.requireIdParameter("organizationId")
                 val createService = call.receive<CreateInfrastructureService>()
 
-                val newService = infrastructureServiceService.createForOrganization(
-                    organizationId,
+                val newService = infrastructureServiceService.createForId(
+                    OrganizationId(organizationId),
                     createService.name,
                     createService.url,
                     createService.description,
@@ -232,8 +233,8 @@ fun Route.organizations() = route("organizations") {
                     val serviceName = call.requireParameter("serviceName")
                     val updateService = call.receive<UpdateInfrastructureService>()
 
-                    val updatedService = infrastructureServiceService.updateForOrganization(
-                        organizationId,
+                    val updatedService = infrastructureServiceService.updateForId(
+                        OrganizationId(organizationId),
                         serviceName,
                         updateService.url.mapToModel(),
                         updateService.description.mapToModel(),
@@ -248,10 +249,10 @@ fun Route.organizations() = route("organizations") {
                 delete(deleteInfrastructureServiceForOrganizationIdAndName) {
                     requirePermission(OrganizationPermission.WRITE)
 
-                    val organizationId = call.requireIdParameter("organizationId")
+                    val orgId = call.requireIdParameter("organizationId")
                     val serviceName = call.requireParameter("serviceName")
 
-                    infrastructureServiceService.deleteForOrganization(organizationId, serviceName)
+                    infrastructureServiceService.deleteForId(OrganizationId(orgId), serviceName)
 
                     call.respond(HttpStatusCode.NoContent)
                 }

--- a/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
@@ -684,8 +684,7 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                         } else {
                             emptySet()
                         },
-                        orgId,
-                        null
+                        OrganizationId(orgId)
                     )
                 }
 
@@ -727,8 +726,7 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                         userSecret,
                         passSecret,
                         EnumSet.of(CredentialsType.NETRC_FILE),
-                        orgId,
-                        null
+                        OrganizationId(orgId)
                     )
                 }
 
@@ -800,8 +798,10 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                 response shouldHaveStatus HttpStatusCode.Created
                 response shouldHaveBody expectedService
 
-                val dbService =
-                    infrastructureServiceRepository.getByOrganizationAndName(orgId, createInfrastructureService.name)
+                val dbService = infrastructureServiceRepository.getByIdAndName(
+                        OrganizationId(orgId),
+                        createInfrastructureService.name
+                    )
                 dbService.shouldNotBeNull()
                 dbService.mapToApi() shouldBe expectedService
             }
@@ -874,8 +874,10 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                 body.message shouldBe "Request validation has failed."
                 body.cause shouldContain "Validation failed for CreateInfrastructureService"
 
-                infrastructureServiceRepository.getByOrganizationAndName(orgId, createInfrastructureService.name)
-                    .shouldBeNull()
+                infrastructureServiceRepository.getByIdAndName(
+                    OrganizationId(orgId),
+                    createInfrastructureService.name
+                ).shouldBeNull()
             }
         }
     }
@@ -895,8 +897,7 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                     userSecret,
                     passSecret,
                     emptySet(),
-                    orgId,
-                    null
+                    OrganizationId(orgId)
                 )
 
                 val newUrl = "https://repo2.example.org/test2"
@@ -926,7 +927,7 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                 response shouldHaveBody updatedService
 
                 val dbService =
-                    infrastructureServiceRepository.getByOrganizationAndName(orgId, service.name)
+                    infrastructureServiceRepository.getByIdAndName(OrganizationId(orgId), service.name)
                 dbService.shouldNotBeNull()
                 dbService.mapToApi() shouldBe updatedService
             }
@@ -944,8 +945,7 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                 userSecret,
                 passSecret,
                 emptySet(),
-                organizationId = createdOrg.id,
-                productId = null
+                OrganizationId(createdOrg.id)
             )
 
             requestShouldRequireRole(OrganizationPermission.WRITE.roleName(createdOrg.id)) {
@@ -976,15 +976,14 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                     userSecret,
                     passSecret,
                     emptySet(),
-                    orgId,
-                    null
+                    OrganizationId(orgId)
                 )
 
                 val response =
                     superuserClient.delete("/api/v1/organizations/$orgId/infrastructure-services/${service.name}")
 
                 response shouldHaveStatus HttpStatusCode.NoContent
-                infrastructureServiceRepository.listForOrganization(orgId).data should beEmpty()
+                infrastructureServiceRepository.listForId(OrganizationId(orgId)).data should beEmpty()
             }
         }
 
@@ -1000,8 +999,7 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                 userSecret,
                 passSecret,
                 emptySet(),
-                organizationId = createdOrg.id,
-                productId = null
+                OrganizationId(createdOrg.id)
             )
 
             requestShouldRequireRole(OrganizationPermission.WRITE.roleName(createdOrg.id), HttpStatusCode.NoContent) {
@@ -1027,9 +1025,11 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                         HttpMethod.Put -> put("/api/v1/organizations/${createdOrg.id}/groups/readers") {
                             setBody(user)
                         }
+
                         HttpMethod.Delete -> delete(
                             "/api/v1/organizations/${createdOrg.id}/groups/readers?username=${user.username}"
                         )
+
                         else -> error("Unsupported method: $method")
                     }
                 }
@@ -1051,9 +1051,11 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                         ) {
                             setBody(user)
                         }
+
                         HttpMethod.Delete -> superuserClient.delete(
                             "/api/v1/organizations/${createdOrg.id}/groups/readers?username=${user.username}"
                         )
+
                         else -> error("Unsupported method: $method")
                     }
 
@@ -1079,9 +1081,11 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                         ) {
                             setBody(user)
                         }
+
                         HttpMethod.Delete -> superuserClient.delete(
                             "/api/v1/organizations/999999/groups/readers?username=${user.username}"
                         )
+
                         else -> error("Unsupported method: $method")
                     }
 
@@ -1107,6 +1111,7 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                         ) {
                             setBody(org)
                         }
+
                         else -> error("Unsupported method: $method")
                     }
 
@@ -1130,9 +1135,11 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                         ) {
                             setBody(user)
                         }
+
                         HttpMethod.Delete -> superuserClient.delete(
                             "/api/v1/organizations/${createdOrg.id}/groups/non-existing-group?username=${user.username}"
                         )
+
                         else -> error("Unsupported method: $method")
                     }
 

--- a/dao/src/test/kotlin/repositories/infrastructureservice/InfrastructureServiceDeclarationRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/infrastructureservice/InfrastructureServiceDeclarationRepositoryTest.kt
@@ -37,6 +37,7 @@ import org.eclipse.apoapsis.ortserver.model.InfrastructureServiceDeclaration
 import org.eclipse.apoapsis.ortserver.model.Organization
 import org.eclipse.apoapsis.ortserver.model.OrganizationId
 import org.eclipse.apoapsis.ortserver.model.Product
+import org.eclipse.apoapsis.ortserver.model.ProductId
 import org.eclipse.apoapsis.ortserver.model.Secret
 import org.eclipse.apoapsis.ortserver.model.validation.ValidationException
 
@@ -210,6 +211,7 @@ private fun DaoInfrastructureServiceRepository.create(service: InfrastructureSer
         service.usernameSecret,
         service.passwordSecret,
         service.credentialsTypes,
-        service.organization?.id,
-        service.product?.id
+        service.organization?.let { OrganizationId(it.id) }
+            ?: service.product?.let { ProductId(it.id) }
+            ?: error("At least one of organization or product must be set.")
     )

--- a/model/src/commonMain/kotlin/repositories/InfrastructureServiceRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/InfrastructureServiceRepository.kt
@@ -20,6 +20,7 @@
 package org.eclipse.apoapsis.ortserver.model.repositories
 
 import org.eclipse.apoapsis.ortserver.model.CredentialsType
+import org.eclipse.apoapsis.ortserver.model.HierarchyId
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 import org.eclipse.apoapsis.ortserver.model.Secret
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
@@ -32,8 +33,7 @@ import org.eclipse.apoapsis.ortserver.model.util.OptionalValue
 @Suppress("TooManyFunctions")
 interface InfrastructureServiceRepository {
     /**
-     * Create a new [InfrastructureService] from the given properties that belongs to either an organization with the
-     * given [organizationId] or a product with the given [productId].
+     * Create a new [InfrastructureService] from the given properties for the hierarchy entity [id].
      */
     fun create(
         name: String,
@@ -42,31 +42,30 @@ interface InfrastructureServiceRepository {
         usernameSecret: Secret,
         passwordSecret: Secret,
         credentialsTypes: Set<CredentialsType>,
-        organizationId: Long?,
-        productId: Long?
+        id: HierarchyId
     ): InfrastructureService
 
     /**
-     * Return a list with the [InfrastructureService]s that belong to the given [organization][organizationId]
-     * according to the given [parameters].
+     * Return a list with the [InfrastructureService]s that belong to the given hierarchy entity [id],
+     * and apply the given [parameters].
      */
-    fun listForOrganization(
-        organizationId: Long,
+    fun listForId(
+        id: HierarchyId,
         parameters: ListQueryParameters = ListQueryParameters.DEFAULT
     ): ListQueryResult<InfrastructureService>
 
     /**
      * Return the [InfrastructureService] with the given [name] that is assigned to the given
-     * [organization][organizationId] or *null* if no such service exists.
+     * hierarchy entity [id] or *null* if no such service exists.
      */
-    fun getByOrganizationAndName(organizationId: Long, name: String): InfrastructureService?
+    fun getByIdAndName(id: HierarchyId, name: String): InfrastructureService?
 
     /**
      * Update selected properties of the [InfrastructureService] with the given [name] that is assigned to the given
-     * [organization][organizationId].
+     * hierarchy entity [id].
      */
-    fun updateForOrganizationAndName(
-        organizationId: Long,
+    fun updateForIdAndName(
+        id: HierarchyId,
         name: String,
         url: OptionalValue<String>,
         description: OptionalValue<String?>,
@@ -77,44 +76,9 @@ interface InfrastructureServiceRepository {
 
     /**
      * Delete the [InfrastructureService] with the given [name] that is assigned to the given
-     * [organization][organizationId]. Throw an exception if the service cannot be found.
+     * hierarchy entity [id]. Throw an exception if the service cannot be found.
      */
-    fun deleteForOrganizationAndName(organizationId: Long, name: String)
-
-    /**
-     * Return a list with the [InfrastructureService]s that belong to the given [product][productId]
-     * according to the given [parameters].
-     */
-    fun listForProduct(
-        productId: Long,
-        parameters: ListQueryParameters = ListQueryParameters.DEFAULT
-    ): List<InfrastructureService>
-
-    /**
-     * Return the [InfrastructureService] with the given [name] that is assigned to the given
-     * [organization][productId] or *null* if no such service exists.
-     */
-    fun getByProductAndName(productId: Long, name: String): InfrastructureService?
-
-    /**
-     * Update selected properties of the [InfrastructureService] with the given [name] that is assigned to the given
-     * [product][productId].
-     */
-    fun updateForProductAndName(
-        productId: Long,
-        name: String,
-        url: OptionalValue<String>,
-        description: OptionalValue<String?>,
-        usernameSecret: OptionalValue<Secret>,
-        passwordSecret: OptionalValue<Secret>,
-        credentialsTypes: OptionalValue<Set<CredentialsType>> = OptionalValue.Absent,
-    ): InfrastructureService
-
-    /**
-     * Delete the [InfrastructureService] with the given [name] that is assigned to the given [product][productId].
-     * Throw an exception if the service cannot be found.
-     */
-    fun deleteForProductAndName(productId: Long, name: String)
+    fun deleteForIdAndName(id: HierarchyId, name: String)
 
     /**
      * Return a list with [InfrastructureService]s that are associated with the given [organizationId], or

--- a/services/infrastructure/src/test/kotlin/InfrastructureServiceServiceTest.kt
+++ b/services/infrastructure/src/test/kotlin/InfrastructureServiceServiceTest.kt
@@ -81,12 +81,11 @@ class InfrastructureServiceServiceTest : WordSpec({
                         userSecret,
                         passSecret,
                         EnumSet.of(CredentialsType.NETRC_FILE),
-                        ORGANIZATION_ID,
-                        null
+                        ORGANIZATION_ID
                     )
                 } returns infrastructureService
 
-                val createResult = service.createForOrganization(
+                val createResult = service.createForId(
                     ORGANIZATION_ID,
                     SERVICE_NAME,
                     SERVICE_URL,
@@ -104,11 +103,11 @@ class InfrastructureServiceServiceTest : WordSpec({
             testWithHelper(verifyTx = false) {
                 mockOrganizationSecret(USERNAME_SECRET)
                 coEvery {
-                    secretService.getSecretByIdAndName(OrganizationId(ORGANIZATION_ID), PASSWORD_SECRET)
+                    secretService.getSecretByIdAndName(ORGANIZATION_ID, PASSWORD_SECRET)
                 } returns null
 
                 val exception = shouldThrow<InvalidSecretReferenceException> {
-                    service.createForOrganization(
+                    service.createForId(
                         ORGANIZATION_ID,
                         SERVICE_NAME,
                         SERVICE_URL,
@@ -132,7 +131,7 @@ class InfrastructureServiceServiceTest : WordSpec({
 
                 val infrastructureService = mockk<InfrastructureService>()
                 every {
-                    repository.updateForOrganizationAndName(
+                    repository.updateForIdAndName(
                         ORGANIZATION_ID,
                         SERVICE_NAME,
                         any(),
@@ -143,7 +142,7 @@ class InfrastructureServiceServiceTest : WordSpec({
                     )
                 } returns infrastructureService
 
-                val updateResult = service.updateForOrganization(
+                val updateResult = service.updateForId(
                     ORGANIZATION_ID,
                     SERVICE_NAME,
                     SERVICE_URL.asPresent(),
@@ -161,7 +160,7 @@ class InfrastructureServiceServiceTest : WordSpec({
                 val slotPasswordSecret = slot<OptionalValue<Secret>>()
                 val slotCredentialsType = slot<OptionalValue<Set<CredentialsType>>>()
                 verify {
-                    repository.updateForOrganizationAndName(
+                    repository.updateForIdAndName(
                         ORGANIZATION_ID,
                         SERVICE_NAME,
                         capture(slotUrl),
@@ -188,7 +187,7 @@ class InfrastructureServiceServiceTest : WordSpec({
                 coEvery { secretService.getSecretByIdAndName(any(), any()) } returns null
 
                 shouldThrow<InvalidSecretReferenceException> {
-                    service.updateForOrganization(
+                    service.updateForId(
                         ORGANIZATION_ID,
                         SERVICE_NAME,
                         OptionalValue.Absent,
@@ -205,12 +204,12 @@ class InfrastructureServiceServiceTest : WordSpec({
     "deleteForOrganization" should {
         "delete an infrastructure service" {
             testWithHelper {
-                every { repository.deleteForOrganizationAndName(ORGANIZATION_ID, SERVICE_NAME) } just runs
+                every { repository.deleteForIdAndName(ORGANIZATION_ID, SERVICE_NAME) } just runs
 
-                service.deleteForOrganization(ORGANIZATION_ID, SERVICE_NAME)
+                service.deleteForId(ORGANIZATION_ID, SERVICE_NAME)
 
                 verify {
-                    repository.deleteForOrganizationAndName(ORGANIZATION_ID, SERVICE_NAME)
+                    repository.deleteForIdAndName(ORGANIZATION_ID, SERVICE_NAME)
                 }
             }
         }
@@ -223,9 +222,9 @@ class InfrastructureServiceServiceTest : WordSpec({
             val expectedResult = ListQueryResult(services, parameters, services.size.toLong())
 
             testWithHelper {
-                every { repository.listForOrganization(ORGANIZATION_ID, parameters) } returns expectedResult
+                every { repository.listForId(ORGANIZATION_ID, parameters) } returns expectedResult
 
-                val result = service.listForOrganization(ORGANIZATION_ID, parameters)
+                val result = service.listForId(ORGANIZATION_ID, parameters)
 
                 result shouldBe expectedResult
             }
@@ -268,7 +267,7 @@ private class TestHelper(
     fun mockOrganizationSecret(name: String): Secret {
         val secret = mockk<Secret>()
         coEvery {
-            secretService.getSecretByIdAndName(OrganizationId(ORGANIZATION_ID), name)
+            secretService.getSecretByIdAndName(ORGANIZATION_ID, name)
         } returns secret
 
         return secret
@@ -308,7 +307,7 @@ private fun <T> equalsOptionalValues(v1: OptionalValue<T>, v2: OptionalValue<T>)
         else -> false
     }
 
-private const val ORGANIZATION_ID = 1000L
+private val ORGANIZATION_ID = OrganizationId(1000L)
 private const val SERVICE_NAME = "TestInfrastructureService"
 private const val SERVICE_URL = "https://repo.example.org/infra/test"
 private const val SERVICE_DESC = "This is a test infrastructure service"

--- a/workers/common/src/main/kotlin/common/env/config/EnvironmentConfigLoader.kt
+++ b/workers/common/src/main/kotlin/common/env/config/EnvironmentConfigLoader.kt
@@ -382,11 +382,13 @@ private class ServiceResolver(
     private val repositoryServices by lazy { configServices.associateByName() }
 
     /** A map with the services defined for the current product. */
-    private val productServices by lazy { serviceRepository.listForProduct(hierarchy.product.id).associateByName() }
+    private val productServices by lazy {
+        serviceRepository.listForId(ProductId(hierarchy.product.id)).data.associateByName()
+    }
 
     /** A map with the services defined for the current organization. */
     private val organizationServices by lazy {
-        serviceRepository.listForOrganization(hierarchy.organization.id).data.associateByName()
+        serviceRepository.listForId(OrganizationId(hierarchy.organization.id)).data.associateByName()
     }
 
     /**

--- a/workers/common/src/test/kotlin/common/env/config/EnvironmentConfigLoaderTest.kt
+++ b/workers/common/src/test/kotlin/common/env/config/EnvironmentConfigLoaderTest.kt
@@ -566,8 +566,9 @@ private class TestHelper(
      * services based on the data that has been defined.
      */
     private fun initServiceRepository() {
-        every { serviceRepository.listForProduct(hierarchy.product.id) } returns productServices
-        every { serviceRepository.listForOrganization(hierarchy.organization.id) } returns
+        every { serviceRepository.listForId(ProductId(hierarchy.product.id)) } returns
+                ListQueryResult(productServices, ListQueryParameters.DEFAULT, productServices.size.toLong())
+        every { serviceRepository.listForId(OrganizationId(hierarchy.organization.id)) } returns
                 ListQueryResult(organizationServices, ListQueryParameters.DEFAULT, organizationServices.size.toLong())
     }
 }


### PR DESCRIPTION
Refactoring only: Replace duplicated service functions for Infrastructure Services at _Organization_ and _Product_ levels with a shared approach based on the existing `Hierarchy` abstraction. This reduces **code duplication** and simplifies maintenance.

This change removes duplicate code sections for _Organizations_ and _Products_ by using the already existing concept of `Hierarchy` and `HierarchyId`. It prepares the introduction of additional functionality on _Repository_ level, that would have led to even more code duplication in future.