### PR TITLE
Plugin template UI

### DIFF
--- a/components/plugin-manager/implementation/src/main/kotlin/Routing.kt
+++ b/components/plugin-manager/implementation/src/main/kotlin/Routing.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.components.pluginmanager
 import io.ktor.server.routing.Route
 
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.endpoints.addTemplateToOrganization
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.endpoints.createTemplate
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.endpoints.deleteTemplate
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.endpoints.disableGlobalTemplate
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.endpoints.disablePlugin
@@ -40,6 +41,7 @@ fun Route.pluginManagerRoutes(
     pluginTemplateService: PluginTemplateService
 ) {
     addTemplateToOrganization(pluginTemplateService)
+    createTemplate(pluginTemplateService)
     deleteTemplate(pluginTemplateService)
     disableGlobalTemplate(pluginTemplateService)
     disablePlugin(eventStore)

--- a/components/plugin-manager/implementation/src/main/kotlin/endpoints/CreateTemplate.kt
+++ b/components/plugin-manager/implementation/src/main/kotlin/endpoints/CreateTemplate.kt
@@ -22,7 +22,7 @@ package org.eclipse.apoapsis.ortserver.components.pluginmanager.endpoints
 import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.onSuccess
 
-import io.github.smiley4.ktoropenapi.put
+import io.github.smiley4.ktoropenapi.post
 
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
@@ -41,12 +41,12 @@ import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.TemplateError
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireParameter
 
-internal fun Route.updateTemplateOptions(
+internal fun Route.createTemplate(
     pluginTemplateService: PluginTemplateService
-) = put("admin/plugins/{pluginType}/{pluginId}/templates/{templateName}", {
-    operationId = "UpdatePluginTemplateOptions"
-    summary = "Update the options of a plugin template"
-    description = "Update the options of a plugin template."
+) = post("admin/plugins/{pluginType}/{pluginId}/templates/{templateName}", {
+    operationId = "CreatePluginTemplate"
+    summary = "Create a new plugin template"
+    description = "Create a new plugin template."
     tags = listOf("Plugins")
 
     request {
@@ -61,7 +61,7 @@ internal fun Route.updateTemplateOptions(
         }
 
         pathParameter<String>("templateName") {
-            description = "The name of the template to update."
+            description = "The name of the template to create."
             required = true
         }
 
@@ -81,11 +81,11 @@ internal fun Route.updateTemplateOptions(
 
     response {
         HttpStatusCode.OK to {
-            description = "The options were successfully updated."
+            description = "The template was successfully created."
         }
 
         HttpStatusCode.BadRequest to {
-            description = "The specified plugin is not installed or the template could not be updated."
+            description = "The specified plugin is not installed or the template could not be created."
         }
     }
 }) {
@@ -98,8 +98,8 @@ internal fun Route.updateTemplateOptions(
 
     val options = call.receive<List<PluginOptionTemplate>>()
 
-    pluginTemplateService.updateOptions(templateName, pluginType, pluginId, userId, options).onSuccess {
-        call.respond(HttpStatusCode.OK, "Template options updated successfully.")
+    pluginTemplateService.create(templateName, pluginType, pluginId, userId, options).onSuccess {
+        call.respond(HttpStatusCode.OK, "Template created successfully.")
     }.onFailure {
         when (it) {
             is TemplateError.InvalidPlugin -> call.respond(HttpStatusCode.BadRequest, it.message)

--- a/components/plugin-manager/implementation/src/main/kotlin/endpoints/UpdateTemplateOptions.kt
+++ b/components/plugin-manager/implementation/src/main/kotlin/endpoints/UpdateTemplateOptions.kt
@@ -22,7 +22,7 @@ package org.eclipse.apoapsis.ortserver.components.pluginmanager.endpoints
 import com.github.michaelbull.result.onFailure
 import com.github.michaelbull.result.onSuccess
 
-import io.github.smiley4.ktoropenapi.post
+import io.github.smiley4.ktoropenapi.put
 
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
@@ -43,7 +43,7 @@ import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireParameter
 
 internal fun Route.updateTemplateOptions(
     pluginTemplateService: PluginTemplateService
-) = post("admin/plugins/{pluginType}/{pluginId}/templates/{templateName}", {
+) = put("admin/plugins/{pluginType}/{pluginId}/templates/{templateName}", {
     operationId = "UpdatePluginTemplateOptions"
     summary = "Update the options of a plugin template"
     description = "Update the options of a plugin template. If the template does not exist, it will be created."

--- a/components/plugin-manager/implementation/src/main/kotlin/queries/GetPluginTemplatesQuery.kt
+++ b/components/plugin-manager/implementation/src/main/kotlin/queries/GetPluginTemplatesQuery.kt
@@ -23,6 +23,7 @@ import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplate
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplatesReadModel
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
 import org.eclipse.apoapsis.ortserver.dao.Query
+import org.jetbrains.exposed.sql.SortOrder
 
 import org.jetbrains.exposed.sql.andWhere
 import org.jetbrains.exposed.sql.selectAll
@@ -33,6 +34,7 @@ internal class GetPluginTemplatesQuery(val pluginType: PluginType, val pluginId:
             .selectAll()
             .where { PluginTemplatesReadModel.pluginType eq pluginType }
             .andWhere { PluginTemplatesReadModel.pluginId eq pluginId }
+            .orderBy(PluginTemplatesReadModel.name, order = SortOrder.ASC)
             .map {
                 PluginTemplate(
                     name = it[PluginTemplatesReadModel.name],

--- a/components/plugin-manager/implementation/src/main/kotlin/queries/GetPluginTemplatesQuery.kt
+++ b/components/plugin-manager/implementation/src/main/kotlin/queries/GetPluginTemplatesQuery.kt
@@ -23,8 +23,8 @@ import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplate
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplatesReadModel
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
 import org.eclipse.apoapsis.ortserver.dao.Query
-import org.jetbrains.exposed.sql.SortOrder
 
+import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.andWhere
 import org.jetbrains.exposed.sql.selectAll
 

--- a/components/plugin-manager/implementation/src/test/kotlin/endpoints/AddTemplateToOrganizationIntegrationTest.kt
+++ b/components/plugin-manager/implementation/src/test/kotlin/endpoints/AddTemplateToOrganizationIntegrationTest.kt
@@ -66,7 +66,7 @@ class AddTemplateToOrganizationIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication(
                 routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
             ) { client ->
-                pluginTemplateService.updateOptions("template1", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
 
                 val organizationId2 = dbExtension.fixtures.createOrganization(name = "org2").id
 
@@ -102,7 +102,7 @@ class AddTemplateToOrganizationIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication(
                 routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
             ) { client ->
-                pluginTemplateService.updateOptions("template1", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
 
                 client.post(
                     "/admin/plugins/$pluginType/$pluginId/templates/template1" +
@@ -115,7 +115,7 @@ class AddTemplateToOrganizationIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication(
                 routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
             ) { client ->
-                pluginTemplateService.updateOptions("template1", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
                 pluginTemplateService.addOrganization("template1", pluginType, pluginId, 1, "test-user")
 
                 client.post(
@@ -129,7 +129,7 @@ class AddTemplateToOrganizationIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication(
                 routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
             ) { client ->
-                pluginTemplateService.updateOptions("template1", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
 
                 client.post(
                     "/admin/plugins/$pluginType/${pluginId.uppercase()}/templates/template1" +

--- a/components/plugin-manager/implementation/src/test/kotlin/endpoints/CreateTemplateIntegrationTest.kt
+++ b/components/plugin-manager/implementation/src/test/kotlin/endpoints/CreateTemplateIntegrationTest.kt
@@ -25,6 +25,7 @@ import io.kotest.assertions.ktor.client.shouldHaveStatus
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 
+import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import io.ktor.http.HttpStatusCode
@@ -41,7 +42,7 @@ import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
 
 import org.ossreviewtoolkit.plugins.advisors.vulnerablecode.VulnerableCodeFactory
 
-class UpdateTemplateOptionsIntegrationTest : AbstractIntegrationTest({
+class CreateTemplateIntegrationTest : AbstractIntegrationTest({
     lateinit var pluginEventStore: PluginEventStore
     lateinit var pluginService: PluginService
     lateinit var pluginTemplateService: PluginTemplateService
@@ -62,8 +63,8 @@ class UpdateTemplateOptionsIntegrationTest : AbstractIntegrationTest({
         )
     }
 
-    "UpdateTemplateOptions" should {
-        "fail if the template does not exist" {
+    "CreateTemplate" should {
+        "create a template" {
             integrationTestApplication(
                 routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
             ) { client ->
@@ -77,56 +78,7 @@ class UpdateTemplateOptionsIntegrationTest : AbstractIntegrationTest({
                 )
 
                 val response =
-                    client.put("/admin/plugins/$pluginType/$pluginId/templates/template1") {
-                        setBody(options)
-                    }
-
-                response shouldHaveStatus HttpStatusCode.NotFound
-            }
-        }
-
-        "fail if the template was deleted before" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
-            ) { client ->
-                val options = listOf(
-                    PluginOptionTemplate(
-                        option = serverUrlOption.name,
-                        type = serverUrlOption.type.mapToApi(),
-                        value = "https://example.org",
-                        isFinal = true
-                    )
-                )
-
-                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
-                pluginTemplateService.delete("template1", pluginType, pluginId, "test-user")
-
-                val response =
-                    client.put("/admin/plugins/$pluginType/$pluginId/templates/template1") {
-                        setBody(options)
-                    }
-
-                response shouldHaveStatus HttpStatusCode.BadRequest
-            }
-        }
-
-        "update the options of an existing template" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
-            ) { client ->
-                val options = listOf(
-                    PluginOptionTemplate(
-                        option = serverUrlOption.name,
-                        type = serverUrlOption.type.mapToApi(),
-                        value = "https://example.org",
-                        isFinal = true
-                    )
-                )
-
-                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
-
-                val response =
-                    client.put("/admin/plugins/$pluginType/$pluginId/templates/template1") {
+                    client.post("/admin/plugins/$pluginType/$pluginId/templates/template1") {
                         setBody(options)
                     }
 
@@ -145,7 +97,43 @@ class UpdateTemplateOptionsIntegrationTest : AbstractIntegrationTest({
             }
         }
 
-        "normalize the plugin ID" {
+        "create a template if it was deleted before" {
+            integrationTestApplication(
+                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
+            ) { client ->
+                val options = listOf(
+                    PluginOptionTemplate(
+                        option = serverUrlOption.name,
+                        type = serverUrlOption.type.mapToApi(),
+                        value = "https://example.org",
+                        isFinal = true
+                    )
+                )
+
+                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.delete("template1", pluginType, pluginId, "test-user")
+
+                val response =
+                    client.post("/admin/plugins/$pluginType/$pluginId/templates/template1") {
+                        setBody(options)
+                    }
+
+                response shouldHaveStatus HttpStatusCode.OK
+
+                val result = pluginTemplateService.getTemplate("template1", pluginType, pluginId)
+                result.isOk shouldBe true
+
+                val template = result.get()
+                template shouldNotBeNull {
+                    name shouldBe "template1"
+                    this.pluginType shouldBe PluginType.ADVISOR
+                    this.pluginId shouldBe pluginId
+                    this.options shouldBe options
+                }
+            }
+        }
+
+        "fail if the template does already exist" {
             integrationTestApplication(
                 routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
             ) { client ->
@@ -161,7 +149,29 @@ class UpdateTemplateOptionsIntegrationTest : AbstractIntegrationTest({
                 pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
 
                 val response =
-                    client.put("/admin/plugins/$pluginType/${pluginId.uppercase()}/templates/template1") {
+                    client.post("/admin/plugins/$pluginType/$pluginId/templates/template1") {
+                        setBody(options)
+                    }
+
+                response shouldHaveStatus HttpStatusCode.BadRequest
+            }
+        }
+
+        "normalize the plugin ID" {
+            integrationTestApplication(
+                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
+            ) { client ->
+                val options = listOf(
+                    PluginOptionTemplate(
+                        option = serverUrlOption.name,
+                        type = serverUrlOption.type.mapToApi(),
+                        value = "https://example.org",
+                        isFinal = true
+                    )
+                )
+
+                val response =
+                    client.post("/admin/plugins/$pluginType/${pluginId.uppercase()}/templates/template1") {
                         setBody(options)
                     }
 
@@ -191,9 +201,7 @@ class UpdateTemplateOptionsIntegrationTest : AbstractIntegrationTest({
                     isFinal = true
                 )
 
-                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
-
-                client.put("/admin/plugins/$pluginType/$pluginId/templates/template1") {
+                client.post("/admin/plugins/$pluginType/$pluginId/templates/template1") {
                     setBody(listOf(nonExistingOption))
                 } shouldHaveStatus HttpStatusCode.BadRequest
 

--- a/components/plugin-manager/implementation/src/test/kotlin/endpoints/DeleteTemplateIntegrationTest.kt
+++ b/components/plugin-manager/implementation/src/test/kotlin/endpoints/DeleteTemplateIntegrationTest.kt
@@ -59,7 +59,7 @@ class DeleteTemplateIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication(
                 routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
             ) { client ->
-                pluginTemplateService.updateOptions("template1", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
 
                 client.delete("/admin/plugins/$pluginType/$pluginId/templates/template1") shouldHaveStatus
                         HttpStatusCode.OK
@@ -81,7 +81,7 @@ class DeleteTemplateIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication(
                 routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
             ) { client ->
-                pluginTemplateService.updateOptions("template1", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
 
                 client.delete("/admin/plugins/$pluginType/${pluginId.uppercase()}/templates/template1") shouldHaveStatus
                         HttpStatusCode.OK

--- a/components/plugin-manager/implementation/src/test/kotlin/endpoints/DisableGlobalTemplateIntegrationTest.kt
+++ b/components/plugin-manager/implementation/src/test/kotlin/endpoints/DisableGlobalTemplateIntegrationTest.kt
@@ -62,7 +62,7 @@ class DisableGlobalTemplateIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication(
                 routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
             ) { client ->
-                pluginTemplateService.updateOptions("template1", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
                 pluginTemplateService.enableGlobal("template1", pluginType, pluginId, "test-user")
 
                 client.post(
@@ -92,7 +92,7 @@ class DisableGlobalTemplateIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication(
                 routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
             ) { client ->
-                pluginTemplateService.updateOptions("template1", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
 
                 client.post(
                     "/admin/plugins/$pluginType/$pluginId/templates/template1/disableGlobal"
@@ -104,7 +104,7 @@ class DisableGlobalTemplateIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication(
                 routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
             ) { client ->
-                pluginTemplateService.updateOptions("template1", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
                 pluginTemplateService.enableGlobal("template1", pluginType, pluginId, "test-user")
 
                 client.post(

--- a/components/plugin-manager/implementation/src/test/kotlin/endpoints/EnableGlobalTemplateIntegrationTest.kt
+++ b/components/plugin-manager/implementation/src/test/kotlin/endpoints/EnableGlobalTemplateIntegrationTest.kt
@@ -62,7 +62,7 @@ class EnableGlobalTemplateIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication(
                 routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
             ) { client ->
-                pluginTemplateService.updateOptions("template1", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
 
                 client.post(
                     "/admin/plugins/$pluginType/$pluginId/templates/template1/enableGlobal"
@@ -91,7 +91,7 @@ class EnableGlobalTemplateIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication(
                 routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
             ) { client ->
-                pluginTemplateService.updateOptions("template1", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
                 pluginTemplateService.enableGlobal("template1", pluginType, pluginId, "test-user")
 
                 client.post(
@@ -104,8 +104,8 @@ class EnableGlobalTemplateIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication(
                 routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
             ) { client ->
-                pluginTemplateService.updateOptions("template1", pluginType, pluginId, "test-user", emptyList())
-                pluginTemplateService.updateOptions("template2", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template2", pluginType, pluginId, "test-user", emptyList())
                 pluginTemplateService.enableGlobal("template2", pluginType, pluginId, "test-user")
 
                 client.post(
@@ -118,7 +118,7 @@ class EnableGlobalTemplateIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication(
                 routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
             ) { client ->
-                pluginTemplateService.updateOptions("template1", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
 
                 client.post(
                     "/admin/plugins/$pluginType/${pluginId.uppercase()}/templates/template1/enableGlobal"

--- a/components/plugin-manager/implementation/src/test/kotlin/endpoints/GetTemplateIntegrationTest.kt
+++ b/components/plugin-manager/implementation/src/test/kotlin/endpoints/GetTemplateIntegrationTest.kt
@@ -62,7 +62,7 @@ class GetTemplateIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication(
                 routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
             ) { client ->
-                pluginTemplateService.updateOptions("template1", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
 
                 val response = client.get("/admin/plugins/$pluginType/$pluginId/templates/template1")
                 response shouldHaveStatus HttpStatusCode.OK
@@ -90,7 +90,7 @@ class GetTemplateIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication(
                 routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
             ) { client ->
-                pluginTemplateService.updateOptions("template1", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
 
                 val response = client.get(
                     "/admin/plugins/$pluginType/${pluginId.uppercase()}/templates/template1"

--- a/components/plugin-manager/implementation/src/test/kotlin/endpoints/GetTemplatesIntegrationTest.kt
+++ b/components/plugin-manager/implementation/src/test/kotlin/endpoints/GetTemplatesIntegrationTest.kt
@@ -20,6 +20,7 @@
 package org.eclipse.apoapsis.ortserver.components.pluginmanager.endpoints
 
 import io.kotest.assertions.ktor.client.shouldHaveStatus
+import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.should
 
@@ -58,20 +59,20 @@ class GetTemplatesIntegrationTest : AbstractIntegrationTest({
     }
 
     "GetTemplates" should {
-        "return the templates for a plugin" {
+        "return the templates for a plugin in alphabetic order" {
             integrationTestApplication(
                 routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
             ) { client ->
                 pluginTemplateService.updateOptions("template1", pluginType, pluginId, "test-user", emptyList())
-                pluginTemplateService.updateOptions("template2", pluginType, pluginId, "test-user", emptyList())
                 pluginTemplateService.updateOptions("template3", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.updateOptions("template2", pluginType, pluginId, "test-user", emptyList())
 
                 val response = client.get("/admin/plugins/$pluginType/$pluginId/templates")
                 response shouldHaveStatus HttpStatusCode.OK
 
                 val templates = response.body<List<PluginTemplate>>()
 
-                templates should containExactlyInAnyOrder(
+                templates should containExactly(
                     PluginTemplate(
                         name = "template1",
                         pluginType = pluginType,

--- a/components/plugin-manager/implementation/src/test/kotlin/endpoints/GetTemplatesIntegrationTest.kt
+++ b/components/plugin-manager/implementation/src/test/kotlin/endpoints/GetTemplatesIntegrationTest.kt
@@ -63,9 +63,9 @@ class GetTemplatesIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication(
                 routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
             ) { client ->
-                pluginTemplateService.updateOptions("template1", pluginType, pluginId, "test-user", emptyList())
-                pluginTemplateService.updateOptions("template3", pluginType, pluginId, "test-user", emptyList())
-                pluginTemplateService.updateOptions("template2", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template3", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template2", pluginType, pluginId, "test-user", emptyList())
 
                 val response = client.get("/admin/plugins/$pluginType/$pluginId/templates")
                 response shouldHaveStatus HttpStatusCode.OK
@@ -112,9 +112,9 @@ class GetTemplatesIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication(
                 routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
             ) { client ->
-                pluginTemplateService.updateOptions("template1", pluginType, pluginId, "test-user", emptyList())
-                pluginTemplateService.updateOptions("template2", pluginType, pluginId, "test-user", emptyList())
-                pluginTemplateService.updateOptions("template3", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template2", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template3", pluginType, pluginId, "test-user", emptyList())
 
                 val response = client.get(
                     "/admin/plugins/$pluginType/${pluginId.uppercase()}/templates"

--- a/components/plugin-manager/implementation/src/test/kotlin/endpoints/RemoveTemplateFromOrganizationIntegrationTest.kt
+++ b/components/plugin-manager/implementation/src/test/kotlin/endpoints/RemoveTemplateFromOrganizationIntegrationTest.kt
@@ -69,7 +69,7 @@ class RemoveTemplateFromOrganizationIntegrationTest : AbstractIntegrationTest({
             ) { client ->
                 val organizationId2 = dbExtension.fixtures.createOrganization(name = "org2").id
 
-                pluginTemplateService.updateOptions("template1", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
                 pluginTemplateService.addOrganization("template1", pluginType, pluginId, organizationId, "test-user")
                 pluginTemplateService.addOrganization("template1", pluginType, pluginId, organizationId2, "test-user")
 
@@ -101,7 +101,7 @@ class RemoveTemplateFromOrganizationIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication(
                 routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
             ) { client ->
-                pluginTemplateService.updateOptions("template1", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
 
                 client.post(
                     "/admin/plugins/$pluginType/$pluginId/templates/template1/removeFromOrganization?organizationId=1"
@@ -113,7 +113,7 @@ class RemoveTemplateFromOrganizationIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication(
                 routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
             ) { client ->
-                pluginTemplateService.updateOptions("template1", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
                 pluginTemplateService.addOrganization("template1", pluginType, pluginId, organizationId, "test-user")
 
                 client.post(

--- a/components/plugin-manager/implementation/src/test/kotlin/endpoints/UpdateTemplateOptionsIntegrationTest.kt
+++ b/components/plugin-manager/implementation/src/test/kotlin/endpoints/UpdateTemplateOptionsIntegrationTest.kt
@@ -26,6 +26,7 @@ import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 
 import io.ktor.client.request.post
+import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import io.ktor.http.HttpStatusCode
 
@@ -77,7 +78,7 @@ class UpdateTemplateOptionsIntegrationTest : AbstractIntegrationTest({
                 )
 
                 val response =
-                    client.post("/admin/plugins/$pluginType/$pluginId/templates/template1") {
+                    client.put("/admin/plugins/$pluginType/$pluginId/templates/template1") {
                         setBody(options)
                     }
 
@@ -113,7 +114,7 @@ class UpdateTemplateOptionsIntegrationTest : AbstractIntegrationTest({
                 pluginTemplateService.delete("template1", pluginType, pluginId, "test-user")
 
                 val response =
-                    client.post("/admin/plugins/$pluginType/$pluginId/templates/template1") {
+                    client.put("/admin/plugins/$pluginType/$pluginId/templates/template1") {
                         setBody(options)
                     }
 
@@ -148,7 +149,7 @@ class UpdateTemplateOptionsIntegrationTest : AbstractIntegrationTest({
                 pluginTemplateService.updateOptions("template1", pluginType, pluginId, "test-user", emptyList())
 
                 val response =
-                    client.post("/admin/plugins/$pluginType/$pluginId/templates/template1") {
+                    client.put("/admin/plugins/$pluginType/$pluginId/templates/template1") {
                         setBody(options)
                     }
 
@@ -181,7 +182,7 @@ class UpdateTemplateOptionsIntegrationTest : AbstractIntegrationTest({
                 )
 
                 val response =
-                    client.post("/admin/plugins/$pluginType/${pluginId.uppercase()}/templates/template1") {
+                    client.put("/admin/plugins/$pluginType/${pluginId.uppercase()}/templates/template1") {
                         setBody(options)
                     }
 
@@ -211,7 +212,7 @@ class UpdateTemplateOptionsIntegrationTest : AbstractIntegrationTest({
                     isFinal = true
                 )
 
-                client.post("/admin/plugins/$pluginType/$pluginId/templates/template1") {
+                client.put("/admin/plugins/$pluginType/$pluginId/templates/template1") {
                     setBody(listOf(nonExistingOption))
                 } shouldHaveStatus HttpStatusCode.BadRequest
 
@@ -222,7 +223,7 @@ class UpdateTemplateOptionsIntegrationTest : AbstractIntegrationTest({
                     isFinal = true
                 )
 
-                client.post("/admin/plugins/$pluginType/$pluginId/templates/template1") {
+                client.put("/admin/plugins/$pluginType/$pluginId/templates/template1") {
                     setBody(listOf(wrongOptionType))
                 } shouldHaveStatus HttpStatusCode.BadRequest
 
@@ -233,7 +234,7 @@ class UpdateTemplateOptionsIntegrationTest : AbstractIntegrationTest({
                     isFinal = true
                 )
 
-                client.post("/admin/plugins/$pluginType/$pluginId/templates/template1") {
+                client.put("/admin/plugins/$pluginType/$pluginId/templates/template1") {
                     setBody(listOf(invalidOptionValue))
                 } shouldHaveStatus HttpStatusCode.BadRequest
             }

--- a/ui/src/routes/admin/plugins/$pluginType/$pluginId/create-template/index.tsx
+++ b/ui/src/routes/admin/plugins/$pluginType/$pluginId/create-template/index.tsx
@@ -1,0 +1,381 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import {
+  createFileRoute,
+  useLoaderData,
+  useNavigate,
+} from '@tanstack/react-router';
+import { Loader2 } from 'lucide-react';
+import { useForm } from 'react-hook-form';
+import { z, ZodTypeAny } from 'zod';
+
+import { usePluginsServicePostApiV1AdminPluginsByPluginTypeByPluginIdTemplatesByTemplateName } from '@/api/queries';
+import {
+  ApiError,
+  PluginOption,
+  PluginOptionTemplate,
+  PluginOptionType,
+} from '@/api/requests';
+import { OptionalInput } from '@/components/form/optional-input';
+import { ToastError } from '@/components/toast-error';
+import { Badge } from '@/components/ui/badge.tsx';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { toast } from '@/lib/toast';
+import { Route as LayoutRoute } from '../../../route.tsx';
+
+function optionTypeToZodType(type: PluginOptionType): ZodTypeAny {
+  switch (type) {
+    case 'BOOLEAN':
+      return z.boolean();
+    case 'INTEGER':
+      return z.coerce.number();
+    case 'LONG':
+      return z.coerce.bigint();
+    case 'SECRET':
+      return z.string();
+    case 'STRING':
+      return z.string();
+    case 'STRING_LIST':
+      return z.array(z.string());
+    default:
+      throw new Error(`Unsupported option type: ${type}`);
+  }
+}
+
+const templateName = 'Template Name';
+
+function buildFormSchema(options: Array<PluginOption>) {
+  const shape: Record<string, ZodTypeAny> = {};
+  shape[templateName] = z.string().min(1);
+  for (const opt of options) {
+    let schema = optionTypeToZodType(opt.type);
+    if (opt.isNullable) {
+      schema = schema.nullable();
+    }
+    if (!opt.isRequired) {
+      schema = schema.optional();
+    }
+    shape[opt.name] = schema;
+    shape[`${opt.name}_isFinal`] = z.boolean().default(false);
+    shape[`${opt.name}_isNotSet`] = z.boolean().default(false);
+  }
+
+  return z.object(shape);
+}
+
+type FormValues = {
+  [templateName]: string;
+  [key: string]: unknown;
+};
+
+const CreateTemplate = () => {
+  const navigate = useNavigate();
+  const { plugins } = useLoaderData({ from: LayoutRoute.id });
+  const params = Route.useParams();
+
+  const plugin = plugins.find(
+    (p) => p.type === params.pluginType && p.id === params.pluginId
+  );
+
+  const formSchema = plugin?.options
+    ? buildFormSchema(plugin.options)
+    : z.object({ [templateName]: z.string().min(1) });
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: {
+      [templateName]: '',
+      ...(plugin?.options?.reduce(
+        (acc, option) => {
+          acc[option.name] = option.defaultValue ?? '';
+          acc[`${option.name}_isFinal`] = false;
+          acc[`${option.name}_isNotSet`] = false;
+          return acc;
+        },
+        {} as Record<string, unknown>
+      ) || {}),
+    },
+  });
+
+  const { mutateAsync: createTemplate, isPending: isCreateTemplatePending } =
+    usePluginsServicePostApiV1AdminPluginsByPluginTypeByPluginIdTemplatesByTemplateName(
+      {
+        onSuccess() {
+          toast.info('Create Template', {
+            description: `Template created successfully.`,
+          });
+          navigate({
+            to: '/admin/plugins/$pluginType/$pluginId',
+            params: {
+              pluginType: params.pluginType,
+              pluginId: params.pluginId,
+            },
+          });
+        },
+        onError(error: ApiError) {
+          toast.error(error.message, {
+            description: <ToastError error={error} />,
+            duration: Infinity,
+            cancel: {
+              label: 'Dismiss',
+              onClick: () => {},
+            },
+          });
+        },
+      }
+    );
+
+  async function onSubmit(values: z.infer<typeof formSchema>) {
+    const formValues = values as FormValues;
+    const requestBody: PluginOptionTemplate[] =
+      plugin?.options
+        ?.filter((option) => !formValues[`${option.name}_isNotSet`])
+        ?.map((option) => {
+          const value = formValues[option.name];
+          const isFinal = Boolean(formValues[`${option.name}_isFinal`]);
+
+          let stringValue: string | null;
+          if (value === null || value === undefined) {
+            stringValue = null;
+          } else if (Array.isArray(value)) {
+            stringValue = value.join(',');
+          } else if (
+            typeof value === 'bigint' ||
+            typeof value === 'number' ||
+            typeof value === 'boolean'
+          ) {
+            stringValue = value.toString();
+          } else {
+            stringValue = value as string;
+          }
+
+          return {
+            option: option.name,
+            type: option.type,
+            value: stringValue,
+            isFinal,
+          };
+        }) ?? [];
+
+    await createTemplate({
+      pluginType: params.pluginType,
+      pluginId: params.pluginId,
+      templateName: formValues[templateName],
+      requestBody: requestBody,
+    });
+  }
+
+  if (plugin === undefined) {
+    toast.error('Unable to find plugin', {
+      description: <ToastError error='Plugin not found.' />,
+      duration: Infinity,
+      cancel: {
+        label: 'Dismiss',
+        onClick: () => {},
+      },
+    });
+    return;
+  }
+
+  return (
+    <Card className='col-span-2 w-full'>
+      <CardHeader>
+        <CardTitle>Create Template</CardTitle>
+        <CardDescription>
+          Create a new plugin template for the {params.pluginId}{' '}
+          {params.pluginType} plugin.
+          <br />
+          Options that are set to final can not be overwritten by the user.
+          <br />
+          Options that are set to undefined will not be set in the template.
+        </CardDescription>
+      </CardHeader>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)}>
+          <CardContent className='space-y-4'>
+            <FormField
+              key={templateName}
+              control={form.control}
+              name={templateName}
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Template Name</FormLabel>
+                  <FormControl>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    The name of the template to create.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            {plugin.options?.map((option) => {
+              const isNotSet = form.watch(`${option.name}_isNotSet`);
+
+              return (
+                <FormItem key={option.name}>
+                  <FormLabel>
+                    {option.name}
+                    <Badge className='ml-2 bg-blue-200 text-black'>
+                      {option.type}
+                    </Badge>
+                  </FormLabel>
+                  <div
+                    style={{ display: 'flex', alignItems: 'center', gap: 8 }}
+                  >
+                    <FormField
+                      control={form.control}
+                      name={option.name}
+                      render={({ field }) => (
+                        <FormControl>
+                          {option.type === 'BOOLEAN' ? (
+                            <Checkbox {...field} />
+                          ) : option.isRequired ? (
+                            <Input
+                              {...field}
+                              type={
+                                option.type === 'INTEGER' ||
+                                option.type === 'LONG'
+                                  ? 'number'
+                                  : 'text'
+                              }
+                              disabled={isNotSet}
+                            />
+                          ) : (
+                            <OptionalInput
+                              {...field}
+                              type={
+                                option.type === 'INTEGER' ||
+                                option.type === 'LONG'
+                                  ? 'number'
+                                  : 'text'
+                              }
+                              disabled={isNotSet}
+                            />
+                          )}
+                        </FormControl>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name={`${option.name}_isFinal`}
+                      render={({ field }) => (
+                        <label
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 4,
+                          }}
+                        >
+                          <Checkbox
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                            disabled={isNotSet}
+                          />
+                          isFinal
+                        </label>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name={`${option.name}_isNotSet`}
+                      render={({ field }) => (
+                        <label
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 4,
+                          }}
+                        >
+                          <Checkbox
+                            checked={field.value}
+                            onCheckedChange={field.onChange}
+                          />
+                          undefined
+                        </label>
+                      )}
+                    />
+                  </div>
+                  <FormDescription>
+                    {option.description}
+                    {option.type === 'SECRET' && (
+                      <>
+                        <br />
+                        <span className='text-red-500'>
+                          Enter the name of the secret, not the value! A secret
+                          with this name must be configured in the context of
+                          the ORT run.
+                        </span>
+                      </>
+                    )}
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              );
+            })}
+          </CardContent>
+          <CardFooter>
+            <Button
+              type='submit'
+              disabled={isCreateTemplatePending}
+              className='mt-4'
+            >
+              {isCreateTemplatePending ? (
+                <>
+                  <span className='sr-only'>Creating Template...</span>
+                  <Loader2 size={16} className='mx-3 animate-spin' />
+                </>
+              ) : (
+                'Create Template'
+              )}
+            </Button>
+          </CardFooter>
+        </form>
+      </Form>
+    </Card>
+  );
+};
+
+export const Route = createFileRoute(
+  '/admin/plugins/$pluginType/$pluginId/create-template/'
+)({
+  component: CreateTemplate,
+});

--- a/ui/src/routes/admin/plugins/$pluginType/$pluginId/index.tsx
+++ b/ui/src/routes/admin/plugins/$pluginType/$pluginId/index.tsx
@@ -1,0 +1,555 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { createFileRoute, Link, useLoaderData } from '@tanstack/react-router';
+import { ChevronsUpDownIcon } from 'lucide-react';
+
+import {
+  useOrganizationsServiceGetApiV1Organizations,
+  usePluginsServiceDeleteApiV1AdminPluginsByPluginTypeByPluginIdTemplatesByTemplateName,
+  usePluginsServiceGetApiV1AdminPluginsByPluginTypeByPluginIdTemplates,
+  usePluginsServiceGetApiV1AdminPluginsByPluginTypeByPluginIdTemplatesKey,
+  usePluginsServicePostApiV1AdminPluginsByPluginTypeByPluginIdTemplatesByTemplateNameAddToOrganization,
+  usePluginsServicePostApiV1AdminPluginsByPluginTypeByPluginIdTemplatesByTemplateNameDisableGlobal,
+  usePluginsServicePostApiV1AdminPluginsByPluginTypeByPluginIdTemplatesByTemplateNameEnableGlobal,
+  usePluginsServicePostApiV1AdminPluginsByPluginTypeByPluginIdTemplatesByTemplateNameRemoveFromOrganization,
+} from '@/api/queries';
+import { prefetchUsePluginsServiceGetApiV1AdminPluginsByPluginTypeByPluginIdTemplates } from '@/api/queries/prefetch.ts';
+import { ApiError, PluginDescriptor, PluginTemplate } from '@/api/requests';
+import { DeleteDialog } from '@/components/delete-dialog.tsx';
+import { DeleteIconButton } from '@/components/delete-icon-button.tsx';
+import { LoadingIndicator } from '@/components/loading-indicator.tsx';
+import { ToastError } from '@/components/toast-error.tsx';
+import { Badge } from '@/components/ui/badge.tsx';
+import { Button } from '@/components/ui/button.tsx';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card.tsx';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command.tsx';
+import { Option } from '@/components/ui/multiple-selector.tsx';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover.tsx';
+import { Switch } from '@/components/ui/switch.tsx';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { ALL_ITEMS } from '@/lib/constants.ts';
+import { queryClient } from '@/lib/query-client.ts';
+import { toast } from '@/lib/toast';
+import { Route as LayoutRoute } from '@/routes/admin/plugins/route.tsx';
+
+type PluginTemplateCardProps = {
+  plugin: PluginDescriptor;
+  template: PluginTemplate;
+  organizationOptions: Option[];
+};
+
+const PluginTemplateCard = ({
+  plugin,
+  template,
+  organizationOptions,
+}: PluginTemplateCardProps) => {
+  const enableGlobal =
+    usePluginsServicePostApiV1AdminPluginsByPluginTypeByPluginIdTemplatesByTemplateNameEnableGlobal();
+  const disableGlobal =
+    usePluginsServicePostApiV1AdminPluginsByPluginTypeByPluginIdTemplatesByTemplateNameDisableGlobal();
+  const deleteTemplate =
+    usePluginsServiceDeleteApiV1AdminPluginsByPluginTypeByPluginIdTemplatesByTemplateName();
+
+  const toggleIsGlobal = () => {
+    if (template.isGlobal) {
+      disableGlobal.mutate(
+        {
+          pluginType: template.pluginType,
+          pluginId: template.pluginId,
+          templateName: template.name,
+        },
+        {
+          onSuccess: () => {
+            toast.info('Template disabled globally', {
+              description: `Template "${template.name}" is no longer global.`,
+            });
+            queryClient.invalidateQueries({
+              queryKey: [
+                usePluginsServiceGetApiV1AdminPluginsByPluginTypeByPluginIdTemplatesKey,
+                {
+                  pluginType: template.pluginType,
+                  pluginId: template.pluginId,
+                },
+              ],
+            });
+          },
+          onError: (error: unknown) => {
+            const apiError = error as ApiError;
+            toast.error('Failed to disable template globally', {
+              description: <ToastError error={apiError} />,
+              duration: Infinity,
+              cancel: {
+                label: 'Dismiss',
+                onClick: () => {},
+              },
+            });
+          },
+        }
+      );
+    } else {
+      enableGlobal.mutate(
+        {
+          pluginType: template.pluginType,
+          pluginId: template.pluginId,
+          templateName: template.name,
+        },
+        {
+          onSuccess: () => {
+            toast.info('Template enabled globally', {
+              description: `Template "${template.name}" is now global.`,
+            });
+            queryClient.invalidateQueries({
+              queryKey: [
+                usePluginsServiceGetApiV1AdminPluginsByPluginTypeByPluginIdTemplatesKey,
+                {
+                  pluginType: template.pluginType,
+                  pluginId: template.pluginId,
+                },
+              ],
+            });
+          },
+          onError: (error: unknown) => {
+            const apiError = error as ApiError;
+            toast.error('Failed to enable template globally', {
+              description: <ToastError error={apiError} />,
+              duration: Infinity,
+              cancel: {
+                label: 'Dismiss',
+                onClick: () => {},
+              },
+            });
+          },
+        }
+      );
+    }
+  };
+
+  const onDelete = () => {
+    deleteTemplate.mutate(
+      {
+        pluginType: template.pluginType,
+        pluginId: template.pluginId,
+        templateName: template.name,
+      },
+      {
+        onSuccess: () => {
+          toast.info('Template deleted', {
+            description: `Template "${template.name}" deleted successfully.`,
+          });
+          queryClient.invalidateQueries({
+            queryKey: [
+              usePluginsServiceGetApiV1AdminPluginsByPluginTypeByPluginIdTemplatesKey,
+              {
+                pluginType: template.pluginType,
+                pluginId: template.pluginId,
+              },
+            ],
+          });
+        },
+        onError: (error: unknown) => {
+          const apiError = error as ApiError;
+          toast.error('Failed to delete template', {
+            description: <ToastError error={apiError} />,
+            duration: Infinity,
+            cancel: {
+              label: 'Dismiss',
+              onClick: () => {},
+            },
+          });
+        },
+      }
+    );
+  };
+
+  const { mutateAsync: addOrganization } =
+    usePluginsServicePostApiV1AdminPluginsByPluginTypeByPluginIdTemplatesByTemplateNameAddToOrganization(
+      {
+        onSuccess: () => {
+          toast.info('Organization added to template', {
+            description: `Organization added to template "${template.name}".`,
+          });
+          queryClient.invalidateQueries({
+            queryKey: [
+              usePluginsServiceGetApiV1AdminPluginsByPluginTypeByPluginIdTemplatesKey,
+              {
+                pluginType: template.pluginType,
+                pluginId: template.pluginId,
+              },
+            ],
+          });
+        },
+        onError: (error: unknown) => {
+          const apiError = error as ApiError;
+          toast.error('Failed to add organization to template', {
+            description: <ToastError error={apiError} />,
+            duration: Infinity,
+            cancel: {
+              label: 'Dismiss',
+              onClick: () => {},
+            },
+          });
+        },
+      }
+    );
+
+  const { mutateAsync: removeOrganization } =
+    usePluginsServicePostApiV1AdminPluginsByPluginTypeByPluginIdTemplatesByTemplateNameRemoveFromOrganization(
+      {
+        onSuccess: () => {
+          toast.info('Organization removed from template', {
+            description: `Organization removed from template "${template.name}".`,
+          });
+          queryClient.invalidateQueries({
+            queryKey: [
+              usePluginsServiceGetApiV1AdminPluginsByPluginTypeByPluginIdTemplatesKey,
+              {
+                pluginType: template.pluginType,
+                pluginId: template.pluginId,
+              },
+            ],
+          });
+        },
+        onError: (error: unknown) => {
+          const apiError = error as ApiError;
+          toast.error('Failed to remove organization from template', {
+            description: <ToastError error={apiError} />,
+            duration: Infinity,
+            cancel: {
+              label: 'Dismiss',
+              onClick: () => {},
+            },
+          });
+        },
+      }
+    );
+
+  return (
+    <Card key={template.name} className='mb-2'>
+      <CardHeader className='flex items-start justify-between'>
+        <CardTitle>{template.name}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div>
+          Global Template
+          <Switch
+            className='ml-2 data-[state:checked]:bg-green-500'
+            checked={template.isGlobal}
+            onCheckedChange={() => toggleIsGlobal()}
+          />
+        </div>
+
+        <p className='text-muted-foreground mb-1 text-sm'>
+          {template.isGlobal
+            ? 'This template is global, it is active for all organizations that do not have another template assigned.'
+            : 'This template is not global, it is only active for organizations that it is assigned to.'}
+        </p>
+
+        <div className='my-4 border-t' />
+
+        <p className='text-muted-foreground mb-1 text-sm'>
+          {template.organizationIds && template.organizationIds.length > 0
+            ? 'This template is assigned to the following organizations:'
+            : 'This template is not assigned to any organizations.'}
+        </p>
+
+        <div>
+          {template.organizationIds && template.organizationIds.length > 0 && (
+            <div className='mb-2 flex flex-wrap gap-2'>
+              {template.organizationIds.map((orgId) => {
+                const org = organizationOptions.find(
+                  (o) => o.value === orgId.toString()
+                );
+                return (
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Badge
+                        asChild
+                        key={orgId}
+                        className='bg-amber-200 text-black'
+                      >
+                        <Button
+                          variant='ghost'
+                          onClick={() => {
+                            removeOrganization({
+                              pluginType: template.pluginType,
+                              pluginId: template.pluginId,
+                              templateName: template.name,
+                              organizationId: orgId.toString(),
+                            });
+                          }}
+                        >
+                          {org ? org.label : orgId}
+                        </Button>
+                      </Badge>
+                    </TooltipTrigger>
+                    <TooltipContent>Remove Organization</TooltipContent>
+                  </Tooltip>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        <Popover>
+          <PopoverTrigger asChild>
+            <Button variant='ghost' role='combobox' className='px-1'>
+              Add to Organization
+              <ChevronsUpDownIcon className='ml-2 h-4 w-4 shrink-0 opacity-50' />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent>
+            <Command>
+              <CommandInput placeholder='Search organization...' />
+              <CommandList>
+                <CommandEmpty>No organization found.</CommandEmpty>
+                <CommandGroup>
+                  {organizationOptions
+                    .filter(
+                      (option) =>
+                        !template.organizationIds?.includes(
+                          Number(option.value)
+                        )
+                    )
+                    .map((option) => (
+                      <CommandItem
+                        key={option.value}
+                        value={option.label}
+                        onSelect={() => {
+                          addOrganization({
+                            pluginType: template.pluginType,
+                            pluginId: template.pluginId,
+                            templateName: template.name,
+                            organizationId: option.value,
+                          });
+                        }}
+                      >
+                        {option.label}
+                      </CommandItem>
+                    ))}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+
+        <div className='my-4 border-t' />
+
+        {plugin.options?.map((pluginOption) => {
+          const templateOption = template.options.find(
+            (opt) => opt.option === pluginOption.name
+          );
+          return (
+            <div key={pluginOption.name} className='mb-2'>
+              <strong>{pluginOption.name}:</strong>{' '}
+              {templateOption ? (
+                <>
+                  {templateOption.value}
+                  {templateOption.isFinal && (
+                    <Badge className='ml-2 bg-green-200 text-black'>
+                      Final
+                    </Badge>
+                  )}
+                </>
+              ) : (
+                <Badge className='ml-2 bg-gray-200 text-black'>Not set</Badge>
+              )}
+              <Badge className='ml-2 bg-blue-200 text-black'>
+                {pluginOption.type}
+              </Badge>
+            </div>
+          );
+        })}
+      </CardContent>
+      <CardFooter>
+        Delete Template
+        <span className='ml-2'>
+          <DeleteDialog
+            thingName={'template'}
+            uiComponent={<DeleteIconButton />}
+            onDelete={onDelete}
+            tooltip='Delete Template'
+          />
+        </span>
+      </CardFooter>
+    </Card>
+  );
+};
+
+const PluginTemplatesComponent = () => {
+  const params = Route.useParams();
+  const { plugins } = useLoaderData({ from: LayoutRoute.id });
+
+  const pluginType = params.pluginType;
+  const pluginId = params.pluginId;
+
+  const plugin = plugins.find(
+    (p) => p.type === pluginType && p.id === pluginId
+  );
+
+  const {
+    data: organizations,
+    isPending: orgIsPending,
+    isError: orgIsError,
+    error: orgError,
+  } = useOrganizationsServiceGetApiV1Organizations({
+    limit: ALL_ITEMS,
+  });
+
+  const {
+    data: pluginTemplates,
+    error: pluginTemplatesError,
+    isPending: pluginTemplatesIsPending,
+    isError: pluginTemplatesIsError,
+  } = usePluginsServiceGetApiV1AdminPluginsByPluginTypeByPluginIdTemplates({
+    pluginType: pluginType,
+    pluginId: pluginId,
+  });
+
+  if (!plugin) {
+    toast.error('Plugin not found', {
+      description: `No plugin found with type "${pluginType}" and id "${pluginId}".`,
+      duration: Infinity,
+      cancel: {
+        label: 'Dismiss',
+        onClick: () => {},
+      },
+    });
+    return;
+  }
+
+  if (pluginTemplatesIsPending) {
+    return <LoadingIndicator />;
+  }
+
+  if (pluginTemplatesIsError) {
+    toast.error('Failed to load plugin templates', {
+      description: <ToastError error={pluginTemplatesError} />,
+      duration: Infinity,
+      cancel: {
+        label: 'Dismiss',
+        onClick: () => {},
+      },
+    });
+    return;
+  }
+
+  if (orgIsPending) {
+    return <LoadingIndicator />;
+  }
+
+  if (orgIsError) {
+    toast.error('Unable to load data', {
+      description: <ToastError error={orgError} />,
+      duration: Infinity,
+      cancel: {
+        label: 'Dismiss',
+        onClick: () => {},
+      },
+    });
+    return;
+  }
+
+  const organizationOptions: Option[] = organizations.data.map((o) => ({
+    label: o.name,
+    value: o.id.toString(),
+  }));
+
+  return (
+    <Card className='mb-4 h-fit'>
+      <CardHeader>
+        <CardTitle>
+          {pluginId} Templates ({pluginTemplates.length})
+        </CardTitle>
+        <CardDescription>
+          Manage plugin templates for the {pluginId} {pluginType} plugin.
+        </CardDescription>
+        <div className='py-2'>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button asChild size='sm' className='ml-auto gap-1'>
+                <Link
+                  to={'/admin/plugins/$pluginType/$pluginId/create-template'}
+                  params={{
+                    pluginType: pluginType,
+                    pluginId: pluginId,
+                  }}
+                >
+                  Create Template
+                </Link>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              Create a new plugin configuration template.
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </CardHeader>
+      <CardContent>
+        {pluginTemplates.length > 0 ? (
+          pluginTemplates.map((template) => (
+            <PluginTemplateCard
+              plugin={plugin}
+              template={template}
+              organizationOptions={organizationOptions}
+            />
+          ))
+        ) : (
+          <p>No templates found for this plugin.</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+export const Route = createFileRoute('/admin/plugins/$pluginType/$pluginId/')({
+  loader: async ({ context, params }) => {
+    await prefetchUsePluginsServiceGetApiV1AdminPluginsByPluginTypeByPluginIdTemplates(
+      context.queryClient,
+      {
+        pluginType: params.pluginType,
+        pluginId: params.pluginId,
+      }
+    );
+  },
+  component: PluginTemplatesComponent,
+  pendingComponent: LoadingIndicator,
+});

--- a/ui/src/routes/admin/plugins/index.tsx
+++ b/ui/src/routes/admin/plugins/index.tsx
@@ -17,17 +17,14 @@
  * License-Filename: LICENSE
  */
 
-import { createFileRoute } from '@tanstack/react-router';
+import { createFileRoute, Link, useLoaderData } from '@tanstack/react-router';
 
 import {
   usePluginsServiceGetApiV1AdminPluginsKey,
   usePluginsServicePostApiV1AdminPluginsByPluginTypeByPluginIdDisable,
   usePluginsServicePostApiV1AdminPluginsByPluginTypeByPluginIdEnable,
 } from '@/api/queries';
-import { prefetchUsePluginsServiceGetApiV1AdminPlugins } from '@/api/queries/prefetch.ts';
-import { usePluginsServiceGetApiV1AdminPluginsSuspense } from '@/api/queries/suspense.ts';
 import { ApiError, PluginDescriptor } from '@/api/requests';
-import { LoadingIndicator } from '@/components/loading-indicator.tsx';
 import { ToastError } from '@/components/toast-error.tsx';
 import {
   Card,
@@ -39,6 +36,7 @@ import {
 import { Switch } from '@/components/ui/switch.tsx';
 import { queryClient } from '@/lib/query-client.ts';
 import { toast } from '@/lib/toast.ts';
+import { Route as LayoutRoute } from './route.tsx';
 
 type PluginListCardProps = {
   title: string;
@@ -130,6 +128,17 @@ const PluginListCard = ({
                 onCheckedChange={() => handleToggle(plugin)}
               />
             </CardHeader>
+            <CardContent>
+              <Link
+                to={'/admin/plugins/$pluginType/$pluginId'}
+                params={{
+                  pluginType: plugin.type,
+                  pluginId: plugin.id,
+                }}
+              >
+                Manage Templates
+              </Link>
+            </CardContent>
           </Card>
         ))}
       </CardContent>
@@ -138,7 +147,7 @@ const PluginListCard = ({
 };
 
 const PluginsComponent = () => {
-  const { data: plugins } = usePluginsServiceGetApiV1AdminPluginsSuspense();
+  const { plugins } = useLoaderData({ from: LayoutRoute.id });
 
   const advisors = plugins?.filter((plugin) => plugin.type === 'ADVISOR') || [];
   const packageConfigurationProviders =
@@ -191,9 +200,5 @@ const PluginsComponent = () => {
 };
 
 export const Route = createFileRoute('/admin/plugins/')({
-  loader: async ({ context }) => {
-    prefetchUsePluginsServiceGetApiV1AdminPlugins(context.queryClient);
-  },
   component: PluginsComponent,
-  pendingComponent: LoadingIndicator,
 });

--- a/ui/src/routes/admin/plugins/route.tsx
+++ b/ui/src/routes/admin/plugins/route.tsx
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { createFileRoute, Outlet } from '@tanstack/react-router';
+
+import { usePluginsServiceGetApiV1AdminPluginsKey } from '@/api/queries';
+import { PluginsService } from '@/api/requests';
+
+export const Route = createFileRoute('/admin/plugins')({
+  loader: async ({ context }) => {
+    const plugins = await context.queryClient.ensureQueryData({
+      queryKey: [usePluginsServiceGetApiV1AdminPluginsKey],
+      queryFn: () => PluginsService.getApiV1AdminPlugins(),
+    });
+    return { plugins };
+  },
+  component: () => <Outlet />,
+});


### PR DESCRIPTION
Add the UI for managing plugin templates. This is a first version that needs improvements in presentation and error handling. Also, currently templates can not be edited, this will be added later. Note that plugin templates are still not applied when creating ORT runs, this will follow in another PR.

![image](https://github.com/user-attachments/assets/84ea6622-2521-4b6a-9393-9c7d42aa9ee1)

![image](https://github.com/user-attachments/assets/cde72b79-9c5c-4912-91bc-2123791746d8)
