### PR TITLE
feat(ui): Suggest naming conventions when creating new credentials

### DIFF
--- a/ui/src/components/ui/tooltip.tsx
+++ b/ui/src/components/ui/tooltip.tsx
@@ -26,11 +26,14 @@ function TooltipProvider({
 }
 
 function Tooltip({
+  children,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
   return (
     <TooltipProvider>
-      <TooltipPrimitive.Root data-slot='tooltip' {...props} />
+      <TooltipPrimitive.Root data-slot='tooltip' {...props}>
+        {children}
+      </TooltipPrimitive.Root>
     </TooltipProvider>
   );
 }

--- a/ui/src/routes/organizations/$orgId/infrastructure-services/create/index.tsx
+++ b/ui/src/routes/organizations/$orgId/infrastructure-services/create/index.tsx
@@ -19,7 +19,7 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { Loader2 } from 'lucide-react';
+import { InfoIcon, Loader2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -54,6 +54,11 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip.tsx';
 import { ALL_ITEMS } from '@/lib/constants';
 import { toast } from '@/lib/toast';
 
@@ -157,7 +162,24 @@ const CreateInfrastructureServicePage = () => {
               name='name'
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Name</FormLabel>
+                  <FormLabel>
+                    Name
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <span>
+                          <InfoIcon size={16} />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        Provide a meaningful name that explains the purpose of
+                        this infrastructure service.
+                        <br />A meaningful name helps you and others in your
+                        organization <br />
+                        <b>identify and reuse</b> the infrastructure service
+                        easily, avoiding duplicates.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FormLabel>
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/$secretName/edit/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/$secretName/edit/index.tsx
@@ -20,7 +20,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { Loader2 } from 'lucide-react';
+import { InfoIcon, Loader2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import z from 'zod';
 
@@ -49,6 +49,11 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip.tsx';
 import { toast } from '@/lib/toast';
 
 const editSecretFormSchema = z.object({
@@ -168,7 +173,22 @@ const EditRepositorySecretPage = () => {
               name='description'
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Description</FormLabel>
+                  <FormLabel>
+                    Description
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <span>
+                          <InfoIcon size={16} />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        Provide a meaningful description that explains the
+                        purpose of this secret.
+                        <br />A good description helps you and others{' '}
+                        <b>identify</b> the secret easily.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FormLabel>
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/create-secret/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/create-secret/index.tsx
@@ -19,7 +19,7 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { Loader2 } from 'lucide-react';
+import { InfoIcon, Loader2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -43,6 +43,11 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip.tsx';
 import { toast } from '@/lib/toast';
 
 const formSchema = z.object({
@@ -112,7 +117,23 @@ const CreateRepositorySecretPage = () => {
               name='name'
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Name</FormLabel>
+                  <FormLabel>
+                    Name
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <span>
+                          <InfoIcon size={16} />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        Use clear names like <i>username-abc123</i>,{' '}
+                        <i>password-for-user-abc123</i>, or{' '}
+                        <i>token-for-user-abc123</i>.<br />
+                        This strongly recommended convention makes it easier to{' '}
+                        <b>identify secrets</b>.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FormLabel>
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
@@ -138,7 +159,22 @@ const CreateRepositorySecretPage = () => {
               name='description'
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Description</FormLabel>
+                  <FormLabel>
+                    Description
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <span>
+                          <InfoIcon size={16} />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        Provide a meaningful description that explains the
+                        purpose of this secret.
+                        <br />A good description helps you and others{' '}
+                        <b>identify</b> the secret easily.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FormLabel>
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>

--- a/ui/src/routes/organizations/$orgId/products/$productId/secrets/$secretName/edit/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/secrets/$secretName/edit/index.tsx
@@ -20,7 +20,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { Loader2 } from 'lucide-react';
+import { InfoIcon, Loader2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import z from 'zod';
 
@@ -49,6 +49,11 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip.tsx';
 import { toast } from '@/lib/toast';
 
 const editSecretFormSchema = z.object({
@@ -160,7 +165,23 @@ const EditProductSecretPage = () => {
               name='description'
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Description</FormLabel>
+                  <FormLabel>
+                    Description
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <span>
+                          <InfoIcon size={16} />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        Provide a meaningful description that explains the
+                        purpose of this secret.
+                        <br />A good description helps you and others in your
+                        product area <b>identify and reuse</b> the secret
+                        easily.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FormLabel>
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>

--- a/ui/src/routes/organizations/$orgId/products/$productId/secrets/create-secret/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/secrets/create-secret/index.tsx
@@ -19,7 +19,7 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { Loader2 } from 'lucide-react';
+import { InfoIcon, Loader2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -43,6 +43,11 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip.tsx';
 import { toast } from '@/lib/toast';
 
 const formSchema = z.object({
@@ -108,7 +113,25 @@ const CreateProductSecretPage = () => {
               name='name'
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Name</FormLabel>
+                  <FormLabel>
+                    Name
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <span>
+                          <InfoIcon size={16} />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        Use clear names like <i>username-abc123</i>,{' '}
+                        <i>password-for-user-abc123</i>, or{' '}
+                        <i>token-for-user-abc123</i>.<br />
+                        This strongly recommended convention makes it easier to{' '}
+                        <b>identify, reuse and share secrets</b>
+                        <br />
+                        within your product area and <b>avoid duplicates</b>.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FormLabel>
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
@@ -134,7 +157,23 @@ const CreateProductSecretPage = () => {
               name='description'
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Description</FormLabel>
+                  <FormLabel>
+                    Description
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <span>
+                          <InfoIcon size={16} />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        Provide a meaningful description that explains the
+                        purpose of this secret.
+                        <br />A good description helps you and others in your
+                        product area <b>identify and reuse</b> the secret
+                        easily.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FormLabel>
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>

--- a/ui/src/routes/organizations/$orgId/secrets/$secretName/edit/index.tsx
+++ b/ui/src/routes/organizations/$orgId/secrets/$secretName/edit/index.tsx
@@ -20,7 +20,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { Loader2 } from 'lucide-react';
+import { InfoIcon, Loader2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import z from 'zod';
 
@@ -49,6 +49,11 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip.tsx';
 import { toast } from '@/lib/toast';
 
 const editSecretFormSchema = z.object({
@@ -165,7 +170,23 @@ const EditOrganizationSecretPage = () => {
               name='description'
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Description</FormLabel>
+                  <FormLabel>
+                    Description
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <span>
+                          <InfoIcon size={16} />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        Provide a meaningful description that explains the
+                        purpose of this secret.
+                        <br />A good description helps you and others in your
+                        organization <b>identify and reuse</b> the secret
+                        easily.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FormLabel>
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>

--- a/ui/src/routes/organizations/$orgId/secrets/create-secret/index.tsx
+++ b/ui/src/routes/organizations/$orgId/secrets/create-secret/index.tsx
@@ -19,7 +19,7 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { Loader2 } from 'lucide-react';
+import { InfoIcon, Loader2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -43,6 +43,11 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip.tsx';
 import { toast } from '@/lib/toast';
 
 const formSchema = z.object({
@@ -108,7 +113,25 @@ const CreateOrganizationSecretPage = () => {
               name='name'
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Name</FormLabel>
+                  <FormLabel>
+                    Name
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <span>
+                          <InfoIcon size={16} />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        Use clear names like <i>username-abc123</i>,{' '}
+                        <i>password-for-user-abc123</i>, or{' '}
+                        <i>token-for-user-abc123</i>.<br />
+                        This strongly recommended convention makes it easier to{' '}
+                        <b>identify, reuse and share secrets</b>
+                        <br />
+                        within your organization and <b>avoid duplicates</b>.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FormLabel>
                   <FormControl autoFocus>
                     <Input {...field} />
                   </FormControl>
@@ -134,7 +157,23 @@ const CreateOrganizationSecretPage = () => {
               name='description'
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>Description</FormLabel>
+                  <FormLabel>
+                    Description
+                    <Tooltip>
+                      <TooltipTrigger>
+                        <span>
+                          <InfoIcon size={16} />
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        Provide a meaningful description that explains the
+                        purpose of this secret.
+                        <br />A good description helps you and others in your
+                        organization <b>identify and reuse</b> the secret
+                        easily.
+                      </TooltipContent>
+                    </Tooltip>
+                  </FormLabel>
                   <FormControl>
                     <Input {...field} placeholder='(optional)' />
                   </FormControl>


### PR DESCRIPTION
Improve the credential creation flow by showing tooltips behind information icons that **recommend naming conventions** for secrets. This helps distinguish between usernames, passwords, and tokens, and is essential for **enabling effective secret sharing and avoiding duplicates secrets**.

<img width="876" height="906" alt="image" src="https://github.com/user-attachments/assets/fb15a9f5-125f-4550-bab5-16a5e2fd0bdd" />
