### PR TITLE
fix: Adjust timestamp precision for database compatibility

### DIFF
--- a/dao/src/main/kotlin/tables/ScanSummariesIssuesTable.kt
+++ b/dao/src/main/kotlin/tables/ScanSummariesIssuesTable.kt
@@ -21,6 +21,7 @@ package org.eclipse.apoapsis.ortserver.dao.tables
 
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IssueDao
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IssuesTable
+import org.eclipse.apoapsis.ortserver.dao.utils.transformToDatabasePrecision
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
 
 import org.jetbrains.exposed.dao.LongEntity
@@ -53,7 +54,7 @@ class ScanSummariesIssuesDao(id: EntityID<Long>) : LongEntity(id) {
 
     var scanSummary by ScanSummaryDao referencedOn ScanSummariesIssuesTable.scanSummaryId
     var issue by IssueDao referencedOn ScanSummariesIssuesTable.issueId
-    var timestamp by ScanSummariesIssuesTable.timestamp
+    var timestamp by ScanSummariesIssuesTable.timestamp.transformToDatabasePrecision()
 
     /**
      * Map this DAO to an [Issue].

--- a/dao/src/test/kotlin/tables/ScanSummariesIssuesTableTest.kt
+++ b/dao/src/test/kotlin/tables/ScanSummariesIssuesTableTest.kt
@@ -44,7 +44,7 @@ class ScanSummariesIssuesTableTest : WordSpec() {
             "create an entity for an issue" {
                 val summary = createScanSummary()
                 val issue = Issue(
-                    timestamp = Instant.parse("2024-10-18T05:56:06Z"),
+                    timestamp = Instant.parse("2024-10-18T05:56:06.123455Z"),
                     source = "test",
                     message = "Some test issue",
                     severity = Severity.WARNING,
@@ -59,6 +59,8 @@ class ScanSummariesIssuesTableTest : WordSpec() {
                     ScanSummariesIssuesDao.all().toList() shouldContainExactlyInAnyOrder listOf(newEntity)
 
                     val expectedIssue = issue.copy(
+                        // Check if the timestamp is normalized to the database precision.
+                        timestamp = Instant.parse("2024-10-18T05:56:06Z"),
                         identifier = null,
                         worker = null
                     )


### PR DESCRIPTION
This commit normalizes timestamp precision to standard one used in ORT. Precision problem is caused by conversion between Java and Kotlin Instant type. Higher precision (nanosecons) has been introduced in Java 15 [1].

[1] https://bugs.openjdk.org/browse/JDK-8242504