### PR TITLE
build(gradle): Remove the Jakarta migration plugin

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,7 +25,6 @@ buildConfigPlugin = "5.6.7"
 dependencyAnalysisPlugin = "2.19.0"
 detektPlugin = "1.23.8"
 gitSemverPlugin = "0.16.1"
-jakartaMigrationPlugin = "0.25.0"
 jibPlugin = "3.4.5"
 kotlinPlugin = "2.2.0"
 kotlinxCoroutines = "1.10.2"
@@ -80,7 +79,6 @@ wiremock = "3.0.1"
 [plugins]
 buildConfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildConfigPlugin" }
 gitSemver = { id = "com.github.jmongard.git-semver-plugin", version.ref = "gitSemverPlugin" }
-jakartaMigration = { id = "com.netflix.nebula.jakartaee-migration", version.ref = "jakartaMigrationPlugin" }
 jib = { id = "com.google.cloud.tools.jib", version.ref = "jibPlugin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinPlugin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "kspPlugin" }

--- a/workers/notifier/build.gradle.kts
+++ b/workers/notifier/build.gradle.kts
@@ -33,13 +33,7 @@ plugins {
     id("ort-server-publication-conventions")
 
     // Apply third-party plugins.
-    alias(libs.plugins.jakartaMigration)
     alias(libs.plugins.jib)
-}
-
-jakartaeeMigration {
-    includeTransform("com.atlassian.jira:jira-rest-java-client-core")
-    configurations.filterNot { it.isCanBeDeclared }.forEach(::transform)
 }
 
 group = "org.eclipse.apoapsis.ortserver.workers"


### PR DESCRIPTION
This should not be required anymore as of jira-rest-java-client version 7, see [1].

[1]: https://bitbucket.org/atlassian/jira-rest-java-client/commits/c313359cd8205e5ca724a3a8dad9d03baf494505