### PR TITLE
build: Define local maven repository definition

### DIFF
--- a/buildSrc/src/main/kotlin/ort-server-base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-base-conventions.gradle.kts
@@ -20,7 +20,7 @@
 repositories {
     mavenCentral()
 
-    mavenLocal() {
+    mavenLocal {
         name = "localOrt"
 
         content {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -118,6 +118,14 @@ plugins {
 
 dependencyResolutionManagement {
     repositories {
+        mavenLocal {
+            name = "localOrt"
+
+            content {
+                includeGroupByRegex("org\\.ossreviewtoolkit(\\..*)?")
+            }
+        }
+
         mavenCentral()
     }
 


### PR DESCRIPTION
The intention for using a local maven repository for ORT was to allow
changing the ORT version during development. [1] broke the current
approach to do this.

To restore the old behavior, add the local maven repository to the
dependency resolution management repositories definition.

Signed-off-by: Marcel Bochtler <marcel.bochtler@bosch.com>