### PR TITLE
Add route to get the available secrets for a repository

### DIFF
--- a/components/secrets/backend/build.gradle.kts
+++ b/components/secrets/backend/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
 
     implementation(projects.components.authorization.backend)
     implementation(projects.model)
+    implementation(projects.services.hierarchyService)
     implementation(projects.services.secretService)
     implementation(projects.shared.apiMappings)
     implementation(projects.shared.apiModel)
@@ -46,4 +47,5 @@ dependencies {
     testImplementation(ktorLibs.server.testHost)
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestAssertionsKtor)
+    testImplementation(libs.mockk)
 }

--- a/components/secrets/backend/src/main/kotlin/Routing.kt
+++ b/components/secrets/backend/src/main/kotlin/Routing.kt
@@ -32,13 +32,15 @@ import org.eclipse.apoapsis.ortserver.components.secrets.routes.product.getSecre
 import org.eclipse.apoapsis.ortserver.components.secrets.routes.product.patchSecretByProductIdAndName
 import org.eclipse.apoapsis.ortserver.components.secrets.routes.product.postSecretForProduct
 import org.eclipse.apoapsis.ortserver.components.secrets.routes.repository.deleteSecretByRepositoryIdAndName
+import org.eclipse.apoapsis.ortserver.components.secrets.routes.repository.getAvailableSecretsByRepositoryId
 import org.eclipse.apoapsis.ortserver.components.secrets.routes.repository.getSecretByRepositoryIdAndName
 import org.eclipse.apoapsis.ortserver.components.secrets.routes.repository.getSecretsByRepositoryId
 import org.eclipse.apoapsis.ortserver.components.secrets.routes.repository.patchSecretByRepositoryIdAndName
 import org.eclipse.apoapsis.ortserver.components.secrets.routes.repository.postSecretForRepository
+import org.eclipse.apoapsis.ortserver.services.RepositoryService
 import org.eclipse.apoapsis.ortserver.services.SecretService
 
