### PR TITLE
feat(api): Add Infrastructure Services on Repository level

### DIFF
--- a/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
@@ -30,6 +30,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.AdvisorJob
 import org.eclipse.apoapsis.ortserver.api.v1.model.AdvisorJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.AnalyzerJob
 import org.eclipse.apoapsis.ortserver.api.v1.model.AnalyzerJobConfiguration
+import org.eclipse.apoapsis.ortserver.api.v1.model.CreateInfrastructureService
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.EnvironmentConfig
 import org.eclipse.apoapsis.ortserver.api.v1.model.EvaluatorJob
@@ -58,6 +59,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.RepositoryType
 import org.eclipse.apoapsis.ortserver.api.v1.model.ScannerJob
 import org.eclipse.apoapsis.ortserver.api.v1.model.ScannerJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.SubmoduleFetchStrategy.FULLY_RECURSIVE
+import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateInfrastructureService
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateRepository
 import org.eclipse.apoapsis.ortserver.api.v1.model.User
 import org.eclipse.apoapsis.ortserver.api.v1.model.UserDisplayName
@@ -524,6 +526,157 @@ val deleteOrtRunByIndex: RouteConfig.() -> Unit = {
 
         HttpStatusCode.NotFound to {
             description = "The ORT run does not exist."
+        }
+    }
+}
+
+val getInfrastructureServicesByRepositoryId: RouteConfig.() -> Unit = {
+    operationId = "GetInfrastructureServicesByRepositoryId"
+    summary = "List all infrastructure services of a repository"
+    tags = listOf("Repositories")
+
+    request {
+        pathParameter<Long>("repositoryId") {
+            description = "The ID of an repository."
+        }
+        standardListQueryParameters()
+    }
+
+    response {
+        HttpStatusCode.OK to {
+            description = "Success"
+            jsonBody<PagedResponse<InfrastructureService>> {
+                example("List all infrastructure services for a repository") {
+                    value = PagedResponse(
+                        listOf(
+                            InfrastructureService(
+                                name = "Artifactory",
+                                url = "https://artifactory.example.org/releases",
+                                description = "Artifactory repository",
+                                usernameSecretRef = "artifactoryUsername",
+                                passwordSecretRef = "artifactoryPassword"
+                            ),
+                            InfrastructureService(
+                                name = "GitHub",
+                                url = "https://github.com",
+                                description = "GitHub server",
+                                usernameSecretRef = "gitHubUsername",
+                                passwordSecretRef = "gitHubPassword"
+                            )
+                        ),
+                        PagingData(
+                            limit = 20,
+                            offset = 0,
+                            totalCount = 2,
+                            sortProperties = listOf(SortProperty("name", SortDirection.ASCENDING)),
+                        )
+                    )
+                }
+            }
+        }
+    }
+}
+
+val postInfrastructureServiceForRepository: RouteConfig.() -> Unit = {
+    operationId = "PostInfrastructureServiceForRepository"
+    summary = "Create an infrastructure service for a repository"
+    tags = listOf("Repositories")
+
+    request {
+        pathParameter<Long>("repositoryId") {
+            description = "The repository's ID."
+        }
+        jsonBody<CreateInfrastructureService> {
+            example("Create infrastructure service") {
+                value = CreateInfrastructureService(
+                    name = "Artifactory",
+                    url = "https://artifactory.example.org/releases",
+                    description = "Artifactory repository",
+                    usernameSecretRef = "artifactoryUsername",
+                    passwordSecretRef = "artifactoryPassword"
+                )
+            }
+        }
+    }
+
+    response {
+        HttpStatusCode.Created to {
+            description = "Success"
+            jsonBody<InfrastructureService> {
+                example("Create infrastructure service") {
+                    value = InfrastructureService(
+                        name = "Artifactory",
+                        url = "https://artifactory.example.org/releases",
+                        description = "Artifactory repository",
+                        usernameSecretRef = "artifactoryUsername",
+                        passwordSecretRef = "artifactoryPassword"
+                    )
+                }
+            }
+        }
+    }
+}
+
+val patchInfrastructureServiceForRepositoryIdAndName: RouteConfig.() -> Unit = {
+    operationId = "PatchInfrastructureServiceForRepositoryIdAndName"
+    summary = "Update an infrastructure service for a repository"
+    tags = listOf("Repositories")
+
+    request {
+        pathParameter<Long>("repositoryId") {
+            description = "The repository's ID."
+        }
+        pathParameter<String>("serviceName") {
+            description = "The name of the infrastructure service."
+        }
+        jsonBody<UpdateInfrastructureService> {
+            example("Update infrastructure service") {
+                value = UpdateInfrastructureService(
+                    url = "https://github.com".asPresent(),
+                    description = "Updated description".asPresent(),
+                    usernameSecretRef = "newGitHubUser".asPresent(),
+                    passwordSecretRef = "newGitHubPassword".asPresent()
+                )
+            }
+            description = "Set the values that should be updated. To delete a value, set it explicitly to null."
+        }
+    }
+
+    response {
+        HttpStatusCode.OK to {
+            description = "Success"
+            jsonBody<InfrastructureService> {
+                example("Update infrastructure service") {
+                    value = InfrastructureService(
+                        name = "GitHub",
+                        url = "https://github.com",
+                        description = "Updated description",
+                        usernameSecretRef = "newGitHubUser",
+                        passwordSecretRef = "newGitHubPassword"
+                    )
+                }
+            }
+        }
+    }
+}
+
+val deleteInfrastructureServiceForRepositoryIdAndName: RouteConfig.() -> Unit = {
+    operationId = "DeleteInfrastructureServiceForRepositoryIdAndName"
+    summary = "Delete an infrastructure service from a repository"
+    tags = listOf("Repositories")
+
+    request {
+        pathParameter<Long>("repositoryId") {
+            description = "The repository's ID."
+        }
+        pathParameter<String>("serviceName") {
+            description = "The name of the infrastructure service."
+        }
+    }
+
+    response {
+        HttpStatusCode.NoContent to {
+            description = "Success"
         }
     }
 }

