### PR TITLE
test(components): Add helper classes to reduce boilerplate

### DIFF
--- a/components/admin-config/backend/src/test/kotlin/AdminConfigIntegrationTest.kt
+++ b/components/admin-config/backend/src/test/kotlin/AdminConfigIntegrationTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.components.adminconfig
+
+import io.ktor.client.HttpClient
+import io.ktor.server.testing.ApplicationTestBuilder
+
+import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
+
+/** An [AbstractIntegrationTest] pre-configured for testing the admin-config routes. */
+@Suppress("UnnecessaryAbstractClass")
+abstract class AdminConfigIntegrationTest(body: AdminConfigIntegrationTest.() -> Unit) : AbstractIntegrationTest({}) {
+    init {
+        body()
+    }
+
+    fun adminConfigTestApplication(
+        block: suspend ApplicationTestBuilder.(client: HttpClient) -> Unit
+    ) = integrationTestApplication(
+        routes = { adminConfigRoutes(dbExtension.db) },
+        block = block
+    )
+}

--- a/components/admin-config/backend/src/test/kotlin/routes/GetConfigByKeyIntegrationTest.kt
+++ b/components/admin-config/backend/src/test/kotlin/routes/GetConfigByKeyIntegrationTest.kt
@@ -28,14 +28,13 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.HttpStatusCode
 
+import org.eclipse.apoapsis.ortserver.components.adminconfig.AdminConfigIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.adminconfig.Config
-import org.eclipse.apoapsis.ortserver.components.adminconfig.adminConfigRoutes
-import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
 
