### PR TITLE
ui: Tweak the main layout

### DIFF
--- a/ui/src/components/data-table/data-table-header.tsx
+++ b/ui/src/components/data-table/data-table-header.tsx
@@ -99,7 +99,8 @@ export function DataTableHeader<TData>({
                   >
                     <Button
                       variant='ghost'
-                      className='px-1'
+                      size='narrow'
+                      className='ml-4'
                       onClick={column.getToggleSortingHandler()}
                     >
                       {column.getIsSorted() === 'asc' ? (
@@ -131,9 +132,9 @@ export function DataTableHeader<TData>({
                 colSpan={header.colSpan}
               >
                 {header.isPlaceholder ? null : (
-                  <div className='flex items-center gap-2'>
+                  <div className='flex items-center'>
                     {flexRender(column.columnDef.header, header.getContext())}
-                    <div className='flex items-center gap-1'>
+                    <div className='flex items-center'>
                       {groupingEnabled &&
                       setGroupingOptions &&
                       column.getCanGroup()

--- a/ui/src/components/data-table/filter-multi-select.tsx
+++ b/ui/src/components/data-table/filter-multi-select.tsx
@@ -59,7 +59,7 @@ export function FilterMultiSelect<TValue>({
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button variant='ghost' size='sm' className='px-1'>
+        <Button variant='ghost' size='narrow'>
           <Filter
             className={cn(
               selected.length > 0 ? 'text-blue-500' : undefined,

--- a/ui/src/components/data-table/filter-text.tsx
+++ b/ui/src/components/data-table/filter-text.tsx
@@ -53,7 +53,7 @@ export function FilterText({
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button variant='ghost' className='px-1'>
+        <Button variant='ghost' size='narrow'>
           <Filter
             className={cn(value.length > 0 && 'text-blue-500', 'h-4 w-4')}
           />

--- a/ui/src/components/page-layout.tsx
+++ b/ui/src/components/page-layout.tsx
@@ -45,7 +45,7 @@ export const PageLayout = ({
             <Sidebar sections={sections} />
           </Pane>
         )}
-        <Content className='w-full md:max-w-5xl'>{children}</Content>
+        <Content className='w-full md:max-w-6xl'>{children}</Content>
       </Page>
     </>
   );

--- a/ui/src/components/ui/button-variants.ts
+++ b/ui/src/components/ui/button-variants.ts
@@ -28,6 +28,7 @@ export const buttonVariants = cva(
       },
       size: {
         default: 'h-9 px-4 py-2 has-[>svg]:px-3',
+        narrow: 'h-8 rounded-md px-1.5 has-[>svg]:px-1',
         sm: 'h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5',
         lg: 'h-10 rounded-md px-6 has-[>svg]:px-4',
         icon: 'size-9',


### PR DESCRIPTION
This PR includes some minor modifications to the main layout and tables:
- action buttons in table headers are moved  more closely together
- main layout is made a bit wider to prevent horizontal overflow of some tables

<img width="1586" height="746" alt="Screenshot from 2025-08-07 08-10-40" src="https://github.com/user-attachments/assets/b04feaa1-c790-4f88-9ffa-0d7d688502ea" />

Please see the commits for details.