### PR TITLE
refactor(model): Remove the default value for `ScannerRun.issues`

### DIFF
--- a/model/src/commonMain/kotlin/runs/scanner/ScannerRun.kt
+++ b/model/src/commonMain/kotlin/runs/scanner/ScannerRun.kt
@@ -34,6 +34,6 @@ data class ScannerRun(
     val config: ScannerConfiguration?,
     val provenances: Set<ProvenanceResolutionResult>,
     val scanResults: Set<ScanResult>,
-    val issues: Map<Identifier, Set<Issue>> = emptyMap(),
+    val issues: Map<Identifier, Set<Issue>>,
     val scanners: Map<Identifier, Set<String>>
 )

--- a/services/ort-run/src/test/kotlin/OrtServerMappingsTest.kt
+++ b/services/ort-run/src/test/kotlin/OrtServerMappingsTest.kt
@@ -471,6 +471,7 @@ class OrtServerMappingsTest : WordSpec({
                 config = scannerConfiguration,
                 provenances = setOf(provenanceResolutionResult),
                 scanResults = setOf(scanResult),
+                issues = emptyMap(),
                 scanners = mapOf(pkgIdentifier to setOf(scanResult.scanner.name, "TestScanner"))
             )
 


### PR DESCRIPTION
The default value was only used in a single place in tests. Removing the default value reduces the risk that the value is not set by accident.