### PR TITLE
feat(reporter): Ignore trailing slash in download link prefix

### DIFF
--- a/workers/reporter/src/main/kotlin/reporter/ReportDownloadLinkGenerator.kt
+++ b/workers/reporter/src/main/kotlin/reporter/ReportDownloadLinkGenerator.kt
@@ -89,7 +89,7 @@ internal class ReportDownloadLinkGenerator(
         random.nextBytes(tokenBytes)
         val tokenString = Base64.UrlSafe.encode(tokenBytes)
 
-        val link = "$linkPrefix/api/v1/runs/$runId/downloads/report/$tokenString"
+        val link = "${linkPrefix.removeSuffix("/")}/api/v1/runs/$runId/downloads/report/$tokenString"
         return ReportDownloadLink(link, clock.now() + validityTime)
     }
 }

--- a/workers/reporter/src/test/kotlin/reporter/ReportDownloadLinkGeneratorTest.kt
+++ b/workers/reporter/src/test/kotlin/reporter/ReportDownloadLinkGeneratorTest.kt
@@ -77,6 +77,14 @@ class ReportDownloadLinkGeneratorTest : WordSpec({
             link.downloadLink shouldBe ""
             link.expirationTime shouldBe Instant.fromEpochMilliseconds(0)
         }
+
+        "ignore a trailing slash in the link prefix" {
+            val generator = ReportDownloadLinkGenerator("$LINK_PREFIX/", 32, 1.minutes)
+
+            val link = generator.generateLink(RUN_ID)
+
+            link.downloadLink shouldStartWith EXPECTED_LINK_PREFIX
+        }
     }
 })
 


### PR DESCRIPTION
This reduces the risk for misconfiguration.