### PR TITLE
ui: Infrastructure durations

### DIFF
--- a/ui/src/components/charts/job-durations.tsx
+++ b/ui/src/components/charts/job-durations.tsx
@@ -116,41 +116,41 @@ export const JobDurations = ({
 
   const chartData = runs?.data?.map((run) => {
     const analyzerDuration =
-      run.jobs.analyzer?.createdAt && run.jobs.analyzer?.finishedAt
+      run.jobs.analyzer?.startedAt && run.jobs.analyzer?.finishedAt
         ? calculateDuration(
-            run.jobs.analyzer.createdAt,
+            run.jobs.analyzer.startedAt,
             run.jobs.analyzer.finishedAt
           ).durationMs
         : null;
 
     const advisorDuration =
-      run.jobs.advisor?.createdAt && run.jobs.advisor?.finishedAt
+      run.jobs.advisor?.startedAt && run.jobs.advisor?.finishedAt
         ? calculateDuration(
-            run.jobs.advisor.createdAt,
+            run.jobs.advisor.startedAt,
             run.jobs.advisor.finishedAt
           ).durationMs
         : null;
 
     const scannerDuration =
-      run.jobs.scanner?.createdAt && run.jobs.scanner?.finishedAt
+      run.jobs.scanner?.startedAt && run.jobs.scanner?.finishedAt
         ? calculateDuration(
-            run.jobs.scanner.createdAt,
+            run.jobs.scanner.startedAt,
             run.jobs.scanner.finishedAt
           ).durationMs
         : null;
 
     const evaluatorDuration =
-      run.jobs.evaluator?.createdAt && run.jobs.evaluator?.finishedAt
+      run.jobs.evaluator?.startedAt && run.jobs.evaluator?.finishedAt
         ? calculateDuration(
-            run.jobs.evaluator.createdAt,
+            run.jobs.evaluator.startedAt,
             run.jobs.evaluator.finishedAt
           ).durationMs
         : null;
 
     const reporterDuration =
-      run.jobs.reporter?.createdAt && run.jobs.reporter?.finishedAt
+      run.jobs.reporter?.startedAt && run.jobs.reporter?.finishedAt
         ? calculateDuration(
-            run.jobs.reporter.createdAt,
+            run.jobs.reporter.startedAt,
             run.jobs.reporter.finishedAt
           ).durationMs
         : null;

--- a/ui/src/components/charts/job-durations.tsx
+++ b/ui/src/components/charts/job-durations.tsx
@@ -18,7 +18,6 @@
  */
 
 import { useNavigate } from '@tanstack/react-router';
-import { Sigma } from 'lucide-react';
 import { useState } from 'react';
 import { Bar, BarChart, CartesianGrid, XAxis } from 'recharts';
 
@@ -248,10 +247,7 @@ export const JobDurations = ({
                         {index === item.payload.finishedDurations - 1 && (
                           <div className='flex w-full flex-col items-center justify-between'>
                             <div className='flex w-full items-center justify-between'>
-                              <div className='flex items-center gap-1'>
-                                <Sigma className='text-muted-foreground -ml-0.5 size-4 shrink-0' />
-                                <div>Total</div>
-                              </div>
+                              Total run duration:
                               <div className='text-muted-foreground mt-0.5 flex flex-col font-mono text-xs'>
                                 <RunDuration
                                   createdAt={item.payload.createdAt}

--- a/ui/src/components/charts/job-durations.tsx
+++ b/ui/src/components/charts/job-durations.tsx
@@ -42,8 +42,8 @@ import {
 } from '@/components/ui/chart';
 import { config } from '@/config';
 import {
-  calculateDuration,
   convertDurationToHms,
+  getDurationChartData,
 } from '@/helpers/calculate-duration';
 import { toast } from '@/lib/toast';
 
@@ -118,97 +118,7 @@ export const JobDurations = ({
     }
   );
 
-  const chartData = runs?.data?.map((run) => {
-    const analyzerDuration =
-      run.jobs.analyzer?.startedAt && run.jobs.analyzer?.finishedAt
-        ? calculateDuration(
-            run.jobs.analyzer.startedAt,
-            run.jobs.analyzer.finishedAt
-          ).durationMs
-        : null;
-
-    const advisorDuration =
-      run.jobs.advisor?.startedAt && run.jobs.advisor?.finishedAt
-        ? calculateDuration(
-            run.jobs.advisor.startedAt,
-            run.jobs.advisor.finishedAt
-          ).durationMs
-        : null;
-
-    const scannerDuration =
-      run.jobs.scanner?.startedAt && run.jobs.scanner?.finishedAt
-        ? calculateDuration(
-            run.jobs.scanner.startedAt,
-            run.jobs.scanner.finishedAt
-          ).durationMs
-        : null;
-
-    const evaluatorDuration =
-      run.jobs.evaluator?.startedAt && run.jobs.evaluator?.finishedAt
-        ? calculateDuration(
-            run.jobs.evaluator.startedAt,
-            run.jobs.evaluator.finishedAt
-          ).durationMs
-        : null;
-
-    const reporterDuration =
-      run.jobs.reporter?.startedAt && run.jobs.reporter?.finishedAt
-        ? calculateDuration(
-            run.jobs.reporter.startedAt,
-            run.jobs.reporter.finishedAt
-          ).durationMs
-        : null;
-
-    const finishedJobsDuration =
-      (analyzerDuration ?? 0) +
-      (advisorDuration ?? 0) +
-      (scannerDuration ?? 0) +
-      (evaluatorDuration ?? 0) +
-      (reporterDuration ?? 0);
-
-    const runDuration =
-      run.createdAt && run.finishedAt
-        ? calculateDuration(run.createdAt, run.finishedAt).durationMs
-        : null;
-
-    // For an unknown reason, the logic for calculating the infrastructure duration
-    // based on [startedAt, finishedAt] of the individual jobs and [createdAt, finishedAt]
-    // of the run produces negative values sometimes in the Docker Compose setup.
-    //
-    // This doesn't make sense, as the total run should always take more time than the sum
-    // of the durations of the individual jobs included in the run.
-    //
-    // TO prevent weird results showing, negative values for the intrastructure durations
-    // are filtered out.
-    const infrastructureDuration =
-      runDuration && runDuration - finishedJobsDuration > 0
-        ? runDuration - finishedJobsDuration
-        : null;
-
-    // Calculate how many durations are non-null. This is needed for proper indexing in the tooltip,
-    // to render the total duration at the end of the tooltip.
-    const finishedDurations = [
-      analyzerDuration,
-      advisorDuration,
-      scannerDuration,
-      evaluatorDuration,
-      reporterDuration,
-      infrastructureDuration,
-    ].filter((duration) => duration !== null).length;
-
-    return {
-      runId: run.index,
-      finishedDurations,
-      createdAt: run.createdAt,
-      finishedAt: run.finishedAt,
-      infrastructure: infrastructureDuration,
-      analyzer: analyzerDuration,
-      advisor: advisorDuration,
-      scanner: scannerDuration,
-      evaluator: evaluatorDuration,
-      reporter: reporterDuration,
-    };
-  });
+  const chartData = getDurationChartData(runs);
 
   if (runsIsPending) {
     return <LoadingIndicator />;

--- a/ui/src/components/charts/job-durations.tsx
+++ b/ui/src/components/charts/job-durations.tsx
@@ -40,6 +40,8 @@ import {
   ChartTooltip,
   ChartTooltipContent,
 } from '@/components/ui/chart';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
 import { config } from '@/config';
 import {
   convertDurationToHms,
@@ -95,6 +97,9 @@ export const JobDurations = ({
     nRuns: DEFAULT_RUNS,
   });
 
+  // This state is used to toggle the visibility of the infrastructure duration in the chart.
+  const [showInfrastructure, setShowInfrastructure] = useState(false);
+
   // Compute query params from applied values.
   const limit = applied.fetchMode === 'VISIBLE_RUNS' ? pageSize : applied.nRuns;
   const offset =
@@ -118,7 +123,7 @@ export const JobDurations = ({
     }
   );
 
-  const chartData = getDurationChartData(runs);
+  const chartData = getDurationChartData(runs, showInfrastructure);
 
   if (runsIsPending) {
     return <LoadingIndicator />;
@@ -159,21 +164,35 @@ export const JobDurations = ({
       <CardHeader>
         <CardTitle className='flex items-center justify-between'>
           Durations
-          <div className='flex items-center space-x-2'>
-            <div className='text-sm font-normal'>Show durations for</div>
-            <RunsFilterForm
-              initialValues={applied}
-              onApply={(values) => {
-                // Normalize and apply; this triggers refetch via derived params.
-                setApplied({
-                  fetchMode: values.fetchMode,
-                  nRuns:
-                    values.fetchMode === 'CUSTOM_RUNS'
-                      ? (values.nRuns ?? DEFAULT_RUNS)
-                      : undefined,
-                });
-              }}
-            />
+          <div className='flex flex-col items-end'>
+            <div className='flex items-center space-x-2'>
+              <div className='text-sm font-normal'>Show durations for</div>
+              <RunsFilterForm
+                initialValues={applied}
+                onApply={(values) => {
+                  // Normalize and apply; this triggers refetch via derived params.
+                  setApplied({
+                    fetchMode: values.fetchMode,
+                    nRuns:
+                      values.fetchMode === 'CUSTOM_RUNS'
+                        ? (values.nRuns ?? DEFAULT_RUNS)
+                        : undefined,
+                  });
+                }}
+              />
+            </div>
+            <div className='flex items-center gap-3'>
+              <Checkbox
+                id='infra'
+                checked={showInfrastructure}
+                onCheckedChange={(value) => {
+                  setShowInfrastructure(value === true);
+                }}
+              />
+              <Label htmlFor='infra'>
+                Show effect of infrastructure to run durations
+              </Label>
+            </div>
           </div>
         </CardTitle>
       </CardHeader>

--- a/ui/src/helpers/calculate-duration.ts
+++ b/ui/src/helpers/calculate-duration.ts
@@ -93,7 +93,8 @@ type DurationChartData = {
 };
 
 export function getDurationChartData(
-  runs: PagedResponse_OrtRunSummary | undefined
+  runs: PagedResponse_OrtRunSummary | undefined,
+  showInfra: boolean
 ): DurationChartData[] | undefined {
   return runs?.data.map((run) => {
     const getJobDuration = (job: JobSummary | null | undefined) => {
@@ -123,7 +124,7 @@ export function getDurationChartData(
     // As a safety measure to prevent illogical results showing, negative values
     // for the intrastructure durations are filtered out.
     const infrastructureDuration =
-      runDuration && runDuration - finishedJobsDuration > 0
+      runDuration && showInfra && runDuration - finishedJobsDuration > 0
         ? runDuration - finishedJobsDuration
         : null;
 


### PR DESCRIPTION
This PR was a required feature from @sschuberth: to separate and show the time spent on "infrastructure" (for example, spinning up a Kubernetes pod) from the "actual" running time of the jobs.

The main calculation principle in this PR is as follows:
```
infrastructureDuration = totalRunDuration - sum(jobDurations)
```
where `totalRunDuration` is calculated from `[createdAt, finishedAt]` of the run, and `jobDurations` is calculated from `[startedAt, finishedAt]` of each respective job. Advisor and Scanner are typically run in parallel, so the longer of those jobs is included in calculation.

As the DoubleOpen team doesn't know the deep details of the state machines of the jobs and runs, I'd like to ask @mnonnenmacher (or anyone else more familiar with the back-end implementation): is this a sane assumption at all?

<img width="1268" height="625" alt="Screenshot from 2025-08-14 13-28-24" src="https://github.com/user-attachments/assets/b341f4e9-8b78-401c-9f07-65c47a3d2018" />

<img width="1268" height="625" alt="Screenshot from 2025-08-14 13-28-47" src="https://github.com/user-attachments/assets/fc06d3a5-c2e8-4aba-819f-1a3c74b59fb8" />

As we are missing a staging environment, there really is no means to test whether this feature shows with any reliability the time spent on infrastructure, before it is merged and deployed. But I'd still like to get an answer to whether my original assumption holds at all or not.