### PR TITLE
chore(docker): Set `linux/amd64` platform for images that install ScanCode

### DIFF
--- a/workers/reporter/docker/Reporter.Dockerfile
+++ b/workers/reporter/docker/Reporter.Dockerfile
@@ -20,7 +20,7 @@
 # License-Filename: LICENSE
 
 # Build-Stage for Python executing scancode-license-data to get the license texts in a directory
-FROM python:3.13-slim AS scancode-license-data-build
+FROM --platform=linux/amd64 python:3.13-slim AS scancode-license-data-build
 
 # Keep in sync with Scanner.Dockerfile
 ARG SCANCODE_VERSION=32.4.0

--- a/workers/scanner/docker/Scanner.Dockerfile
+++ b/workers/scanner/docker/Scanner.Dockerfile
@@ -21,7 +21,7 @@
 # License-Filename: LICENSE
 
 # When updating this version make sure to keep it in sync with the other worker Dockerfiles and libs.version.toml.
-FROM eclipse-temurin:21.0.7_6-jdk-jammy@sha256:746ad7128069fdaa77df1f06a0463ad50f4ae787648cbbcc6d6ab0e702e6c97e AS base-image
+FROM --platform=linux/amd64 eclipse-temurin:21.0.7_6-jdk-jammy@sha256:746ad7128069fdaa77df1f06a0463ad50f4ae787648cbbcc6d6ab0e702e6c97e AS base-image
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     --mount=type=cache,target=/var/lib/apt,sharing=locked \


### PR DESCRIPTION
ScanCode does not support to be installed on `ARM64` machines, see [1], [2] and [3].
Use `linux/amd64` base-images for any all images that install ScanCode to be able to build them on `ARM64` machines.

[1]: https://scancode-toolkit.readthedocs.io/en/stable/getting-started/install.html#system-requirements
[2]: https://github.com/aboutcode-org/scancode-toolkit/issues/3141
[3]: https://github.com/aboutcode-org/scancode-toolkit/issues/3958