### PR TITLE
Use plugins endpoint for create ORT run form

### DIFF
--- a/ui/src/components/form/multi-select-field.tsx
+++ b/ui/src/components/form/multi-select-field.tsx
@@ -46,7 +46,7 @@ type MultiSelectFieldProps<
   name: TName;
   label?: string;
   description?: React.ReactNode;
-  options: readonly { id: string; label: string }[];
+  options: readonly { id: string; label: string; description?: string }[];
   className?: string;
 };
 
@@ -126,7 +126,14 @@ export const MultiSelectField = <
                   }}
                 />
               </FormControl>
-              <FormLabel className='font-normal'>{option.label}</FormLabel>
+              <div className='flex flex-col'>
+                <FormLabel className='font-normal'>{option.label}</FormLabel>
+                {option.description != null && (
+                  <div className='text-sm text-gray-500'>
+                    {option.description}
+                  </div>
+                )}
+              </div>
             </FormItem>
           ))}
           <FormMessage />

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -28,21 +28,6 @@ import { RepositoryType } from '@/api/requests';
 // limited set of values. Define the possible values here to use in the UI.
 // Note: with the upcoming plugin support, some of these types may be deprecated or changed.
 
-export const advisors = [
-  {
-    id: 'OssIndex',
-    label: 'OSS Index',
-  },
-  {
-    id: 'OSV',
-    label: 'OSV',
-  },
-  {
-    id: 'VulnerableCode',
-    label: 'VulnerableCode',
-  },
-] as const;
-
 export const packageManagers = [
   {
     id: 'Bazel',
@@ -149,37 +134,6 @@ export const packageManagers = [
 // To make sure the package manager ids are used type-safely elsewhere,
 // export them as a type.
 export type PackageManagerId = (typeof packageManagers)[number]['id'];
-
-export const reportFormats = [
-  {
-    id: 'CycloneDX',
-    label: 'CycloneDX SBOM (JSON and XML formats)',
-  },
-  {
-    id: 'SpdxDocument',
-    label: 'SPDX SBOM (JSON and YAML formats)',
-  },
-  {
-    id: 'PlainTextTemplate',
-    label: 'NOTICE file (DEFAULT and SUMMARY formats)',
-  },
-  {
-    id: 'WebApp',
-    label: 'ORT Web App',
-  },
-  {
-    id: 'PdfTemplate',
-    label: 'ORT PDF Reports',
-  },
-  {
-    id: 'OrtResult',
-    label: 'ORT Result',
-  },
-  {
-    id: 'RunStatistics',
-    label: 'Run Statistics',
-  },
-] as const;
 
 // Some types coming from the query client need to be shown in a more user-friendly way.
 

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/advisor-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/advisor-fields.tsx
@@ -19,6 +19,7 @@
 
 import { UseFormReturn } from 'react-hook-form';
 
+import { PreconfiguredPluginDescriptor } from '@/api/requests';
 import { MultiSelectField } from '@/components/form/multi-select-field';
 import {
   AccordionContent,
@@ -33,20 +34,26 @@ import {
   FormLabel,
 } from '@/components/ui/form';
 import { Switch } from '@/components/ui/switch';
-import { advisors } from '@/lib/types';
 import { CreateRunFormValues } from '../_repo-layout/create-run/-create-run-utils';
 
 type AdvisorFieldsProps = {
   form: UseFormReturn<CreateRunFormValues>;
   value: string;
   onToggle: () => void;
+  advisorPlugins: PreconfiguredPluginDescriptor[];
 };
 
 export const AdvisorFields = ({
   form,
   value,
   onToggle,
+  advisorPlugins,
 }: AdvisorFieldsProps) => {
+  const advisorOptions = advisorPlugins.map((plugin) => ({
+    id: plugin.id,
+    label: plugin.displayName,
+  }));
+
   return (
     <div className='flex flex-row align-middle'>
       <FormField
@@ -91,7 +98,7 @@ export const AdvisorFields = ({
             name='jobConfigs.advisor.advisors'
             label='Enabled advisors'
             description={<>Select the advisors enabled for this run.</>}
-            options={advisors}
+            options={advisorOptions}
           />
         </AccordionContent>
       </AccordionItem>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/advisor-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/advisor-fields.tsx
@@ -52,6 +52,7 @@ export const AdvisorFields = ({
   const advisorOptions = advisorPlugins.map((plugin) => ({
     id: plugin.id,
     label: plugin.displayName,
+    description: plugin.description,
   }));
 
   return (

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/reporter-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/reporter-fields.tsx
@@ -52,6 +52,7 @@ export const ReporterFields = ({
   const reporterOptions = reporterPlugins.map((plugin) => ({
     id: plugin.id,
     label: plugin.displayName,
+    description: plugin.description,
   }));
 
   return (

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/reporter-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/reporter-fields.tsx
@@ -19,6 +19,7 @@
 
 import { UseFormReturn } from 'react-hook-form';
 
+import { PreconfiguredPluginDescriptor } from '@/api/requests';
 import { MultiSelectField } from '@/components/form/multi-select-field';
 import {
   AccordionContent,
@@ -33,20 +34,26 @@ import {
   FormLabel,
 } from '@/components/ui/form';
 import { Switch } from '@/components/ui/switch';
-import { reportFormats } from '@/lib/types';
 import { CreateRunFormValues } from '../_repo-layout/create-run/-create-run-utils';
 
 type ReporterFieldsProps = {
   form: UseFormReturn<CreateRunFormValues>;
   value: string;
   onToggle: () => void;
+  reporterPlugins: PreconfiguredPluginDescriptor[];
 };
 
 export const ReporterFields = ({
   form,
   value,
   onToggle,
+  reporterPlugins,
 }: ReporterFieldsProps) => {
+  const reporterOptions = reporterPlugins.map((plugin) => ({
+    id: plugin.id,
+    label: plugin.displayName,
+  }));
+
   return (
     <div className='flex flex-row align-middle'>
       <FormField
@@ -72,7 +79,7 @@ export const ReporterFields = ({
             description={
               <>Select the report formats to generate from the run.</>
             }
-            options={reportFormats}
+            options={reporterOptions}
           />
           {form.getValues('jobConfigs.reporter.formats').includes('WebApp') && (
             <FormField


### PR DESCRIPTION
Use the endpoint from #3168 to populate the advisor and reporter lists in the create ORT run form. This is a small first step of applying the admin configuration for plugins to the form. The form will now show all installed plugins, except for those which are globally disabled.

Advisor section:

<img width="939" height="309" alt="image" src="https://github.com/user-attachments/assets/26d0b875-c8e0-4392-b933-6c6b47689c3b" />

Reporter section:

<img width="937" height="980" alt="image" src="https://github.com/user-attachments/assets/061453aa-d2da-4d83-84b5-aa8656561c92" />

Reporter section with some plugins globally disabled:

<img width="940" height="563" alt="image" src="https://github.com/user-attachments/assets/6b8fe7ec-2d22-49b8-b1da-e16e7043f923" />
