### PR TITLE
fix(scanner): Account issues from failed scans to job status

### DIFF
--- a/workers/scanner/src/main/kotlin/scanner/ScannerWorker.kt
+++ b/workers/scanner/src/main/kotlin/scanner/ScannerWorker.kt
@@ -94,7 +94,9 @@ class ScannerWorker(
                 )
             }
 
-            if (issues.any { it.severity >= Severity.WARNING }) {
+            val allIssues = issues + scannerRunResult.scannerRun.issues.values.flatten().map { it.mapToModel() }
+
+            if (allIssues.any { it.severity >= Severity.WARNING }) {
                 RunResult.FinishedWithIssues
             } else {
                 RunResult.Success


### PR DESCRIPTION
Take the issues from `ScannerRun` into account when determining the job status.