### PR TITLE
chore(common): Migrate generator tests to use blocks for expected lines

### DIFF
--- a/workers/common/src/test/kotlin/common/env/ConanGeneratorTest.kt
+++ b/workers/common/src/test/kotlin/common/env/ConanGeneratorTest.kt
@@ -66,17 +66,17 @@ class ConanGeneratorTest : WordSpec({
 
             ConanGenerator().generate(mockBuilder.builder, listOf(definition))
 
-            val expectedLines = listOf(
-                "{",
-                "  \"remotes\": [",
-                "    {",
-                "      \"name\": \"$REMOTE_NAME\",",
-                "      \"url\": \"$REMOTE_URL\",",
-                "      \"verify_ssl\": true",
-                "    }",
-                "  ]",
-                "}"
-            )
+            val expectedLines = """
+                {
+                  "remotes": [
+                    {
+                      "name": "$REMOTE_NAME",
+                      "url": "$REMOTE_URL",
+                      "verify_ssl": true
+                    }
+                  ]
+                }
+            """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
         }
@@ -103,22 +103,22 @@ class ConanGeneratorTest : WordSpec({
 
             ConanGenerator().generate(mockBuilder.builder, definitions)
 
-            val expectedLines = listOf(
-                "{",
-                "  \"remotes\": [",
-                "    {",
-                "      \"name\": \"$REMOTE_NAME\",",
-                "      \"url\": \"$REMOTE_URL\",",
-                "      \"verify_ssl\": true",
-                "    },",
-                "    {",
-                "      \"name\": \"${REMOTE_NAME + 1}\",",
-                "      \"url\": \"${REMOTE_URL + 1}\",",
-                "      \"verify_ssl\": false",
-                "    }",
-                "  ]",
-                "}"
-            )
+            val expectedLines = """
+                {
+                  "remotes": [
+                    {
+                      "name": "$REMOTE_NAME",
+                      "url": "$REMOTE_URL",
+                      "verify_ssl": true
+                    },
+                    {
+                      "name": "${REMOTE_NAME + 1}",
+                      "url": "${REMOTE_URL + 1}",
+                      "verify_ssl": false
+                    }
+                  ]
+                }
+            """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
         }
@@ -136,17 +136,17 @@ class ConanGeneratorTest : WordSpec({
 
             ConanGenerator().generate(mockBuilder.builder, listOf(definition))
 
-            val expectedLines = listOf(
-                "{",
-                "  \"remotes\": [",
-                "    {",
-                "      \"name\": \"$REMOTE_NAME\",",
-                "      \"url\": \"$REMOTE_URL\",",
-                "      \"verify_ssl\": true",
-                "    }",
-                "  ]",
-                "}"
-            )
+            val expectedLines = """
+                {
+                  "remotes": [
+                    {
+                      "name": "$REMOTE_NAME",
+                      "url": "$REMOTE_URL",
+                      "verify_ssl": true
+                    }
+                  ]
+                }
+            """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
         }
@@ -164,17 +164,17 @@ class ConanGeneratorTest : WordSpec({
 
             ConanGenerator().generate(mockBuilder.builder, listOf(definition))
 
-            val expectedLines = listOf(
-                "{",
-                "  \"remotes\": [",
-                "    {",
-                "      \"name\": \"$REMOTE_NAME\",",
-                "      \"url\": \"$REMOTE_URL\",",
-                "      \"verify_ssl\": true",
-                "    }",
-                "  ]",
-                "}"
-            )
+            val expectedLines = """
+                {
+                  "remotes": [
+                    {
+                      "name": "$REMOTE_NAME",
+                      "url": "$REMOTE_URL",
+                      "verify_ssl": true
+                    }
+                  ]
+                }
+            """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
         }

--- a/workers/common/src/test/kotlin/common/env/GradleInitGeneratorTest.kt
+++ b/workers/common/src/test/kotlin/common/env/GradleInitGeneratorTest.kt
@@ -69,42 +69,42 @@ class GradleInitGeneratorTest : WordSpec({
 
             GradleInitGenerator().generate(mockBuilder.builder, emptyList())
 
-            val expectedLines = listOf(
-                "allprojects {",
-                "    repositories {",
-                "        maven {",
-                "            url = uri(\"${mavenCentralMirror.url}\")",
-                "        }",
-                "    }",
-                "",
-                "    buildscript {",
-                "        repositories {",
-                "            maven {",
-                "                url = uri(\"${mavenCentralMirror.url}\")",
-                "            }",
-                "        }",
-                "    }",
-                "}",
-                "",
-                "settingsEvaluated {",
-                "    settings.pluginManagement {",
-                "        repositories {",
-                "            maven {",
-                "                url = uri(\"${mavenCentralMirror.url}\")",
-                "            }",
-                "            gradlePluginPortal()",
-                "        }",
-                "    }",
-                "",
-                "    settings.dependencyResolutionManagement {",
-                "        repositories {",
-                "            maven {",
-                "                url = uri(\"${mavenCentralMirror.url}\")",
-                "            }",
-                "        }",
-                "    }",
-                "}"
-            )
+            val expectedLines = """
+                allprojects {
+                    repositories {
+                        maven {
+                            url = uri("${mavenCentralMirror.url}")
+                        }
+                    }
+
+                    buildscript {
+                        repositories {
+                            maven {
+                                url = uri("${mavenCentralMirror.url}")
+                            }
+                        }
+                    }
+                }
+
+                settingsEvaluated {
+                    settings.pluginManagement {
+                        repositories {
+                            maven {
+                                url = uri("${mavenCentralMirror.url}")
+                            }
+                            gradlePluginPortal()
+                        }
+                    }
+
+                    settings.dependencyResolutionManagement {
+                        repositories {
+                            maven {
+                                url = uri("${mavenCentralMirror.url}")
+                            }
+                        }
+                    }
+                }
+            """.trimIndent().lines()
 
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
@@ -131,58 +131,58 @@ class GradleInitGeneratorTest : WordSpec({
 
             GradleInitGenerator().generate(mockBuilder.builder, emptyList())
 
-            val expectedLines = listOf(
-                "allprojects {",
-                "    repositories {",
-                "        maven {",
-                "            url = uri(\"${mavenCentralMirror.url}\")",
-                "            credentials {",
-                "                username = \"$username\"",
-                "                password = \"$password\"",
-                "            }",
-                "        }",
-                "    }",
-                "",
-                "    buildscript {",
-                "        repositories {",
-                "            maven {",
-                "                url = uri(\"${mavenCentralMirror.url}\")",
-                "                credentials {",
-                "                    username = \"$username\"",
-                "                    password = \"$password\"",
-                "                }",
-                "            }",
-                "        }",
-                "    }",
-                "}",
-                "",
-                "settingsEvaluated {",
-                "    settings.pluginManagement {",
-                "        repositories {",
-                "            maven {",
-                "                url = uri(\"${mavenCentralMirror.url}\")",
-                "                credentials {",
-                "                    username = \"$username\"",
-                "                    password = \"$password\"",
-                "                }",
-                "            }",
-                "            gradlePluginPortal()",
-                "        }",
-                "    }",
-                "",
-                "    settings.dependencyResolutionManagement {",
-                "        repositories {",
-                "            maven {",
-                "                url = uri(\"${mavenCentralMirror.url}\")",
-                "                credentials {",
-                "                    username = \"$username\"",
-                "                    password = \"$password\"",
-                "                }",
-                "            }",
-                "        }",
-                "    }",
-                "}"
-            )
+            val expectedLines = """
+                allprojects {
+                    repositories {
+                        maven {
+                            url = uri("${mavenCentralMirror.url}")
+                            credentials {
+                                username = "$username"
+                                password = "$password"
+                            }
+                        }
+                    }
+
+                    buildscript {
+                        repositories {
+                            maven {
+                                url = uri("${mavenCentralMirror.url}")
+                                credentials {
+                                    username = "$username"
+                                    password = "$password"
+                                }
+                            }
+                        }
+                    }
+                }
+
+                settingsEvaluated {
+                    settings.pluginManagement {
+                        repositories {
+                            maven {
+                                url = uri("${mavenCentralMirror.url}")
+                                credentials {
+                                    username = "$username"
+                                    password = "$password"
+                                }
+                            }
+                            gradlePluginPortal()
+                        }
+                    }
+
+                    settings.dependencyResolutionManagement {
+                        repositories {
+                            maven {
+                                url = uri("${mavenCentralMirror.url}")
+                                credentials {
+                                    username = "$username"
+                                    password = "$password"
+                                }
+                            }
+                        }
+                    }
+                }
+            """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
         }

--- a/workers/common/src/test/kotlin/common/env/NetRcGeneratorTest.kt
+++ b/workers/common/src/test/kotlin/common/env/NetRcGeneratorTest.kt
@@ -62,11 +62,11 @@ class NetRcGeneratorTest : StringSpec({
 
             val mockBuilder = MockConfigFileBuilder()
 
-            val expectedLines = listOf(
-                "machine repo1.example.org login ${testSecretRef(secUser1)} password ${testSecretRef(secPass1)}",
-                "machine repo2.example.org login ${testSecretRef(secUser2)} password ${testSecretRef(secPass2)}",
-                "machine repo3.example.org login ${testSecretRef(secUser2)} password ${testSecretRef(secPass2)}"
-            )
+            val expectedLines = """
+                machine repo1.example.org login ${testSecretRef(secUser1)} password ${testSecretRef(secPass1)}
+                machine repo2.example.org login ${testSecretRef(secUser2)} password ${testSecretRef(secPass2)}
+                machine repo3.example.org login ${testSecretRef(secUser2)} password ${testSecretRef(secPass2)}
+            """.trimIndent().lines()
 
             val generator = NetRcGenerator()
             generator.generate(mockBuilder.builder, definitions(serviceIgnored, service1, service2, service3))
@@ -88,9 +88,9 @@ class NetRcGeneratorTest : StringSpec({
 
             val mockBuilder = MockConfigFileBuilder()
 
-            val expectedLines = listOf(
-                "machine repo.example.org login ${testSecretRef(secUser1)} password ${testSecretRef(secPass1)}"
-            )
+            val expectedLines = """
+                machine repo.example.org login ${testSecretRef(secUser1)} password ${testSecretRef(secPass1)}
+            """.trimIndent().lines()
 
             val generator = NetRcGenerator()
             generator.generate(mockBuilder.builder, definitions(service1, service2, service3))
@@ -109,9 +109,9 @@ class NetRcGeneratorTest : StringSpec({
 
             val mockBuilder = MockConfigFileBuilder()
 
-            val expectedLines = listOf(
-                "machine repo.example.org login ${testSecretRef(secUser1)} password ${testSecretRef(secPass1)}"
-            )
+            val expectedLines = """
+                machine repo.example.org login ${testSecretRef(secUser1)} password ${testSecretRef(secPass1)}
+            """.trimIndent().lines()
 
             val generator = NetRcGenerator()
             generator.generate(mockBuilder.builder, definitions(service1, service2))
@@ -138,9 +138,9 @@ class NetRcGeneratorTest : StringSpec({
 
             val mockBuilder = MockConfigFileBuilder()
 
-            val expectedLines = listOf(
-                "machine repo1.example.org login ${testSecretRef(secUser)} password ${testSecretRef(secPass)}"
-            )
+            val expectedLines = """
+                machine repo1.example.org login ${testSecretRef(secUser)} password ${testSecretRef(secPass)}
+            """.trimIndent().lines()
 
             val generator = NetRcGenerator()
             generator.generate(mockBuilder.builder, definitions)

--- a/workers/common/src/test/kotlin/common/env/NpmRcGeneratorTest.kt
+++ b/workers/common/src/test/kotlin/common/env/NpmRcGeneratorTest.kt
@@ -62,11 +62,11 @@ class NpmRcGeneratorTest : WordSpec({
 
             NpmRcGenerator().generate(mockBuilder.builder, listOf(definition))
 
-            val expectedLines = listOf(
-                "$REGISTRY_URI_FRAGMENT:username=${MockConfigFileBuilder.testSecretRef(usernameSecret)}",
-                "$REGISTRY_URI_FRAGMENT:_password=${MockConfigFileBuilder.testSecretRef(passwordSecret)}",
-                "$REGISTRY_URI_FRAGMENT:always-auth=true"
-            )
+            val expectedLines = """
+                $REGISTRY_URI_FRAGMENT:username=${MockConfigFileBuilder.testSecretRef(usernameSecret)}
+                $REGISTRY_URI_FRAGMENT:_password=${MockConfigFileBuilder.testSecretRef(passwordSecret)}
+                $REGISTRY_URI_FRAGMENT:always-auth=true
+            """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
         }
@@ -96,15 +96,15 @@ class NpmRcGeneratorTest : WordSpec({
 
             NpmRcGenerator().generate(mockBuilder.builder, definitions)
 
-            val expectedLines = listOf(
-                "$REGISTRY_URI_FRAGMENT:username=${MockConfigFileBuilder.testSecretRef(usernameSecret)}",
-                "$REGISTRY_URI_FRAGMENT:_password=${MockConfigFileBuilder.testSecretRef(passwordSecret1)}",
-                "$REGISTRY_URI_FRAGMENT:always-auth=true",
-                "",
-                "$otherRegistryFragment:username=${MockConfigFileBuilder.testSecretRef(usernameSecret)}",
-                "$otherRegistryFragment:_password=${MockConfigFileBuilder.testSecretRef(passwordSecret2)}",
-                "$otherRegistryFragment:always-auth=true"
-            )
+            val expectedLines = """
+                $REGISTRY_URI_FRAGMENT:username=${MockConfigFileBuilder.testSecretRef(usernameSecret)}
+                $REGISTRY_URI_FRAGMENT:_password=${MockConfigFileBuilder.testSecretRef(passwordSecret1)}
+                $REGISTRY_URI_FRAGMENT:always-auth=true
+
+                $otherRegistryFragment:username=${MockConfigFileBuilder.testSecretRef(usernameSecret)}
+                $otherRegistryFragment:_password=${MockConfigFileBuilder.testSecretRef(passwordSecret2)}
+                $otherRegistryFragment:always-auth=true
+            """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
         }
@@ -143,10 +143,10 @@ class NpmRcGeneratorTest : WordSpec({
 
             NpmRcGenerator().generate(mockBuilder.builder, listOf(definition))
 
-            val expectedLines = listOf(
-                "$REGISTRY_URI_FRAGMENT:_auth=${MockConfigFileBuilder.testSecretRef(passwordSecret)}",
-                "$REGISTRY_URI_FRAGMENT:always-auth=true"
-            )
+            val expectedLines = """
+                $REGISTRY_URI_FRAGMENT:_auth=${MockConfigFileBuilder.testSecretRef(passwordSecret)}
+                $REGISTRY_URI_FRAGMENT:always-auth=true
+            """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
         }
@@ -163,10 +163,10 @@ class NpmRcGeneratorTest : WordSpec({
 
             NpmRcGenerator().generate(mockBuilder.builder, listOf(definition))
 
-            val expectedLines = listOf(
-                "$REGISTRY_URI_FRAGMENT:_authToken=${MockConfigFileBuilder.testSecretRef(passwordSecret)}",
-                "$REGISTRY_URI_FRAGMENT:always-auth=true"
-            )
+            val expectedLines = """
+                $REGISTRY_URI_FRAGMENT:_authToken=${MockConfigFileBuilder.testSecretRef(passwordSecret)}
+                $REGISTRY_URI_FRAGMENT:always-auth=true
+            """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
         }
@@ -189,10 +189,10 @@ class NpmRcGeneratorTest : WordSpec({
 
             NpmRcGenerator().generate(mockBuilder.builder, listOf(definition))
 
-            val expectedLines = listOf(
-                "$REGISTRY_URI_FRAGMENT:_auth=$authBase64",
-                "$REGISTRY_URI_FRAGMENT:always-auth=true"
-            )
+            val expectedLines = """
+                $REGISTRY_URI_FRAGMENT:_auth=$authBase64
+                $REGISTRY_URI_FRAGMENT:always-auth=true
+            """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
         }
@@ -229,11 +229,11 @@ class NpmRcGeneratorTest : WordSpec({
 
             NpmRcGenerator().generate(mockBuilder.builder, listOf(definition))
 
-            val expectedLines = listOf(
-                "$REGISTRY_URI_FRAGMENT:_auth=${MockConfigFileBuilder.testSecretRef(passwordSecret)}",
-                "$REGISTRY_URI_FRAGMENT:email=$email",
-                "$REGISTRY_URI_FRAGMENT:always-auth=true"
-            )
+            val expectedLines = """
+                $REGISTRY_URI_FRAGMENT:_auth=${MockConfigFileBuilder.testSecretRef(passwordSecret)}
+                $REGISTRY_URI_FRAGMENT:email=$email
+                $REGISTRY_URI_FRAGMENT:always-auth=true
+            """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
         }
@@ -252,11 +252,11 @@ class NpmRcGeneratorTest : WordSpec({
 
             NpmRcGenerator().generate(mockBuilder.builder, listOf(definition))
 
-            val expectedLines = listOf(
-                "@$scope:registry=$REGISTRY_URI",
-                "$REGISTRY_URI_FRAGMENT:_auth=${MockConfigFileBuilder.testSecretRef(passwordSecret)}",
-                "$REGISTRY_URI_FRAGMENT:always-auth=true"
-            )
+            val expectedLines = """
+                @$scope:registry=$REGISTRY_URI
+                $REGISTRY_URI_FRAGMENT:_auth=${MockConfigFileBuilder.testSecretRef(passwordSecret)}
+                $REGISTRY_URI_FRAGMENT:always-auth=true
+            """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
         }
@@ -278,11 +278,11 @@ class NpmRcGeneratorTest : WordSpec({
 
             NpmRcGenerator().generate(mockBuilder.builder, listOf(definition))
 
-            val expectedLines = listOf(
-                "@$scope:registry=$REGISTRY_URI",
-                "$REGISTRY_URI_FRAGMENT:_auth=${MockConfigFileBuilder.testSecretRef(passwordSecret)}",
-                "$REGISTRY_URI_FRAGMENT:always-auth=true"
-            )
+            val expectedLines = """
+                @$scope:registry=$REGISTRY_URI
+                $REGISTRY_URI_FRAGMENT:_auth=${MockConfigFileBuilder.testSecretRef(passwordSecret)}
+                $REGISTRY_URI_FRAGMENT:always-auth=true
+            """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
         }
@@ -310,12 +310,12 @@ class NpmRcGeneratorTest : WordSpec({
                 NpmRcGenerator().generate(mockBuilder.builder, listOf(definition))
             }
 
-            val expectedLines = listOf(
-                "",
-                "proxy=$proxy",
-                "https-proxy=$httpsProxy",
-                "noproxy=$noProxy"
-            )
+            val expectedLines = """
+
+                proxy=$proxy
+                https-proxy=$httpsProxy
+                noproxy=$noProxy
+            """.trimIndent().lines()
             val lines = mockBuilder.generatedLines().takeLast(4)
             lines shouldContainExactly expectedLines
         }

--- a/workers/common/src/test/kotlin/common/env/NuGetGeneratorTest.kt
+++ b/workers/common/src/test/kotlin/common/env/NuGetGeneratorTest.kt
@@ -69,22 +69,21 @@ class NuGetGeneratorTest : WordSpec({
 
             NuGetGenerator().generate(mockBuilder.builder, listOf(definition))
 
-            val expectedLines = listOf(
-                "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
-                "<configuration>",
-                "  <packageSources>",
-                "    <add key=\"nuget.org\" value=\"https://api.nuget.org/v3/index.json\" protocolVersion=\"3\" />",
-                "  </packageSources>",
-                "",
-                "  <packageSourceCredentials>",
-                "  </packageSourceCredentials>",
-                "",
-                "  <apikeys>",
-                "    <add key=https://api.nuget.org/v3/index.json " +
-                        "value=\"${MockConfigFileBuilder.testSecretRef(passwordSecret)}\" />",
-                "  </apikeys>",
-                "</configuration>"
-            )
+            val expectedLines = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                  <packageSources>
+                    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+                  </packageSources>
+
+                  <packageSourceCredentials>
+                  </packageSourceCredentials>
+
+                  <apikeys>
+                    <add key=https://api.nuget.org/v3/index.json value="${MockConfigFileBuilder.testSecretRef(passwordSecret)}" />
+                  </apikeys>
+                </configuration>
+            """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
         }
@@ -133,39 +132,33 @@ class NuGetGeneratorTest : WordSpec({
 
             NuGetGenerator().generate(mockBuilder.builder, definitions)
 
-            val expectedLines = listOf(
-                "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
-                "<configuration>",
-                "  <packageSources>",
-                "    <add key=\"nuget.org\" value=\"https://api.nuget.org/v3/index.json\" protocolVersion=\"3\" />",
-                "    <add key=\"nuget.org1\" value=\"https://api.nuget.org/v3/index.json1\" protocolVersion=\"3\" />",
-                "    <add key=\"nuget.org2\" value=\"https://api.nuget.org/v3/index.json2\" protocolVersion=\"3\" />",
-                "    <add key=\"nuget.org3\" value=\"https://api.nuget.org/v3/index.json3\" protocolVersion=\"3\" />",
-                "  </packageSources>",
-                "",
-                "  <packageSourceCredentials>",
-                "    <nuget.org1>",
-                "      <add key=\"Username\" " +
-                        "value=\"${MockConfigFileBuilder.testSecretRef(usernameSecret)}\" />",
-                "      <add key=\"ClearTextPassword\" " +
-                        "value=\"${MockConfigFileBuilder.testSecretRef(passwordSecret2)}\" />",
-                "    </nuget.org1>",
-                "    <nuget.org2>",
-                "      <add key=\"Username\" " +
-                        "value=\"${MockConfigFileBuilder.testSecretRef(usernameSecret)}\" />",
-                "      <add key=\"ClearTextPassword\" " +
-                        "value=\"${MockConfigFileBuilder.testSecretRef(passwordSecret3)}\" />",
-                "    </nuget.org2>",
-                "  </packageSourceCredentials>",
-                "",
-                "  <apikeys>",
-                "    <add key=https://api.nuget.org/v3/index.json " +
-                        "value=\"${MockConfigFileBuilder.testSecretRef(passwordSecret1)}\" />",
-                "    <add key=https://api.nuget.org/v3/index.json3 " +
-                        "value=\"${MockConfigFileBuilder.testSecretRef(passwordSecret4)}\" />",
-                "  </apikeys>",
-                "</configuration>"
-            )
+            val expectedLines = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                  <packageSources>
+                    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+                    <add key="nuget.org1" value="https://api.nuget.org/v3/index.json1" protocolVersion="3" />
+                    <add key="nuget.org2" value="https://api.nuget.org/v3/index.json2" protocolVersion="3" />
+                    <add key="nuget.org3" value="https://api.nuget.org/v3/index.json3" protocolVersion="3" />
+                  </packageSources>
+
+                  <packageSourceCredentials>
+                    <nuget.org1>
+                      <add key="Username" value="${MockConfigFileBuilder.testSecretRef(usernameSecret)}" />
+                      <add key="ClearTextPassword" value="${MockConfigFileBuilder.testSecretRef(passwordSecret2)}" />
+                    </nuget.org1>
+                    <nuget.org2>
+                      <add key="Username" value="${MockConfigFileBuilder.testSecretRef(usernameSecret)}" />
+                      <add key="ClearTextPassword" value="${MockConfigFileBuilder.testSecretRef(passwordSecret3)}" />
+                    </nuget.org2>
+                  </packageSourceCredentials>
+
+                  <apikeys>
+                    <add key=https://api.nuget.org/v3/index.json value="${MockConfigFileBuilder.testSecretRef(passwordSecret1)}" />
+                    <add key=https://api.nuget.org/v3/index.json3 value="${MockConfigFileBuilder.testSecretRef(passwordSecret4)}" />
+                  </apikeys>
+                </configuration>
+            """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
 
             lines shouldContainExactly expectedLines
@@ -187,26 +180,24 @@ class NuGetGeneratorTest : WordSpec({
 
             NuGetGenerator().generate(mockBuilder.builder, listOf(definition))
 
-            val expectedLines = listOf(
-                "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
-                "<configuration>",
-                "  <packageSources>",
-                "    <add key=\"nuget.org\" value=\"https://api.nuget.org/v3/index.json\" protocolVersion=\"3\" />",
-                "  </packageSources>",
-                "",
-                "  <packageSourceCredentials>",
-                "    <nuget.org>",
-                "      <add key=\"Username\" " +
-                        "value=\"${MockConfigFileBuilder.testSecretRef(usernameSecret)}\" />",
-                "      <add key=\"ClearTextPassword\" " +
-                        "value=\"${MockConfigFileBuilder.testSecretRef(passwordSecret)}\" />",
-                "    </nuget.org>",
-                "  </packageSourceCredentials>",
-                "",
-                "  <apikeys>",
-                "  </apikeys>",
-                "</configuration>"
-            )
+            val expectedLines = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                  <packageSources>
+                    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
+                  </packageSources>
+
+                  <packageSourceCredentials>
+                    <nuget.org>
+                      <add key="Username" value="${MockConfigFileBuilder.testSecretRef(usernameSecret)}" />
+                      <add key="ClearTextPassword" value="${MockConfigFileBuilder.testSecretRef(passwordSecret)}" />
+                    </nuget.org>
+                  </packageSourceCredentials>
+
+                  <apikeys>
+                  </apikeys>
+                </configuration>
+            """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
         }
@@ -227,26 +218,24 @@ class NuGetGeneratorTest : WordSpec({
 
             NuGetGenerator().generate(mockBuilder.builder, listOf(definition))
 
-            val expectedLines = listOf(
-                "<?xml version=\"1.0\" encoding=\"utf-8\"?>",
-                "<configuration>",
-                "  <packageSources>",
-                "    <add key=\"nuget.org\" value=\"https://api.nuget.org/v3/index.json\" />",
-                "  </packageSources>",
-                "",
-                "  <packageSourceCredentials>",
-                "    <nuget.org>",
-                "      <add key=\"Username\" " +
-                        "value=\"${MockConfigFileBuilder.testSecretRef(usernameSecret)}\" />",
-                "      <add key=\"ClearTextPassword\" " +
-                        "value=\"${MockConfigFileBuilder.testSecretRef(passwordSecret)}\" />",
-                "    </nuget.org>",
-                "  </packageSourceCredentials>",
-                "",
-                "  <apikeys>",
-                "  </apikeys>",
-                "</configuration>"
-            )
+            val expectedLines = """
+                <?xml version="1.0" encoding="utf-8"?>
+                <configuration>
+                  <packageSources>
+                    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
+                  </packageSources>
+
+                  <packageSourceCredentials>
+                    <nuget.org>
+                      <add key="Username" value="${MockConfigFileBuilder.testSecretRef(usernameSecret)}" />
+                      <add key="ClearTextPassword" value="${MockConfigFileBuilder.testSecretRef(passwordSecret)}" />
+                    </nuget.org>
+                  </packageSourceCredentials>
+
+                  <apikeys>
+                  </apikeys>
+                </configuration>
+            """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
         }

--- a/workers/common/src/test/kotlin/common/env/YarnRcGeneratorTest.kt
+++ b/workers/common/src/test/kotlin/common/env/YarnRcGeneratorTest.kt
@@ -67,14 +67,12 @@ class YarnRcGeneratorTest : WordSpec({
 
             YarnRcGenerator().generate(mockBuilder.builder, listOf(definition))
 
-            val expectedLines = listOf(
-                "npmRegistries:",
-                "  \"$REGISTRY_URI\":",
-                "    npmAlwaysAuth: true",
-                "    npmAuthIdent: \"" +
-                        "${MockConfigFileBuilder.testSecretRef(usernameSecret)}:" +
-                        "${MockConfigFileBuilder.testSecretRef(passwordSecret)}\""
-            )
+            val expectedLines = """
+                npmRegistries:
+                  "$REGISTRY_URI":
+                    npmAlwaysAuth: true
+                    npmAuthIdent: "${MockConfigFileBuilder.testSecretRef(usernameSecret)}:${MockConfigFileBuilder.testSecretRef(passwordSecret)}"
+            """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
         }
@@ -106,20 +104,16 @@ class YarnRcGeneratorTest : WordSpec({
 
             YarnRcGenerator().generate(mockBuilder.builder, definitions)
 
-            val expectedLines = listOf(
-                "npmRegistries:",
-                "  \"$REGISTRY_URI\":",
-                "    npmAlwaysAuth: true",
-                "    npmAuthIdent: \"" +
-                        "${MockConfigFileBuilder.testSecretRef(usernameSecret)}:" +
-                        "${MockConfigFileBuilder.testSecretRef(passwordSecret1)}\"",
-                "",
-                "  \"${REGISTRY_URI}1\":",
-                "    npmAlwaysAuth: true",
-                "    npmAuthIdent: \"" +
-                        "${MockConfigFileBuilder.testSecretRef(usernameSecret)}:" +
-                        "${MockConfigFileBuilder.testSecretRef(passwordSecret2)}\""
-            )
+            val expectedLines = """
+                npmRegistries:
+                  "$REGISTRY_URI":
+                    npmAlwaysAuth: true
+                    npmAuthIdent: "${MockConfigFileBuilder.testSecretRef(usernameSecret)}:${MockConfigFileBuilder.testSecretRef(passwordSecret1)}"
+
+                  "${REGISTRY_URI}1":
+                    npmAlwaysAuth: true
+                    npmAuthIdent: "${MockConfigFileBuilder.testSecretRef(usernameSecret)}:${MockConfigFileBuilder.testSecretRef(passwordSecret2)}"
+            """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
 
             lines shouldContainExactly expectedLines
@@ -139,12 +133,12 @@ class YarnRcGeneratorTest : WordSpec({
 
             YarnRcGenerator().generate(mockBuilder.builder, listOf(definition))
 
-            val expectedLines = listOf(
-                "npmRegistries:",
-                "  \"$REGISTRY_URI\":",
-                "    npmAlwaysAuth: true",
-                "    npmAuthToken: \"${MockConfigFileBuilder.testSecretRef(passwordSecret)}\""
-            )
+            val expectedLines = """
+                npmRegistries:
+                  "$REGISTRY_URI":
+                    npmAlwaysAuth: true
+                    npmAuthToken: "${MockConfigFileBuilder.testSecretRef(passwordSecret)}"
+            """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
         }
@@ -163,11 +157,11 @@ class YarnRcGeneratorTest : WordSpec({
 
             YarnRcGenerator().generate(mockBuilder.builder, listOf(definition))
 
-            val expectedLines = listOf(
-                "npmRegistries:",
-                "  \"$REGISTRY_URI\":",
-                "    npmAuthToken: \"${MockConfigFileBuilder.testSecretRef(passwordSecret)}\""
-            )
+            val expectedLines = """
+                npmRegistries:
+                  "$REGISTRY_URI":
+                    npmAuthToken: "${MockConfigFileBuilder.testSecretRef(passwordSecret)}"
+            """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
         }


### PR DESCRIPTION
This improves readability.