### PR TITLE
Apply resolutions to vulnerablities endpoint

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
@@ -86,6 +86,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.VcsInfoCurationData as ApiVcs
 import org.eclipse.apoapsis.ortserver.api.v1.model.Vulnerability as ApiVulnerability
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityRating as ApiVulnerabilityRating
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityReference as ApiVulnerabilityReference
+import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityResolution as ApiVulnerabilityResolution
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityWithIdentifier as ApiVulnerabilityWithIdentifier
 import org.eclipse.apoapsis.ortserver.model.AdvisorJob
 import org.eclipse.apoapsis.ortserver.model.AdvisorJobConfiguration
@@ -152,6 +153,7 @@ import org.eclipse.apoapsis.ortserver.model.runs.repository.IssueResolution
 import org.eclipse.apoapsis.ortserver.model.runs.repository.PackageCurationData
 import org.eclipse.apoapsis.ortserver.model.runs.repository.RuleViolationResolution
 import org.eclipse.apoapsis.ortserver.model.runs.repository.VcsInfoCurationData
+import org.eclipse.apoapsis.ortserver.model.runs.repository.VulnerabilityResolution
 import org.eclipse.apoapsis.ortserver.model.util.ComparisonOperator
 import org.eclipse.apoapsis.ortserver.model.util.FilterOperatorAndValue
 
@@ -583,7 +585,12 @@ fun ApiScannerJobConfiguration.mapToModel() = ScannerJobConfiguration(
 )
 
 fun VulnerabilityWithIdentifier.mapToApi() =
-    ApiVulnerabilityWithIdentifier(vulnerability.mapToApi(), identifier.mapToApi(), rating.mapToApi())
+    ApiVulnerabilityWithIdentifier(
+        vulnerability.mapToApi(),
+        identifier.mapToApi(),
+        rating.mapToApi(),
+        resolutions.map { it.mapToApi() }
+    )
 
 fun Vulnerability.mapToApi() = ApiVulnerability(externalId, summary, description, references.map { it.mapToApi() })
 
@@ -793,6 +800,8 @@ fun PackageCurationData.mapToApi() = ApiPackageCurationData(
 )
 
 fun RuleViolationResolution.mapToApi() = ApiRuleViolationResolution(message, reason, comment)
+
+fun VulnerabilityResolution.mapToApi() = ApiVulnerabilityResolution(externalId, reason, comment)
 
 fun VcsInfoCurationData.mapToApi() = ApiVcsInfoCurationData(
     type = type?.mapToApi(),

--- a/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/Mappings.kt
@@ -84,6 +84,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.UserGroup as ApiUserGroup
 import org.eclipse.apoapsis.ortserver.api.v1.model.VcsInfo as ApiVcsInfo
 import org.eclipse.apoapsis.ortserver.api.v1.model.VcsInfoCurationData as ApiVcsInfoCurationData
 import org.eclipse.apoapsis.ortserver.api.v1.model.Vulnerability as ApiVulnerability
+import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityFilters as ApiVulnerabilityFilters
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityRating as ApiVulnerabilityRating
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityReference as ApiVulnerabilityReference
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityResolution as ApiVulnerabilityResolution
@@ -131,6 +132,7 @@ import org.eclipse.apoapsis.ortserver.model.SubmoduleFetchStrategy
 import org.eclipse.apoapsis.ortserver.model.User
 import org.eclipse.apoapsis.ortserver.model.UserDisplayName
 import org.eclipse.apoapsis.ortserver.model.UserGroup
+import org.eclipse.apoapsis.ortserver.model.VulnerabilityFilters
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityRating
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityWithAccumulatedData
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityWithIdentifier
@@ -818,6 +820,8 @@ fun ApiPackageFilters.mapToModel(): PackageFilters =
     )
 
 fun ApiRuleViolationFilters.mapToModel(): RuleViolationFilters = RuleViolationFilters(resolved = resolved)
