### PR TITLE
fix(config): Fix an issue with collaborating authenticators

### DIFF
--- a/config/git/src/main/kotlin/GitConfigFileProviderAuthenticator.kt
+++ b/config/git/src/main/kotlin/GitConfigFileProviderAuthenticator.kt
@@ -22,11 +22,13 @@ package org.eclipse.apoapsis.ortserver.config.git
 import java.net.Authenticator
 import java.net.PasswordAuthentication
 
+import org.ossreviewtoolkit.utils.ort.OrtAuthenticator
+
 import org.slf4j.LoggerFactory
 
 private val logger = LoggerFactory.getLogger(GitConfigFileProviderAuthenticator::class.java)
 
-internal class GitConfigFileProviderAuthenticator(val username: String, val password: String) : Authenticator() {
+internal class GitConfigFileProviderAuthenticator(val username: String, val password: String) : OrtAuthenticator() {
     companion object {
         var original: Authenticator? = null
 


### PR DESCRIPTION
It can happen that while `GitConfigFileProviderAuthenticator` is active for the checkout of the config repository, ORT's authenticator is installed. This breaks the chain of temporary authenticators, and the original one (typically the custom authenticator for ORT Server) is not enabled again. Afterward authentication in ORT Server is broken.

As a quick fix, let `GitConfigFileProviderAuthenticator` extend `OrtAuthenticator`. This prevents another installation of ORT's authenticator. A better fix may be added later to make the collaboration of the involved authenticators more robust.