### PR TITLE
fix(analyzer): Take all issues into account for run status

### DIFF
--- a/workers/analyzer/src/main/kotlin/analyzer/AnalyzerWorker.kt
+++ b/workers/analyzer/src/main/kotlin/analyzer/AnalyzerWorker.kt
@@ -135,7 +135,7 @@ internal class AnalyzerWorker(
                 ortRunService.storeAnalyzerRun(analyzerRun.mapToModel(jobId), shortestPathsByIdentifier)
             }
 
-            if (analyzerRun.result.issues.values.flatten().any { it.severity >= Severity.WARNING }) {
+            if (analyzerRun.result.getAllIssues().values.flatten().any { it.severity >= Severity.WARNING }) {
                 RunResult.FinishedWithIssues
             } else {
                 RunResult.Success


### PR DESCRIPTION
Use the `AnalyzerResult.getAllIssues()` function instead of the `AnalzyerResult.issues` property when determining the analyzer job status, because that also includes issues from the dependency trees.