### PR TITLE
Add support for advisor and reporter plugin options in the UI

### DIFF
--- a/components/secrets/backend/build.gradle.kts
+++ b/components/secrets/backend/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
 
     implementation(projects.components.authorization.backend)
     implementation(projects.model)
+    implementation(projects.services.hierarchyService)
     implementation(projects.services.secretService)
     implementation(projects.shared.apiMappings)
     implementation(projects.shared.apiModel)
@@ -46,4 +47,5 @@ dependencies {
     testImplementation(ktorLibs.server.testHost)
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestAssertionsKtor)
+    testImplementation(libs.mockk)
 }

--- a/components/secrets/backend/src/main/kotlin/Routing.kt
+++ b/components/secrets/backend/src/main/kotlin/Routing.kt
@@ -32,13 +32,15 @@ import org.eclipse.apoapsis.ortserver.components.secrets.routes.product.getSecre
 import org.eclipse.apoapsis.ortserver.components.secrets.routes.product.patchSecretByProductIdAndName
 import org.eclipse.apoapsis.ortserver.components.secrets.routes.product.postSecretForProduct
 import org.eclipse.apoapsis.ortserver.components.secrets.routes.repository.deleteSecretByRepositoryIdAndName
+import org.eclipse.apoapsis.ortserver.components.secrets.routes.repository.getAvailableSecretsByRepositoryId
 import org.eclipse.apoapsis.ortserver.components.secrets.routes.repository.getSecretByRepositoryIdAndName
 import org.eclipse.apoapsis.ortserver.components.secrets.routes.repository.getSecretsByRepositoryId
 import org.eclipse.apoapsis.ortserver.components.secrets.routes.repository.patchSecretByRepositoryIdAndName
 import org.eclipse.apoapsis.ortserver.components.secrets.routes.repository.postSecretForRepository
+import org.eclipse.apoapsis.ortserver.services.RepositoryService
 import org.eclipse.apoapsis.ortserver.services.SecretService
 