-class GetConfigByKeyIntegrationTest : AbstractIntegrationTest({
+class GetConfigByKeyIntegrationTest : AdminConfigIntegrationTest({
     "GetConfigByKey" should {
         "return the value and enabled status of an existing config key" {
-            integrationTestApplication(routes = { adminConfigRoutes(dbExtension.db) }) { client ->
+            adminConfigTestApplication { client ->
                 // Insert a test config key to database
                 client.post("/admin/config/HOME_ICON_URL") {
                     setBody(
@@ -57,7 +56,7 @@ class GetConfigByKeyIntegrationTest : AbstractIntegrationTest({
         }
 
         "return the default value if the config key does not exist in db" {
-            integrationTestApplication(routes = { adminConfigRoutes(dbExtension.db) }) { client ->
+            adminConfigTestApplication { client ->
                 val response = client.get("/admin/config/HOME_ICON_URL")
                 response shouldHaveStatus HttpStatusCode.OK
 
@@ -69,7 +68,7 @@ class GetConfigByKeyIntegrationTest : AbstractIntegrationTest({
         }
 
         "return BadRequest if the config key is invalid" {
-            integrationTestApplication(routes = { adminConfigRoutes(dbExtension.db) }) { client ->
+            adminConfigTestApplication { client ->
                 client.get("/admin/config/INVALID_KEY") shouldHaveStatus HttpStatusCode.BadRequest
             }
         }

--- a/components/admin-config/backend/src/test/kotlin/routes/InsertOrUpdateConfigIntegrationTest.kt
+++ b/components/admin-config/backend/src/test/kotlin/routes/InsertOrUpdateConfigIntegrationTest.kt
@@ -28,14 +28,13 @@ import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.HttpStatusCode
 
+import org.eclipse.apoapsis.ortserver.components.adminconfig.AdminConfigIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.adminconfig.Config
-import org.eclipse.apoapsis.ortserver.components.adminconfig.adminConfigRoutes
-import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
 
-class InsertOrUpdateConfigIntegrationTest : AbstractIntegrationTest({
+class InsertOrUpdateConfigIntegrationTest : AdminConfigIntegrationTest({
     "InsertOrUpdateConfig" should {
         "insert the new config key if it doesn't exist" {
-            integrationTestApplication(routes = { adminConfigRoutes(dbExtension.db) }) { client ->
+            adminConfigTestApplication { client ->
                 client.post("/admin/config/HOME_ICON_URL") {
                     setBody(
                         Config(
@@ -56,7 +55,7 @@ class InsertOrUpdateConfigIntegrationTest : AbstractIntegrationTest({
         }
 
         "update the value and isEnabled status of an existing config key" {
-            integrationTestApplication(routes = { adminConfigRoutes(dbExtension.db) }) { client ->
+            adminConfigTestApplication { client ->
                 client.post("/admin/config/HOME_ICON_URL") {
                     setBody(
                         Config(
@@ -94,7 +93,7 @@ class InsertOrUpdateConfigIntegrationTest : AbstractIntegrationTest({
         }
 
         "return BadRequest if the config key is invalid" {
-            integrationTestApplication(routes = { adminConfigRoutes(dbExtension.db) }) { client ->
+            adminConfigTestApplication { client ->
                 client.get("/admin/config/INVALID_KEY") shouldHaveStatus HttpStatusCode.BadRequest
             }
         }

--- a/components/plugin-manager/backend/src/test/kotlin/PluginManagerIntegrationTest.kt
+++ b/components/plugin-manager/backend/src/test/kotlin/PluginManagerIntegrationTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.components.pluginmanager
+
+import io.ktor.client.HttpClient
+import io.ktor.server.testing.ApplicationTestBuilder
+
+import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
+
+/** An [AbstractIntegrationTest] pre-configured for testing the plugin-manager routes. */
+@Suppress("UnnecessaryAbstractClass")
+abstract class PluginManagerIntegrationTest(
+    body: PluginManagerIntegrationTest.() -> Unit
+) : AbstractIntegrationTest({}) {
+    lateinit var eventStore: PluginEventStore
+    lateinit var pluginService: PluginService
+    lateinit var pluginTemplateService: PluginTemplateService
+
+    init {
+        beforeEach {
+            eventStore = PluginEventStore(dbExtension.db)
+            pluginService = PluginService(dbExtension.db)
+            pluginTemplateService = PluginTemplateService(
+                dbExtension.db,
+                PluginTemplateEventStore(dbExtension.db),
+                pluginService,
+                dbExtension.fixtures.organizationRepository
+            )
+        }
+
+        body()
+    }
+
+    fun pluginManagerTestApplication(
+        block: suspend ApplicationTestBuilder.(client: HttpClient) -> Unit
+    ) = integrationTestApplication(
+        routes = { pluginManagerRoutes(eventStore, pluginService, pluginTemplateService) },
+        block = block
+    )
+}

--- a/components/plugin-manager/backend/src/test/kotlin/endpoints/CreateTemplateIntegrationTest.kt
+++ b/components/plugin-manager/backend/src/test/kotlin/endpoints/CreateTemplateIntegrationTest.kt
@@ -30,44 +30,22 @@ import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import io.ktor.http.HttpStatusCode
 
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginEventStore
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginManagerIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginOptionTemplate
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginOptionType
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginService
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplateEventStore
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplateService
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.pluginManagerRoutes
-import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
 
 import org.ossreviewtoolkit.plugins.advisors.vulnerablecode.VulnerableCodeFactory
 
-class CreateTemplateIntegrationTest : AbstractIntegrationTest({
-    lateinit var pluginEventStore: PluginEventStore
-    lateinit var pluginService: PluginService
-    lateinit var pluginTemplateService: PluginTemplateService
-
+class CreateTemplateIntegrationTest : PluginManagerIntegrationTest({
     val pluginType = PluginType.ADVISOR
     val pluginId = VulnerableCodeFactory.descriptor.id
     val serverUrlOption = VulnerableCodeFactory.descriptor.options.single { it.name == "serverUrl" }
     val readTimeoutOption = VulnerableCodeFactory.descriptor.options.single { it.name == "readTimeout" }
 
-    beforeEach {
-        pluginEventStore = PluginEventStore(dbExtension.db)
-        pluginService = PluginService(dbExtension.db)
-        pluginTemplateService = PluginTemplateService(
-            dbExtension.db,
-            PluginTemplateEventStore(dbExtension.db),
-            pluginService,
-            dbExtension.fixtures.organizationRepository
-        )
-    }
-
     "CreateTemplate" should {
         "create a template" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
-            ) { client ->
+            pluginManagerTestApplication { client ->
                 val options = listOf(
                     PluginOptionTemplate(
                         option = serverUrlOption.name,
@@ -98,9 +76,7 @@ class CreateTemplateIntegrationTest : AbstractIntegrationTest({
         }
 
         "create a template if it was deleted before" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
-            ) { client ->
+            pluginManagerTestApplication { client ->
                 val options = listOf(
                     PluginOptionTemplate(
                         option = serverUrlOption.name,
@@ -134,9 +110,7 @@ class CreateTemplateIntegrationTest : AbstractIntegrationTest({
         }
 
         "fail if the template does already exist" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
-            ) { client ->
+            pluginManagerTestApplication { client ->
                 val options = listOf(
                     PluginOptionTemplate(
                         option = serverUrlOption.name,
@@ -158,9 +132,7 @@ class CreateTemplateIntegrationTest : AbstractIntegrationTest({
         }
 
         "normalize the plugin ID" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
-            ) { client ->
+            pluginManagerTestApplication { client ->
                 val options = listOf(
                     PluginOptionTemplate(
                         option = serverUrlOption.name,
@@ -191,9 +163,7 @@ class CreateTemplateIntegrationTest : AbstractIntegrationTest({
         }
 
         "fail if a plugin option is invalid" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
-            ) { client ->
+            pluginManagerTestApplication { client ->
                 val nonExistingOption = PluginOptionTemplate(
                     option = "invalidOption",
                     type = PluginOptionType.STRING,

--- a/components/plugin-manager/backend/src/test/kotlin/endpoints/DisableGlobalTemplateIntegrationTest.kt
+++ b/components/plugin-manager/backend/src/test/kotlin/endpoints/DisableGlobalTemplateIntegrationTest.kt
@@ -28,40 +28,18 @@ import io.kotest.matchers.shouldBe
 import io.ktor.client.request.post
 import io.ktor.http.HttpStatusCode
 
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginEventStore
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginService
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplateEventStore
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplateService
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginManagerIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.pluginManagerRoutes
-import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
 
 import org.ossreviewtoolkit.plugins.advisors.ossindex.OssIndexFactory
 
-class DisableGlobalTemplateIntegrationTest : AbstractIntegrationTest({
-    lateinit var pluginEventStore: PluginEventStore
-    lateinit var pluginService: PluginService
-    lateinit var pluginTemplateService: PluginTemplateService
-
+class DisableGlobalTemplateIntegrationTest : PluginManagerIntegrationTest({
     val pluginType = PluginType.ADVISOR
     val pluginId = OssIndexFactory.descriptor.id
 
-    beforeEach {
-        pluginEventStore = PluginEventStore(dbExtension.db)
-        pluginService = PluginService(dbExtension.db)
-        pluginTemplateService = PluginTemplateService(
-            dbExtension.db,
-            PluginTemplateEventStore(dbExtension.db),
-            pluginService,
-            dbExtension.fixtures.organizationRepository
-        )
-    }
-
     "DisableGlobalTemplate" should {
         "disable a global template" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
-            ) { client ->
+            pluginManagerTestApplication { client ->
                 pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
                 pluginTemplateService.enableGlobal("template1", pluginType, pluginId, "test-user")
 
@@ -79,9 +57,7 @@ class DisableGlobalTemplateIntegrationTest : AbstractIntegrationTest({
         }
 
         "return NotFound if the template does not exist" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
-            ) { client ->
+            pluginManagerTestApplication { client ->
                 client.post(
                     "/admin/plugins/$pluginType/$pluginId/templates/non-existing-template/disableGlobal"
                 ) shouldHaveStatus HttpStatusCode.NotFound
@@ -89,9 +65,7 @@ class DisableGlobalTemplateIntegrationTest : AbstractIntegrationTest({
         }
 
         "return BadRequest if the template is global" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
-            ) { client ->
+            pluginManagerTestApplication { client ->
                 pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
 
                 client.post(
@@ -101,9 +75,7 @@ class DisableGlobalTemplateIntegrationTest : AbstractIntegrationTest({
         }
 
         "normalize the plugin ID" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
-            ) { client ->
+            pluginManagerTestApplication { client ->
                 pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
                 pluginTemplateService.enableGlobal("template1", pluginType, pluginId, "test-user")
 

--- a/components/plugin-manager/backend/src/test/kotlin/endpoints/DisablePluginIntegrationTest.kt
+++ b/components/plugin-manager/backend/src/test/kotlin/endpoints/DisablePluginIntegrationTest.kt
@@ -24,37 +24,15 @@ import io.kotest.assertions.ktor.client.shouldHaveStatus
 import io.ktor.client.request.post
 import io.ktor.http.HttpStatusCode
 
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginEventStore
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginService
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplateEventStore
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplateService
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginManagerIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.pluginManagerRoutes
-import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
 
 import org.ossreviewtoolkit.plugins.advisors.vulnerablecode.VulnerableCodeFactory
 
-class DisablePluginIntegrationTest : AbstractIntegrationTest({
-    lateinit var eventStore: PluginEventStore
-    lateinit var pluginService: PluginService
-    lateinit var pluginTemplateService: PluginTemplateService
-
-    beforeEach {
-        eventStore = PluginEventStore(dbExtension.db)
-        pluginService = PluginService(dbExtension.db)
-        pluginTemplateService = PluginTemplateService(
-            dbExtension.db,
-            PluginTemplateEventStore(dbExtension.db),
-            pluginService,
-            dbExtension.fixtures.organizationRepository
-        )
-    }
-
+class DisablePluginIntegrationTest : PluginManagerIntegrationTest({
     "DisablePlugin" should {
         "return Accepted if the plugin was disabled" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(eventStore, pluginService, pluginTemplateService) }
-            ) { client ->
+            pluginManagerTestApplication { client ->
                 val pluginType = PluginType.ADVISOR
                 val pluginId = VulnerableCodeFactory.descriptor.id
 
@@ -68,9 +46,7 @@ class DisablePluginIntegrationTest : AbstractIntegrationTest({
         }
 
         "return NotFound if the plugin is not installed" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(eventStore, pluginService, pluginTemplateService) }
-            ) { client ->
+            pluginManagerTestApplication { client ->
                 val pluginType = PluginType.ADVISOR
 
                 client.post("/admin/plugins/$pluginType/unknown/disable") shouldHaveStatus HttpStatusCode.NotFound
@@ -78,9 +54,7 @@ class DisablePluginIntegrationTest : AbstractIntegrationTest({
         }
 
         "return NotModified if the plugin was already disabled" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(eventStore, pluginService, pluginTemplateService) }
-            ) { client ->
+            pluginManagerTestApplication { client ->
                 val pluginType = PluginType.ADVISOR
                 val pluginId = VulnerableCodeFactory.descriptor.id
 

--- a/components/plugin-manager/backend/src/test/kotlin/endpoints/GetInstalledPluginsIntegrationTest.kt
+++ b/components/plugin-manager/backend/src/test/kotlin/endpoints/GetInstalledPluginsIntegrationTest.kt
@@ -30,38 +30,16 @@ import io.ktor.client.request.post
 import io.ktor.http.HttpStatusCode
 
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginDescriptor
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginEventStore
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginService
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplateEventStore
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplateService
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginManagerIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.pluginManagerRoutes
-import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
 
 import org.ossreviewtoolkit.plugins.advisors.vulnerablecode.VulnerableCodeFactory
 import org.ossreviewtoolkit.plugins.packagemanagers.node.npm.NpmFactory
 
-class GetInstalledPluginsIntegrationTest : AbstractIntegrationTest({
-    lateinit var eventStore: PluginEventStore
-    lateinit var pluginService: PluginService
-    lateinit var pluginTemplateService: PluginTemplateService
-
-    beforeEach {
-        eventStore = PluginEventStore(dbExtension.db)
-        pluginService = PluginService(dbExtension.db)
-        pluginTemplateService = PluginTemplateService(
-            dbExtension.db,
-            PluginTemplateEventStore(dbExtension.db),
-            pluginService,
-            dbExtension.fixtures.organizationRepository
-        )
-    }
-
+class GetInstalledPluginsIntegrationTest : PluginManagerIntegrationTest({
     "GetInstalledPlugins" should {
         "return all installed ORT plugins" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(eventStore, pluginService, pluginTemplateService) }
-            ) { client ->
+            pluginManagerTestApplication { client ->
                 val response = client.get("/admin/plugins")
 
                 response shouldHaveStatus HttpStatusCode.OK
@@ -70,12 +48,10 @@ class GetInstalledPluginsIntegrationTest : AbstractIntegrationTest({
                     pluginDescriptors.filter { it.type == pluginType } shouldNot beEmpty()
                 }
             }
-        }
+            }
 
         "return if plugins are enabled or disabled" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(eventStore, pluginService, pluginTemplateService) }
-            ) { client ->
+            pluginManagerTestApplication { client ->
                 val npmType = PluginType.PACKAGE_MANAGER
                 val npmId = NpmFactory.descriptor.id
                 val vulnerableCodeType = PluginType.ADVISOR

--- a/components/plugin-manager/backend/src/test/kotlin/endpoints/GetTemplateIntegrationTest.kt
+++ b/components/plugin-manager/backend/src/test/kotlin/endpoints/GetTemplateIntegrationTest.kt
@@ -27,41 +27,19 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginEventStore
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginService
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginManagerIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplate
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplateEventStore
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplateService
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.pluginManagerRoutes
-import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
 
 import org.ossreviewtoolkit.plugins.advisors.ossindex.OssIndexFactory
 
-class GetTemplateIntegrationTest : AbstractIntegrationTest({
-    lateinit var pluginEventStore: PluginEventStore
-    lateinit var pluginService: PluginService
-    lateinit var pluginTemplateService: PluginTemplateService
-
+class GetTemplateIntegrationTest : PluginManagerIntegrationTest({
     val pluginType = PluginType.ADVISOR
     val pluginId = OssIndexFactory.descriptor.id
 
-    beforeEach {
-        pluginEventStore = PluginEventStore(dbExtension.db)
-        pluginService = PluginService(dbExtension.db)
-        pluginTemplateService = PluginTemplateService(
-            dbExtension.db,
-            PluginTemplateEventStore(dbExtension.db),
-            pluginService,
-            dbExtension.fixtures.organizationRepository
-        )
-    }
-
     "GetTemplate" should {
         "return a template if it exists" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
-            ) { client ->
+            pluginManagerTestApplication { client ->
                 pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
 
                 val response = client.get("/admin/plugins/$pluginType/$pluginId/templates/template1")
@@ -77,9 +55,7 @@ class GetTemplateIntegrationTest : AbstractIntegrationTest({
         }
 
         "return NotFound if the template does not exist" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
-            ) { client ->
+            pluginManagerTestApplication { client ->
                 client.get(
                     "/admin/plugins/$pluginType/$pluginId/templates/template1"
                 ) shouldHaveStatus HttpStatusCode.NotFound
@@ -87,9 +63,7 @@ class GetTemplateIntegrationTest : AbstractIntegrationTest({
         }
 
         "normalize the plugin ID" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
-            ) { client ->
+            pluginManagerTestApplication { client ->
                 pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
 
                 val response = client.get(

--- a/components/plugin-manager/backend/src/test/kotlin/endpoints/UpdateTemplateOptionsIntegrationTest.kt
+++ b/components/plugin-manager/backend/src/test/kotlin/endpoints/UpdateTemplateOptionsIntegrationTest.kt
@@ -29,44 +29,22 @@ import io.ktor.client.request.put
 import io.ktor.client.request.setBody
 import io.ktor.http.HttpStatusCode
 
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginEventStore
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginManagerIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginOptionTemplate
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginOptionType
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginService
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplateEventStore
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplateService
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.pluginManagerRoutes
-import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
 
 import org.ossreviewtoolkit.plugins.advisors.vulnerablecode.VulnerableCodeFactory
 
-class UpdateTemplateOptionsIntegrationTest : AbstractIntegrationTest({
-    lateinit var pluginEventStore: PluginEventStore
-    lateinit var pluginService: PluginService
-    lateinit var pluginTemplateService: PluginTemplateService
-
+class UpdateTemplateOptionsIntegrationTest : PluginManagerIntegrationTest({
     val pluginType = PluginType.ADVISOR
     val pluginId = VulnerableCodeFactory.descriptor.id
     val serverUrlOption = VulnerableCodeFactory.descriptor.options.single { it.name == "serverUrl" }
     val readTimeoutOption = VulnerableCodeFactory.descriptor.options.single { it.name == "readTimeout" }
 
-    beforeEach {
-        pluginEventStore = PluginEventStore(dbExtension.db)
-        pluginService = PluginService(dbExtension.db)
-        pluginTemplateService = PluginTemplateService(
-            dbExtension.db,
-            PluginTemplateEventStore(dbExtension.db),
-            pluginService,
-            dbExtension.fixtures.organizationRepository
-        )
-    }
-
     "UpdateTemplateOptions" should {
         "fail if the template does not exist" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
-            ) { client ->
+            pluginManagerTestApplication { client ->
                 val options = listOf(
                     PluginOptionTemplate(
                         option = serverUrlOption.name,
@@ -86,9 +64,7 @@ class UpdateTemplateOptionsIntegrationTest : AbstractIntegrationTest({
         }
 
         "fail if the template was deleted before" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
-            ) { client ->
+            pluginManagerTestApplication { client ->
                 val options = listOf(
                     PluginOptionTemplate(
                         option = serverUrlOption.name,
@@ -111,9 +87,7 @@ class UpdateTemplateOptionsIntegrationTest : AbstractIntegrationTest({
         }
 
         "update the options of an existing template" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
-            ) { client ->
+            pluginManagerTestApplication { client ->
                 val options = listOf(
                     PluginOptionTemplate(
                         option = serverUrlOption.name,
@@ -146,9 +120,7 @@ class UpdateTemplateOptionsIntegrationTest : AbstractIntegrationTest({
         }
 
         "normalize the plugin ID" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
-            ) { client ->
+            pluginManagerTestApplication { client ->
                 val options = listOf(
                     PluginOptionTemplate(
                         option = serverUrlOption.name,
@@ -181,9 +153,7 @@ class UpdateTemplateOptionsIntegrationTest : AbstractIntegrationTest({
         }
 
         "fail if a plugin option is invalid" {
-            integrationTestApplication(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
-            ) { client ->
+            pluginManagerTestApplication { client ->
                 val nonExistingOption = PluginOptionTemplate(
                     option = "invalidOption",
                     type = PluginOptionType.STRING,

--- a/components/secrets/backend/src/test/kotlin/SecretsIntegrationTest.kt
+++ b/components/secrets/backend/src/test/kotlin/SecretsIntegrationTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.components.secrets
+
+import io.ktor.client.HttpClient
+import io.ktor.server.testing.ApplicationTestBuilder
+
+import org.eclipse.apoapsis.ortserver.model.repositories.SecretRepository
+import org.eclipse.apoapsis.ortserver.secrets.SecretStorage
+import org.eclipse.apoapsis.ortserver.secrets.SecretsProviderFactoryForTesting
+import org.eclipse.apoapsis.ortserver.services.SecretService
+import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
+
+/** An [AbstractIntegrationTest] pre-configured for testing the secrets routes. */
+@Suppress("UnnecessaryAbstractClass")
+abstract class SecretsIntegrationTest(body: SecretsIntegrationTest.() -> Unit) : AbstractIntegrationTest({}) {
+    lateinit var secretRepository: SecretRepository
+    lateinit var secretService: SecretService
+
+    val secretErrorPath = "error-path"
+
+    init {
+        beforeEach {
+            secretRepository = dbExtension.fixtures.secretRepository
+            secretService = SecretService(
+                dbExtension.db,
+                dbExtension.fixtures.secretRepository,
+                dbExtension.fixtures.infrastructureServiceRepository,
+                SecretStorage(SecretsProviderFactoryForTesting().createProvider(secretErrorPath))
+            )
+        }
+
+        body()
+    }
+
+    fun secretsTestApplication(
+        block: suspend ApplicationTestBuilder.(client: HttpClient) -> Unit
+    ) = integrationTestApplication(
+        routes = { secretsRoutes(secretService) },
+        validations = { secretsValidations() },
+        block = block
+    )
+}

--- a/components/secrets/backend/src/test/kotlin/routes/organization/GetSecretsByOrganizationIdIntegrationTest.kt
+++ b/components/secrets/backend/src/test/kotlin/routes/organization/GetSecretsByOrganizationIdIntegrationTest.kt
@@ -24,40 +24,26 @@ import io.kotest.assertions.ktor.client.shouldHaveStatus
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 
+import org.eclipse.apoapsis.ortserver.components.secrets.SecretsIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.secrets.mapToApi
 import org.eclipse.apoapsis.ortserver.components.secrets.routes.createOrganizationSecret
-import org.eclipse.apoapsis.ortserver.components.secrets.secretsRoutes
-import org.eclipse.apoapsis.ortserver.model.repositories.SecretRepository
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters.Companion.DEFAULT_LIMIT
-import org.eclipse.apoapsis.ortserver.secrets.SecretStorage
-import org.eclipse.apoapsis.ortserver.secrets.SecretsProviderFactoryForTesting
-import org.eclipse.apoapsis.ortserver.services.SecretService
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagingData
 import org.eclipse.apoapsis.ortserver.shared.apimodel.SortDirection
 import org.eclipse.apoapsis.ortserver.shared.apimodel.SortProperty
-import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.shouldHaveBody
 
-class GetSecretsByOrganizationIdIntegrationTest : AbstractIntegrationTest({
+class GetSecretsByOrganizationIdIntegrationTest : SecretsIntegrationTest({
     var orgId = 0L
-    lateinit var secretRepository: SecretRepository
-    lateinit var secretService: SecretService
 
     beforeEach {
         orgId = dbExtension.fixtures.organization.id
-        secretRepository = dbExtension.fixtures.secretRepository
-        secretService = SecretService(
-            dbExtension.db,
-            dbExtension.fixtures.secretRepository,
-            dbExtension.fixtures.infrastructureServiceRepository,
-            SecretStorage(SecretsProviderFactoryForTesting().createProvider())
-        )
     }
 
     "GetSecretsByOrganizationId" should {
         "return all secrets for this organization" {
-            integrationTestApplication(routes = { secretsRoutes(secretService) }) { client ->
+            secretsTestApplication { client ->
                 val secret1 = secretRepository.createOrganizationSecret(orgId, "path1", "name1", "description1")
                 val secret2 = secretRepository.createOrganizationSecret(orgId, "path2", "name2", "description2")
 
@@ -77,7 +63,7 @@ class GetSecretsByOrganizationIdIntegrationTest : AbstractIntegrationTest({
         }
 
         "support query parameters" {
-            integrationTestApplication(routes = { secretsRoutes(secretService) }) { client ->
+            secretsTestApplication { client ->
                 secretRepository.createOrganizationSecret(orgId, "path1", "name1", "description1")
                 val secret = secretRepository.createOrganizationSecret(orgId, "path2", "name2", "description2")
 

--- a/components/secrets/backend/src/test/kotlin/routes/organization/PatchSecretByOrganizationIdAndNameIntegrationTest.kt
+++ b/components/secrets/backend/src/test/kotlin/routes/organization/PatchSecretByOrganizationIdAndNameIntegrationTest.kt
@@ -27,41 +27,28 @@ import io.ktor.client.request.setBody
 import io.ktor.http.HttpStatusCode
 
 import org.eclipse.apoapsis.ortserver.components.secrets.Secret
+import org.eclipse.apoapsis.ortserver.components.secrets.SecretsIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.secrets.UpdateSecret
 import org.eclipse.apoapsis.ortserver.components.secrets.mapToApi
 import org.eclipse.apoapsis.ortserver.components.secrets.routes.createOrganizationSecret
-import org.eclipse.apoapsis.ortserver.components.secrets.secretsRoutes
 import org.eclipse.apoapsis.ortserver.model.OrganizationId
-import org.eclipse.apoapsis.ortserver.model.repositories.SecretRepository
 import org.eclipse.apoapsis.ortserver.secrets.Path
-import org.eclipse.apoapsis.ortserver.secrets.SecretStorage
 import org.eclipse.apoapsis.ortserver.secrets.SecretsProviderFactoryForTesting
-import org.eclipse.apoapsis.ortserver.services.SecretService
 import org.eclipse.apoapsis.ortserver.shared.apimodel.asPresent
-import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.shouldHaveBody
 
-class PatchSecretByOrganizationIdAndNameIntegrationTest : AbstractIntegrationTest({
+class PatchSecretByOrganizationIdAndNameIntegrationTest : SecretsIntegrationTest({
     var orgId = 0L
-    lateinit var secretRepository: SecretRepository
-    lateinit var secretService: SecretService
 
     val secretErrorPath = "error-path"
 
     beforeEach {
         orgId = dbExtension.fixtures.organization.id
-        secretRepository = dbExtension.fixtures.secretRepository
-        secretService = SecretService(
-            dbExtension.db,
-            dbExtension.fixtures.secretRepository,
-            dbExtension.fixtures.infrastructureServiceRepository,
-            SecretStorage(SecretsProviderFactoryForTesting().createProvider(secretErrorPath))
-        )
     }
 
     "PatchSecretByOrganizationIdAndName" should {
         "update a secret's metadata" {
-            integrationTestApplication(routes = { secretsRoutes(secretService) }) { client ->
+            secretsTestApplication { client ->
                 val secret = secretRepository.createOrganizationSecret(orgId)
 
                 val updatedDescription = "updated description"
@@ -80,7 +67,7 @@ class PatchSecretByOrganizationIdAndNameIntegrationTest : AbstractIntegrationTes
         }
 
         "update a secret's value" {
-            integrationTestApplication(routes = { secretsRoutes(secretService) }) { client ->
+            secretsTestApplication { client ->
                 val secret = secretRepository.createOrganizationSecret(orgId)
 
                 val updateSecret = UpdateSecret("value".asPresent(), "description".asPresent())
@@ -97,7 +84,7 @@ class PatchSecretByOrganizationIdAndNameIntegrationTest : AbstractIntegrationTes
         }
 
         "handle a failure from the SecretStorage" {
-            integrationTestApplication(routes = { secretsRoutes(secretService) }) { client ->
+            secretsTestApplication { client ->
                 val secret = secretRepository.createOrganizationSecret(orgId, path = secretErrorPath)
 
                 val updateSecret = UpdateSecret("value".asPresent(), "newDesc".asPresent())

--- a/components/secrets/backend/src/test/kotlin/routes/product/GetSecretByProductIdAndNameIntegrationTest.kt
+++ b/components/secrets/backend/src/test/kotlin/routes/product/GetSecretByProductIdAndNameIntegrationTest.kt
@@ -24,35 +24,21 @@ import io.kotest.assertions.ktor.client.shouldHaveStatus
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 
+import org.eclipse.apoapsis.ortserver.components.secrets.SecretsIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.secrets.mapToApi
 import org.eclipse.apoapsis.ortserver.components.secrets.routes.createProductSecret
-import org.eclipse.apoapsis.ortserver.components.secrets.secretsRoutes
-import org.eclipse.apoapsis.ortserver.model.repositories.SecretRepository
-import org.eclipse.apoapsis.ortserver.secrets.SecretStorage
-import org.eclipse.apoapsis.ortserver.secrets.SecretsProviderFactoryForTesting
-import org.eclipse.apoapsis.ortserver.services.SecretService
-import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.shouldHaveBody
 
-class GetSecretByProductIdAndNameIntegrationTest : AbstractIntegrationTest({
+class GetSecretByProductIdAndNameIntegrationTest : SecretsIntegrationTest({
     var prodId = 0L
-    lateinit var secretRepository: SecretRepository
-    lateinit var secretService: SecretService
 
     beforeEach {
         prodId = dbExtension.fixtures.product.id
-        secretRepository = dbExtension.fixtures.secretRepository
-        secretService = SecretService(
-            dbExtension.db,
-            dbExtension.fixtures.secretRepository,
-            dbExtension.fixtures.infrastructureServiceRepository,
-            SecretStorage(SecretsProviderFactoryForTesting().createProvider())
-        )
     }
 
     "GetSecretByProductIdAndName" should {
         "return a single secret" {
-            integrationTestApplication(routes = { secretsRoutes(secretService) }) { client ->
+            secretsTestApplication { client ->
                 val secret = secretRepository.createProductSecret(prodId)
 
                 val response = client.get("/products/$prodId/secrets/${secret.name}")
@@ -63,7 +49,7 @@ class GetSecretByProductIdAndNameIntegrationTest : AbstractIntegrationTest({
         }
 
         "respond with NotFound if no secret exists" {
-            integrationTestApplication(routes = { secretsRoutes(secretService) }) { client ->
+            secretsTestApplication { client ->
                 client.get("/products/$prodId/secrets/999999") shouldHaveStatus
                         HttpStatusCode.NotFound
             }

--- a/components/secrets/backend/src/test/kotlin/routes/product/GetSecretsByProductIdIntegrationTest.kt
+++ b/components/secrets/backend/src/test/kotlin/routes/product/GetSecretsByProductIdIntegrationTest.kt
@@ -24,39 +24,25 @@ import io.kotest.assertions.ktor.client.shouldHaveStatus
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 
+import org.eclipse.apoapsis.ortserver.components.secrets.SecretsIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.secrets.mapToApi
 import org.eclipse.apoapsis.ortserver.components.secrets.routes.createProductSecret
-import org.eclipse.apoapsis.ortserver.components.secrets.secretsRoutes
-import org.eclipse.apoapsis.ortserver.model.repositories.SecretRepository
-import org.eclipse.apoapsis.ortserver.secrets.SecretStorage
-import org.eclipse.apoapsis.ortserver.secrets.SecretsProviderFactoryForTesting
-import org.eclipse.apoapsis.ortserver.services.SecretService
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagingData
 import org.eclipse.apoapsis.ortserver.shared.apimodel.SortDirection
 import org.eclipse.apoapsis.ortserver.shared.apimodel.SortProperty
-import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.shouldHaveBody
 
-class GetSecretsByProductIdIntegrationTest : AbstractIntegrationTest({
+class GetSecretsByProductIdIntegrationTest : SecretsIntegrationTest({
     var prodId = 0L
-    lateinit var secretRepository: SecretRepository
-    lateinit var secretService: SecretService
 
     beforeEach {
         prodId = dbExtension.fixtures.product.id
-        secretRepository = dbExtension.fixtures.secretRepository
-        secretService = SecretService(
-            dbExtension.db,
-            dbExtension.fixtures.secretRepository,
-            dbExtension.fixtures.infrastructureServiceRepository,
-            SecretStorage(SecretsProviderFactoryForTesting().createProvider())
-        )
     }
 
     "GetSecretsByProductId" should {
         "return all secrets for this product" {
-            integrationTestApplication(routes = { secretsRoutes(secretService) }) { client ->
+            secretsTestApplication { client ->
                 val secret1 = secretRepository.createProductSecret(prodId, "path1", "name1", "description1")
                 val secret2 = secretRepository.createProductSecret(prodId, "path2", "name2", "description2")
 
@@ -76,7 +62,7 @@ class GetSecretsByProductIdIntegrationTest : AbstractIntegrationTest({
         }
 
         "support query parameters" {
-            integrationTestApplication(routes = { secretsRoutes(secretService) }) { client ->
+            secretsTestApplication { client ->
                 secretRepository.createProductSecret(prodId, "path1", "name1", "description1")
                 val secret = secretRepository.createProductSecret(prodId, "path2", "name2", "description2")
 

--- a/components/secrets/backend/src/test/kotlin/routes/product/PostSecretForProductIntegrationTest.kt
+++ b/components/secrets/backend/src/test/kotlin/routes/product/PostSecretForProductIntegrationTest.kt
@@ -34,39 +34,25 @@ import io.ktor.server.response.respond
 
 import org.eclipse.apoapsis.ortserver.components.secrets.CreateSecret
 import org.eclipse.apoapsis.ortserver.components.secrets.Secret
+import org.eclipse.apoapsis.ortserver.components.secrets.SecretsIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.secrets.mapToApi
-import org.eclipse.apoapsis.ortserver.components.secrets.secretsRoutes
-import org.eclipse.apoapsis.ortserver.components.secrets.secretsValidations
 import org.eclipse.apoapsis.ortserver.dao.UniqueConstraintException
 import org.eclipse.apoapsis.ortserver.model.ProductId
-import org.eclipse.apoapsis.ortserver.model.repositories.SecretRepository
 import org.eclipse.apoapsis.ortserver.secrets.Path
-import org.eclipse.apoapsis.ortserver.secrets.SecretStorage
 import org.eclipse.apoapsis.ortserver.secrets.SecretsProviderFactoryForTesting
-import org.eclipse.apoapsis.ortserver.services.SecretService
 import org.eclipse.apoapsis.ortserver.shared.apimodel.ErrorResponse
-import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.shouldHaveBody
 
-class PostSecretForProductIntegrationTest : AbstractIntegrationTest({
+class PostSecretForProductIntegrationTest : SecretsIntegrationTest({
     var prodId = 0L
-    lateinit var secretRepository: SecretRepository
-    lateinit var secretService: SecretService
 
     beforeEach {
         prodId = dbExtension.fixtures.product.id
-        secretRepository = dbExtension.fixtures.secretRepository
-        secretService = SecretService(
-            dbExtension.db,
-            dbExtension.fixtures.secretRepository,
-            dbExtension.fixtures.infrastructureServiceRepository,
-            SecretStorage(SecretsProviderFactoryForTesting().createProvider())
-        )
     }
 
     "PostSecretForProduct" should {
         "create a secret in the database" {
-            integrationTestApplication(routes = { secretsRoutes(secretService) }) { client ->
+            secretsTestApplication { client ->
                 val secret = CreateSecret("name", "value", "description")
 
                 val response = client.post("/products/$prodId/secrets") {
@@ -85,7 +71,7 @@ class PostSecretForProductIntegrationTest : AbstractIntegrationTest({
         }
 
         "respond with CONFLICT if the secret already exists" {
-            integrationTestApplication(routes = { secretsRoutes(secretService) }) { client ->
+            secretsTestApplication { client ->
                 install(StatusPages) {
                     // TODO: This should use the same config as in core.
                     exception<UniqueConstraintException> { call, e ->
@@ -109,10 +95,7 @@ class PostSecretForProductIntegrationTest : AbstractIntegrationTest({
         }
 
         "respond with 'Bad Request' if the secret's name is invalid" {
-            integrationTestApplication(
-                routes = { secretsRoutes(secretService) },
-                validations = { secretsValidations() }
-            ) { client ->
+            secretsTestApplication { client ->
                 install(StatusPages) {
                     // TODO: This should use the same config as in core.
                     exception<RequestValidationException> { call, e ->

--- a/components/secrets/backend/src/test/kotlin/routes/repository/DeleteSecretByRepositoryIdAndNameIntegrationTest.kt
+++ b/components/secrets/backend/src/test/kotlin/routes/repository/DeleteSecretByRepositoryIdAndNameIntegrationTest.kt
@@ -27,37 +27,22 @@ import io.kotest.matchers.shouldBe
 import io.ktor.client.request.delete
 import io.ktor.http.HttpStatusCode
 
+import org.eclipse.apoapsis.ortserver.components.secrets.SecretsIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.secrets.routes.createRepositorySecret
-import org.eclipse.apoapsis.ortserver.components.secrets.secretsRoutes
 import org.eclipse.apoapsis.ortserver.model.RepositoryId
-import org.eclipse.apoapsis.ortserver.model.repositories.SecretRepository
 import org.eclipse.apoapsis.ortserver.secrets.Path
-import org.eclipse.apoapsis.ortserver.secrets.SecretStorage
 import org.eclipse.apoapsis.ortserver.secrets.SecretsProviderFactoryForTesting
-import org.eclipse.apoapsis.ortserver.services.SecretService
-import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
 
-class DeleteSecretByRepositoryIdAndNameIntegrationTest : AbstractIntegrationTest({
+class DeleteSecretByRepositoryIdAndNameIntegrationTest : SecretsIntegrationTest({
     var repoId = 0L
-    lateinit var secretRepository: SecretRepository
-    lateinit var secretService: SecretService
-
-    val secretErrorPath = "error-path"
 
     beforeEach {
         repoId = dbExtension.fixtures.repository.id
-        secretRepository = dbExtension.fixtures.secretRepository
-        secretService = SecretService(
-            dbExtension.db,
-            dbExtension.fixtures.secretRepository,
-            dbExtension.fixtures.infrastructureServiceRepository,
-            SecretStorage(SecretsProviderFactoryForTesting().createProvider(secretErrorPath))
-        )
     }
 
     "DeleteSecretByRepositoryIdAndName" should {
         "delete a secret" {
-            integrationTestApplication(routes = { secretsRoutes(secretService) }) { client ->
+            secretsTestApplication { client ->
                 val secret = secretRepository.createRepositorySecret(repoId)
 
                 client.delete("/repositories/$repoId/secrets/${secret.name}") shouldHaveStatus
@@ -71,7 +56,7 @@ class DeleteSecretByRepositoryIdAndNameIntegrationTest : AbstractIntegrationTest
         }
 
         "handle a failure from the SecretStorage" {
-            integrationTestApplication(routes = { secretsRoutes(secretService) }) { client ->
+            secretsTestApplication { client ->
                 val secret = secretRepository.createRepositorySecret(repoId, path = secretErrorPath)
 
                 client.delete("/repositories/$repoId/secrets/${secret.name}") shouldHaveStatus

--- a/components/secrets/backend/src/test/kotlin/routes/repository/GetSecretByRepositoryIdAndNameIntegrationTest.kt
+++ b/components/secrets/backend/src/test/kotlin/routes/repository/GetSecretByRepositoryIdAndNameIntegrationTest.kt
@@ -24,35 +24,21 @@ import io.kotest.assertions.ktor.client.shouldHaveStatus
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 
+import org.eclipse.apoapsis.ortserver.components.secrets.SecretsIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.secrets.mapToApi
 import org.eclipse.apoapsis.ortserver.components.secrets.routes.createRepositorySecret
-import org.eclipse.apoapsis.ortserver.components.secrets.secretsRoutes
-import org.eclipse.apoapsis.ortserver.model.repositories.SecretRepository
-import org.eclipse.apoapsis.ortserver.secrets.SecretStorage
-import org.eclipse.apoapsis.ortserver.secrets.SecretsProviderFactoryForTesting
-import org.eclipse.apoapsis.ortserver.services.SecretService
-import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.shouldHaveBody
 
-class GetSecretByRepositoryIdAndNameIntegrationTest : AbstractIntegrationTest({
+class GetSecretByRepositoryIdAndNameIntegrationTest : SecretsIntegrationTest({
     var repoId = 0L
-    lateinit var secretRepository: SecretRepository
-    lateinit var secretService: SecretService
 
     beforeEach {
         repoId = dbExtension.fixtures.repository.id
-        secretRepository = dbExtension.fixtures.secretRepository
-        secretService = SecretService(
-            dbExtension.db,
-            dbExtension.fixtures.secretRepository,
-            dbExtension.fixtures.infrastructureServiceRepository,
-            SecretStorage(SecretsProviderFactoryForTesting().createProvider())
-        )
     }
 
     "GetSecretByRepositoryIdAndName" should {
         "return a single secret" {
-            integrationTestApplication(routes = { secretsRoutes(secretService) }) { client ->
+            secretsTestApplication { client ->
                 val secret = secretRepository.createRepositorySecret(repoId)
 
                 val response = client.get("/repositories/$repoId/secrets/${secret.name}")
@@ -63,7 +49,7 @@ class GetSecretByRepositoryIdAndNameIntegrationTest : AbstractIntegrationTest({
         }
 
         "respond with NotFound if no secret exists" {
-            integrationTestApplication(routes = { secretsRoutes(secretService) }) { client ->
+            secretsTestApplication { client ->
                 client.get("/repositories/$repoId/secrets/999999") shouldHaveStatus
                         HttpStatusCode.NotFound
             }

--- a/components/secrets/backend/src/test/kotlin/routes/repository/GetSecretsByRepositoryIdIntegrationTest.kt
+++ b/components/secrets/backend/src/test/kotlin/routes/repository/GetSecretsByRepositoryIdIntegrationTest.kt
@@ -24,40 +24,26 @@ import io.kotest.assertions.ktor.client.shouldHaveStatus
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 
+import org.eclipse.apoapsis.ortserver.components.secrets.SecretsIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.secrets.mapToApi
 import org.eclipse.apoapsis.ortserver.components.secrets.routes.createRepositorySecret
-import org.eclipse.apoapsis.ortserver.components.secrets.secretsRoutes
-import org.eclipse.apoapsis.ortserver.model.repositories.SecretRepository
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters.Companion.DEFAULT_LIMIT
-import org.eclipse.apoapsis.ortserver.secrets.SecretStorage
-import org.eclipse.apoapsis.ortserver.secrets.SecretsProviderFactoryForTesting
-import org.eclipse.apoapsis.ortserver.services.SecretService
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagingData
 import org.eclipse.apoapsis.ortserver.shared.apimodel.SortDirection
 import org.eclipse.apoapsis.ortserver.shared.apimodel.SortProperty
-import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.shouldHaveBody
 
-class GetSecretsByRepositoryIdIntegrationTest : AbstractIntegrationTest({
+class GetSecretsByRepositoryIdIntegrationTest : SecretsIntegrationTest({
     var repoId = 0L
-    lateinit var secretRepository: SecretRepository
-    lateinit var secretService: SecretService
 
     beforeEach {
         repoId = dbExtension.fixtures.repository.id
-        secretRepository = dbExtension.fixtures.secretRepository
-        secretService = SecretService(
-            dbExtension.db,
-            dbExtension.fixtures.secretRepository,
-            dbExtension.fixtures.infrastructureServiceRepository,
-            SecretStorage(SecretsProviderFactoryForTesting().createProvider())
-        )
     }
 
     "GetSecretsByRepositoryId" should {
         "return all secrets for this repository" {
-            integrationTestApplication(routes = { secretsRoutes(secretService) }) { client ->
+            secretsTestApplication { client ->
                 val secret1 = secretRepository.createRepositorySecret(repoId, "path1", "name1", "description1")
                 val secret2 = secretRepository.createRepositorySecret(repoId, "path2", "name2", "description2")
 
@@ -77,7 +63,7 @@ class GetSecretsByRepositoryIdIntegrationTest : AbstractIntegrationTest({
         }
 
         "support query parameters" {
-            integrationTestApplication(routes = { secretsRoutes(secretService) }) { client ->
+            secretsTestApplication { client ->
                 secretRepository.createRepositorySecret(repoId, "path1", "name1", "description1")
                 val secret = secretRepository.createRepositorySecret(repoId, "path2", "name2", "description2")
 

--- a/components/secrets/backend/src/test/kotlin/routes/repository/PatchSecretByRepositoryIdAndNameIntegrationTest.kt
+++ b/components/secrets/backend/src/test/kotlin/routes/repository/PatchSecretByRepositoryIdAndNameIntegrationTest.kt
@@ -27,41 +27,26 @@ import io.ktor.client.request.setBody
 import io.ktor.http.HttpStatusCode
 
 import org.eclipse.apoapsis.ortserver.components.secrets.Secret
+import org.eclipse.apoapsis.ortserver.components.secrets.SecretsIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.secrets.UpdateSecret
 import org.eclipse.apoapsis.ortserver.components.secrets.mapToApi
 import org.eclipse.apoapsis.ortserver.components.secrets.routes.createRepositorySecret
-import org.eclipse.apoapsis.ortserver.components.secrets.secretsRoutes
 import org.eclipse.apoapsis.ortserver.model.RepositoryId
-import org.eclipse.apoapsis.ortserver.model.repositories.SecretRepository
 import org.eclipse.apoapsis.ortserver.secrets.Path
-import org.eclipse.apoapsis.ortserver.secrets.SecretStorage
 import org.eclipse.apoapsis.ortserver.secrets.SecretsProviderFactoryForTesting
-import org.eclipse.apoapsis.ortserver.services.SecretService
 import org.eclipse.apoapsis.ortserver.shared.apimodel.asPresent
-import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.shouldHaveBody
 
-class PatchSecretByRepositoryIdAndNameIntegrationTest : AbstractIntegrationTest({
+class PatchSecretByRepositoryIdAndNameIntegrationTest : SecretsIntegrationTest({
     var repoId = 0L
-    lateinit var secretRepository: SecretRepository
-    lateinit var secretService: SecretService
-
-    val secretErrorPath = "error-path"
 
     beforeEach {
         repoId = dbExtension.fixtures.repository.id
-        secretRepository = dbExtension.fixtures.secretRepository
-        secretService = SecretService(
-            dbExtension.db,
-            dbExtension.fixtures.secretRepository,
-            dbExtension.fixtures.infrastructureServiceRepository,
-            SecretStorage(SecretsProviderFactoryForTesting().createProvider(secretErrorPath))
-        )
     }
 
     "PatchSecretByRepositoryIdAndName" should {
         "update a secret's metadata" {
-            integrationTestApplication(routes = { secretsRoutes(secretService) }) { client ->
+            secretsTestApplication { client ->
                 val secret = secretRepository.createRepositorySecret(repoId)
 
                 val updatedDescription = "updated description"
@@ -80,7 +65,7 @@ class PatchSecretByRepositoryIdAndNameIntegrationTest : AbstractIntegrationTest(
         }
 
         "update a secret's value" {
-            integrationTestApplication(routes = { secretsRoutes(secretService) }) { client ->
+            secretsTestApplication { client ->
                 val secret = secretRepository.createRepositorySecret(repoId)
 
                 val updateSecret = UpdateSecret("value".asPresent(), "description".asPresent())
@@ -97,7 +82,7 @@ class PatchSecretByRepositoryIdAndNameIntegrationTest : AbstractIntegrationTest(
         }
 
         "handle a failure from the SecretsStorage" {
-            integrationTestApplication(routes = { secretsRoutes(secretService) }) { client ->
+            secretsTestApplication { client ->
                 val secret = secretRepository.createRepositorySecret(repoId, path = secretErrorPath)
 
                 val updateSecret = UpdateSecret("value".asPresent(), "newDesc".asPresent())

--- a/components/secrets/backend/src/test/kotlin/routes/repository/PostSecretForRepositoryIntegrationTest.kt
+++ b/components/secrets/backend/src/test/kotlin/routes/repository/PostSecretForRepositoryIntegrationTest.kt
@@ -34,39 +34,25 @@ import io.ktor.server.response.respond
 
 import org.eclipse.apoapsis.ortserver.components.secrets.CreateSecret
 import org.eclipse.apoapsis.ortserver.components.secrets.Secret
+import org.eclipse.apoapsis.ortserver.components.secrets.SecretsIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.secrets.mapToApi
-import org.eclipse.apoapsis.ortserver.components.secrets.secretsRoutes
-import org.eclipse.apoapsis.ortserver.components.secrets.secretsValidations
 import org.eclipse.apoapsis.ortserver.dao.UniqueConstraintException
 import org.eclipse.apoapsis.ortserver.model.RepositoryId
-import org.eclipse.apoapsis.ortserver.model.repositories.SecretRepository
 import org.eclipse.apoapsis.ortserver.secrets.Path
-import org.eclipse.apoapsis.ortserver.secrets.SecretStorage
 import org.eclipse.apoapsis.ortserver.secrets.SecretsProviderFactoryForTesting
-import org.eclipse.apoapsis.ortserver.services.SecretService
 import org.eclipse.apoapsis.ortserver.shared.apimodel.ErrorResponse
-import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.shouldHaveBody
 
-class PostSecretForRepositoryIntegrationTest : AbstractIntegrationTest({
+class PostSecretForRepositoryIntegrationTest : SecretsIntegrationTest({
     var repoId = 0L
-    lateinit var secretRepository: SecretRepository
-    lateinit var secretService: SecretService
 
     beforeEach {
         repoId = dbExtension.fixtures.repository.id
-        secretRepository = dbExtension.fixtures.secretRepository
-        secretService = SecretService(
-            dbExtension.db,
-            dbExtension.fixtures.secretRepository,
-            dbExtension.fixtures.infrastructureServiceRepository,
-            SecretStorage(SecretsProviderFactoryForTesting().createProvider())
-        )
     }
 
     "PostSecretForRepository" should {
         "create a secret in the database" {
-            integrationTestApplication(routes = { secretsRoutes(secretService) }) { client ->
+            secretsTestApplication { client ->
                 val secret = CreateSecret("name", "value", "description")
 
                 val response = client.post("/repositories/$repoId/secrets") {
@@ -85,7 +71,7 @@ class PostSecretForRepositoryIntegrationTest : AbstractIntegrationTest({
         }
 
         "respond with CONFLICT if the secret already exists" {
-            integrationTestApplication(routes = { secretsRoutes(secretService) }) { client ->
+            secretsTestApplication { client ->
                 install(StatusPages) {
                     // TODO: This should use the same config as in core.
                     exception<UniqueConstraintException> { call, e ->
@@ -109,10 +95,7 @@ class PostSecretForRepositoryIntegrationTest : AbstractIntegrationTest({
         }
 
         "respond with 'Bad Request' if the secret's name is invalid" {
-            integrationTestApplication(
-                routes = { secretsRoutes(secretService) },
-                validations = { secretsValidations() }
-            ) { client ->
+            secretsTestApplication { client ->
                 install(StatusPages) {
                     // TODO: This should use the same config as in core.
                     exception<RequestValidationException> { call, e ->


### PR DESCRIPTION
Add helper classes for integration tests to reduce the amount of boilerplate code in the test classes and ensure consistent configuration of the test application.