### PR TITLE
feat(api): Restrict keepAliveWorker flag to superusers

### DIFF
--- a/core/src/main/kotlin/api/ForbiddenConfigurationPropertyException.kt
+++ b/core/src/main/kotlin/api/ForbiddenConfigurationPropertyException.kt
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.core.api
+
+/** Used when the calling user is not allowed to use a particular configuration property. */
+class ForbiddenConfigurationPropertyException(propertyName: String) : RuntimeException(propertyName)

--- a/core/src/main/kotlin/plugins/StatusPages.kt
+++ b/core/src/main/kotlin/plugins/StatusPages.kt
@@ -31,6 +31,7 @@ import io.ktor.server.response.respond
 
 import org.eclipse.apoapsis.ortserver.components.authorization.AuthorizationException
 import org.eclipse.apoapsis.ortserver.core.api.AuthenticationException
+import org.eclipse.apoapsis.ortserver.core.api.ForbiddenConfigurationPropertyException
 import org.eclipse.apoapsis.ortserver.dao.QueryParametersException
 import org.eclipse.apoapsis.ortserver.dao.UniqueConstraintException
 import org.eclipse.apoapsis.ortserver.services.InvalidSecretReferenceException
@@ -65,10 +66,16 @@ fun Application.configureStatusPages() {
         exception<EntityNotFoundException> { call, _ ->
             call.respond(HttpStatusCode.NotFound)
         }
+        exception<ForbiddenConfigurationPropertyException> { call, e ->
+            call.respond(
+                HttpStatusCode.Forbidden,
+                ErrorResponse("Forbidden configuration property ${e.message} used by non-superuser.", e.message)
+            )
+        }
         exception<InvalidSecretReferenceException> { call, e ->
             call.respond(
                 HttpStatusCode.BadRequest,
-                ErrorResponse(message = "Secret reference could not be resolved.", e.message)
+                ErrorResponse("Secret reference could not be resolved.", e.message)
             )
         }
         exception<MissingRequestParameterException> { call, e ->


### PR DESCRIPTION
Limit access to the _keepAliveWorker_ job configuration option to superusers only. This flag is useful for debugging by support or developers, but should not be exposed to regular users as it prevents worker shutdown and may lead to unnecessary resource usage.