### PR TITLE
feat(ui): Add inputs for `keepAliveWorker` flags

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/advisor-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/advisor-fields.tsx
@@ -41,6 +41,7 @@ type AdvisorFieldsProps = {
   value: string;
   onToggle: () => void;
   advisorPlugins: PreconfiguredPluginDescriptor[];
+  isSuperuser: boolean;
 };
 
 export const AdvisorFields = ({
@@ -48,6 +49,7 @@ export const AdvisorFields = ({
   value,
   onToggle,
   advisorPlugins,
+  isSuperuser,
 }: AdvisorFieldsProps) => {
   const advisorOptions = advisorPlugins.map((plugin) => ({
     id: plugin.id,
@@ -101,6 +103,30 @@ export const AdvisorFields = ({
             description={<>Select the advisors enabled for this run.</>}
             options={advisorOptions}
           />
+          {isSuperuser && (
+            <FormField
+              control={form.control}
+              name='jobConfigs.advisor.keepAliveWorker'
+              render={({ field }) => (
+                <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
+                  <div className='space-y-0.5'>
+                    <FormLabel>Keep worker alive</FormLabel>
+                    <FormDescription>
+                      A flag to control whether the worker is kept alive for
+                      debugging purposes. This flag only has an effect if the
+                      ORT Server is deployed on Kubernetes.
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          )}
         </AccordionContent>
       </AccordionItem>
     </div>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
@@ -44,12 +44,14 @@ type AnalyzerFieldsProps = {
   form: UseFormReturn<CreateRunFormValues>;
   value: string;
   onToggle: () => void;
+  isSuperuser: boolean;
 };
 
 export const AnalyzerFields = ({
   form,
   value,
   onToggle,
+  isSuperuser,
 }: AnalyzerFieldsProps) => {
   const {
     fields: environmentVariablesFields,
@@ -216,6 +218,30 @@ export const AnalyzerFields = ({
             </Button>
           </div>
           <PackageManagerField form={form} />
+          {isSuperuser && (
+            <FormField
+              control={form.control}
+              name='jobConfigs.analyzer.keepAliveWorker'
+              render={({ field }) => (
+                <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
+                  <div className='space-y-0.5'>
+                    <FormLabel>Keep worker alive</FormLabel>
+                    <FormDescription>
+                      A flag to control whether the worker is kept alive for
+                      debugging purposes. This flag only has an effect if the
+                      ORT Server is deployed on Kubernetes.
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          )}
         </AccordionContent>
       </AccordionItem>
     </div>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/evaluator-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/evaluator-fields.tsx
@@ -19,16 +19,35 @@
 
 import { UseFormReturn } from 'react-hook-form';
 
-import { FormControl, FormField } from '@/components/ui/form';
+import {
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion.tsx';
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+} from '@/components/ui/form';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { CreateRunFormValues } from '../_repo-layout/create-run/-create-run-utils';
 
 type EvaluatorFieldsProps = {
   form: UseFormReturn<CreateRunFormValues>;
+  value: string;
+  onToggle: () => void;
+  isSuperuser: boolean;
 };
 
-export const EvaluatorFields = ({ form }: EvaluatorFieldsProps) => {
+export const EvaluatorFields = ({
+  form,
+  value,
+  onToggle,
+  isSuperuser,
+}: EvaluatorFieldsProps) => {
   return (
     <div className='flex flex-row align-middle'>
       <FormField
@@ -36,18 +55,49 @@ export const EvaluatorFields = ({ form }: EvaluatorFieldsProps) => {
         name='jobConfigs.evaluator.enabled'
         render={({ field }) => (
           <FormControl>
-            <div className='flex items-center space-x-2'>
+            <>
               <Switch
                 className='my-4 mr-4 data-[state=checked]:bg-green-500'
                 checked={field.value}
                 onCheckedChange={field.onChange}
                 id='evaluator-enabled-switch'
               />
-              <Label htmlFor='evaluator-enabled-switch'>Evaluator</Label>
-            </div>
+              {!isSuperuser && (
+                <Label htmlFor='evaluator-enabled-switch'>Evaluator</Label>
+              )}
+            </>
           </FormControl>
         )}
       />
+      {isSuperuser && (
+        <AccordionItem value={value} className='flex-1'>
+          <AccordionTrigger onClick={onToggle}>Evaluator</AccordionTrigger>
+          <AccordionContent>
+            <FormField
+              control={form.control}
+              name='jobConfigs.evaluator.keepAliveWorker'
+              render={({ field }) => (
+                <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
+                  <div className='space-y-0.5'>
+                    <FormLabel>Keep worker alive</FormLabel>
+                    <FormDescription>
+                      A flag to control whether the worker is kept alive for
+                      debugging purposes. This flag only has an effect if the
+                      ORT Server is deployed on Kubernetes.
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          </AccordionContent>
+        </AccordionItem>
+      )}
     </div>
   );
 };

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/notifier-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/notifier-fields.tsx
@@ -28,6 +28,7 @@ import {
 import { Button } from '@/components/ui/button';
 import {
   FormControl,
+  FormDescription,
   FormField,
   FormItem,
   FormLabel,
@@ -42,12 +43,14 @@ type NotifierFieldsProps = {
   form: UseFormReturn<CreateRunFormValues>;
   value: string;
   onToggle: () => void;
+  isSuperuser: boolean;
 };
 
 export const NotifierFields = ({
   form,
   value,
   onToggle,
+  isSuperuser,
 }: NotifierFieldsProps) => {
   const { fields, append, remove } = useFieldArray({
     name: 'jobConfigs.notifier.recipientAddresses',
@@ -119,6 +122,30 @@ export const NotifierFields = ({
             Add recipient address
             <PlusIcon className='ml-1 h-4 w-4' />
           </Button>
+          {isSuperuser && (
+            <FormField
+              control={form.control}
+              name='jobConfigs.notifier.keepAliveWorker'
+              render={({ field }) => (
+                <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
+                  <div className='space-y-0.5'>
+                    <FormLabel>Keep worker alive</FormLabel>
+                    <FormDescription>
+                      A flag to control whether the worker is kept alive for
+                      debugging purposes. This flag only has an effect if the
+                      ORT Server is deployed on Kubernetes.
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          )}
         </AccordionContent>
       </AccordionItem>
     </div>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/reporter-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/reporter-fields.tsx
@@ -41,6 +41,7 @@ type ReporterFieldsProps = {
   value: string;
   onToggle: () => void;
   reporterPlugins: PreconfiguredPluginDescriptor[];
+  isSuperuser: boolean;
 };
 
 export const ReporterFields = ({
@@ -48,6 +49,7 @@ export const ReporterFields = ({
   value,
   onToggle,
   reporterPlugins,
+  isSuperuser,
 }: ReporterFieldsProps) => {
   const reporterOptions = reporterPlugins.map((plugin) => ({
     id: plugin.id,
@@ -101,6 +103,30 @@ export const ReporterFields = ({
                     <FormDescription>
                       NOTE: This option is currently effective only for the
                       WebApp report format.
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          )}
+          {isSuperuser && (
+            <FormField
+              control={form.control}
+              name='jobConfigs.reporter.keepAliveWorker'
+              render={({ field }) => (
+                <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
+                  <div className='space-y-0.5'>
+                    <FormLabel>Keep worker alive</FormLabel>
+                    <FormDescription>
+                      A flag to control whether the worker is kept alive for
+                      debugging purposes. This flag only has an effect if the
+                      ORT Server is deployed on Kubernetes.
                     </FormDescription>
                   </div>
                   <FormControl>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/scanner-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/scanner-fields.tsx
@@ -38,12 +38,14 @@ type ScannerFieldsProps = {
   form: UseFormReturn<CreateRunFormValues>;
   value: string;
   onToggle: () => void;
+  isSuperuser: boolean;
 };
 
 export const ScannerFields = ({
   form,
   value,
   onToggle,
+  isSuperuser,
 }: ScannerFieldsProps) => {
   return (
     <div className='flex flex-row align-middle'>
@@ -106,6 +108,30 @@ export const ScannerFields = ({
               </FormItem>
             )}
           />
+          {isSuperuser && (
+            <FormField
+              control={form.control}
+              name='jobConfigs.scanner.keepAliveWorker'
+              render={({ field }) => (
+                <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
+                  <div className='space-y-0.5'>
+                    <FormLabel>Keep worker alive</FormLabel>
+                    <FormDescription>
+                      A flag to control whether the worker is kept alive for
+                      debugging purposes. This flag only has an effect if the
+                      ORT Server is deployed on Kubernetes.
+                    </FormDescription>
+                  </div>
+                  <FormControl>
+                    <Switch
+                      checked={field.value}
+                      onCheckedChange={field.onChange}
+                    />
+                  </FormControl>
+                </FormItem>
+              )}
+            />
+          )}
         </AccordionContent>
       </AccordionItem>
     </div>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -51,6 +51,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
+import { useUser } from '@/hooks/use-user.ts';
 import { toast } from '@/lib/toast';
 import { AdvisorFields } from '../../-components/advisor-fields';
 import { AnalyzerFields } from '../../-components/analyzer-fields';
@@ -71,6 +72,8 @@ const CreateRunPage = () => {
   const params = Route.useParams();
   const { ortRun, plugins } = Route.useLoaderData();
   const [isTest, setIsTest] = useState(false);
+  const user = useUser();
+  const isSuperuser = user.hasRole(['superuser']);
 
   const advisorPlugins =
     plugins?.filter((plugin) => plugin.type === 'ADVISOR') || [];
@@ -126,7 +129,7 @@ const CreateRunPage = () => {
 
   const form = useForm({
     resolver: zodResolver(createRunFormSchema),
-    defaultValues: defaultValues(ortRun),
+    defaultValues: defaultValues(ortRun, isSuperuser),
   });
 
   const {
@@ -419,29 +422,39 @@ const CreateRunPage = () => {
                 form={form}
                 value='analyzer'
                 onToggle={() => toggleAccordionOpen('analyzer')}
+                isSuperuser={isSuperuser}
               />
               <AdvisorFields
                 form={form}
                 value='advisor'
                 onToggle={() => toggleAccordionOpen('advisor')}
                 advisorPlugins={advisorPlugins}
+                isSuperuser={isSuperuser}
               />
               <ScannerFields
                 form={form}
                 value='scanner'
                 onToggle={() => toggleAccordionOpen('scanner')}
+                isSuperuser={isSuperuser}
               />
-              <EvaluatorFields form={form} />
+              <EvaluatorFields
+                form={form}
+                value='evaluator'
+                onToggle={() => toggleAccordionOpen('evaluator')}
+                isSuperuser={isSuperuser}
+              />
               <ReporterFields
                 form={form}
                 value='reporter'
                 onToggle={() => toggleAccordionOpen('reporter')}
                 reporterPlugins={reporterPlugins}
+                isSuperuser={isSuperuser}
               />
               <NotifierFields
                 form={form}
                 value='notifier'
                 onToggle={() => toggleAccordionOpen('notifier')}
+                isSuperuser={isSuperuser}
               />
             </Accordion>
           </CardContent>


### PR DESCRIPTION
Add inputs for the `keepAliveWorker` flags for each job when creating an ORT run. The inputs are only shown for superusers because only they can use the flags.