### PR TITLE
ui: Wrap Package ID around ":" and "::" where needed

### DIFF
--- a/ui/src/components/breakable-string.tsx
+++ b/ui/src/components/breakable-string.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { Fragment } from 'react';
+
+import { cn } from '@/lib/utils';
+
+type BreakableStringProps = {
+  text: string;
+  className?: string;
+};
+
+export const BreakableString = ({ text, className }: BreakableStringProps) => {
+  const parts = text.split(/(:+)/g); // Split by ':' or '::', keeping delimiters
+
+  return (
+    <span className={cn('break-words', className)}>
+      {parts.map((part, index) => (
+        <Fragment key={index}>
+          {part}
+          {part.startsWith(':') && <wbr />}
+        </Fragment>
+      ))}
+    </span>
+  );
+};

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues/index.tsx
@@ -37,6 +37,7 @@ import { useRunsServiceGetApiV1RunsByRunIdIssues } from '@/api/queries';
 import { prefetchUseRepositoriesServiceGetApiV1RepositoriesByRepositoryIdRunsByOrtRunIndex } from '@/api/queries/prefetch';
 import { useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdRunsByOrtRunIndexSuspense } from '@/api/queries/suspense';
 import { Issue, Severity } from '@/api/requests';
+import { BreakableString } from '@/components/breakable-string';
 import { DataTable } from '@/components/data-table/data-table';
 import { MarkItems } from '@/components/data-table/mark-items';
 import { FormattedValue } from '@/components/formatted-value';
