### PR TITLE
build: Make the CLI command used to build containers configurable

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,6 +24,7 @@ import git.semver.plugin.gradle.PrintTask
 val dockerBaseBuildArgs: String by project
 val dockerBaseImageTag: String by project
 val dockerImageTag: String by project
+val containerEngineCommand: String by project
 
 plugins {
     alias(libs.plugins.gitSemver)
@@ -120,7 +121,7 @@ rootDir.walk().maxDepth(4).filter { it.isFile && it.extension == "Dockerfile" }.
             inputs.dir(context)
 
             commandLine = listOf(
-                "docker", "build",
+                containerEngineCommand, "build",
                 "-f", dockerfile.path,
                 *buildArgs.toTypedArray(),
                 "-t", "ort-server-${name.lowercase()}:$dockerImageTag",
@@ -139,7 +140,7 @@ rootDir.walk().maxDepth(4).filter { it.isFile && it.extension == "Dockerfile" }.
             inputs.dir(context)
 
             commandLine = listOf(
-                "docker", "build",
+                containerEngineCommand, "build",
                 "-f", dockerfile.path,
                 *buildArgs.toTypedArray(),
                 "-t", "ort-server-${name.lowercase()}-worker-base-image:$dockerBaseImageTag",

--- a/gradle.properties
+++ b/gradle.properties
@@ -30,6 +30,7 @@ kotlin.native.ignoreDisabledTargets = true
 # Keep this aligned with `toolchainVersion` in `gradle/gradle-daemon-jvm.properties`.
 javaLanguageVersion = 21
 
+containerEngineCommand = docker
 dockerImagePrefix =
 dockerImageTag = latest
 dockerBaseBuildArgs =


### PR DESCRIPTION
Enable the usage of Docker compatible container engines like Podman [1] by making the command configurable for the `buildAllImages` task.

[1]: https://podman-desktop.io/docs/migrating-from-docker/managing-docker-compatibility