### PR TITLE
ui: Minor changes and fixes to sibling navigation in breadcrumb

### DIFF
--- a/ui/src/components/siblings.tsx
+++ b/ui/src/components/siblings.tsx
@@ -18,7 +18,7 @@
  */
 
 import { Link, useParams, useRouter } from '@tanstack/react-router';
-import { ChevronDown } from 'lucide-react';
+import { Check, ChevronDown } from 'lucide-react';
 
 import {
   useOrganizationsServiceGetApiV1Organizations,
@@ -129,19 +129,10 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
           ? breadcrumbs.repo
           : breadcrumbs.run;
 
-  const orgSiblings = organizations?.data.filter(
-    (org) => org.id !== Number(params.orgId)
-  );
-
-  const prodSiblings = products?.data.filter(
-    (prod) => prod.id !== Number(params.productId)
-  );
-  const repoSiblings = repositories?.data.filter(
-    (repo) => repo.id !== Number(params.repoId)
-  );
-  const runSiblings = runs?.data
-    .sort((a, b) => b.index - a.index)
-    .filter((run) => run.index !== Number(params.runIndex));
+  const orgSiblings = organizations?.data;
+  const prodSiblings = products?.data;
+  const repoSiblings = repositories?.data;
+  const runSiblings = runs?.data.sort((a, b) => b.index - a.index);
 
   return (
     <BreadcrumbItem>
@@ -160,12 +151,17 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
                 </DropdownMenuItem>
               )}
               {orgSiblings.map((org) => (
-                <DropdownMenuItem key={org.id} className='ml-2'>
+                <DropdownMenuItem key={org.id} className='ml-2' asChild>
                   <Link
                     to='/organizations/$orgId'
                     params={{ orgId: org.id.toString() ?? '' }}
                   >
-                    {org.name}
+                    <div className='grid w-full grid-cols-6 items-center gap-2'>
+                      <div className='col-span-5'>{org.name}</div>
+                      {org.id === Number(params.orgId) && (
+                        <Check className='ml-auto h-4 w-4' />
+                      )}
+                    </div>
                   </Link>
                 </DropdownMenuItem>
               ))}
@@ -190,7 +186,7 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
                 </DropdownMenuItem>
               )}
               {prodSiblings.map((prod) => (
-                <DropdownMenuItem key={prod.id} className='ml-2'>
+                <DropdownMenuItem key={prod.id} className='ml-2' asChild>
                   <Link
                     to='/organizations/$orgId/products/$productId'
                     params={{
@@ -198,7 +194,12 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
                       productId: prod.id.toString() ?? '',
                     }}
                   >
-                    {prod.name}
+                    <div className='grid w-full grid-cols-6 items-center gap-2'>
+                      <div className='col-span-5'>{prod.name}</div>
+                      {prod.id === Number(params.productId) && (
+                        <Check className='ml-auto h-4 w-4' />
+                      )}
+                    </div>
                   </Link>
                 </DropdownMenuItem>
               ))}
@@ -223,7 +224,7 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
                 </DropdownMenuItem>
               )}
               {repoSiblings?.map((repo) => (
-                <DropdownMenuItem key={repo.id} className='ml-2'>
+                <DropdownMenuItem key={repo.id} className='ml-2' asChild>
                   <Link
                     to='/organizations/$orgId/products/$productId/repositories/$repoId'
                     params={{
@@ -232,7 +233,12 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
                       repoId: repo.id.toString() ?? '',
                     }}
                   >
-                    {repo.url}
+                    <div className='grid w-full grid-cols-6 items-center gap-2'>
+                      <div className='col-span-5'>{repo.url}</div>
+                      {repo.id === Number(params.repoId) && (
+                        <Check className='ml-auto h-4 w-4' />
+                      )}
+                    </div>
                   </Link>
                 </DropdownMenuItem>
               ))}
@@ -255,7 +261,7 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
                 </DropdownMenuItem>
               )}
               {runSiblings?.map((run) => (
-                <DropdownMenuItem key={run.index} className='ml-2'>
+                <DropdownMenuItem key={run.index} className='ml-2' asChild>
                   <Link
                     to='/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex'
                     params={{
@@ -265,7 +271,12 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
                       runIndex: run.index.toString() ?? '',
                     }}
                   >
-                    {run.index}
+                    <div className='grid w-full grid-cols-6 items-center gap-2'>
+                      <div className='col-span-5'>{run.index}</div>
+                      {run.index === Number(params.runIndex) && (
+                        <Check className='ml-auto h-4 w-4' />
+                      )}
+                    </div>
                   </Link>
                 </DropdownMenuItem>
               ))}