-fun Route.secretsRoutes(secretService: SecretService) {
+fun Route.secretsRoutes(repositoryService: RepositoryService, secretService: SecretService) {
     // Organization secrets
     deleteSecretByOrganizationIdAndName(secretService)
     getSecretByOrganizationIdAndName(secretService)
@@ -55,6 +57,7 @@ fun Route.secretsRoutes(secretService: SecretService) {
 
     // Repository secrets
     deleteSecretByRepositoryIdAndName(secretService)
+    getAvailableSecretsByRepositoryId(repositoryService, secretService)
     getSecretByRepositoryIdAndName(secretService)
     getSecretsByRepositoryId(secretService)
     patchSecretByRepositoryIdAndName(secretService)

--- a/components/secrets/backend/src/main/kotlin/routes/repository/GetAvailableSecretsByRepositoryId.kt
+++ b/components/secrets/backend/src/main/kotlin/routes/repository/GetAvailableSecretsByRepositoryId.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.components.secrets.routes.repository
+
+import io.github.smiley4.ktoropenapi.get
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+
+import org.eclipse.apoapsis.ortserver.components.authorization.permissions.RepositoryPermission
+import org.eclipse.apoapsis.ortserver.components.authorization.requirePermission
+import org.eclipse.apoapsis.ortserver.components.secrets.Secret
+import org.eclipse.apoapsis.ortserver.components.secrets.mapToApi
+import org.eclipse.apoapsis.ortserver.services.RepositoryService
+import org.eclipse.apoapsis.ortserver.services.SecretService
+import org.eclipse.apoapsis.ortserver.shared.ktorutils.jsonBody
+import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireIdParameter
+import org.eclipse.apoapsis.ortserver.shared.ktorutils.standardListQueryParameters
+
+internal fun Route.getAvailableSecretsByRepositoryId(
+    repositoryService: RepositoryService,
+    secretService: SecretService
+) = get("/repositories/{repositoryId}/availableSecrets", {
+    operationId = "GetAvailableSecretsByRepositoryId"
+    summary = "Get all available secrets for a repository"
+    description = "Get all secrets that are available in the context of the provided repository. In addition to " +
+            "the repository secrets, this includes secrets from the product and organization the repository " +
+            "belongs to."
+    tags = listOf("Repositories")
+
+    request {
+        pathParameter<Long>("repositoryId") {
+            description = "The ID of the repository."
+        }
+        standardListQueryParameters()
+    }
+
+    response {
+        HttpStatusCode.OK to {
+            description = "Success"
+            jsonBody<List<Secret>> {
+                example("Get all available secrets for a repository") {
+                    value = listOf(
+                        Secret(name = "USERNAME-SECRET", description = "The username."),
+                        Secret(name = "PASSWORD-SECRET", description = "The password.")
+                    )
+                }
+            }
+        }
+    }
+}) {
+    requirePermission(RepositoryPermission.READ)
+
+    val repositoryId = call.requireIdParameter("repositoryId")
+
+    val hierarchy = repositoryService.getHierarchy(repositoryId)
+    val secrets = secretService.listForHierarchy(hierarchy)
+
+    call.respond(HttpStatusCode.OK, secrets.map { it.mapToApi() })
+}

--- a/components/secrets/backend/src/test/kotlin/routes/repository/GetAvailableSecretsByRepositoryIdIntegrationTest.kt
+++ b/components/secrets/backend/src/test/kotlin/routes/repository/GetAvailableSecretsByRepositoryIdIntegrationTest.kt
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.components.secrets.routes.repository
+
+import io.kotest.assertions.ktor.client.shouldHaveStatus
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.should
+
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+
+import org.eclipse.apoapsis.ortserver.components.secrets.Secret
+import org.eclipse.apoapsis.ortserver.components.secrets.SecretsIntegrationTest
+import org.eclipse.apoapsis.ortserver.components.secrets.mapToApi
+import org.eclipse.apoapsis.ortserver.components.secrets.routes.createOrganizationSecret
+import org.eclipse.apoapsis.ortserver.components.secrets.routes.createProductSecret
+import org.eclipse.apoapsis.ortserver.components.secrets.routes.createRepositorySecret
+
+class GetAvailableSecretsByRepositoryIdIntegrationTest : SecretsIntegrationTest({
+    var organizationId = 0L
+    var productId = 0L
+    var repoId = 0L
+
+    beforeEach {
+        organizationId = dbExtension.fixtures.organization.id
+        productId = dbExtension.fixtures.product.id
+        repoId = dbExtension.fixtures.repository.id
+    }
+
+    "GetAvailableSecretsByRepositoryId" should {
+        "return all secrets from the hierarchy" {
+            secretsTestApplication { client ->
+                val secret1 =
+                    secretRepository.createOrganizationSecret(organizationId, "path1", "name1", "description1")
+                val secret2 = secretRepository.createProductSecret(productId, "path2", "name2", "description2")
+                val secret3 = secretRepository.createRepositorySecret(repoId, "path3", "name3", "description3")
+
+                val response = client.get("/repositories/$repoId/availableSecrets")
+
+                response shouldHaveStatus HttpStatusCode.OK
+                response.body<List<Secret>>() should containExactlyInAnyOrder(
+                    secret1.mapToApi(),
+                    secret2.mapToApi(),
+                    secret3.mapToApi()
+                )
+            }
+        }
+    }
+})

--- a/core/src/main/kotlin/di/Module.kt
+++ b/core/src/main/kotlin/di/Module.kt
@@ -113,9 +113,9 @@ import org.ossreviewtoolkit.scanner.utils.FileListResolver
 
 /**
  * Creates the Koin module for the ORT server. The [config] is used to configure the application and the database. For
- * integration tests, the [database][db] from the testcontainer can be provided directly.
+ * integration tests, the [database][db] from the testcontainer and an [authorizationService] can be provided directly.
  */
-fun ortServerModule(config: ApplicationConfig, db: Database?) = module {
+fun ortServerModule(config: ApplicationConfig, db: Database?, authorizationService: AuthorizationService?) = module {
     single { config }
     single { ConfigFactory.parseMap(config.toMap()) }
     singleOf(ConfigManager::create)
@@ -194,9 +194,13 @@ fun ortServerModule(config: ApplicationConfig, db: Database?) = module {
     singleOf(::SecretService)
     singleOf(::VulnerabilityService)
 
-    single<AuthorizationService> {
-        val keycloakGroupPrefix = get<ApplicationConfig>().tryGetString("keycloak.groupPrefix").orEmpty()
-        KeycloakAuthorizationService(get(), get(), get(), get(), get(), keycloakGroupPrefix)
+    if (authorizationService != null) {
+        single<AuthorizationService> { authorizationService }
+    } else {
+        single<AuthorizationService> {
+            val keycloakGroupPrefix = get<ApplicationConfig>().tryGetString("keycloak.groupPrefix").orEmpty()
+            KeycloakAuthorizationService(get(), get(), get(), get(), get(), keycloakGroupPrefix)
+        }
     }
 
     single<UserService> {

--- a/core/src/main/kotlin/plugins/Koin.kt
+++ b/core/src/main/kotlin/plugins/Koin.kt
@@ -23,15 +23,16 @@ import io.ktor.server.application.Application
 import io.ktor.server.application.install
 
 import org.eclipse.apoapsis.ortserver.core.di.ortServerModule
+import org.eclipse.apoapsis.ortserver.services.AuthorizationService
 
 import org.jetbrains.exposed.sql.Database
 
 import org.koin.ktor.plugin.Koin
 
-fun Application.configureKoin(db: Database? = null) {
+fun Application.configureKoin(db: Database? = null, authorizationService: AuthorizationService? = null) {
     install(Koin) {
         modules(
-            ortServerModule(environment.config, db)
+            ortServerModule(environment.config, db, authorizationService)
         )
     }
 }

--- a/core/src/main/kotlin/plugins/Routing.kt
+++ b/core/src/main/kotlin/plugins/Routing.kt
@@ -54,7 +54,7 @@ fun Application.configureRouting() {
                 products()
                 repositories()
                 runs()
-                secretsRoutes(get())
+                secretsRoutes(get(), get())
                 versions()
             }
         }

--- a/core/src/test/kotlin/ApplicationTest.kt
+++ b/core/src/test/kotlin/ApplicationTest.kt
@@ -21,6 +21,8 @@ package org.eclipse.apoapsis.ortserver.core
 
 import io.ktor.server.application.Application
 
+import io.mockk.mockk
+
 import org.eclipse.apoapsis.ortserver.components.authorization.configureAuthentication
 import org.eclipse.apoapsis.ortserver.core.plugins.*
 import org.eclipse.apoapsis.ortserver.core.testutils.configureTestAuthentication
@@ -41,7 +43,7 @@ fun main(args: Array<String>) = io.ktor.server.netty.EngineMain.main(args)
  *                   authentication which is always valid.
  */
 fun Application.testModule(db: Database) {
-    configureKoin(db)
+    configureKoin(db, authorizationService = mockk())
     configureTestAuthentication()
     configureStatusPages()
     configureRouting()

--- a/services/hierarchy/src/main/kotlin/RepositoryService.kt
+++ b/services/hierarchy/src/main/kotlin/RepositoryService.kt
@@ -25,6 +25,7 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.advisorjob.AdvisorJobsTab
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerjob.AnalyzerJobsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.evaluatorjob.EvaluatorJobsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.ortrun.OrtRunsTable
+import org.eclipse.apoapsis.ortserver.model.Hierarchy
 import org.eclipse.apoapsis.ortserver.model.JobStatus
 import org.eclipse.apoapsis.ortserver.model.Jobs
 import org.eclipse.apoapsis.ortserver.model.OrtRun
@@ -96,6 +97,11 @@ class RepositoryService(
         val reporterJob = reporterJobRepository.getForOrtRun(ortRun.id)
         val notifierJob = notifierJobRepository.getForOrtRun(ortRun.id)
         Jobs(analyzerJob, advisorJob, scannerJob, evaluatorJob, reporterJob, notifierJob)
+    }
+
+    /** Get the [Hierarchy] for the provided [repository][repositoryId]. */
+    suspend fun getHierarchy(repositoryId: Long): Hierarchy = db.dbQuery {
+        repositoryRepository.getHierarchy(repositoryId)
     }
 
     suspend fun getOrtRun(repositoryId: Long, ortRunIndex: Long): OrtRun? = db.dbQuery {

--- a/services/hierarchy/src/test/kotlin/RepositoryServiceTest.kt
+++ b/services/hierarchy/src/test/kotlin/RepositoryServiceTest.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.apoapsis.ortserver.services
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -36,6 +37,7 @@ import org.eclipse.apoapsis.ortserver.dao.test.Fixtures
 import org.eclipse.apoapsis.ortserver.model.JobStatus
 import org.eclipse.apoapsis.ortserver.model.util.asPresent
 
+import org.jetbrains.exposed.dao.exceptions.EntityNotFoundException
 import org.jetbrains.exposed.sql.Database
 
 class RepositoryServiceTest : WordSpec({
@@ -135,6 +137,26 @@ class RepositoryServiceTest : WordSpec({
             val service = createService()
 
             service.getJobs(fixtures.repository.id, -1L) should beNull()
+        }
+    }
+
+    "getHierarchy" should {
+        "return the hierarchy of the repository" {
+            val service = createService()
+
+            service.getHierarchy(fixtures.repository.id).shouldNotBeNull {
+                organization.id shouldBe fixtures.organization.id
+                product.id shouldBe fixtures.product.id
+                repository.id shouldBe fixtures.repository.id
+            }
+        }
+
+        "throw an exception if the repository does not exist" {
+            val service = createService()
+
+            shouldThrow<EntityNotFoundException> {
+                service.getHierarchy(9999)
+            }
         }
     }
 

--- a/services/secret/build.gradle.kts
+++ b/services/secret/build.gradle.kts
@@ -35,6 +35,9 @@ dependencies {
 
     runtimeOnly(libs.logback)
 
+    testImplementation(testFixtures(projects.dao))
+    testImplementation(testFixtures(projects.secrets.secretsSpi))
+
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
 }

--- a/services/secret/src/main/kotlin/SecretService.kt
+++ b/services/secret/src/main/kotlin/SecretService.kt
@@ -20,7 +20,11 @@
 package org.eclipse.apoapsis.ortserver.services
 
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
+import org.eclipse.apoapsis.ortserver.model.Hierarchy
 import org.eclipse.apoapsis.ortserver.model.HierarchyId
+import org.eclipse.apoapsis.ortserver.model.OrganizationId
+import org.eclipse.apoapsis.ortserver.model.ProductId
+import org.eclipse.apoapsis.ortserver.model.RepositoryId
 import org.eclipse.apoapsis.ortserver.model.Secret
 import org.eclipse.apoapsis.ortserver.model.repositories.InfrastructureServiceRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.SecretRepository
@@ -82,6 +86,33 @@ class SecretService(
      */
     suspend fun getSecretByIdAndName(id: HierarchyId, name: String): Secret? = db.dbQuery {
         secretRepository.getByIdAndName(id, name)
+    }
+
+    /**
+     * List all secrets for the provided [hierarchy]. If there are secrets with the same name in different levels of the
+     * hierarchy, only the one closest to the repository is returned.
+     */
+    suspend fun listForHierarchy(
+        hierarchy: Hierarchy
+    ): List<Secret> = db.dbQuery {
+        val parameters = ListQueryParameters(limit = Integer.MAX_VALUE)
+        val organizationSecrets = secretRepository.listForId(OrganizationId(hierarchy.organization.id), parameters)
+        val productSecrets = secretRepository.listForId(ProductId(hierarchy.product.id), parameters)
+        val repositorySecrets = secretRepository.listForId(RepositoryId(hierarchy.repository.id), parameters)
+
+        val secretNames = mutableSetOf<String>()
+
+        buildList {
+            addAll(repositorySecrets.data)
+            secretNames.addAll(repositorySecrets.data.map { it.name })
+
+            productSecrets.data.filterNot { it.name in secretNames }.let { filteredProductSecrets ->
+                addAll(filteredProductSecrets)
+                secretNames.addAll(filteredProductSecrets.map { it.name })
+            }
+
+            addAll(organizationSecrets.data.filterNot { it.name in secretNames })
+        }
     }
 
     /**

--- a/services/secret/src/test/kotlin/SecretServiceTest.kt
+++ b/services/secret/src/test/kotlin/SecretServiceTest.kt
@@ -1,0 +1,196 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.services
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.nulls.beNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
+import org.eclipse.apoapsis.ortserver.dao.test.Fixtures
+import org.eclipse.apoapsis.ortserver.model.Hierarchy
+import org.eclipse.apoapsis.ortserver.model.OrganizationId
+import org.eclipse.apoapsis.ortserver.model.ProductId
+import org.eclipse.apoapsis.ortserver.model.RepositoryId
+import org.eclipse.apoapsis.ortserver.secrets.SecretStorage
+import org.eclipse.apoapsis.ortserver.secrets.SecretsProviderFactoryForTesting
+
+import org.jetbrains.exposed.sql.Database
+
+class SecretServiceTest : WordSpec({
+    val dbExtension = extension(DatabaseTestExtension())
+
+    lateinit var db: Database
+    lateinit var fixtures: Fixtures
+    lateinit var secretService: SecretService
+
+    beforeEach {
+        db = dbExtension.db
+        fixtures = dbExtension.fixtures
+        secretService = SecretService(
+            db,
+            fixtures.secretRepository,
+            fixtures.infrastructureServiceRepository,
+            SecretStorage(SecretsProviderFactoryForTesting().createProvider())
+        )
+    }
+
+    "listForHierarchy" should {
+        "return an empty list if there are no secrets" {
+            val hierarchy = Hierarchy(
+                repository = fixtures.repository,
+                product = fixtures.product,
+                organization = fixtures.organization
+            )
+
+            secretService.listForHierarchy(hierarchy) should beEmpty()
+        }
+
+        "return secrets from all levels of the hierarchy" {
+            val hierarchy = Hierarchy(
+                repository = fixtures.repository,
+                product = fixtures.product,
+                organization = fixtures.organization
+            )
+
+            secretService.createSecret(
+                "organizationSecret",
+                "value",
+                "description",
+                OrganizationId(hierarchy.organization.id)
+            )
+            secretService.createSecret(
+                "productSecret",
+                "value",
+                "description",
+                ProductId(fixtures.product.id)
+            )
+            secretService.createSecret(
+                "repositorySecret",
+                "value",
+                "description",
+                RepositoryId(fixtures.repository.id)
+            )
+
+            secretService.listForHierarchy(hierarchy).map { it.name } should
+                    containExactlyInAnyOrder("organizationSecret", "productSecret", "repositorySecret")
+        }
+
+        "resolve conflicts for secrets with the same name correctly" {
+            val hierarchy = Hierarchy(
+                repository = fixtures.repository,
+                product = fixtures.product,
+                organization = fixtures.organization
+            )
+
+            // Create a secret on all levels.
+            secretService.createSecret(
+                "secret1",
+                "value",
+                "description",
+                OrganizationId(hierarchy.organization.id)
+            )
+            secretService.createSecret(
+                "secret1",
+                "value",
+                "description",
+                ProductId(hierarchy.organization.id)
+            )
+            secretService.createSecret(
+                "secret1",
+                "value",
+                "description",
+                RepositoryId(hierarchy.organization.id)
+            )
+
+            // Create a secret on organization and product levels.
+            secretService.createSecret(
+                "secret2",
+                "value",
+                "description",
+                OrganizationId(hierarchy.organization.id)
+            )
+            secretService.createSecret(
+                "secret2",
+                "value",
+                "description",
+                ProductId(hierarchy.product.id)
+            )
+
+            // Create a secret on organization and repository levels.
+            secretService.createSecret(
+                "secret3",
+                "value",
+                "description",
+                OrganizationId(hierarchy.organization.id)
+            )
+            secretService.createSecret(
+                "secret3",
+                "value",
+                "description",
+                RepositoryId(hierarchy.repository.id)
+            )
+
+            // Create a secret on product and repository levels.
+            secretService.createSecret(
+                "secret4",
+                "value",
+                "description",
+                ProductId(hierarchy.product.id)
+            )
+            secretService.createSecret(
+                "secret4",
+                "value",
+                "description",
+                RepositoryId(hierarchy.repository.id)
+            )
+
+            val secrets = secretService.listForHierarchy(hierarchy)
+
+            secrets.find { it.name == "secret1" }.shouldNotBeNull {
+                organization should beNull()
+                product should beNull()
+                repository shouldBe hierarchy.repository
+            }
+
+            secrets.find { it.name == "secret2" }.shouldNotBeNull {
+                organization should beNull()
+                product shouldBe hierarchy.product
+                repository should beNull()
+            }
+
+            secrets.find { it.name == "secret3" }.shouldNotBeNull {
+                organization should beNull()
+                product should beNull()
+                repository shouldBe hierarchy.repository
+            }
+
+            secrets.find { it.name == "secret4" }.shouldNotBeNull {
+                organization should beNull()
+                product should beNull()
+                repository shouldBe hierarchy.repository
+            }
+        }
+    }
+})


### PR DESCRIPTION
Add a route that returns all available secrets in the context of a repository. This will be used to implement drop-downs to select secrets when triggering a run via the UI.