### PR TITLE
Improve ConfigFileProvider.contains

### DIFF
--- a/config/git/src/main/kotlin/GitConfigFileProvider.kt
+++ b/config/git/src/main/kotlin/GitConfigFileProvider.kt
@@ -100,7 +100,10 @@ class GitConfigFileProvider internal constructor(
 
     override fun contains(context: Context, path: Path): Boolean {
         updateWorkingTree(context.name)
-        return configDir.resolve(path.path).isFile
+        val p = configDir.resolve(path.path)
+        val isDirectoryPath = path.path.endsWith("/")
+
+        return (!isDirectoryPath && p.isFile) || (isDirectoryPath && p.isDirectory)
     }
 
     override fun listFiles(context: Context, path: Path): Set<Path> {

--- a/config/git/src/test/kotlin/GitConfigFileProviderTest.kt
+++ b/config/git/src/test/kotlin/GitConfigFileProviderTest.kt
@@ -113,7 +113,13 @@ class GitConfigFileProviderTest : WordSpec({
         "return `false` if the path refers to a directory" {
             val provider = GitConfigFileProvider(GIT_URL, tempdir())
 
-            provider.contains(RESOLVED_CONTEXT_MAIN, Path("customer1/")) shouldBe false
+            provider.contains(RESOLVED_CONTEXT_MAIN, Path("customer1")) shouldBe false
+        }
+
+        "return `true` if the path ending on a slash refers to a directory" {
+            val provider = GitConfigFileProvider(GIT_URL, tempdir())
+
+            provider.contains(RESOLVED_CONTEXT_MAIN, Path("customer1/")) shouldBe true
         }
 
         "return `false` if a the file cannot be found" {
@@ -126,6 +132,20 @@ class GitConfigFileProviderTest : WordSpec({
     "listFiles" should {
         "return a list of files inside a given directory" {
             val filesPath = "customer2/product2"
+            val expectedFiles = listOf(
+                "customer2/product2/copyright-garbage.yml",
+                "customer2/product2/evaluator.rules.kts",
+                "customer2/product2/license-classifications.yml"
+            )
+            val provider = GitConfigFileProvider(GIT_URL, tempdir())
+
+            val listFiles = provider.listFiles(RESOLVED_CONTEXT_MAIN, Path(filesPath)).map { it.path }
+
+            listFiles shouldContainExactlyInAnyOrder expectedFiles
+        }
+
+        "return a list of files inside a given directory if the paths end with a slash" {
+            val filesPath = "customer2/product2/"
             val expectedFiles = listOf(
                 "customer2/product2/copyright-garbage.yml",
                 "customer2/product2/evaluator.rules.kts",

--- a/config/github/src/test/kotlin/GitHubConfigFileProviderTest.kt
+++ b/config/github/src/test/kotlin/GitHubConfigFileProviderTest.kt
@@ -282,6 +282,14 @@ class GitHubConfigFileProviderTest : WordSpec({
             provider.contains(Context(REVISION), Path(DIRECTORY_PATH)) shouldBe false
         }
 
+        "return `true` if the path ending with a slash refers a directory" {
+            server.stubDirectory()
+
+            val provider = getProvider()
+
+            provider.contains(Context(REVISION), Path("$DIRECTORY_PATH/")) shouldBe true
+        }
+
         "return `false` if a `NotFound` response is received" {
             server.stubFileNotFound()
 
@@ -300,6 +308,18 @@ class GitHubConfigFileProviderTest : WordSpec({
             val provider = getProvider()
 
             val listFiles = provider.listFiles(Context(REVISION), Path(DIRECTORY_PATH))
+
+            listFiles shouldContainExactlyInAnyOrder expectedPaths
+        }
+
+        "return a list of files inside a given directory if the path ends with a slash" {
+            server.stubDirectory()
+
+            val expectedPaths = setOf(Path(CONFIG_PATH + "1"), Path(CONFIG_PATH + "2"))
+
+            val provider = getProvider()
+
+            val listFiles = provider.listFiles(Context(REVISION), Path("$DIRECTORY_PATH/"))
 
             listFiles shouldContainExactlyInAnyOrder expectedPaths
         }

--- a/config/local/src/main/kotlin/LocalConfigFileProvider.kt
+++ b/config/local/src/main/kotlin/LocalConfigFileProvider.kt
@@ -65,7 +65,12 @@ class LocalConfigFileProvider(
             throw ConfigException("Cannot read path '${path.path}'.", it)
         }
 
-    override fun contains(context: Context, path: Path) = configDir.resolve(path.path).isFile
+    override fun contains(context: Context, path: Path): Boolean {
+        val isDirectoryPath = path.path.endsWith("/")
+        val p = configDir.resolve(path.path)
+
+        return (!isDirectoryPath && p.isFile) || (isDirectoryPath && p.isDirectory)
+    }
 
     override fun listFiles(context: Context, path: Path): Set<Path> {
         val dir = configDir.resolve(path.path)

--- a/config/local/src/test/kotlin/LocalConfigFileProviderTest.kt
+++ b/config/local/src/test/kotlin/LocalConfigFileProviderTest.kt
@@ -112,6 +112,15 @@ class LocalConfigFileProviderTest : WordSpec({
             provider.contains(Context(""), CONFIG_PATH) shouldBe false
         }
 
+        "return `true` if the path ending on a slash refers to a directory" {
+            val directory = tempdir()
+            directory.resolve(CONFIG_PATH.path).mkdir()
+            val directoryPath = CONFIG_PATH.path + "/"
+            val provider = LocalConfigFileProvider(directory)
+
+            provider.contains(Context(""), Path(directoryPath)) shouldBe true
+        }
+
         "return `false` if a the file cannot be found" {
             val directory = tempdir()
             val provider = LocalConfigFileProvider(directory)
@@ -130,6 +139,20 @@ class LocalConfigFileProviderTest : WordSpec({
             val listFiles = provider.listFiles(Context(""), Path(""))
 
             val expectedFiles = files.map { Path(directory.resolve(it).absolutePath) }
+            listFiles shouldContainExactlyInAnyOrder expectedFiles
+        }
+
+        "return a list of files inside a given directory for a path ending on a slash" {
+            val directory = tempdir()
+            val subDirectory = directory.resolve("sub")
+            subDirectory.mkdir()
+            val files = listOf("file-1", "file-2", "file-3")
+            files.forEach { subDirectory.resolve(it).createNewFile() }
+            val provider = LocalConfigFileProvider(directory)
+
+            val listFiles = provider.listFiles(Context(""), Path("sub/"))
+
+            val expectedFiles = files.map { Path(subDirectory.resolve(it).absolutePath) }
             listFiles shouldContainExactlyInAnyOrder expectedFiles
         }
 

--- a/config/spi/src/main/kotlin/ConfigFileProvider.kt
+++ b/config/spi/src/main/kotlin/ConfigFileProvider.kt
@@ -45,8 +45,10 @@ interface ConfigFileProvider {
     fun getFile(context: Context, path: Path): InputStream
 
     /**
-     * Return a flag whether there is a configuration file with the given [path] in the given [context]. If this
-     * function returns *true*, it should be possible to actually read this file via the [getFile] function.
+     * Return a flag whether the specified [path] exists in the given [context]. The [path] can either denote a file or
+     * a folder; in the latter case, it should end with a slash. If this function returns *true*, it should be possible
+     * to actually read this file via the [getFile] function or, in case of a directory, list its content via the
+     * [listFiles] function.
      */
     fun contains(context: Context, path: Path): Boolean
 


### PR DESCRIPTION
This PR changes the `contains` implementation in config file providers to allow checking whether a path refers to an existing directory. This is needed for validation of the admin configuration.

Refer to the single commits for further details.