--- a/dao/src/main/kotlin/repositories/infrastructureservice/InfrastructureServicesTable.kt
+++ b/dao/src/main/kotlin/repositories/infrastructureservice/InfrastructureServicesTable.kt
@@ -25,6 +25,8 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.organization.Organization
 import org.eclipse.apoapsis.ortserver.dao.repositories.organization.OrganizationsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.product.ProductDao
 import org.eclipse.apoapsis.ortserver.dao.repositories.product.ProductsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.repository.RepositoriesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.repository.RepositoryDao
 import org.eclipse.apoapsis.ortserver.dao.repositories.secret.SecretDao
 import org.eclipse.apoapsis.ortserver.dao.repositories.secret.SecretsTable
 import org.eclipse.apoapsis.ortserver.dao.utils.SortableEntityClass
@@ -51,6 +53,7 @@ object InfrastructureServicesTable : SortableTable("infrastructure_services") {
 
     val organizationId = reference("organization_id", OrganizationsTable).nullable()
     val productId = reference("product_id", ProductsTable).nullable()
+    val repositoryId = reference("repository_id", RepositoriesTable).nullable()
 }
 
 class InfrastructureServicesDao(id: EntityID<Long>) : LongEntity(id) {
@@ -119,6 +122,8 @@ class InfrastructureServicesDao(id: EntityID<Long>) : LongEntity(id) {
     var organization by OrganizationDao optionalReferencedOn InfrastructureServicesTable.organizationId
     var productId by InfrastructureServicesTable.productId.transformToEntityId()
     var product by ProductDao optionalReferencedOn InfrastructureServicesTable.productId
+    var repositoryId by InfrastructureServicesTable.repositoryId.transformToEntityId()
+    var repository by RepositoryDao optionalReferencedOn InfrastructureServicesTable.repositoryId
 
     fun mapToModel() = InfrastructureService(
         name,
@@ -128,6 +133,7 @@ class InfrastructureServicesDao(id: EntityID<Long>) : LongEntity(id) {
         passwordSecret.mapToModel(),
         organization?.mapToModel(),
         product?.mapToModel(),
+        repository?.mapToModel(),
         credentialsTypes
     )
 }

--- a/dao/src/main/kotlin/repositories/infrastructureservice/InfrastructureServicesTable.kt
+++ b/dao/src/main/kotlin/repositories/infrastructureservice/InfrastructureServicesTable.kt
@@ -37,7 +37,6 @@ import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 
 import org.jetbrains.exposed.dao.LongEntity
 import org.jetbrains.exposed.dao.id.EntityID
-import org.jetbrains.exposed.sql.and
 
 /**
  * A table to store infrastructure services, such as source code or artifact repositories.
@@ -58,38 +57,6 @@ object InfrastructureServicesTable : SortableTable("infrastructure_services") {
 
 class InfrastructureServicesDao(id: EntityID<Long>) : LongEntity(id) {
     companion object : SortableEntityClass<InfrastructureServicesDao>(InfrastructureServicesTable) {
-        /**
-         * Try to find an entity with properties matching the ones of the given [service].
-         */
-        fun findByInfrastructureService(service: InfrastructureService): InfrastructureServicesDao? =
-            find {
-                InfrastructureServicesTable.name eq service.name and
-                        (InfrastructureServicesTable.url eq service.url) and
-                        (InfrastructureServicesTable.description eq service.description) and
-                        (InfrastructureServicesTable.usernameSecretId eq service.usernameSecret.id) and
-                        (InfrastructureServicesTable.passwordSecretId eq service.passwordSecret.id) and
-                        (
-                                InfrastructureServicesTable.credentialsType eq
-                                    toCredentialsTypeString(service.credentialsTypes)
-                                ) and
-                        (InfrastructureServicesTable.organizationId eq service.organization?.id) and
-                        (InfrastructureServicesTable.productId eq service.product?.id)
-            }.firstOrNull()
-
-        /**
-         * Return an entity with properties matching the ones of the given [service]. If no such entity exists yet, a
-         * new one is created now.
-         */
-        fun getOrPut(service: InfrastructureService): InfrastructureServicesDao =
-            findByInfrastructureService(service) ?: new {
-                name = service.name
-                url = service.url
-                description = service.description
-                credentialsTypes = service.credentialsTypes
-                usernameSecret = SecretDao[service.usernameSecret.id]
-                passwordSecret = SecretDao[service.passwordSecret.id]
-            }
-
         /**
          * Convert a set of [CredentialsType]s to a string representation.
          */

--- a/dao/src/main/resources/db/migration/V111__addRepositoryLevelToInfrastructureServices.sql
+++ b/dao/src/main/resources/db/migration/V111__addRepositoryLevelToInfrastructureServices.sql
@@ -1,0 +1,23 @@
+ALTER TABLE infrastructure_services
+    ADD COLUMN repository_id bigint REFERENCES repositories NULL;
+
+
+-- An infrastructure service is either associated with an organization, a product or a repository.
+-- The check below ensures that an infrastructure service cannot be associated with an organization, a product
+-- or a repository at the same time.
+ALTER TABLE infrastructure_services
+DROP CONSTRAINT infrastructure_services_references_check;
+
+ALTER TABLE infrastructure_services
+    ADD CONSTRAINT infrastructure_services_references_check
+        CHECK (
+            (organization_id IS NOT NULL)::integer
+    + (product_id IS NOT NULL)::integer
+    + (repository_id IS NOT NULL)::integer
+    <= 1
+    );
+
+DROP INDEX infrastructure_services_all_value_columns;
+
+CREATE INDEX infrastructure_services_all_value_columns
+    ON infrastructure_services (name, url, description, username_secret_id, password_secret_id, credentials_type, organization_id, product_id, repository_id);

--- a/dao/src/test/kotlin/repositories/infrastructureservice/DaoInfrastructureServiceRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/infrastructureservice/DaoInfrastructureServiceRepositoryTest.kt
@@ -37,6 +37,7 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.secret.DaoSecretRepositor
 import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
 import org.eclipse.apoapsis.ortserver.dao.test.Fixtures
 import org.eclipse.apoapsis.ortserver.model.CredentialsType
+import org.eclipse.apoapsis.ortserver.model.Hierarchy
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 import org.eclipse.apoapsis.ortserver.model.Organization
 import org.eclipse.apoapsis.ortserver.model.OrganizationId
@@ -608,9 +609,7 @@ class DaoInfrastructureServiceRepositoryTest : WordSpec() {
                 }
 
                 val services = infrastructureServicesRepository.listForHierarchy(
-                    OrganizationId(fixtures.organization.id),
-                    ProductId(fixtures.product.id),
-                    RepositoryId(fixtures.repository.id)
+                    Hierarchy(fixtures.repository, fixtures.product, fixtures.organization)
                 )
 
                 services shouldContainExactlyInAnyOrder listOf(match1, match2, match3, match4)
@@ -647,9 +646,7 @@ class DaoInfrastructureServiceRepositoryTest : WordSpec() {
                 }
 
                 val services = infrastructureServicesRepository.listForHierarchy(
-                    OrganizationId(fixtures.organization.id),
-                    ProductId(fixtures.product.id),
-                    RepositoryId(fixtures.repository.id)
+                    Hierarchy(fixtures.repository, fixtures.product, fixtures.organization)
                 )
 
                 services shouldContainExactlyInAnyOrder listOf(repositoryService, orgService2)
@@ -671,9 +668,7 @@ class DaoInfrastructureServiceRepositoryTest : WordSpec() {
                 }
 
                 val services = infrastructureServicesRepository.listForHierarchy(
-                    OrganizationId(fixtures.organization.id),
-                    ProductId(fixtures.product.id),
-                    RepositoryId(fixtures.repository.id)
+                    Hierarchy(fixtures.repository, fixtures.product, fixtures.organization)
                 )
 
                 services shouldContainExactlyInAnyOrder listOf(repositoryService, productService2)

--- a/dao/src/test/kotlin/repositories/infrastructureservice/InfrastructureServiceDeclarationRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/infrastructureservice/InfrastructureServiceDeclarationRepositoryTest.kt
@@ -38,6 +38,8 @@ import org.eclipse.apoapsis.ortserver.model.Organization
 import org.eclipse.apoapsis.ortserver.model.OrganizationId
 import org.eclipse.apoapsis.ortserver.model.Product
 import org.eclipse.apoapsis.ortserver.model.ProductId
+import org.eclipse.apoapsis.ortserver.model.Repository
+import org.eclipse.apoapsis.ortserver.model.RepositoryId
 import org.eclipse.apoapsis.ortserver.model.Secret
 import org.eclipse.apoapsis.ortserver.model.validation.ValidationException
 
@@ -165,6 +167,7 @@ class InfrastructureServiceDeclarationRepositoryTest : WordSpec() {
         passwordSecret: Secret = this.passwordSecret,
         organization: Organization? = null,
         product: Product? = null,
+        repository: Repository? = null,
         credentialsTypes: Set<CredentialsType> = setOf(CredentialsType.NETRC_FILE),
     ): InfrastructureService =
         InfrastructureService(
@@ -175,6 +178,7 @@ class InfrastructureServiceDeclarationRepositoryTest : WordSpec() {
             passwordSecret,
             organization,
             product,
+            repository,
             credentialsTypes
         )
 
@@ -213,5 +217,6 @@ private fun DaoInfrastructureServiceRepository.create(service: InfrastructureSer
         service.credentialsTypes,
         service.organization?.let { OrganizationId(it.id) }
             ?: service.product?.let { ProductId(it.id) }
-            ?: error("At least one of organization or product must be set.")
+            ?: service.repository?.let { RepositoryId(it.id) }
+            ?: error("At least one of organization, product or repository must be set.")
     )

--- a/model/src/commonMain/kotlin/InfrastructureService.kt
+++ b/model/src/commonMain/kotlin/InfrastructureService.kt
@@ -55,6 +55,9 @@ data class InfrastructureService(
     /** The [Product] this infrastructure service belongs to if any. */
     val product: Product?,
 
+    /** The [Repository] this infrastructure service belongs to if any. */
+    val repository: Repository?,
+
     /**
      * The set of [CredentialsType]s for this infrastructure service. This determines in which configuration files the
      * credentials of the service are listed when generating the runtime environment for a worker. All services

--- a/model/src/commonMain/kotlin/repositories/InfrastructureServiceRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/InfrastructureServiceRepository.kt
@@ -20,11 +20,9 @@
 package org.eclipse.apoapsis.ortserver.model.repositories
 
 import org.eclipse.apoapsis.ortserver.model.CredentialsType
+import org.eclipse.apoapsis.ortserver.model.Hierarchy
 import org.eclipse.apoapsis.ortserver.model.HierarchyId
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
-import org.eclipse.apoapsis.ortserver.model.OrganizationId
-import org.eclipse.apoapsis.ortserver.model.ProductId
-import org.eclipse.apoapsis.ortserver.model.RepositoryId
 import org.eclipse.apoapsis.ortserver.model.Secret
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
@@ -84,12 +82,11 @@ interface InfrastructureServiceRepository {
     fun deleteForIdAndName(id: HierarchyId, name: String)
 
     /**
-     * Return a list with [InfrastructureService]s that are associated with the given [organizationId],
-     * [productId] or [repositoryId]. If there are multiple services with the same URL, instances on a lower level of
-     * the hierarchy are preferred, and others are dropped.
+     * Return a list with [InfrastructureService]s that are associated with the given [Hierarchy].
+     * If there are multiple services with the same URL, instances on a lower level of the hierarchy are preferred,
+     * and others are dropped.
      */
-    fun listForHierarchy(organizationId: OrganizationId, productId: ProductId, repositoryId: RepositoryId):
-            List<InfrastructureService>
+    fun listForHierarchy(hierarchy: Hierarchy): List<InfrastructureService>
 
     /**
      * Return a list with the [InfrastructureService]s that are associated with the given [Secret][secretId].

--- a/model/src/commonMain/kotlin/repositories/InfrastructureServiceRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/InfrastructureServiceRepository.kt
@@ -22,6 +22,9 @@ package org.eclipse.apoapsis.ortserver.model.repositories
 import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.HierarchyId
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
+import org.eclipse.apoapsis.ortserver.model.OrganizationId
+import org.eclipse.apoapsis.ortserver.model.ProductId
+import org.eclipse.apoapsis.ortserver.model.RepositoryId
 import org.eclipse.apoapsis.ortserver.model.Secret
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
@@ -81,11 +84,12 @@ interface InfrastructureServiceRepository {
     fun deleteForIdAndName(id: HierarchyId, name: String)
 
     /**
-     * Return a list with [InfrastructureService]s that are associated with the given [organizationId], or
-     * [productId]. If there are multiple services with the same URL, instances on a lower level of
+     * Return a list with [InfrastructureService]s that are associated with the given [organizationId],
+     * [productId] or [repositoryId]. If there are multiple services with the same URL, instances on a lower level of
      * the hierarchy are preferred, and others are dropped.
      */
-    fun listForHierarchy(organizationId: Long, productId: Long): List<InfrastructureService>
+    fun listForHierarchy(organizationId: OrganizationId, productId: ProductId, repositoryId: RepositoryId):
+            List<InfrastructureService>
 
     /**
      * Return a list with the [InfrastructureService]s that are associated with the given [Secret][secretId].

--- a/workers/common/src/main/kotlin/common/env/EnvironmentForkHelper.kt
+++ b/workers/common/src/main/kotlin/common/env/EnvironmentForkHelper.kt
@@ -130,7 +130,8 @@ object EnvironmentForkHelper {
             passwordSecret = createDummySecret(passwordSecret),
             credentialsTypes = credentialsTypes,
             organization = null,
-            product = null
+            product = null,
+            repository = null
         )
 
     /**

--- a/workers/common/src/main/kotlin/common/env/EnvironmentService.kt
+++ b/workers/common/src/main/kotlin/common/env/EnvironmentService.kt
@@ -89,11 +89,8 @@ class EnvironmentService(
         context: WorkerContext,
         config: EnvironmentConfig?
     ): List<InfrastructureService> {
-        val hierarchyServices = infrastructureServiceRepository.listForHierarchy(
-            OrganizationId(context.hierarchy.organization.id),
-            ProductId(context.hierarchy.product.id),
-            RepositoryId(context.hierarchy.repository.id)
-        ).associateBy(InfrastructureService::url)
+        val hierarchyServices = infrastructureServiceRepository.listForHierarchy(context.hierarchy)
+            .associateBy(InfrastructureService::url)
 
         val configServices = config?.let {
             configLoader.resolve(it, context.hierarchy).infrastructureServices

--- a/workers/common/src/main/kotlin/common/env/EnvironmentService.kt
+++ b/workers/common/src/main/kotlin/common/env/EnvironmentService.kt
@@ -90,8 +90,9 @@ class EnvironmentService(
         config: EnvironmentConfig?
     ): List<InfrastructureService> {
         val hierarchyServices = infrastructureServiceRepository.listForHierarchy(
-            context.hierarchy.organization.id,
-            context.hierarchy.product.id
+            OrganizationId(context.hierarchy.organization.id),
+            ProductId(context.hierarchy.product.id),
+            RepositoryId(context.hierarchy.repository.id)
         ).associateBy(InfrastructureService::url)
 
         val configServices = config?.let {
@@ -221,6 +222,7 @@ class EnvironmentService(
                         passwordSecret = passwordSecret,
                         organization = null,
                         product = null,
+                        repository = null,
                         credentialsTypes = service.credentialsTypes
                     )
                 }

--- a/workers/common/src/main/kotlin/common/env/config/EnvironmentConfigLoader.kt
+++ b/workers/common/src/main/kotlin/common/env/config/EnvironmentConfigLoader.kt
@@ -204,6 +204,7 @@ class EnvironmentConfigLoader(
                         passwordSecret,
                         null,
                         null,
+                        null,
                         service.credentialsTypes
                     )
                 }

--- a/workers/common/src/test/kotlin/auth/OrtServerAuthenticatorTest.kt
+++ b/workers/common/src/test/kotlin/auth/OrtServerAuthenticatorTest.kt
@@ -524,6 +524,7 @@ private fun createService(
         passwordSecret = password ?: createSecret("unknown-password"),
         organization = null,
         product = null,
+        repository = null,
         credentialsTypes = credentialsTypes
     )
 

--- a/workers/common/src/test/kotlin/common/context/WorkerContextFactoryTest.kt
+++ b/workers/common/src/test/kotlin/common/context/WorkerContextFactoryTest.kt
@@ -495,7 +495,8 @@ class WorkerContextFactoryTest : WordSpec({
                 usernameSecret = secUser1,
                 passwordSecret = secPass1,
                 organization = null,
-                product = null
+                product = null,
+                repository = null
             )
             val service2 = InfrastructureService(
                 name = "service2",
@@ -503,7 +504,8 @@ class WorkerContextFactoryTest : WordSpec({
                 usernameSecret = secUser2,
                 passwordSecret = secPass2,
                 organization = null,
-                product = null
+                product = null,
+                repository = null
             )
             val listener = mockk<AuthenticationListener>()
 
@@ -561,7 +563,8 @@ class WorkerContextFactoryTest : WordSpec({
                 usernameSecret = secUser,
                 passwordSecret = secPass,
                 organization = null,
-                product = null
+                product = null,
+                repository = null
             )
             context.setupAuthentication(listOf(service), mockk())
 
@@ -594,7 +597,8 @@ class WorkerContextFactoryTest : WordSpec({
                 usernameSecret = secUser,
                 passwordSecret = secPass,
                 organization = null,
-                product = null
+                product = null,
+                repository = null
             )
             context.setupAuthentication(listOf(service), mockk())
 

--- a/workers/common/src/test/kotlin/common/env/EnvironmentForkHelperTest.kt
+++ b/workers/common/src/test/kotlin/common/env/EnvironmentForkHelperTest.kt
@@ -211,7 +211,8 @@ private fun createService(
         passwordSecret = passwordSecret,
         credentialsTypes = credentialsTypes,
         organization = null,
-        product = null
+        product = null,
+        repository = null
     )
 
 /**

--- a/workers/common/src/test/kotlin/common/env/EnvironmentServiceTest.kt
+++ b/workers/common/src/test/kotlin/common/env/EnvironmentServiceTest.kt
@@ -88,13 +88,11 @@ class EnvironmentServiceTest : WordSpec({
             )
 
             val repository = mockk<InfrastructureServiceRepository> {
-                every {
-                    listForHierarchy(
-                        OrganizationId(ORGANIZATION_ID),
-                        ProductId(PRODUCT_ID),
-                        RepositoryId(REPOSITORY_ID)
-                    )
-                } returns services
+                every { listForHierarchy(any<Hierarchy>()) } returns services
+            }
+
+            val workerConext = mockk<WorkerContext> {
+                every { hierarchy } returns repositoryHierarchy
             }
 
             val environmentService = EnvironmentService(
@@ -105,7 +103,7 @@ class EnvironmentServiceTest : WordSpec({
                 mockk(),
                 mockk()
             )
-            val result = environmentService.findInfrastructureServicesForRepository(mockContext(), null)
+            val result = environmentService.findInfrastructureServicesForRepository(workerConext, null)
 
             result shouldContainExactlyInAnyOrder services
         }
@@ -123,13 +121,7 @@ class EnvironmentServiceTest : WordSpec({
             }
 
             val repository = mockk<InfrastructureServiceRepository> {
-                every {
-                    listForHierarchy(
-                        OrganizationId(ORGANIZATION_ID),
-                        ProductId(PRODUCT_ID),
-                        RepositoryId(REPOSITORY_ID)
-                    )
-                } returns emptyList()
+                every { listForHierarchy(repositoryHierarchy) } returns emptyList()
             }
 
             val environmentService = EnvironmentService(
@@ -152,13 +144,7 @@ class EnvironmentServiceTest : WordSpec({
             val overrideService = createInfrastructureService()
 
             val repository = mockk<InfrastructureServiceRepository> {
-                every {
-                    listForHierarchy(
-                        OrganizationId(ORGANIZATION_ID),
-                        ProductId(PRODUCT_ID),
-                        RepositoryId(REPOSITORY_ID)
-                    )
-                } returns listOf(hierarchyService, overriddenService)
+                every { listForHierarchy(repositoryHierarchy) } returns listOf(hierarchyService, overriddenService)
             }
 
             val config = mockk<EnvironmentConfig>()

--- a/workers/common/src/test/kotlin/common/env/EnvironmentServiceTest.kt
+++ b/workers/common/src/test/kotlin/common/env/EnvironmentServiceTest.kt
@@ -88,7 +88,13 @@ class EnvironmentServiceTest : WordSpec({
             )
 
             val repository = mockk<InfrastructureServiceRepository> {
-                every { listForHierarchy(ORGANIZATION_ID, PRODUCT_ID) } returns services
+                every {
+                    listForHierarchy(
+                        OrganizationId(ORGANIZATION_ID),
+                        ProductId(PRODUCT_ID),
+                        RepositoryId(REPOSITORY_ID)
+                    )
+                } returns services
             }
 
             val environmentService = EnvironmentService(
@@ -117,7 +123,13 @@ class EnvironmentServiceTest : WordSpec({
             }
 
             val repository = mockk<InfrastructureServiceRepository> {
-                every { listForHierarchy(ORGANIZATION_ID, PRODUCT_ID) } returns emptyList()
+                every {
+                    listForHierarchy(
+                        OrganizationId(ORGANIZATION_ID),
+                        ProductId(PRODUCT_ID),
+                        RepositoryId(REPOSITORY_ID)
+                    )
+                } returns emptyList()
             }
 
             val environmentService = EnvironmentService(
@@ -141,7 +153,11 @@ class EnvironmentServiceTest : WordSpec({
 
             val repository = mockk<InfrastructureServiceRepository> {
                 every {
-                    listForHierarchy(ORGANIZATION_ID, PRODUCT_ID)
+                    listForHierarchy(
+                        OrganizationId(ORGANIZATION_ID),
+                        ProductId(PRODUCT_ID),
+                        RepositoryId(REPOSITORY_ID)
+                    )
                 } returns listOf(hierarchyService, overriddenService)
             }
 
@@ -370,7 +386,8 @@ class EnvironmentServiceTest : WordSpec({
                     every { name } returns "some-password-secret-name"
                 },
                 organization = null,
-                product = null
+                product = null,
+                repository = null
             )
             val definition = EnvironmentServiceDefinition(
                 service,

--- a/workers/common/src/test/kotlin/common/env/EnvironmentServiceTest.kt
+++ b/workers/common/src/test/kotlin/common/env/EnvironmentServiceTest.kt
@@ -836,7 +836,7 @@ private const val RESOLVED_JOB_CONFIG_CONTEXT = "12345678"
 
 /** A [Hierarchy] object for the test repository. */
 private val repositoryHierarchy = Hierarchy(
-    Repository(20230613071811L, ORGANIZATION_ID, PRODUCT_ID, RepositoryType.GIT, REPOSITORY_URL),
+    Repository(REPOSITORY_ID, ORGANIZATION_ID, PRODUCT_ID, RepositoryType.GIT, REPOSITORY_URL),
     Product(PRODUCT_ID, ORGANIZATION_ID, "testProduct"),
     Organization(ORGANIZATION_ID, "test organization")
 )

--- a/workers/common/src/test/kotlin/common/env/MockConfigFileBuilder.kt
+++ b/workers/common/src/test/kotlin/common/env/MockConfigFileBuilder.kt
@@ -77,6 +77,7 @@ class MockConfigFileBuilder {
                 passwordSecret = passwordSecret,
                 organization = null,
                 product = null,
+                repository = null,
                 credentialsTypes = credentialsTypes
             )
 

--- a/workers/common/src/test/kotlin/common/env/config/EnvironmentConfigLoaderTest.kt
+++ b/workers/common/src/test/kotlin/common/env/config/EnvironmentConfigLoaderTest.kt
@@ -598,6 +598,7 @@ private fun createTestService(index: Int, userSecret: Secret, passSecret: Secret
         passwordSecret = passSecret,
         organization = null,
         product = null,
+        repository = null,
         credentialsTypes = setOf(CredentialsType.entries[index % 2])
     )
 


### PR DESCRIPTION
Add functionality to manage Infrastructure Services on Repository level.

This change also contains a commit that ...

- makes use of the existing `Hierarchy` data class to simplify the call to `listForHierarchy`
- removes obsolete code in the `InfrastructureServiceDAO` that is no longer used since the introduction of `InfrastructureServiceDeclaration`. (With #2957, the respective code went to `InfrastructureServiceDeclarationDao`).