+
+fun ApiVulnerabilityFilters.mapToModel(): VulnerabilityFilters = VulnerabilityFilters(resolved = resolved)
 
 fun Project.mapToApi() = ApiProject(
     identifier.mapToApi(),

--- a/api/v1/model/src/commonMain/kotlin/Vulnerability.kt
+++ b/api/v1/model/src/commonMain/kotlin/Vulnerability.kt
@@ -28,3 +28,15 @@ data class Vulnerability(
     val description: String?,
     val references: List<VulnerabilityReference>
 )
+
+/**
+ * Filters to apply when querying for rule violations.
+ */
+@Serializable
+data class VulnerabilityFilters(
+    /**
+     * Filter to only return resolved vulnerabilities. Null if both, resolved an unresolved vulnerabilities should be
+     * returned.
+     */
+    val resolved: Boolean? = null
+)

--- a/api/v1/model/src/commonMain/kotlin/VulnerabilityResolution.kt
+++ b/api/v1/model/src/commonMain/kotlin/VulnerabilityResolution.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,15 +22,12 @@ package org.eclipse.apoapsis.ortserver.api.v1.model
 import kotlinx.serialization.Serializable
 
 /**
- * A union data class to associate a [Vulnerability] with an [Identifier].
+ * Defines the resolution of a Vulnerability. This can be used to silence false positives, or vulnerabilities that
+ * have been identified as not being relevant.
  */
 @Serializable
-data class VulnerabilityWithIdentifier(
-    val vulnerability: Vulnerability,
-    val identifier: Identifier,
-
-    /** An advisory rating for the [Vulnerability], derived from the individual references of the [Vulnerability]. */
-    val rating: VulnerabilityRating,
-
-    val resolutions: List<VulnerabilityResolution> = emptyList()
+data class VulnerabilityResolution(
+    val externalId: String,
+    val reason: String,
+    val comment: String
 )

--- a/core/src/main/kotlin/api/OrganizationsRoute.kt
+++ b/core/src/main/kotlin/api/OrganizationsRoute.kt
@@ -70,10 +70,10 @@ import org.eclipse.apoapsis.ortserver.services.InfrastructureServiceService
 import org.eclipse.apoapsis.ortserver.services.OrganizationService
 import org.eclipse.apoapsis.ortserver.services.RepositoryService
 import org.eclipse.apoapsis.ortserver.services.UserService
-import org.eclipse.apoapsis.ortserver.services.VulnerabilityService
 import org.eclipse.apoapsis.ortserver.services.ortrun.IssueService
 import org.eclipse.apoapsis.ortserver.services.ortrun.PackageService
 import org.eclipse.apoapsis.ortserver.services.ortrun.RuleViolationService
+import org.eclipse.apoapsis.ortserver.services.ortrun.VulnerabilityService
 import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToApi
 import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToModel
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse

--- a/core/src/main/kotlin/api/ProductsRoute.kt
+++ b/core/src/main/kotlin/api/ProductsRoute.kt
@@ -68,10 +68,10 @@ import org.eclipse.apoapsis.ortserver.model.VulnerabilityWithAccumulatedData
 import org.eclipse.apoapsis.ortserver.services.ProductService
 import org.eclipse.apoapsis.ortserver.services.RepositoryService
 import org.eclipse.apoapsis.ortserver.services.UserService
-import org.eclipse.apoapsis.ortserver.services.VulnerabilityService
 import org.eclipse.apoapsis.ortserver.services.ortrun.IssueService
 import org.eclipse.apoapsis.ortserver.services.ortrun.PackageService
 import org.eclipse.apoapsis.ortserver.services.ortrun.RuleViolationService
+import org.eclipse.apoapsis.ortserver.services.ortrun.VulnerabilityService
 import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToApi
 import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToModel
 import org.eclipse.apoapsis.ortserver.shared.apimodel.ErrorResponse

--- a/core/src/main/kotlin/api/RunsRoute.kt
+++ b/core/src/main/kotlin/api/RunsRoute.kt
@@ -80,11 +80,11 @@ import org.eclipse.apoapsis.ortserver.model.runs.Project
 import org.eclipse.apoapsis.ortserver.services.ProjectService
 import org.eclipse.apoapsis.ortserver.services.ReportStorageService
 import org.eclipse.apoapsis.ortserver.services.RepositoryService
-import org.eclipse.apoapsis.ortserver.services.VulnerabilityService
 import org.eclipse.apoapsis.ortserver.services.ortrun.IssueService
 import org.eclipse.apoapsis.ortserver.services.ortrun.OrtRunService
 import org.eclipse.apoapsis.ortserver.services.ortrun.PackageService
 import org.eclipse.apoapsis.ortserver.services.ortrun.RuleViolationService
+import org.eclipse.apoapsis.ortserver.services.ortrun.VulnerabilityService
 import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToApi
 import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToModel
 import org.eclipse.apoapsis.ortserver.shared.apimodel.SortDirection

--- a/core/src/main/kotlin/api/RunsRoute.kt
+++ b/core/src/main/kotlin/api/RunsRoute.kt
@@ -49,6 +49,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatistics
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatus
 import org.eclipse.apoapsis.ortserver.api.v1.model.PackageFilters
 import org.eclipse.apoapsis.ortserver.api.v1.model.RuleViolationFilters
+import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityFilters
 import org.eclipse.apoapsis.ortserver.components.authorization.permissions.RepositoryPermission
 import org.eclipse.apoapsis.ortserver.components.authorization.requirePermission
 import org.eclipse.apoapsis.ortserver.components.authorization.requireSuperuser
@@ -209,9 +210,14 @@ fun Route.runs() = route("runs") {
                     requirePermission(RepositoryPermission.READ_ORT_RUNS.roleName(ortRun.repositoryId))
 
                     val pagingOptions = call.pagingOptions(SortProperty("externalId", SortDirection.ASCENDING))
+                    val filters = call.vulnerabilityFilters()
 
                     val vulnerabilitiesForOrtRun =
-                        vulnerabilityService.listForOrtRunId(ortRun.id, pagingOptions.mapToModel())
+                        vulnerabilityService.listForOrtRunId(
+                            ortRun.id,
+                            pagingOptions.mapToModel(),
+                            filters.mapToModel()
+                        )
 
                     val pagedResponse = vulnerabilitiesForOrtRun.mapToApi(VulnerabilityWithIdentifier::mapToApi)
 
@@ -496,6 +502,14 @@ private fun ApplicationCall.ruleViolationFilters(): RuleViolationFilters =
 private fun ApplicationCall.issueFilters() =
     IssueFilter(
         resolved = parameters["resolved"]?.lowercase()?.toBooleanStrictOrNull(),
+    )
+
+/**
+ * Extract the vulnerability filters from this [ApplicationCall].
+ */
+private fun ApplicationCall.vulnerabilityFilters() =
+    VulnerabilityFilters(
+        resolved = parameters["resolved"]?.lowercase()?.toBooleanStrictOrNull()
     )
 
 /**

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -55,6 +55,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.VcsInfo
 import org.eclipse.apoapsis.ortserver.api.v1.model.Vulnerability
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityRating
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityReference
+import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityResolution
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityWithIdentifier
 import org.eclipse.apoapsis.ortserver.model.LogLevel
 import org.eclipse.apoapsis.ortserver.model.LogSource
@@ -286,7 +287,14 @@ val getVulnerabilitiesByRunId: RouteConfig.() -> Unit = {
                                     )
                                 ),
                                 identifier = Identifier("Maven", "org.namespace", "name", "1.0"),
-                                rating = VulnerabilityRating.HIGH
+                                rating = VulnerabilityRating.HIGH,
+                                listOf(
+                                    VulnerabilityResolution(
+                                        externalId = "CVE-2021-1234",
+                                        reason = "INEFFECTIVE_VULNERABILITY",
+                                        comment = "A comment why the vulnerability can be resolved."
+                                    )
+                                )
                             )
                         ),
                         PagingData(

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -261,6 +261,14 @@ val getVulnerabilitiesByRunId: RouteConfig.() -> Unit = {
             description = "The ID of the ORT run."
         }
 
+        queryParameter<Boolean>("resolved") {
+            description =
+                """
+                    If true, only resolved vulnerabilities are returned. If false, only unresolved vulnerabilities are
+                    returned. If missing, both resolved and unresolved vulnerabilities are returned.
+                """.trimIndent()
+        }
+
         standardListQueryParameters()
     }
 

--- a/core/src/main/kotlin/di/Module.kt
+++ b/core/src/main/kotlin/di/Module.kt
@@ -93,12 +93,12 @@ import org.eclipse.apoapsis.ortserver.services.ReportStorageService
 import org.eclipse.apoapsis.ortserver.services.RepositoryService
 import org.eclipse.apoapsis.ortserver.services.SecretService
 import org.eclipse.apoapsis.ortserver.services.UserService
-import org.eclipse.apoapsis.ortserver.services.VulnerabilityService
 import org.eclipse.apoapsis.ortserver.services.ortrun.IssueService
 import org.eclipse.apoapsis.ortserver.services.ortrun.OrtRunService
 import org.eclipse.apoapsis.ortserver.services.ortrun.OrtServerFileListStorage
 import org.eclipse.apoapsis.ortserver.services.ortrun.PackageService
 import org.eclipse.apoapsis.ortserver.services.ortrun.RuleViolationService
+import org.eclipse.apoapsis.ortserver.services.ortrun.VulnerabilityService
 import org.eclipse.apoapsis.ortserver.storage.Storage
 
 import org.jetbrains.exposed.sql.Database

--- a/model/src/commonMain/kotlin/VulnerabilityRating.kt
+++ b/model/src/commonMain/kotlin/VulnerabilityRating.kt
@@ -22,12 +22,17 @@ package org.eclipse.apoapsis.ortserver.model
 /**
  * The overall rating for a vulnerability. The rating is derived from the severities of the individual references of a
  * vulnerability as the highest severity found, that matches one of the [VulnerabilityRating] values. If no such
- * severities are found, the rating is [NONE].
+ * severities are found, the rating is [NONE]. The values in this enum are ordered from lowest to highest severity.
  * */
 enum class VulnerabilityRating {
     NONE,
     LOW,
     MEDIUM,
     HIGH,
-    CRITICAL
+    CRITICAL;
+
+    companion object {
+        fun fromString(value: String): VulnerabilityRating? =
+            values().find { it.name.equals(value, ignoreCase = true) }
+    }
 }

--- a/model/src/commonMain/kotlin/VulnerabilityWithIdentifier.kt
+++ b/model/src/commonMain/kotlin/VulnerabilityWithIdentifier.kt
@@ -21,6 +21,7 @@ package org.eclipse.apoapsis.ortserver.model
 
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.Vulnerability
+import org.eclipse.apoapsis.ortserver.model.runs.repository.VulnerabilityResolution
 
 /**
  * A union data class to associate a [Vulnerability] with an [Identifier].
@@ -30,5 +31,7 @@ data class VulnerabilityWithIdentifier(
     val identifier: Identifier,
 
     /** An advisory rating for the [Vulnerability], derived from the individual references of the [Vulnerability]. */
-    val rating: VulnerabilityRating
+    val rating: VulnerabilityRating,
+
+    val resolutions: List<VulnerabilityResolution> = emptyList()
 )

--- a/model/src/commonMain/kotlin/VulnerabilityWithIdentifier.kt
+++ b/model/src/commonMain/kotlin/VulnerabilityWithIdentifier.kt
@@ -19,6 +19,8 @@
 
 package org.eclipse.apoapsis.ortserver.model
 
+import kotlinx.serialization.Serializable
+
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.Vulnerability
 import org.eclipse.apoapsis.ortserver.model.runs.repository.VulnerabilityResolution
@@ -34,4 +36,16 @@ data class VulnerabilityWithIdentifier(
     val rating: VulnerabilityRating,
 
     val resolutions: List<VulnerabilityResolution> = emptyList()
+)
+
+/**
+ * Filters to apply when querying for vulnerabilities.
+ */
+@Serializable
+data class VulnerabilityFilters(
+    /**
+     * Filter to only return resolved vulnerabilities. Null if both, resolved and unresolved vulnerabilities should be
+     * returned.
+     */
+    val resolved: Boolean? = null
 )

--- a/services/ort-run/src/main/kotlin/OrtServerMappings.kt
+++ b/services/ort-run/src/main/kotlin/OrtServerMappings.kt
@@ -199,7 +199,12 @@ fun AdvisorConfiguration.mapToOrt() =
 
 fun AdvisorResult.mapToOrt() =
     OrtAdvisorResult(
-        advisor = OrtAdvisorDetails(advisorName, capabilities.mapTo(enumSetOf(), OrtAdvisorCapability::valueOf)),
+        advisor = OrtAdvisorDetails(
+            advisorName,
+            capabilities.mapTo(enumSetOf()) {
+                OrtAdvisorCapability.valueOf(it.uppercase())
+            }
+        ),
         summary = OrtAdvisorSummary(
             startTime = startTime.toJavaInstant(),
             endTime = endTime.toJavaInstant(),

--- a/services/ort-run/src/main/kotlin/VulnerabilityService.kt
+++ b/services/ort-run/src/main/kotlin/VulnerabilityService.kt
@@ -131,8 +131,16 @@ class VulnerabilityService(private val db: Database, private val ortRunService: 
             .drop(parameters.offset?.toInt() ?: 0)
             .take(parameters.limit ?: ListQueryParameters.DEFAULT_LIMIT)
 
+        val resolutions = ortResult.getResolutions().vulnerabilities
+        val vulnerabilitiesWithResolutions = limitedVulnerabilities.map { vulnerabilityWithIdentifier ->
+            val matchingResolutions = resolutions.filter {
+                it.matches(vulnerabilityWithIdentifier.vulnerability.mapToOrt())
+            }
+            vulnerabilityWithIdentifier.copy(resolutions = matchingResolutions.map { it.mapToModel() })
+        }
+
         return ListQueryResult(
-            data = limitedVulnerabilities,
+            data = vulnerabilitiesWithResolutions,
             params = parameters,
             totalCount = vulnerabilities.size.toLong()
         )

--- a/services/ort-run/src/main/kotlin/VulnerabilityService.kt
+++ b/services/ort-run/src/main/kotlin/VulnerabilityService.kt
@@ -33,7 +33,6 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.ortrun.OrtRunsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.repository.RepositoriesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifierDao
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
-import org.eclipse.apoapsis.ortserver.dao.utils.listCustomQuery
 import org.eclipse.apoapsis.ortserver.dao.utils.listCustomQueryCustomOrders
 import org.eclipse.apoapsis.ortserver.model.CountByCategory
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityRating
@@ -41,6 +40,8 @@ import org.eclipse.apoapsis.ortserver.model.VulnerabilityWithAccumulatedData
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityWithIdentifier
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
+import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
+import org.eclipse.apoapsis.ortserver.services.ResourceNotFoundException
 import org.eclipse.apoapsis.ortserver.services.utils.toSortOrder
 
 import org.jetbrains.exposed.sql.Case
@@ -64,26 +65,77 @@ import org.jetbrains.exposed.sql.stringLiteral
 /**
  * A service to interact with vulnerabilities.
  */
-class VulnerabilityService(private val db: Database) {
-    suspend fun listForOrtRunId(
+class VulnerabilityService(private val db: Database, private val ortRunService: OrtRunService) {
+    fun listForOrtRunId(
         ortRunId: Long,
         parameters: ListQueryParameters = ListQueryParameters.DEFAULT
-    ): ListQueryResult<VulnerabilityWithIdentifier> = db.dbQuery {
-        val ratingAlias = ratingAlias()
+    ): ListQueryResult<VulnerabilityWithIdentifier> {
+        val ortRun = ortRunService.getOrtRun(ortRunId) ?: throw ResourceNotFoundException(
+            "ORT run with ID $ortRunId not found."
+        )
 
-        VulnerabilityDao.listCustomQuery(parameters, ResultRow::toVulnerabilityWithIdentifierAndReference) {
-            VulnerabilitiesTable
-                .innerJoin(AdvisorResultsVulnerabilitiesTable)
-                .innerJoin(AdvisorResultsTable)
-                .innerJoin(AdvisorRunsIdentifiersTable)
-                .innerJoin(AdvisorRunsTable)
-                .innerJoin(AdvisorJobsTable)
-                .innerJoin(IdentifiersTable)
-                .innerJoin(VulnerabilityReferencesTable)
-                .select(VulnerabilitiesTable.columns + IdentifiersTable.columns + ratingAlias)
-                .where { AdvisorJobsTable.ortRunId eq ortRunId }
-                .groupBy(VulnerabilitiesTable.id, IdentifiersTable.id)
+        val ortResult = ortRunService.generateOrtResult(
+            ortRun,
+            loadAdvisorRun = true, // Only interested in vulnerabilities (advisor).
+            loadScannerRun = false,
+            loadEvaluatorRun = false,
+            failIfRepoInfoMissing = false
+        )
+
+        val vulnerabilities = ortResult.getVulnerabilities(omitResolved = false)
+            .flatMap { entry ->
+                entry.value.map { vulnerability ->
+                    // Find the vulnerability reference with the highest severity.
+                    val maxSeverity = vulnerability.references
+                        .mapNotNull { it.severity }
+                        .maxByOrNull { severity ->
+                            VulnerabilityRating.fromString(severity)?.ordinal
+                                ?: VulnerabilityRating.NONE.ordinal
+                        } ?: VulnerabilityRating.NONE.name
+
+                    VulnerabilityWithIdentifier(
+                        vulnerability = vulnerability.mapToModel(),
+                        identifier = entry.key.mapToModel(),
+                        rating = VulnerabilityRating.fromString(maxSeverity)
+                            ?: VulnerabilityRating.NONE
+                    )
+                }
+            }
+
+        // Need only to support a single sort order. This is hardcoded in the router implementation.
+        var comparator = compareBy<VulnerabilityWithIdentifier> { 0 } // Default comparator that does nothing.
+
+        // If no sort order is given (which is the case in some test cases), then sort by external id,
+        // in order to return stable results to the test cases.
+        if (parameters.sortFields.isEmpty()) {
+            comparator = comparator.thenBy { it.vulnerability.externalId }
+        } else {
+            parameters.sortFields.forEach { orderField ->
+                when (orderField.name) {
+                    "externalId" -> {
+                        comparator = when (orderField.direction) {
+                            OrderDirection.ASCENDING -> comparator.thenBy { it.vulnerability.externalId }
+                            OrderDirection.DESCENDING -> comparator.thenByDescending { it.vulnerability.externalId }
+                        }
+                    }
+                    else -> {
+                        throw QueryParametersException("Unsupported field for sorting: '${orderField.name}'.")
+                    }
+                }
+            }
         }
+
+        val sortedVulnerabilities = vulnerabilities.sortedWith(comparator)
+
+        val limitedVulnerabilities = sortedVulnerabilities
+            .drop(parameters.offset?.toInt() ?: 0)
+            .take(parameters.limit ?: ListQueryParameters.DEFAULT_LIMIT)
+
+        return ListQueryResult(
+            data = limitedVulnerabilities,
+            params = parameters,
+            totalCount = vulnerabilities.size.toLong()
+        )
     }
 
     /**
@@ -217,10 +269,4 @@ private fun ResultRow.toVulnerabilityWithAccumulatedData() = VulnerabilityWithAc
     rating = VulnerabilityRating.entries[(this[ratingAlias()] ?: 0)],
     ortRunIds = this[runIdsAlias()].split(",").map { it.toLong() },
     repositoriesCount = this[repositoriesCountAlias()]
-)
-
-private fun ResultRow.toVulnerabilityWithIdentifierAndReference() = VulnerabilityWithIdentifier(
-    vulnerability = VulnerabilityDao.wrapRow(this).mapToModel(),
-    identifier = IdentifierDao.wrapRow(this).mapToModel(),
-    rating = VulnerabilityRating.entries[this[ratingAlias()] ?: 0]
 )

--- a/services/ort-run/src/main/kotlin/VulnerabilityService.kt
+++ b/services/ort-run/src/main/kotlin/VulnerabilityService.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.eclipse.apoapsis.ortserver.services
+package org.eclipse.apoapsis.ortserver.services.ortrun
 
 import org.eclipse.apoapsis.ortserver.dao.QueryParametersException
 import org.eclipse.apoapsis.ortserver.dao.dbQuery

--- a/services/ort-run/src/main/kotlin/VulnerabilityService.kt
+++ b/services/ort-run/src/main/kotlin/VulnerabilityService.kt
@@ -35,6 +35,7 @@ import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifierDao
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
 import org.eclipse.apoapsis.ortserver.dao.utils.listCustomQueryCustomOrders
 import org.eclipse.apoapsis.ortserver.model.CountByCategory
+import org.eclipse.apoapsis.ortserver.model.VulnerabilityFilters
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityRating
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityWithAccumulatedData
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityWithIdentifier
@@ -62,13 +63,16 @@ import org.jetbrains.exposed.sql.alias
 import org.jetbrains.exposed.sql.castTo
 import org.jetbrains.exposed.sql.stringLiteral
 
+import org.ossreviewtoolkit.model.config.VulnerabilityResolution
+
 /**
  * A service to interact with vulnerabilities.
  */
 class VulnerabilityService(private val db: Database, private val ortRunService: OrtRunService) {
     fun listForOrtRunId(
         ortRunId: Long,
-        parameters: ListQueryParameters = ListQueryParameters.DEFAULT
+        parameters: ListQueryParameters = ListQueryParameters.DEFAULT,
+        vulnerabilityFilters: VulnerabilityFilters = VulnerabilityFilters()
     ): ListQueryResult<VulnerabilityWithIdentifier> {
         val ortRun = ortRunService.getOrtRun(ortRunId) ?: throw ResourceNotFoundException(
             "ORT run with ID $ortRunId not found."
@@ -102,6 +106,8 @@ class VulnerabilityService(private val db: Database, private val ortRunService: 
                 }
             }
 
+        val resolutions = ortResult.getResolutions().vulnerabilities
+
         // Need only to support a single sort order. This is hardcoded in the router implementation.
         var comparator = compareBy<VulnerabilityWithIdentifier> { 0 } // Default comparator that does nothing.
 
@@ -127,11 +133,12 @@ class VulnerabilityService(private val db: Database, private val ortRunService: 
 
         val sortedVulnerabilities = vulnerabilities.sortedWith(comparator)
 
-        val limitedVulnerabilities = sortedVulnerabilities
+        val filteredVulnerabilities = sortedVulnerabilities.applyResultFilter(vulnerabilityFilters, resolutions)
+
+        val limitedVulnerabilities = filteredVulnerabilities
             .drop(parameters.offset?.toInt() ?: 0)
             .take(parameters.limit ?: ListQueryParameters.DEFAULT_LIMIT)
 
-        val resolutions = ortResult.getResolutions().vulnerabilities
         val vulnerabilitiesWithResolutions = limitedVulnerabilities.map { vulnerabilityWithIdentifier ->
             val matchingResolutions = resolutions.filter {
                 it.matches(vulnerabilityWithIdentifier.vulnerability.mapToOrt())
@@ -142,8 +149,27 @@ class VulnerabilityService(private val db: Database, private val ortRunService: 
         return ListQueryResult(
             data = vulnerabilitiesWithResolutions,
             params = parameters,
-            totalCount = vulnerabilities.size.toLong()
+            totalCount = filteredVulnerabilities.size.toLong()
         )
+    }
+
+    private fun List<VulnerabilityWithIdentifier>.applyResultFilter(
+        vulnerabilityFilters: VulnerabilityFilters,
+        resolutions: List<VulnerabilityResolution>
+    ): List<VulnerabilityWithIdentifier> = when (vulnerabilityFilters.resolved) {
+        true -> {
+            filter { vulnerabilityWithIdentifier ->
+                resolutions.any { it.matches(vulnerabilityWithIdentifier.vulnerability.mapToOrt()) }
+            }
+        }
+
+        false -> {
+            filter { vulnerabilityWithIdentifier ->
+                resolutions.none { it.matches(vulnerabilityWithIdentifier.vulnerability.mapToOrt()) }
+            }
+        }
+
+        null -> this
     }
 
     /**

--- a/services/ort-run/src/test/kotlin/VulnerabilityServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/VulnerabilityServiceTest.kt
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-package org.eclipse.apoapsis.ortserver.services
+package org.eclipse.apoapsis.ortserver.services.ortrun
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
@@ -478,14 +478,14 @@ class VulnerabilityServiceTest : WordSpec() {
                                 )
                             ),
                     Identifier("Maven", "org.apache.logging.log4j", "log4j-core", "2.14.0") to
-                    listOf(
-                        Vulnerability(
-                            externalId = "CVE-2018-14721",
-                            summary = "A vulnerability",
-                            description = "A description",
-                            references = references2
-                        )
-                    )
+                            listOf(
+                                Vulnerability(
+                                    externalId = "CVE-2018-14721",
+                                    summary = "A vulnerability",
+                                    description = "A description",
+                                    references = references2
+                                )
+                            )
                 )
 
                 val advJobId = fixtures.createAdvisorJob(
@@ -707,8 +707,8 @@ class VulnerabilityServiceTest : WordSpec() {
                                         vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
                                     )
                                 )
+                            )
                         )
-                )
 
                 val advisorResult1 = createAdvisorResults(
                     mapOf(

--- a/services/ort-run/src/test/kotlin/VulnerabilityServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/VulnerabilityServiceTest.kt
@@ -27,6 +27,8 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
+import io.mockk.mockk
+
 import kotlinx.datetime.Clock
 
 import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
@@ -55,17 +57,40 @@ class VulnerabilityServiceTest : WordSpec() {
 
     private lateinit var db: Database
     private lateinit var fixtures: Fixtures
+    private lateinit var service: VulnerabilityService
 
     init {
         beforeEach {
             db = dbExtension.db
             fixtures = dbExtension.fixtures
+
+            val ortRunService = OrtRunService(
+                db,
+                fixtures.advisorJobRepository,
+                fixtures.advisorRunRepository,
+                fixtures.analyzerJobRepository,
+                fixtures.analyzerRunRepository,
+                fixtures.evaluatorJobRepository,
+                fixtures.evaluatorRunRepository,
+                fixtures.ortRunRepository,
+                fixtures.reporterJobRepository,
+                fixtures.reporterRunRepository,
+                fixtures.notifierJobRepository,
+                fixtures.notifierRunRepository,
+                fixtures.repositoryConfigurationRepository,
+                fixtures.repositoryRepository,
+                fixtures.resolvedConfigurationRepository,
+                fixtures.scannerJobRepository,
+                fixtures.scannerRunRepository,
+                mockk(),
+                mockk()
+            )
+
+            service = VulnerabilityService(db, ortRunService)
         }
 
         "listForOrtRunId" should {
             "return the vulnerabilities for the given ORT run ID" {
-                val service = VulnerabilityService(db)
-
                 val vulnerabilities = createVulnerabilities(
                     Triple(
                         Identifier("Maven", "org.apache.logging.log4j", "log4j-core", "2.14.0"),
@@ -88,23 +113,6 @@ class VulnerabilityServiceTest : WordSpec() {
 
                 with(results[0]) {
                     with(vulnerability) {
-                        externalId shouldBe "CVE-2021-45046"
-                        summary shouldBe "A vulnerability"
-                        description shouldBe "A description"
-                        references shouldHaveSize 1
-                        references.first().severity shouldBe "10.0"
-                    }
-
-                    with(identifier) {
-                        type shouldBe "Maven"
-                        namespace shouldBe "org.apache.logging.log4j"
-                        name shouldBe "log4j-core"
-                        version shouldBe "2.14.0"
-                    }
-                }
-
-                with(results[1]) {
-                    with(vulnerability) {
                         externalId shouldBe "CVE-2018-14721"
                         summary shouldBe "A vulnerability"
                         description shouldBe "A description"
@@ -119,11 +127,26 @@ class VulnerabilityServiceTest : WordSpec() {
                         version shouldBe "2.9.6"
                     }
                 }
+
+                with(results[1]) {
+                    with(vulnerability) {
+                        externalId shouldBe "CVE-2021-45046"
+                        summary shouldBe "A vulnerability"
+                        description shouldBe "A description"
+                        references shouldHaveSize 1
+                        references.first().severity shouldBe "10.0"
+                    }
+
+                    with(identifier) {
+                        type shouldBe "Maven"
+                        namespace shouldBe "org.apache.logging.log4j"
+                        name shouldBe "log4j-core"
+                        version shouldBe "2.14.0"
+                    }
+                }
             }
 
             "return multiple vulnerabilities and references for a package" {
-                val service = VulnerabilityService(db)
-
                 val vulnerabilities = createVulnerabilities(
                     Triple(
                         Identifier("Maven", "org.apache.logging.log4j", "log4j-core", "2.14.0"),
@@ -173,8 +196,6 @@ class VulnerabilityServiceTest : WordSpec() {
             }
 
             "apply the parameters to the vulnerability result, not to the references" {
-                val service = VulnerabilityService(db)
-
                 val vulnerabilities = createVulnerabilities(
                     Triple(
                         Identifier("Maven", "org.apache.logging.log4j", "log4j-core", "2.14.0"),
@@ -206,8 +227,6 @@ class VulnerabilityServiceTest : WordSpec() {
             }
 
             "return an empty list if an ORT run has no vulnerable packages" {
-                val service = VulnerabilityService(db)
-
                 val ortRun = createVulnerabilityEntries(emptyMap())
 
                 val results = service.listForOrtRunId(ortRun.id).data
@@ -216,8 +235,6 @@ class VulnerabilityServiceTest : WordSpec() {
             }
 
             "return the overall rating for vulnerabilities" {
-                val service = VulnerabilityService(db)
-
                 val runId = fixtures.createOrtRun().id
 
                 val references1 = listOf(
@@ -304,8 +321,6 @@ class VulnerabilityServiceTest : WordSpec() {
 
         "countForOrtRunId" should {
             "return count of vulnerabilities found in an ORT run" {
-                val service = VulnerabilityService(db)
-
                 val vulnerabilities = createVulnerabilities(
                     Triple(
                         Identifier("Maven", "org.apache.logging.log4j", "log4j-core", "2.14.0"),
@@ -321,8 +336,6 @@ class VulnerabilityServiceTest : WordSpec() {
             }
 
             "return count of unique vulnerabilities found in ORT runs" {
-                val service = VulnerabilityService(db)
-
                 val repositoryId = fixtures.createRepository().id
 
                 val vulnerabilities = createVulnerabilities(
@@ -348,8 +361,6 @@ class VulnerabilityServiceTest : WordSpec() {
 
         "listForOrtRuns" should {
             "only accumulate data from specified runs" {
-                val service = VulnerabilityService(db)
-
                 val repo1Id = fixtures.createRepository().id
                 val repo2Id = fixtures.createRepository(url = "https://example.com/repo2.git").id
                 val repo3Id = fixtures.createRepository(url = "https://example.com/repo3.git").id
@@ -407,8 +418,6 @@ class VulnerabilityServiceTest : WordSpec() {
             }
 
             "return overall ratings for vulnerabilities and allow sorting by rating" {
-                val service = VulnerabilityService(db)
-
                 val repoId = fixtures.createRepository().id
                 val runId = fixtures.createOrtRun(repoId).id
 
@@ -518,8 +527,6 @@ class VulnerabilityServiceTest : WordSpec() {
             }
 
             "allow sorting by repositories count and external id" {
-                val service = VulnerabilityService(db)
-
                 val repo1Id = fixtures.createRepository().id
                 val repo2Id = fixtures.createRepository(url = "https://example.com/repo2.git").id
                 val repo3Id = fixtures.createRepository(url = "https://example.com/repo3.git").id
@@ -616,8 +623,6 @@ class VulnerabilityServiceTest : WordSpec() {
             }
 
             "allow sorting by identifier" {
-                val service = VulnerabilityService(db)
-
                 val repoId = fixtures.createRepository().id
                 val runId = fixtures.createOrtRun(repoId).id
 
@@ -685,8 +690,6 @@ class VulnerabilityServiceTest : WordSpec() {
 
         "countByRatingForOrtRunIds" should {
             "return the counts per rating for vulnerabilities found in ORT runs" {
-                val service = VulnerabilityService(db)
-
                 val repositoryId = fixtures.createRepository().id
 
                 val identifier1 = Identifier("Maven", "org.apache.logging.log4j", "log4j-core", "2.14.0")
@@ -818,8 +821,6 @@ class VulnerabilityServiceTest : WordSpec() {
             }
 
             "return counts by rating that sum up to the count returned by countForOrtRunIds" {
-                val service = VulnerabilityService(db)
-
                 val repositoryId = fixtures.createRepository().id
 
                 val identifier1 = Identifier("Maven", "org.apache.logging.log4j", "log4j-core", "2.14.0")
@@ -897,8 +898,6 @@ class VulnerabilityServiceTest : WordSpec() {
             }
 
             "include counts of 0 for ratings that are not found in vulnerabilities" {
-                val service = VulnerabilityService(db)
-
                 val repositoryId = fixtures.createRepository().id
                 val ortRunId = fixtures.createOrtRun(repositoryId).id
 

--- a/services/ort-run/src/test/kotlin/VulnerabilityServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/VulnerabilityServiceTest.kt
@@ -45,6 +45,8 @@ import org.eclipse.apoapsis.ortserver.model.runs.advisor.AdvisorConfiguration
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.AdvisorResult
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.Vulnerability
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.VulnerabilityReference
+import org.eclipse.apoapsis.ortserver.model.runs.repository.Resolutions
+import org.eclipse.apoapsis.ortserver.model.runs.repository.VulnerabilityResolution
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
 import org.eclipse.apoapsis.ortserver.model.util.OrderField
@@ -142,6 +144,81 @@ class VulnerabilityServiceTest : WordSpec() {
                         namespace shouldBe "org.apache.logging.log4j"
                         name shouldBe "log4j-core"
                         version shouldBe "2.14.0"
+                    }
+                }
+            }
+
+            "return the vulnerabilities for the given ORT run ID with resolutions applied" {
+                val vulnerabilities = createVulnerabilities(
+                    Triple(
+                        Identifier("Maven", "org.apache.logging.log4j", "log4j-core", "2.14.0"),
+                        listOf("CVE-2021-45046"),
+                        listOf(10.0)
+                    ),
+                    Triple(
+                        Identifier("Maven", "com.fasterxml.jackson.core", "jackson-databind", "2.9.6"),
+                        listOf("CVE-2018-14721"),
+                        listOf(4.2)
+                    )
+                )
+
+                val advisorResult = createAdvisorResults(vulnerabilities)
+                val ortRun = createVulnerabilityEntries(advisorResult)
+
+                val vulnerabilityResolution = VulnerabilityResolution(
+                    externalId = ".*CVE-2021-45046.*", // RegEx
+                    reason = "INEFFECTIVE_VULNERABILITY",
+                    comment = "This is ineffective because of some reasons."
+                )
+                fixtures.resolvedConfigurationRepository.addResolutions(
+                    ortRun.id,
+                    Resolutions(vulnerabilities = listOf(vulnerabilityResolution))
+                )
+
+                val results = service.listForOrtRunId(ortRun.id).data
+
+                results shouldHaveSize 2
+
+                with(results[0]) {
+                    with(vulnerability) {
+                        externalId shouldBe "CVE-2018-14721"
+                        summary shouldBe "A vulnerability"
+                        description shouldBe "A description"
+                        references shouldHaveSize 1
+                        references.first().severity shouldBe "4.2"
+                    }
+
+                    with(identifier) {
+                        type shouldBe "Maven"
+                        namespace shouldBe "com.fasterxml.jackson.core"
+                        name shouldBe "jackson-databind"
+                        version shouldBe "2.9.6"
+                    }
+
+                    with(resolutions) {
+                        this.size shouldBe 0
+                    }
+                }
+
+                with(results[1]) {
+                    with(vulnerability) {
+                        externalId shouldBe "CVE-2021-45046"
+                        summary shouldBe "A vulnerability"
+                        description shouldBe "A description"
+                        references shouldHaveSize 1
+                        references.first().severity shouldBe "10.0"
+                    }
+
+                    with(identifier) {
+                        type shouldBe "Maven"
+                        namespace shouldBe "org.apache.logging.log4j"
+                        name shouldBe "log4j-core"
+                        version shouldBe "2.14.0"
+                    }
+
+                    with(resolutions) {
+                        this shouldHaveSize 1
+                        this.first() shouldBe vulnerabilityResolution
                     }
                 }
             }

--- a/services/ort-run/src/test/kotlin/VulnerabilityServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/VulnerabilityServiceTest.kt
@@ -38,6 +38,7 @@ import org.eclipse.apoapsis.ortserver.model.AdvisorJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.JobConfigurations
 import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.PluginConfig
+import org.eclipse.apoapsis.ortserver.model.VulnerabilityFilters
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityRating
 import org.eclipse.apoapsis.ortserver.model.runs.Environment
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
@@ -219,6 +220,89 @@ class VulnerabilityServiceTest : WordSpec() {
                     with(resolutions) {
                         this shouldHaveSize 1
                         this.first() shouldBe vulnerabilityResolution
+                    }
+                }
+            }
+
+            "return filtered vulnerabilities" {
+                val vulnerabilities = createVulnerabilities(
+                    Triple(
+                        Identifier("Maven", "org.apache.logging.log4j", "log4j-core", "2.14.0"),
+                        listOf("CVE-2021-45046"),
+                        listOf(10.0)
+                    ),
+                    Triple(
+                        Identifier("Maven", "com.fasterxml.jackson.core", "jackson-databind", "2.9.6"),
+                        listOf("CVE-2018-14721"),
+                        listOf(4.2)
+                    )
+                )
+
+                val advisorResult = createAdvisorResults(vulnerabilities)
+                val ortRun = createVulnerabilityEntries(advisorResult)
+
+                val vulnerabilityResolution = VulnerabilityResolution(
+                    externalId = ".*CVE-2021-45046.*", // RegEx
+                    reason = "INEFFECTIVE_VULNERABILITY",
+                    comment = "This is ineffective because of some reasons."
+                )
+                fixtures.resolvedConfigurationRepository.addResolutions(
+                    ortRun.id,
+                    Resolutions(vulnerabilities = listOf(vulnerabilityResolution))
+                )
+
+                val resultsResolved = service.listForOrtRunId(
+                    ortRun.id,
+                    vulnerabilityFilters = VulnerabilityFilters(resolved = true)
+                ).data
+
+                val resultsUnresolved = service.listForOrtRunId(
+                    ortRun.id,
+                    vulnerabilityFilters = VulnerabilityFilters(resolved = false)
+                ).data
+
+                resultsResolved shouldHaveSize 1
+                with(resultsResolved[0]) {
+                    with(vulnerability) {
+                        externalId shouldBe "CVE-2021-45046"
+                        summary shouldBe "A vulnerability"
+                        description shouldBe "A description"
+                        references shouldHaveSize 1
+                        references.first().severity shouldBe "10.0"
+                    }
+
+                    with(identifier) {
+                        type shouldBe "Maven"
+                        namespace shouldBe "org.apache.logging.log4j"
+                        name shouldBe "log4j-core"
+                        version shouldBe "2.14.0"
+                    }
+
+                    with(resolutions) {
+                        this shouldHaveSize 1
+                        this.first() shouldBe vulnerabilityResolution
+                    }
+                }
+
+                resultsUnresolved shouldHaveSize 1
+                with(resultsUnresolved[0]) {
+                    with(vulnerability) {
+                        externalId shouldBe "CVE-2018-14721"
+                        summary shouldBe "A vulnerability"
+                        description shouldBe "A description"
+                        references shouldHaveSize 1
+                        references.first().severity shouldBe "4.2"
+                    }
+
+                    with(identifier) {
+                        type shouldBe "Maven"
+                        namespace shouldBe "com.fasterxml.jackson.core"
+                        name shouldBe "jackson-databind"
+                        version shouldBe "2.9.6"
+                    }
+
+                    with(resolutions) {
+                        this.size shouldBe 0
                     }
                 }
             }


### PR DESCRIPTION
If resolutions exist for vulnerabilities, add them to the respective vulnerabilities in the `api/v1/runs/{id}/vulnerabilities` endpoint. 

Add a request query parameter to support filtering vulnerabilities by their resolution status, to provide the possibility for clients to only query for relevant data.

For details, please check the commit messages of the respective commits.

For review: The change was split up into several commits. 

- The first commit is pure refactoring done by the IDE, it is just about moving a class to a different package.
- The second commit changes the way that vulnerabilities are looked up (using ORTRunService instead of querying the results directly from the database)
- The third commit adds support for adding resolutions to vulnerabilities
- The fourth commit adds the query parameter used for filtering
