### PR TITLE
deps: Upgrade Eclipse Temurin to 21.0.7_6

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@
 [versions]
 # Docker
 # When updating this version, make sure to keep it in sync with the worker Dockerfiles.
-eclipseTemurin = "21.0.4_7-jdk-jammy@sha256:0472478e22da0f66043fa6acd8cd30126592349f47937adafc2340794e5bf06a"
+eclipseTemurin = "21.0.7_6-jdk-jammy@sha256:e54c6d8517960d3f4abf697a44829af7ead08ccb60d5d309bceedc73b007c2e3"
 
 # Gradle plugins
 buildConfigPlugin = "5.6.7"

--- a/workers/analyzer/docker/Analyzer.Dockerfile
+++ b/workers/analyzer/docker/Analyzer.Dockerfile
@@ -49,7 +49,7 @@ ARG SBT_VERSION=1.10.0
 ARG SWIFT_VERSION=6.0.3
 
 # When updating this version make sure to keep it in sync with the other worker Dockerfiles and libs.version.toml.
-ARG TEMURIN_VERSION=21.0.4_7-jdk-jammy@sha256:0472478e22da0f66043fa6acd8cd30126592349f47937adafc2340794e5bf06a
+ARG TEMURIN_VERSION=21.0.7_6-jdk-jammy@sha256:e54c6d8517960d3f4abf697a44829af7ead08ccb60d5d309bceedc73b007c2e3
 
 FROM eclipse-temurin:$TEMURIN_VERSION AS ort-base-image
 

--- a/workers/config/docker/Config.Dockerfile
+++ b/workers/config/docker/Config.Dockerfile
@@ -20,7 +20,7 @@
 # License-Filename: LICENSE
 
 # When updating this version make sure to keep it in sync with the other worker Dockerfiles and libs.version.toml.
-FROM eclipse-temurin:21.0.4_7-jdk-jammy@sha256:0472478e22da0f66043fa6acd8cd30126592349f47937adafc2340794e5bf06a
+FROM eclipse-temurin:21.0.7_6-jdk-jammy@sha256:e54c6d8517960d3f4abf697a44829af7ead08ccb60d5d309bceedc73b007c2e3
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \

--- a/workers/evaluator/docker/Evaluator.Dockerfile
+++ b/workers/evaluator/docker/Evaluator.Dockerfile
@@ -20,7 +20,7 @@
 # License-Filename: LICENSE
 
 # When updating this version make sure to keep it in sync with the other worker Dockerfiles and libs.version.toml.
-FROM eclipse-temurin:21.0.4_7-jdk-jammy@sha256:0472478e22da0f66043fa6acd8cd30126592349f47937adafc2340794e5bf06a
+FROM eclipse-temurin:21.0.7_6-jdk-jammy@sha256:e54c6d8517960d3f4abf697a44829af7ead08ccb60d5d309bceedc73b007c2e3
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \

--- a/workers/notifier/docker/Notifier.Dockerfile
+++ b/workers/notifier/docker/Notifier.Dockerfile
@@ -20,7 +20,7 @@
 # License-Filename: LICENSE
 
 # When updating this version make sure to keep it in sync with the other worker Dockerfiles and libs.version.toml.
-FROM eclipse-temurin:21.0.4_7-jdk-jammy@sha256:0472478e22da0f66043fa6acd8cd30126592349f47937adafc2340794e5bf06a
+FROM eclipse-temurin:21.0.7_6-jdk-jammy@sha256:e54c6d8517960d3f4abf697a44829af7ead08ccb60d5d309bceedc73b007c2e3
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \

--- a/workers/reporter/docker/Reporter.Dockerfile
+++ b/workers/reporter/docker/Reporter.Dockerfile
@@ -38,7 +38,7 @@ RUN scancode-license-data --path /opt/scancode-license-data \
     && rm -rf /opt/scancode-license-data/static
 
 # When updating this version make sure to keep it in sync with the other worker Dockerfiles and libs.version.toml.
-FROM eclipse-temurin:21.0.4_7-jdk-jammy@sha256:0472478e22da0f66043fa6acd8cd30126592349f47937adafc2340794e5bf06a
+FROM eclipse-temurin:21.0.7_6-jdk-jammy@sha256:e54c6d8517960d3f4abf697a44829af7ead08ccb60d5d309bceedc73b007c2e3
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \

--- a/workers/scanner/docker/Scanner.Dockerfile
+++ b/workers/scanner/docker/Scanner.Dockerfile
@@ -21,7 +21,7 @@
 # License-Filename: LICENSE
 
 # When updating this version make sure to keep it in sync with the other worker Dockerfiles and libs.version.toml.
-FROM eclipse-temurin:21.0.4_7-jdk-jammy@sha256:0472478e22da0f66043fa6acd8cd30126592349f47937adafc2340794e5bf06a AS base-image
+FROM eclipse-temurin:21.0.7_6-jdk-jammy@sha256:e54c6d8517960d3f4abf697a44829af7ead08ccb60d5d309bceedc73b007c2e3 AS base-image
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \


### PR DESCRIPTION
For some reason Renovate stopped upgrading the Eclipse Temurin image, so update it manually.