@@ -293,7 +294,9 @@ const IssuesComponent = () => {
         id: 'packageIdentifier',
         header: 'Package ID',
         cell: ({ getValue }) => {
-          return <div className='font-semibold'>{getValue()}</div>;
+          return (
+            <BreakableString text={getValue()} className='font-semibold' />
+          );
         },
         meta: {
           filter: {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
@@ -38,6 +38,7 @@ import {
   useRunsServiceGetApiV1RunsByRunIdPackagesSuspense,
 } from '@/api/queries/suspense';
 import { Package, RepositoryType } from '@/api/requests';
+import { BreakableString } from '@/components/breakable-string';
 import { DataTable } from '@/components/data-table/data-table';
 import { MarkItems } from '@/components/data-table/mark-items';
 import { DependencyPaths } from '@/components/dependency-paths';
@@ -233,7 +234,9 @@ const PackagesComponent = () => {
         id: `${packageIdType === 'ORT_ID' ? 'identifier' : 'purl'}`,
         header: 'Package ID',
         cell: ({ getValue }) => {
-          return <div className='font-semibold'>{getValue()}</div>;
+          return (
+            <BreakableString text={getValue()} className='font-semibold' />
+          );
         },
         meta: {
           filter: {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
@@ -38,6 +38,7 @@ import { useRunsServiceGetApiV1RunsByRunIdProjects } from '@/api/queries';
 import { prefetchUseRepositoriesServiceGetApiV1RepositoriesByRepositoryIdRunsByOrtRunIndex } from '@/api/queries/prefetch';
 import { useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdRunsByOrtRunIndexSuspense } from '@/api/queries/suspense';
 import { Project, RepositoryType } from '@/api/requests';
+import { BreakableString } from '@/components/breakable-string';
 import { DataTable } from '@/components/data-table/data-table';
 import { MarkItems } from '@/components/data-table/mark-items';
 import { FormattedValue } from '@/components/formatted-value';
@@ -262,7 +263,9 @@ const ProjectsComponent = () => {
         id: 'projectIdentifier',
         header: 'Project ID',
         cell: ({ getValue }) => {
-          return <div className='font-semibold'>{getValue()}</div>;
+          return (
+            <BreakableString text={getValue()} className='font-semibold' />
+          );
         },
         meta: {
           filter: {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
@@ -39,6 +39,7 @@ import {
   useRunsServiceGetApiV1RunsByRunIdRuleViolationsSuspense,
 } from '@/api/queries/suspense';
 import { RuleViolation, Severity } from '@/api/requests';
+import { BreakableString } from '@/components/breakable-string';
 import { DataTable } from '@/components/data-table/data-table';
 import { MarkItems } from '@/components/data-table/mark-items';
 import { FormattedValue } from '@/components/formatted-value';
@@ -260,7 +261,9 @@ const RuleViolationsComponent = () => {
         id: 'packageIdentifier',
         header: 'Package ID',
         cell: ({ getValue }) => {
-          return <div className='font-semibold'>{getValue()}</div>;
+          return (
+            <BreakableString text={getValue()} className='font-semibold' />
+          );
         },
         meta: {
           filter: {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
@@ -40,6 +40,7 @@ import {
   VulnerabilityRating,
   VulnerabilityWithIdentifier,
 } from '@/api/requests';
+import { BreakableString } from '@/components/breakable-string';
 import { VulnerabilityMetrics } from '@/components/charts/vulnerability-metrics';
 import { DataTable } from '@/components/data-table/data-table';
 import { MarkItems } from '@/components/data-table/mark-items';
@@ -320,7 +321,9 @@ const VulnerabilitiesComponent = () => {
         id: 'packageIdentifier',
         header: 'Package ID',
         cell: ({ getValue }) => {
-          return <div className='font-semibold'>{getValue()}</div>;
+          return (
+            <BreakableString text={getValue()} className='font-semibold' />
+          );
         },
         meta: {
           filter: {

--- a/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
@@ -36,6 +36,7 @@ import z from 'zod';
 import { useProductsServiceGetApiV1ProductsByProductIdVulnerabilities } from '@/api/queries';
 import { prefetchUseProductsServiceGetApiV1ProductsByProductId } from '@/api/queries/prefetch';
 import { ProductVulnerability, VulnerabilityRating } from '@/api/requests';
+import { BreakableString } from '@/components/breakable-string';
 import { VulnerabilityMetrics } from '@/components/charts/vulnerability-metrics';
 import { DataTable } from '@/components/data-table/data-table';
 import { MarkItems } from '@/components/data-table/mark-items';
@@ -256,7 +257,9 @@ const ProductVulnerabilitiesComponent = () => {
           id: 'packageIdentifier',
           header: 'Package ID',
           cell: ({ getValue }) => {
-            return <div className='font-semibold'>{getValue()}</div>;
+            return (
+              <BreakableString text={getValue()} className='font-semibold' />
+            );
           },
           meta: {
             filter: {

--- a/ui/src/routes/organizations/$orgId/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/vulnerabilities/index.tsx
@@ -33,6 +33,7 @@ import z from 'zod';
 import { useOrganizationsServiceGetApiV1OrganizationsByOrganizationIdVulnerabilities } from '@/api/queries';
 import { prefetchUseOrganizationsServiceGetApiV1OrganizationsByOrganizationId } from '@/api/queries/prefetch';
 import { OrganizationVulnerability } from '@/api/requests';
+import { BreakableString } from '@/components/breakable-string';
 import { VulnerabilityMetrics } from '@/components/charts/vulnerability-metrics';
 import { DataTable } from '@/components/data-table/data-table';
 import { MarkItems } from '@/components/data-table/mark-items';
@@ -240,9 +241,9 @@ const OrganizationVulnerabilitiesComponent = () => {
         {
           id: 'identifier',
           header: 'Package ID',
-          cell: ({ row }) => {
+          cell: ({ getValue }) => {
             return (
-              <div className='font-semibold'>{row.getValue('identifier')}</div>
+              <BreakableString text={getValue()} className='font-semibold' />
             );
           },
           enableColumnFilter: false,


### PR DESCRIPTION
"Normal" situation with easily word-wrappable Package IDs:

<img width="1070" height="494" alt="Screenshot from 2025-08-08 14-47-45" src="https://github.com/user-attachments/assets/1626739a-276d-45d8-bc21-30e63bbc4f80" />

A Package ID that cannot be word-wrapped with usual supported TailwindCSS classes:

<img width="1144" height="232" alt="Screenshot from 2025-08-08 14-46-56" src="https://github.com/user-attachments/assets/1a3f9238-c7a3-47d8-b86b-372dc95efe94" />


Please see the commits for details.