-fun Route.secretsRoutes(secretService: SecretService) {
+fun Route.secretsRoutes(repositoryService: RepositoryService, secretService: SecretService) {
     // Organization secrets
     deleteSecretByOrganizationIdAndName(secretService)
     getSecretByOrganizationIdAndName(secretService)
@@ -55,6 +57,7 @@ fun Route.secretsRoutes(secretService: SecretService) {
 
     // Repository secrets
     deleteSecretByRepositoryIdAndName(secretService)
+    getAvailableSecretsByRepositoryId(repositoryService, secretService)
     getSecretByRepositoryIdAndName(secretService)
     getSecretsByRepositoryId(secretService)
     patchSecretByRepositoryIdAndName(secretService)

--- a/components/secrets/backend/src/main/kotlin/routes/repository/GetAvailableSecretsByRepositoryId.kt
+++ b/components/secrets/backend/src/main/kotlin/routes/repository/GetAvailableSecretsByRepositoryId.kt
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.components.secrets.routes.repository
+
+import io.github.smiley4.ktoropenapi.get
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+
+import org.eclipse.apoapsis.ortserver.components.authorization.permissions.RepositoryPermission
+import org.eclipse.apoapsis.ortserver.components.authorization.requirePermission
+import org.eclipse.apoapsis.ortserver.components.secrets.Secret
+import org.eclipse.apoapsis.ortserver.components.secrets.mapToApi
+import org.eclipse.apoapsis.ortserver.services.RepositoryService
+import org.eclipse.apoapsis.ortserver.services.SecretService
+import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse
+import org.eclipse.apoapsis.ortserver.shared.ktorutils.jsonBody
+import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireIdParameter
+import org.eclipse.apoapsis.ortserver.shared.ktorutils.standardListQueryParameters
+
+internal fun Route.getAvailableSecretsByRepositoryId(
+    repositoryService: RepositoryService,
+    secretService: SecretService
+) = get("/repositories/{repositoryId}/availableSecrets", {
+    operationId = "GetAvailableSecretsByRepositoryId"
+    summary = "Get all available secrets for a repository"
+    description = "Get all secrets that are available in the context of the provided repository. In addition to " +
+            "the repository secrets, this includes secrets from the product and organization the repository " +
+            "belongs to."
+    tags = listOf("Repositories")
+
+    request {
+        pathParameter<Long>("repositoryId") {
+            description = "The ID of the repository."
+        }
+        standardListQueryParameters()
+    }
+
+    response {
+        HttpStatusCode.OK to {
+            description = "Success"
+            jsonBody<List<Secret>> {
+                example("Get all available secrets for a repository") {
+                    value = listOf(
+                        Secret(name = "USERNAME-SECRET", description = "The username."),
+                        Secret(name = "PASSWORD-SECRET", description = "The password.")
+                    )
+                }
+            }
+        }
+    }
+}) {
+    requirePermission(RepositoryPermission.READ)
+
+    val repositoryId = call.requireIdParameter("repositoryId")
+
+    val hierarchy = repositoryService.getHierarchy(repositoryId)
+    val secrets = secretService.listForHierarchy(hierarchy)
+
+    call.respond(HttpStatusCode.OK, secrets.map { it.mapToApi() })
+}

--- a/components/secrets/backend/src/test/kotlin/routes/SecretsAuthorizationTest.kt
+++ b/components/secrets/backend/src/test/kotlin/routes/SecretsAuthorizationTest.kt
@@ -34,6 +34,7 @@ import org.eclipse.apoapsis.ortserver.components.secrets.UpdateSecret
 import org.eclipse.apoapsis.ortserver.components.secrets.secretsRoutes
 import org.eclipse.apoapsis.ortserver.secrets.SecretStorage
 import org.eclipse.apoapsis.ortserver.secrets.SecretsProviderFactoryForTesting
+import org.eclipse.apoapsis.ortserver.services.RepositoryService
 import org.eclipse.apoapsis.ortserver.services.SecretService
 import org.eclipse.apoapsis.ortserver.shared.apimodel.asPresent
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractAuthorizationTest
@@ -42,6 +43,7 @@ class SecretsAuthorizationTest : AbstractAuthorizationTest({
     var orgId = 0L
     var prodId = 0L
     var repoId = 0L
+    lateinit var repositoryService: RepositoryService
     lateinit var secretService: SecretService
 
     beforeEach {
@@ -50,6 +52,19 @@ class SecretsAuthorizationTest : AbstractAuthorizationTest({
         repoId = dbExtension.fixtures.repository.id
 
         authorizationService.ensureSuperuserAndSynchronizeRolesAndPermissions()
+
+        repositoryService = RepositoryService(
+            dbExtension.db,
+            dbExtension.fixtures.ortRunRepository,
+            dbExtension.fixtures.repositoryRepository,
+            dbExtension.fixtures.analyzerJobRepository,
+            dbExtension.fixtures.advisorJobRepository,
+            dbExtension.fixtures.scannerJobRepository,
+            dbExtension.fixtures.evaluatorJobRepository,
+            dbExtension.fixtures.reporterJobRepository,
+            dbExtension.fixtures.notifierJobRepository,
+            authorizationService
+        )
 
         secretService = SecretService(
             dbExtension.db,
@@ -62,7 +77,7 @@ class SecretsAuthorizationTest : AbstractAuthorizationTest({
     "DeleteSecretByOrganizationIdAndName" should {
         "require OrganizationPermission.WRITE_SECRETS" {
             requestShouldRequireRole(
-                routes = { secretsRoutes(secretService) },
+                routes = { secretsRoutes(repositoryService, secretService) },
                 role = OrganizationPermission.WRITE_SECRETS.roleName(orgId),
                 successStatus = HttpStatusCode.NotFound
             ) {
@@ -74,7 +89,7 @@ class SecretsAuthorizationTest : AbstractAuthorizationTest({
     "DeleteSecretByProductIdAndName" should {
         "require ProductPermission.WRITE_SECRETS" {
             requestShouldRequireRole(
-                routes = { secretsRoutes(secretService) },
+                routes = { secretsRoutes(repositoryService, secretService) },
                 role = ProductPermission.WRITE_SECRETS.roleName(prodId),
                 successStatus = HttpStatusCode.NotFound
             ) {
@@ -86,7 +101,7 @@ class SecretsAuthorizationTest : AbstractAuthorizationTest({
     "DeleteSecretByRepositoryIdAndName" should {
         "require RepositoryPermission.WRITE_SECRETS" {
             requestShouldRequireRole(
-                routes = { secretsRoutes(secretService) },
+                routes = { secretsRoutes(repositoryService, secretService) },
                 role = RepositoryPermission.WRITE_SECRETS.roleName(repoId),
                 successStatus = HttpStatusCode.NotFound
             ) {
@@ -95,10 +110,21 @@ class SecretsAuthorizationTest : AbstractAuthorizationTest({
         }
     }
 
+    "GetAvailableSecretsByRepositoryId" should {
+        "require RepositoryPermission.READ" {
+            requestShouldRequireRole(
+                routes = { secretsRoutes(repositoryService, secretService) },
+                role = RepositoryPermission.READ.roleName(repoId)
+            ) {
+                get("/repositories/$repoId/secrets/availableSecrets")
+            }
+        }
+    }
+
     "GetSecretByOrganizationIdAndName" should {
         "require OrganizationPermission.READ" {
             requestShouldRequireRole(
-                routes = { secretsRoutes(secretService) },
+                routes = { secretsRoutes(repositoryService, secretService) },
                 role = OrganizationPermission.READ.roleName(orgId),
                 successStatus = HttpStatusCode.NotFound
             ) {
@@ -110,7 +136,7 @@ class SecretsAuthorizationTest : AbstractAuthorizationTest({
     "GetSecretByProductIdAndName" should {
         "require ProductPermission.READ" {
             requestShouldRequireRole(
-                routes = { secretsRoutes(secretService) },
+                routes = { secretsRoutes(repositoryService, secretService) },
                 role = ProductPermission.READ.roleName(prodId),
                 successStatus = HttpStatusCode.NotFound
             ) {
@@ -122,7 +148,7 @@ class SecretsAuthorizationTest : AbstractAuthorizationTest({
     "GetSecretByRepositoryIdAndName" should {
         "require RepositoryPermission.READ" {
             requestShouldRequireRole(
-                routes = { secretsRoutes(secretService) },
+                routes = { secretsRoutes(repositoryService, secretService) },
                 role = RepositoryPermission.READ.roleName(repoId),
                 successStatus = HttpStatusCode.NotFound
             ) {
@@ -134,7 +160,7 @@ class SecretsAuthorizationTest : AbstractAuthorizationTest({
     "GetSecretsByOrganizationId" should {
         "require OrganizationPermission.READ" {
             requestShouldRequireRole(
-                routes = { secretsRoutes(secretService) },
+                routes = { secretsRoutes(repositoryService, secretService) },
                 role = OrganizationPermission.READ.roleName(orgId)
             ) {
                 get("/organizations/$orgId/secrets")
@@ -145,7 +171,7 @@ class SecretsAuthorizationTest : AbstractAuthorizationTest({
     "GetSecretsByProductId" should {
         "require ProductPermission.READ" {
             requestShouldRequireRole(
-                routes = { secretsRoutes(secretService) },
+                routes = { secretsRoutes(repositoryService, secretService) },
                 role = ProductPermission.READ.roleName(prodId)
             ) {
                 get("/products/$prodId/secrets")
@@ -156,7 +182,7 @@ class SecretsAuthorizationTest : AbstractAuthorizationTest({
     "GetSecretsByRepositoryId" should {
         "require RepositoryPermission.READ" {
             requestShouldRequireRole(
-                routes = { secretsRoutes(secretService) },
+                routes = { secretsRoutes(repositoryService, secretService) },
                 role = RepositoryPermission.READ.roleName(repoId)
             ) {
                 get("/repositories/$repoId/secrets")
@@ -167,7 +193,7 @@ class SecretsAuthorizationTest : AbstractAuthorizationTest({
     "PatchSecretByOrganizationIdAndName" should {
         "require OrganizationPermission.WRITE_SECRETS" {
             requestShouldRequireRole(
-                routes = { secretsRoutes(secretService) },
+                routes = { secretsRoutes(repositoryService, secretService) },
                 role = OrganizationPermission.WRITE_SECRETS.roleName(orgId),
                 successStatus = HttpStatusCode.NotFound
             ) {
@@ -180,7 +206,7 @@ class SecretsAuthorizationTest : AbstractAuthorizationTest({
     "PatchSecretByProductIdAndName" should {
         "require ProductPermission.WRITE_SECRETS" {
             requestShouldRequireRole(
-                routes = { secretsRoutes(secretService) },
+                routes = { secretsRoutes(repositoryService, secretService) },
                 role = ProductPermission.WRITE_SECRETS.roleName(prodId),
                 successStatus = HttpStatusCode.NotFound
             ) {
@@ -193,7 +219,7 @@ class SecretsAuthorizationTest : AbstractAuthorizationTest({
     "PatchSecretByRepositoryIdAndName" should {
         "require RepositoryPermission.WRITE_SECRETS" {
             requestShouldRequireRole(
-                routes = { secretsRoutes(secretService) },
+                routes = { secretsRoutes(repositoryService, secretService) },
                 role = RepositoryPermission.WRITE_SECRETS.roleName(repoId),
                 successStatus = HttpStatusCode.NotFound
             ) {
@@ -206,7 +232,7 @@ class SecretsAuthorizationTest : AbstractAuthorizationTest({
     "PostSecretForOrganization" should {
         "require OrganizationPermission.WRITE_SECRETS" {
             requestShouldRequireRole(
-                routes = { secretsRoutes(secretService) },
+                routes = { secretsRoutes(repositoryService, secretService) },
                 role = OrganizationPermission.WRITE_SECRETS.roleName(orgId),
                 successStatus = HttpStatusCode.Created
             ) {
@@ -219,7 +245,7 @@ class SecretsAuthorizationTest : AbstractAuthorizationTest({
     "PostSecretForProduct" should {
         "require ProductPermission.WRITE_SECRETS" {
             requestShouldRequireRole(
-                routes = { secretsRoutes(secretService) },
+                routes = { secretsRoutes(repositoryService, secretService) },
                 role = ProductPermission.WRITE_SECRETS.roleName(prodId),
                 successStatus = HttpStatusCode.Created
             ) {
@@ -232,7 +258,7 @@ class SecretsAuthorizationTest : AbstractAuthorizationTest({
     "PostSecretForRepository" should {
         "require RepositoryPermission.WRITE_SECRETS" {
             requestShouldRequireRole(
-                routes = { secretsRoutes(secretService) },
+                routes = { secretsRoutes(repositoryService, secretService) },
                 role = RepositoryPermission.WRITE_SECRETS.roleName(repoId),
                 successStatus = HttpStatusCode.Created
             ) {

--- a/components/secrets/backend/src/test/kotlin/routes/repository/GetAvailableSecretsByRepositoryIdIntegrationTest.kt
+++ b/components/secrets/backend/src/test/kotlin/routes/repository/GetAvailableSecretsByRepositoryIdIntegrationTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.components.secrets.routes.repository
+
+import io.kotest.assertions.ktor.client.shouldHaveStatus
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.should
+
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+
+import org.eclipse.apoapsis.ortserver.components.secrets.Secret
+import org.eclipse.apoapsis.ortserver.components.secrets.SecretsIntegrationTest
+import org.eclipse.apoapsis.ortserver.components.secrets.mapToApi
+import org.eclipse.apoapsis.ortserver.components.secrets.routes.createOrganizationSecret
+import org.eclipse.apoapsis.ortserver.components.secrets.routes.createProductSecret
+import org.eclipse.apoapsis.ortserver.components.secrets.routes.createRepositorySecret
+
+class GetAvailableSecretsByRepositoryIdIntegrationTest : SecretsIntegrationTest({
+    var organizationId = 0L
+    var productId = 0L
+    var repoId = 0L
+
+    beforeEach {
+        organizationId = dbExtension.fixtures.organization.id
+        productId = dbExtension.fixtures.product.id
+        repoId = dbExtension.fixtures.repository.id
+    }
+
+    "GetAvailableSecretsByRepositoryId" should {
+        "return all secrets from the hierarchy" {
+            secretsTestApplication { client ->
+                val secret1 =
+                    secretRepository.createOrganizationSecret(organizationId, "path1", "name1", "description1")
+                val secret2 = secretRepository.createProductSecret(productId, "path2", "name2", "description2")
+                val secret3 = secretRepository.createRepositorySecret(repoId, "path3", "name3", "description3")
+
+                val response = client.get("/repositories/$repoId/availableSecrets")
+
+                response shouldHaveStatus HttpStatusCode.OK
+                response.body<List<Secret>>() should containExactlyInAnyOrder(
+                    secret1.mapToApi(),
+                    secret2.mapToApi(),
+                    secret3.mapToApi()
+                )
+            }
+        }
+    }
+})

--- a/core/src/main/kotlin/plugins/Koin.kt
+++ b/core/src/main/kotlin/plugins/Koin.kt
@@ -23,15 +23,16 @@ import io.ktor.server.application.Application
 import io.ktor.server.application.install
 
 import org.eclipse.apoapsis.ortserver.core.di.ortServerModule
+import org.eclipse.apoapsis.ortserver.services.AuthorizationService
 
 import org.jetbrains.exposed.sql.Database
 
 import org.koin.ktor.plugin.Koin
 
-fun Application.configureKoin(db: Database? = null) {
+fun Application.configureKoin(db: Database? = null, authorizationService: AuthorizationService? = null) {
     install(Koin) {
         modules(
-            ortServerModule(environment.config, db)
+            ortServerModule(environment.config, db, authorizationService)
         )
     }
 }

--- a/core/src/main/kotlin/plugins/Routing.kt
+++ b/core/src/main/kotlin/plugins/Routing.kt
@@ -54,7 +54,7 @@ fun Application.configureRouting() {
                 products()
                 repositories()
                 runs()
-                secretsRoutes(get())
+                secretsRoutes(get(), get())
                 versions()
             }
         }

--- a/core/src/test/kotlin/ApplicationTest.kt
+++ b/core/src/test/kotlin/ApplicationTest.kt
@@ -21,6 +21,8 @@ package org.eclipse.apoapsis.ortserver.core
 
 import io.ktor.server.application.Application
 
+import io.mockk.mockk
+
 import org.eclipse.apoapsis.ortserver.components.authorization.configureAuthentication
 import org.eclipse.apoapsis.ortserver.core.plugins.*
 import org.eclipse.apoapsis.ortserver.core.testutils.configureTestAuthentication
@@ -41,7 +43,7 @@ fun main(args: Array<String>) = io.ktor.server.netty.EngineMain.main(args)
  *                   authentication which is always valid.
  */
 fun Application.testModule(db: Database) {
-    configureKoin(db)
+    configureKoin(db, authorizationService = mockk())
     configureTestAuthentication()
     configureStatusPages()
     configureRouting()

--- a/services/hierarchy/src/main/kotlin/RepositoryService.kt
+++ b/services/hierarchy/src/main/kotlin/RepositoryService.kt
@@ -26,6 +26,7 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.advisorjob.AdvisorJobsTab
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerjob.AnalyzerJobsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.evaluatorjob.EvaluatorJobsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.ortrun.OrtRunsTable
+import org.eclipse.apoapsis.ortserver.model.Hierarchy
 import org.eclipse.apoapsis.ortserver.model.JobStatus
 import org.eclipse.apoapsis.ortserver.model.Jobs
 import org.eclipse.apoapsis.ortserver.model.OrtRun
@@ -98,6 +99,11 @@ class RepositoryService(
         val reporterJob = reporterJobRepository.getForOrtRun(ortRun.id)
         val notifierJob = notifierJobRepository.getForOrtRun(ortRun.id)
         Jobs(analyzerJob, advisorJob, scannerJob, evaluatorJob, reporterJob, notifierJob)
+    }
+
+    /** Get the [Hierarchy] for the provided [repository][repositoryId]. */
+    suspend fun getHierarchy(repositoryId: Long): Hierarchy = db.dbQuery {
+        repositoryRepository.getHierarchy(repositoryId)
     }
 
     suspend fun getOrtRun(repositoryId: Long, ortRunIndex: Long): OrtRun? = db.dbQuery {

--- a/services/hierarchy/src/test/kotlin/RepositoryServiceTest.kt
+++ b/services/hierarchy/src/test/kotlin/RepositoryServiceTest.kt
@@ -40,6 +40,7 @@ import org.eclipse.apoapsis.ortserver.model.Repository
 import org.eclipse.apoapsis.ortserver.model.RepositoryType
 import org.eclipse.apoapsis.ortserver.model.util.asPresent
 
+import org.jetbrains.exposed.dao.exceptions.EntityNotFoundException
 import org.jetbrains.exposed.sql.Database
 
 class RepositoryServiceTest : WordSpec({
@@ -139,6 +140,26 @@ class RepositoryServiceTest : WordSpec({
             val service = createService()
 
             service.getJobs(fixtures.repository.id, -1L) should beNull()
+        }
+    }
+
+    "getHierarchy" should {
+        "return the hierarchy of the repository" {
+            val service = createService()
+
+            service.getHierarchy(fixtures.repository.id).shouldNotBeNull {
+                organization.id shouldBe fixtures.organization.id
+                product.id shouldBe fixtures.product.id
+                repository.id shouldBe fixtures.repository.id
+            }
+        }
+
+        "throw an exception if the repository does not exist" {
+            val service = createService()
+
+            shouldThrow<EntityNotFoundException> {
+                service.getHierarchy(9999)
+            }
         }
     }
 

--- a/services/secret/build.gradle.kts
+++ b/services/secret/build.gradle.kts
@@ -35,6 +35,9 @@ dependencies {
 
     runtimeOnly(libs.logback)
 
+    testImplementation(testFixtures(projects.dao))
+    testImplementation(testFixtures(projects.secrets.secretsSpi))
+
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
 }

--- a/services/secret/src/test/kotlin/SecretServiceTest.kt
+++ b/services/secret/src/test/kotlin/SecretServiceTest.kt
@@ -1,0 +1,196 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.services
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.nulls.beNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
+import org.eclipse.apoapsis.ortserver.dao.test.Fixtures
+import org.eclipse.apoapsis.ortserver.model.Hierarchy
+import org.eclipse.apoapsis.ortserver.model.OrganizationId
+import org.eclipse.apoapsis.ortserver.model.ProductId
+import org.eclipse.apoapsis.ortserver.model.RepositoryId
+import org.eclipse.apoapsis.ortserver.secrets.SecretStorage
+import org.eclipse.apoapsis.ortserver.secrets.SecretsProviderFactoryForTesting
+
+import org.jetbrains.exposed.sql.Database
+
+class SecretServiceTest : WordSpec({
+    val dbExtension = extension(DatabaseTestExtension())
+
+    lateinit var db: Database
+    lateinit var fixtures: Fixtures
+    lateinit var secretService: SecretService
+
+    beforeEach {
+        db = dbExtension.db
+        fixtures = dbExtension.fixtures
+        secretService = SecretService(
+            db,
+            fixtures.secretRepository,
+            fixtures.infrastructureServiceRepository,
+            SecretStorage(SecretsProviderFactoryForTesting().createProvider())
+        )
+    }
+
+    "listForHierarchy" should {
+        "return an empty list if there are no secrets" {
+            val hierarchy = Hierarchy(
+                repository = fixtures.repository,
+                product = fixtures.product,
+                organization = fixtures.organization
+            )
+
+            secretService.listForHierarchy(hierarchy) should beEmpty()
+        }
+
+        "return secrets from all levels of the hierarchy" {
+            val hierarchy = Hierarchy(
+                repository = fixtures.repository,
+                product = fixtures.product,
+                organization = fixtures.organization
+            )
+
+            secretService.createSecret(
+                "organizationSecret",
+                "value",
+                "description",
+                OrganizationId(hierarchy.organization.id)
+            )
+            secretService.createSecret(
+                "productSecret",
+                "value",
+                "description",
+                ProductId(fixtures.product.id)
+            )
+            secretService.createSecret(
+                "repositorySecret",
+                "value",
+                "description",
+                RepositoryId(fixtures.repository.id)
+            )
+
+            secretService.listForHierarchy(hierarchy).map { it.name } should
+                    containExactlyInAnyOrder("organizationSecret", "productSecret", "repositorySecret")
+        }
+
+        "resolve conflicts for secrets with the same name correctly" {
+            val hierarchy = Hierarchy(
+                repository = fixtures.repository,
+                product = fixtures.product,
+                organization = fixtures.organization
+            )
+
+            // Create a secret on all levels.
+            secretService.createSecret(
+                "secret1",
+                "value",
+                "description",
+                OrganizationId(hierarchy.organization.id)
+            )
+            secretService.createSecret(
+                "secret1",
+                "value",
+                "description",
+                ProductId(hierarchy.organization.id)
+            )
+            secretService.createSecret(
+                "secret1",
+                "value",
+                "description",
+                RepositoryId(hierarchy.organization.id)
+            )
+
+            // Create a secret on organization and product levels.
+            secretService.createSecret(
+                "secret2",
+                "value",
+                "description",
+                OrganizationId(hierarchy.organization.id)
+            )
+            secretService.createSecret(
+                "secret2",
+                "value",
+                "description",
+                ProductId(hierarchy.product.id)
+            )
+
+            // Create a secret on organization and repository levels.
+            secretService.createSecret(
+                "secret3",
+                "value",
+                "description",
+                OrganizationId(hierarchy.organization.id)
+            )
+            secretService.createSecret(
+                "secret3",
+                "value",
+                "description",
+                RepositoryId(hierarchy.repository.id)
+            )
+
+            // Create a secret on product and repository levels.
+            secretService.createSecret(
+                "secret4",
+                "value",
+                "description",
+                ProductId(hierarchy.product.id)
+            )
+            secretService.createSecret(
+                "secret4",
+                "value",
+                "description",
+                RepositoryId(hierarchy.repository.id)
+            )
+
+            val secrets = secretService.listForHierarchy(hierarchy)
+
+            secrets.find { it.name == "secret1" }.shouldNotBeNull {
+                organization should beNull()
+                product should beNull()
+                repository shouldBe hierarchy.repository
+            }
+
+            secrets.find { it.name == "secret2" }.shouldNotBeNull {
+                organization should beNull()
+                product shouldBe hierarchy.product
+                repository should beNull()
+            }
+
+            secrets.find { it.name == "secret3" }.shouldNotBeNull {
+                organization should beNull()
+                product should beNull()
+                repository shouldBe hierarchy.repository
+            }
+
+            secrets.find { it.name == "secret4" }.shouldNotBeNull {
+                organization should beNull()
+                product should beNull()
+                repository shouldBe hierarchy.repository
+            }
+        }
+    }
+})

--- a/ui/src/components/form/plugin-multi-select-field.tsx
+++ b/ui/src/components/form/plugin-multi-select-field.tsx
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { CheckedState } from '@radix-ui/react-checkbox';
+import React from 'react';
+import {
+  FieldPathByValue,
+  FieldPathValue,
+  FieldValues,
+  Path,
+  UseFormReturn,
+} from 'react-hook-form';
+
+import { PreconfiguredPluginDescriptor } from '@/api/requests';
+import { OptionalInput } from '@/components/form/optional-input.tsx';
+import { Badge } from '@/components/ui/badge.tsx';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input.tsx';
+import { Label } from '@/components/ui/label';
+import { Separator } from '@/components/ui/separator';
+import { cn } from '@/lib/utils';
+
+type PluginMultiSelectFieldProps<
+  TFieldValues extends FieldValues,
+  TName extends FieldPathByValue<TFieldValues, Array<string>>,
+> = {
+  form: UseFormReturn<TFieldValues, TName>;
+  name: TName;
+  configName: TName;
+  label?: string;
+  description?: React.ReactNode;
+  plugins: readonly PreconfiguredPluginDescriptor[];
+  className?: string;
+};
+
+export const PluginMultiSelectField = <
+  TFieldValues extends FieldValues,
+  TName extends FieldPathByValue<TFieldValues, Array<string>>,
+>({
+  form,
+  name,
+  configName,
+  label,
+  description,
+  plugins,
+  className,
+}: PluginMultiSelectFieldProps<TFieldValues, TName>) => {
+  return (
+    <FormField
+      control={form.control}
+      name={name}
+      render={({ field }) => (
+        <FormItem
+          className={cn(
+            'mb-4 flex flex-col justify-between rounded-lg border p-4',
+            className
+          )}
+        >
+          <FormLabel>{label}</FormLabel>
+          <FormDescription className='pb-4'>{description}</FormDescription>
+          <div className='flex items-center space-x-3'>
+            <Checkbox
+              id='check-all-items'
+              checked={
+                plugins.every((plugin) =>
+                  form.getValues(name).includes(plugin.id)
+                )
+                  ? true
+                  : plugins.some((plugin) =>
+                        form.getValues(name).includes(plugin.id)
+                      )
+                    ? 'indeterminate'
+                    : false
+              }
+              onCheckedChange={(checked) => {
+                const enabledItems = checked
+                  ? plugins.map((plugin) => plugin.id)
+                  : [];
+                form.setValue(
+                  name,
+                  // TypeScript doesn't get this, but TName extends FieldPathByValue<TFieldValues, Array<string>>,
+                  // so the field behind TName is always an Array<string>
+                  // and options.map((option) => option.id) is also Array<string>,
+                  // so this type cast is safe.
+                  enabledItems as FieldPathValue<TFieldValues, TName>
+                );
+              }}
+            />
+            <Label htmlFor='check-all-items' className='font-bold'>
+              Enable/disable all
+            </Label>
+          </div>
+          <Separator />
+          {plugins.map((plugin) => (
+            <FormItem
+              key={plugin.id}
+              className='flex flex-row items-start space-y-0 space-x-3'
+            >
+              <FormControl>
+                <Checkbox
+                  checked={field.value?.includes(plugin.id)}
+                  onCheckedChange={(checked) => {
+                    return checked
+                      ? field.onChange([...field.value, plugin.id])
+                      : field.onChange(
+                          field.value?.filter(
+                            (value: string) => value !== plugin.id
+                          )
+                        );
+                  }}
+                />
+              </FormControl>
+              <div className='flex flex-col'>
+                <FormLabel className='font-normal'>
+                  {plugin.displayName}
+                </FormLabel>
+                {plugin.description != null && (
+                  <FormDescription className='pb-4'>
+                    {plugin.description}
+                  </FormDescription>
+                )}
+                {field.value?.includes(plugin.id) &&
+                  plugin.options.map((option) => (
+                    <FormField
+                      control={form.control}
+                      key={option.name}
+                      name={
+                        `${configName}.${plugin.id}.options.${option.name}` as Path<TFieldValues>
+                      }
+                      render={({ field }) => (
+                        <FormItem className='flex flex-col space-y-1'>
+                          <FormLabel className='mt-2'>
+                            {option.name}
+                            <Badge className='ml-2 bg-blue-200 text-black'>
+                              {option.type}
+                            </Badge>
+                          </FormLabel>
+                          <FormDescription>
+                            {option.description}
+                          </FormDescription>
+                          <FormControl>
+                            {option.type === 'BOOLEAN' ? (
+                              <Checkbox
+                                checked={field.value as CheckedState}
+                                onCheckedChange={field.onChange}
+                              />
+                            ) : option.isRequired ? (
+                              <Input
+                                {...field}
+                                type={
+                                  option.type === 'INTEGER' ||
+                                  option.type === 'LONG'
+                                    ? 'number'
+                                    : 'text'
+                                }
+                                value={field.value}
+                              />
+                            ) : (
+                              <OptionalInput
+                                {...field}
+                                type={
+                                  option.type === 'INTEGER' ||
+                                  option.type === 'LONG'
+                                    ? 'number'
+                                    : 'text'
+                                }
+                                value={field.value}
+                              />
+                            )}
+                          </FormControl>
+                        </FormItem>
+                      )}
+                    />
+                  ))}
+              </div>
+            </FormItem>
+          ))}
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+};

--- a/ui/src/components/form/plugin-multi-select-field.tsx
+++ b/ui/src/components/form/plugin-multi-select-field.tsx
@@ -167,6 +167,7 @@ export const PluginMultiSelectField = <
                               <Checkbox
                                 checked={field.value as CheckedState}
                                 onCheckedChange={field.onChange}
+                                disabled={option.isFixed}
                               />
                             ) : option.isRequired ? (
                               <Input
@@ -178,6 +179,7 @@ export const PluginMultiSelectField = <
                                     : 'text'
                                 }
                                 value={field.value}
+                                disabled={option.isFixed}
                               />
                             ) : (
                               <OptionalInput
@@ -189,9 +191,16 @@ export const PluginMultiSelectField = <
                                     : 'text'
                                 }
                                 value={field.value}
+                                disabled={option.isFixed}
                               />
                             )}
                           </FormControl>
+                          {option.isFixed && (
+                            <FormDescription className='text-muted-foreground font-semibold text-yellow-700'>
+                              This option is set by an administrator and cannot
+                              be changed.
+                            </FormDescription>
+                          )}
                         </FormItem>
                       )}
                     />

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/advisor-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/advisor-fields.tsx
@@ -19,7 +19,7 @@
 
 import { UseFormReturn } from 'react-hook-form';
 
-import { PreconfiguredPluginDescriptor } from '@/api/requests';
+import { PreconfiguredPluginDescriptor, Secret } from '@/api/requests';
 import { PluginMultiSelectField } from '@/components/form/plugin-multi-select-field.tsx';
 import {
   AccordionContent,
@@ -41,6 +41,7 @@ type AdvisorFieldsProps = {
   value: string;
   onToggle: () => void;
   advisorPlugins: PreconfiguredPluginDescriptor[];
+  secrets: Secret[];
 };
 
 export const AdvisorFields = ({
@@ -48,6 +49,7 @@ export const AdvisorFields = ({
   value,
   onToggle,
   advisorPlugins,
+  secrets,
 }: AdvisorFieldsProps) => {
   return (
     <div className='flex flex-row align-middle'>
@@ -95,6 +97,7 @@ export const AdvisorFields = ({
             label='Enabled advisors'
             description={<>Select the advisors enabled for this run.</>}
             plugins={advisorPlugins}
+            secrets={secrets}
           />
         </AccordionContent>
       </AccordionItem>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/advisor-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/advisor-fields.tsx
@@ -20,7 +20,7 @@
 import { UseFormReturn } from 'react-hook-form';
 
 import { PreconfiguredPluginDescriptor } from '@/api/requests';
-import { MultiSelectField } from '@/components/form/multi-select-field';
+import { PluginMultiSelectField } from '@/components/form/plugin-multi-select-field.tsx';
 import {
   AccordionContent,
   AccordionItem,
@@ -49,12 +49,6 @@ export const AdvisorFields = ({
   onToggle,
   advisorPlugins,
 }: AdvisorFieldsProps) => {
-  const advisorOptions = advisorPlugins.map((plugin) => ({
-    id: plugin.id,
-    label: plugin.displayName,
-    description: plugin.description,
-  }));
-
   return (
     <div className='flex flex-row align-middle'>
       <FormField
@@ -94,12 +88,13 @@ export const AdvisorFields = ({
               </FormItem>
             )}
           />
-          <MultiSelectField
+          <PluginMultiSelectField
             form={form}
             name='jobConfigs.advisor.advisors'
+            configName='jobConfigs.advisor.config'
             label='Enabled advisors'
             description={<>Select the advisors enabled for this run.</>}
-            options={advisorOptions}
+            plugins={advisorPlugins}
           />
         </AccordionContent>
       </AccordionItem>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/reporter-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/reporter-fields.tsx
@@ -19,20 +19,14 @@
 
 import { UseFormReturn } from 'react-hook-form';
 
-import { PreconfiguredPluginDescriptor } from '@/api/requests';
-import { MultiSelectField } from '@/components/form/multi-select-field';
+import { PreconfiguredPluginDescriptor, Secret } from '@/api/requests';
+import { PluginMultiSelectField } from '@/components/form/plugin-multi-select-field.tsx';
 import {
   AccordionContent,
   AccordionItem,
   AccordionTrigger,
 } from '@/components/ui/accordion';
-import {
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-} from '@/components/ui/form';
+import { FormControl, FormField } from '@/components/ui/form';
 import { Switch } from '@/components/ui/switch';
 import { CreateRunFormValues } from '../_repo-layout/create-run/-create-run-utils';
 
@@ -41,6 +35,7 @@ type ReporterFieldsProps = {
   value: string;
   onToggle: () => void;
   reporterPlugins: PreconfiguredPluginDescriptor[];
+  secrets: Secret[];
 };
 
 export const ReporterFields = ({
@@ -48,13 +43,8 @@ export const ReporterFields = ({
   value,
   onToggle,
   reporterPlugins,
+  secrets,
 }: ReporterFieldsProps) => {
-  const reporterOptions = reporterPlugins.map((plugin) => ({
-    id: plugin.id,
-    label: plugin.displayName,
-    description: plugin.description,
-  }));
-
   return (
     <div className='flex flex-row align-middle'>
       <FormField
@@ -73,46 +63,17 @@ export const ReporterFields = ({
       <AccordionItem value={value} className='flex-1'>
         <AccordionTrigger onClick={onToggle}>Reporter</AccordionTrigger>
         <AccordionContent>
-          <MultiSelectField
+          <PluginMultiSelectField
             form={form}
             name='jobConfigs.reporter.formats'
+            configName='jobConfigs.reporter.config'
             label='Report formats'
             description={
               <>Select the report formats to generate from the run.</>
             }
-            options={reporterOptions}
+            plugins={reporterPlugins}
+            secrets={secrets}
           />
-          {form.getValues('jobConfigs.reporter.formats').includes('WebApp') && (
-            <FormField
-              control={form.control}
-              name='jobConfigs.reporter.deduplicateDependencyTree'
-              render={({ field }) => (
-                <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
-                  <div className='space-y-0.5'>
-                    <FormLabel>Deduplicate dependency tree</FormLabel>
-                    <FormDescription>
-                      A flag to control whether subtrees occurring multiple
-                      times in the dependency tree are stripped.
-                    </FormDescription>
-                    <FormDescription>
-                      This will significantly reduce memory consumption of the
-                      Reporter and might alleviate some out-of-memory issues.
-                    </FormDescription>
-                    <FormDescription>
-                      NOTE: This option is currently effective only for the
-                      WebApp report format.
-                    </FormDescription>
-                  </div>
-                  <FormControl>
-                    <Switch
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
-          )}
         </AccordionContent>
       </AccordionItem>
     </div>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
@@ -55,83 +55,87 @@ const environmentVariableSchema = z.object({
   value: z.string().min(1).nullable().optional(),
 });
 
-export const createRunFormSchema = z.object({
-  revision: z.string(),
-  path: z.string(),
-  jobConfigs: z.object({
-    analyzer: z.object({
-      enabled: z.boolean(),
-      repositoryConfigPath: z.string().optional(),
-      allowDynamicVersions: z.boolean(),
-      skipExcluded: z.boolean(),
-      environmentVariables: z.array(environmentVariableSchema).optional(),
-      packageManagers: z
-        .object({
-          Bazel: packageManagerOptionsSchema,
-          Bower: packageManagerOptionsSchema,
-          Bundler: packageManagerOptionsSchema,
-          Cargo: packageManagerOptionsSchema,
-          Carthage: packageManagerOptionsSchema,
-          CocoaPods: packageManagerOptionsSchema,
-          Composer: packageManagerOptionsSchema,
-          Conan: packageManagerOptionsSchema,
-          GoMod: packageManagerOptionsSchema,
-          Gradle: packageManagerOptionsSchema,
-          GradleInspector: packageManagerOptionsSchema,
-          Maven: packageManagerOptionsSchema,
-          NPM: packageManagerOptionsSchema,
-          NuGet: packageManagerOptionsSchema,
-          PIP: packageManagerOptionsSchema,
-          Pipenv: packageManagerOptionsSchema,
-          PNPM: packageManagerOptionsSchema,
-          Poetry: packageManagerOptionsSchema,
-          Pub: packageManagerOptionsSchema,
-          SBT: packageManagerOptionsSchema,
-          SpdxDocumentFile: packageManagerOptionsSchema,
-          Stack: packageManagerOptionsSchema,
-          SwiftPM: packageManagerOptionsSchema,
-          Yarn: packageManagerOptionsSchema,
-          Yarn2: packageManagerOptionsSchema,
-        })
-        .refine((schema) => {
-          // Ensure that not both Gradle and GradleInspector are enabled at the same time.
-          return !(schema.Gradle.enabled && schema.GradleInspector.enabled);
-        }, '"Gradle Legacy" and "Gradle" cannot be enabled at the same time.'),
-    }),
-    advisor: z.object({
-      enabled: z.boolean(),
-      skipExcluded: z.boolean(),
-      advisors: z.array(z.string()),
-    }),
-    scanner: z.object({
-      enabled: z.boolean(),
-      skipConcluded: z.boolean(),
-      skipExcluded: z.boolean(),
-    }),
-    evaluator: z.object({
-      enabled: z.boolean(),
+export const createRunFormSchema = () => {
+  return z.object({
+    revision: z.string(),
+    path: z.string(),
+    jobConfigs: z.object({
+      analyzer: z.object({
+        enabled: z.boolean(),
+        repositoryConfigPath: z.string().optional(),
+        allowDynamicVersions: z.boolean(),
+        skipExcluded: z.boolean(),
+        environmentVariables: z.array(environmentVariableSchema).optional(),
+        packageManagers: z
+          .object({
+            Bazel: packageManagerOptionsSchema,
+            Bower: packageManagerOptionsSchema,
+            Bundler: packageManagerOptionsSchema,
+            Cargo: packageManagerOptionsSchema,
+            Carthage: packageManagerOptionsSchema,
+            CocoaPods: packageManagerOptionsSchema,
+            Composer: packageManagerOptionsSchema,
+            Conan: packageManagerOptionsSchema,
+            GoMod: packageManagerOptionsSchema,
+            Gradle: packageManagerOptionsSchema,
+            GradleInspector: packageManagerOptionsSchema,
+            Maven: packageManagerOptionsSchema,
+            NPM: packageManagerOptionsSchema,
+            NuGet: packageManagerOptionsSchema,
+            PIP: packageManagerOptionsSchema,
+            Pipenv: packageManagerOptionsSchema,
+            PNPM: packageManagerOptionsSchema,
+            Poetry: packageManagerOptionsSchema,
+            Pub: packageManagerOptionsSchema,
+            SBT: packageManagerOptionsSchema,
+            SpdxDocumentFile: packageManagerOptionsSchema,
+            Stack: packageManagerOptionsSchema,
+            SwiftPM: packageManagerOptionsSchema,
+            Yarn: packageManagerOptionsSchema,
+            Yarn2: packageManagerOptionsSchema,
+          })
+          .refine((schema) => {
+            // Ensure that not both Gradle and GradleInspector are enabled at the same time.
+            return !(schema.Gradle.enabled && schema.GradleInspector.enabled);
+          }, '"Gradle Legacy" and "Gradle" cannot be enabled at the same time.'),
+      }),
+      advisor: z.object({
+        enabled: z.boolean(),
+        skipExcluded: z.boolean(),
+        advisors: z.array(z.string()),
+      }),
+      scanner: z.object({
+        enabled: z.boolean(),
+        skipConcluded: z.boolean(),
+        skipExcluded: z.boolean(),
+      }),
+      evaluator: z.object({
+        enabled: z.boolean(),
+        ruleSet: z.string().optional(),
+        licenseClassificationsFile: z.string().optional(),
+        copyrightGarbageFile: z.string().optional(),
+        resolutionsFile: z.string().optional(),
+      }),
+      reporter: z.object({
+        enabled: z.boolean(),
+        formats: z.array(z.string()),
+        deduplicateDependencyTree: z.boolean().optional(),
+      }),
+      notifier: z.object({
+        enabled: z.boolean(),
+        recipientAddresses: z.array(z.object({ email: z.string() })).optional(),
+      }),
+      parameters: z.array(keyValueSchema).optional(),
       ruleSet: z.string().optional(),
-      licenseClassificationsFile: z.string().optional(),
-      copyrightGarbageFile: z.string().optional(),
-      resolutionsFile: z.string().optional(),
     }),
-    reporter: z.object({
-      enabled: z.boolean(),
-      formats: z.array(z.string()),
-      deduplicateDependencyTree: z.boolean().optional(),
-    }),
-    notifier: z.object({
-      enabled: z.boolean(),
-      recipientAddresses: z.array(z.object({ email: z.string() })).optional(),
-    }),
-    parameters: z.array(keyValueSchema).optional(),
-    ruleSet: z.string().optional(),
-  }),
-  labels: z.array(keyValueSchema).optional(),
-  jobConfigContext: z.string().optional(),
-});
+    labels: z.array(keyValueSchema).optional(),
+    jobConfigContext: z.string().optional(),
+  });
+};
 
-export type CreateRunFormValues = z.infer<typeof createRunFormSchema>;
+export type CreateRunFormValues = z.infer<
+  ReturnType<typeof createRunFormSchema>
+>;
 
 /**
  * Converts an object map coming from the back-end to an array of key-value pairs.
@@ -219,7 +223,7 @@ export const flattenErrors = (
  */
 export function defaultValues(
   ortRun: OrtRun | null
-): z.infer<typeof createRunFormSchema> {
+): z.infer<ReturnType<typeof createRunFormSchema>> {
   /**
    * Constructs the default options for a package manager, either as a blank set of options
    * or from an earlier ORT run if rerun functionality is used.
@@ -430,7 +434,7 @@ export function defaultValues(
  * to the API. This function converts form values to correct payload to create an ORT run.
  */
 export function formValuesToPayload(
-  values: z.infer<typeof createRunFormSchema>
+  values: z.infer<ReturnType<typeof createRunFormSchema>>
 ): CreateOrtRun {
   /**
    * A helper function to get the enabled package managers from the form values.

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -69,7 +69,7 @@ import {
 const CreateRunPage = () => {
   const navigate = useNavigate();
   const params = Route.useParams();
-  const { ortRun, plugins } = Route.useLoaderData();
+  const { ortRun, plugins, secrets } = Route.useLoaderData();
   const [isTest, setIsTest] = useState(false);
 
   const advisorPlugins =
@@ -427,6 +427,7 @@ const CreateRunPage = () => {
                 value='advisor'
                 onToggle={() => toggleAccordionOpen('advisor')}
                 advisorPlugins={advisorPlugins}
+                secrets={secrets}
               />
               <ScannerFields
                 form={form}
@@ -534,7 +535,7 @@ export const Route = createFileRoute(
   // the query will not be run. This corresponds to the "New run" case, where a new
   // ORT Run is created from scratch, using all defaults.
   loader: async ({ params, deps: { rerunIndex } }) => {
-    const [ortRun, plugins] = await Promise.all([
+    const [ortRun, plugins, secrets] = await Promise.all([
       rerunIndex !== undefined
         ? RepositoriesService.getApiV1RepositoriesByRepositoryIdRunsByOrtRunIndex(
             {
@@ -546,11 +547,15 @@ export const Route = createFileRoute(
       RepositoriesService.getApiV1RepositoriesByRepositoryIdPlugins({
         repositoryId: Number.parseInt(params.repoId),
       }),
+      RepositoriesService.getApiV1RepositoriesByRepositoryIdAvailableSecrets({
+        repositoryId: Number.parseInt(params.repoId),
+      }),
     ]);
 
     return {
       ortRun,
       plugins,
+      secrets,
     };
   },
   component: CreateRunPage,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -124,11 +124,11 @@ const CreateRunPage = () => {
       },
     });
 
-  const formSchema = createRunFormSchema(advisorPlugins);
+  const formSchema = createRunFormSchema(advisorPlugins, reporterPlugins);
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
-    defaultValues: defaultValues(ortRun, advisorPlugins),
+    defaultValues: defaultValues(ortRun, advisorPlugins, reporterPlugins),
   });
 
   const {
@@ -440,6 +440,7 @@ const CreateRunPage = () => {
                 value='reporter'
                 onToggle={() => toggleAccordionOpen('reporter')}
                 reporterPlugins={reporterPlugins}
+                secrets={secrets}
               />
               <NotifierFields
                 form={form}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -124,7 +124,7 @@ const CreateRunPage = () => {
       },
     });
 
-  const formSchema = createRunFormSchema();
+  const formSchema = createRunFormSchema(advisorPlugins);
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -128,7 +128,7 @@ const CreateRunPage = () => {
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
-    defaultValues: defaultValues(ortRun),
+    defaultValues: defaultValues(ortRun, advisorPlugins),
   });
 
   const {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -124,8 +124,10 @@ const CreateRunPage = () => {
       },
     });
 
-  const form = useForm({
-    resolver: zodResolver(createRunFormSchema),
+  const formSchema = createRunFormSchema();
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
     defaultValues: defaultValues(ortRun),
   });
 


### PR DESCRIPTION
Add support for configuration plugin options for advisor and reporter plugins in the UI.
The forms are generated from the plugin descriptors and take default values and plugin config templates into account.

Example for advisor plugins:

<img width="947" height="1025" alt="image" src="https://github.com/user-attachments/assets/8fa43ba3-217e-4429-af4a-0e2ede4eccda" />

Example for reporter plugins:

<img width="948" height="714" alt="image" src="https://github.com/user-attachments/assets/3aab9525-ba9c-4a5d-a054-8788bf5d5176" />

This is a first version that will help to identify required improvements and missing functionality.

@lamppu @Etsija This is still a draft but a review would already be welcome, just ignore the first few Kotlin commits which I will also commit separately.
