### PR TITLE
fix(service): Prevent duplicating infrastructure-service

### DIFF
--- a/dao/src/main/kotlin/Exceptions.kt
+++ b/dao/src/main/kotlin/Exceptions.kt
@@ -33,7 +33,7 @@ enum class PostgresErrorCodes(val value: String) {
     UNIQUE_CONSTRAINT_VIOLATION("23505")
 }
 
-class UniqueConstraintException(msg: String, cause: Throwable) :
+class UniqueConstraintException(msg: String, cause: Throwable? = null) :
     SQLException(msg, cause), CopyableThrowable<UniqueConstraintException> {
     override fun createCopy() = UniqueConstraintException(checkNotNull(message), this)
 }

--- a/dao/src/main/kotlin/repositories/infrastructureservice/DaoInfrastructureServiceRepository.kt
+++ b/dao/src/main/kotlin/repositories/infrastructureservice/DaoInfrastructureServiceRepository.kt
@@ -20,6 +20,7 @@
 package org.eclipse.apoapsis.ortserver.dao.repositories.infrastructureservice
 
 import org.eclipse.apoapsis.ortserver.dao.ConditionBuilder
+import org.eclipse.apoapsis.ortserver.dao.UniqueConstraintException
 import org.eclipse.apoapsis.ortserver.dao.blockingQuery
 import org.eclipse.apoapsis.ortserver.dao.findSingle
 import org.eclipse.apoapsis.ortserver.dao.repositories.secret.SecretDao
@@ -69,6 +70,14 @@ class DaoInfrastructureServiceRepository(private val db: Database) : Infrastruct
         credentialsTypes: Set<CredentialsType>,
         id: HierarchyId
     ): InfrastructureService = db.blockingQuery {
+        InfrastructureServicesDao.find(selectByIdAndName(id, name)).let {
+            if (it.count() > 0) {
+                throw UniqueConstraintException(
+                    "An infrastructure service with name '$name' already exists for the given hierarchy entity."
+                )
+            }
+        }
+
         InfrastructureServicesDao.new {
             this.name = name
             this.url = url

--- a/dao/src/test/kotlin/repositories/infrastructureservice/DaoInfrastructureServiceRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/infrastructureservice/DaoInfrastructureServiceRepositoryTest.kt
@@ -31,6 +31,7 @@ import io.kotest.matchers.shouldBe
 
 import java.util.EnumSet
 
+import org.eclipse.apoapsis.ortserver.dao.UniqueConstraintException
 import org.eclipse.apoapsis.ortserver.dao.repositories.ortrun.DaoOrtRunRepository
 import org.eclipse.apoapsis.ortserver.dao.repositories.secret.DaoSecretRepository
 import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
@@ -440,7 +441,7 @@ class DaoInfrastructureServiceRepositoryTest : WordSpec() {
                 services shouldContainExactlyInAnyOrder listOf(match1, match2, match3)
             }
 
-            "handle infrastructure services with duplicate URL correctly" {
+            "throw exception for duplicated name for same organization" {
                 val productService = createInfrastructureService(product = fixtures.product)
                 val orgService = createInfrastructureService(organization = fixtures.organization)
                 val orgService2 = createInfrastructureService(
@@ -448,16 +449,11 @@ class DaoInfrastructureServiceRepositoryTest : WordSpec() {
                     organization = fixtures.organization
                 )
 
-                listOf(productService, orgService, orgService2).forEach {
-                    infrastructureServicesRepository.create(it)
+                shouldThrow<UniqueConstraintException> {
+                    listOf(productService, orgService, orgService2).forEach {
+                        infrastructureServicesRepository.create(it)
+                    }
                 }
-
-                val services = infrastructureServicesRepository.listForHierarchy(
-                    fixtures.organization.id,
-                    fixtures.product.id
-                )
-
-                services shouldContainExactlyInAnyOrder listOf(productService, orgService2)
             }
         }
 


### PR DESCRIPTION
This commit adds validation for infrastructure services creation that prevents adding infrastructure service with duplicate name for organization.