--- a/ui/src/components/siblings.tsx
+++ b/ui/src/components/siblings.tsx
@@ -129,14 +129,14 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
           ? breadcrumbs.repo
           : breadcrumbs.run;
 
-  const orgSiblings = organizations?.data;
-  const prodSiblings = products?.data;
-  const repoSiblings = repositories?.data;
-  const runSiblings = runs?.data.sort((a, b) => b.index - a.index);
+  const orgs = organizations?.data;
+  const prods = products?.data;
+  const repos = repositories?.data;
+  const runIndexes = runs?.data;
 
   return (
     <BreadcrumbItem>
-      {entity === 'organization' && orgSiblings && orgSiblings.length > 0 && (
+      {entity === 'organization' && orgs && orgs.length > 1 && (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <ChevronDown className='ml-1 size-4 cursor-pointer' />
@@ -150,7 +150,7 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
                   {`Failed to load organizations: ${(orgError as ApiError).message}`}
                 </DropdownMenuItem>
               )}
-              {orgSiblings.map((org) => (
+              {orgs.map((org) => (
                 <DropdownMenuItem key={org.id} className='ml-2' asChild>
                   <Link
                     to='/organizations/$orgId'
@@ -169,7 +169,7 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
           </DropdownMenuContent>
         </DropdownMenu>
       )}
-      {entity === 'product' && prodSiblings && prodSiblings.length > 0 && (
+      {entity === 'product' && prods && prods.length > 1 && (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <ChevronDown className='ml-1 size-4 cursor-pointer' />
@@ -185,7 +185,7 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
                   {`Failed to load products: ${(productsError as ApiError).message}`}
                 </DropdownMenuItem>
               )}
-              {prodSiblings.map((prod) => (
+              {prods.map((prod) => (
                 <DropdownMenuItem key={prod.id} className='ml-2' asChild>
                   <Link
                     to='/organizations/$orgId/products/$productId'
@@ -207,7 +207,7 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
           </DropdownMenuContent>
         </DropdownMenu>
       )}
-      {entity === 'repository' && repoSiblings && repoSiblings.length > 0 && (
+      {entity === 'repository' && repos && repos.length > 1 && (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <ChevronDown className='ml-1 size-4 cursor-pointer' />
@@ -223,7 +223,7 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
                   {`Failed to load repositories: ${(repositoriesError as ApiError).message}`}
                 </DropdownMenuItem>
               )}
-              {repoSiblings?.map((repo) => (
+              {repos.map((repo) => (
                 <DropdownMenuItem key={repo.id} className='ml-2' asChild>
                   <Link
                     to='/organizations/$orgId/products/$productId/repositories/$repoId'
@@ -246,7 +246,7 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
           </DropdownMenuContent>
         </DropdownMenu>
       )}
-      {entity === 'run' && runSiblings && runSiblings.length > 0 && (
+      {entity === 'run' && runIndexes && runIndexes.length > 1 && (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <ChevronDown className='ml-1 size-4 cursor-pointer' />
@@ -260,7 +260,7 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
                   {`Failed to load runs: ${(runsError as ApiError).message}`}
                 </DropdownMenuItem>
               )}
-              {runSiblings?.map((run) => (
+              {runIndexes.map((run) => (
                 <DropdownMenuItem key={run.index} className='ml-2' asChild>
                   <Link
                     to='/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex'

--- a/ui/src/components/siblings.tsx
+++ b/ui/src/components/siblings.tsx
@@ -80,6 +80,7 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
   } = useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdProducts(
     {
       organizationId: Number(params.orgId) ?? '',
+      limit: ALL_ITEMS,
     },
     undefined,
     {
@@ -96,6 +97,7 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
   } = useProductsServiceGetApiV1ProductsByProductIdRepositories(
     {
       productId: Number(params.productId) ?? '',
+      limit: ALL_ITEMS,
     },
     undefined,
     {
@@ -112,6 +114,8 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
   } = useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdRuns(
     {
       repositoryId: Number(params.repoId) ?? '',
+      limit: ALL_ITEMS,
+      sort: '-index',
     },
     undefined,
     {


### PR DESCRIPTION
This PR changes the logic of the `Siblings` component to resemble more closely a select type of dropdown, where the currently active sibling is not filtered out of the list, but instead indicated with a check mark.

Moreover, some fixes to query logic are included.

![Screenshot from 2025-07-02 13-51-30](https://github.com/user-attachments/assets/2a01f7a8-1f70-45a2-a174-c294760c836b)

![Screenshot from 2025-07-02 13-51-45](https://github.com/user-attachments/assets/cd2f73fd-54b9-4709-a024-2c9fa0287a46)

Please see the individual commits for details.