### PR TITLE
fix(services): Always provide report definitions for all plugins

### DIFF
--- a/services/admin-config/src/main/kotlin/AdminConfig.kt
+++ b/services/admin-config/src/main/kotlin/AdminConfig.kt
@@ -104,7 +104,7 @@ class AdminConfig(
          * reports. Typically, some reports should be configured.
          */
         val DEFAULT_REPORTER_CONFIG = ReporterConfig(
-            reportDefinitionsMap = emptyMap(),
+            reportDefinitionsMap = ReporterConfig.addDefinitionsForUnreferencedPlugins(emptyMap()),
             howToFixTextProviderFile = ORT_HOW_TO_FIX_TEXT_PROVIDER_FILENAME,
             customLicenseTextDir = null
         )

--- a/services/admin-config/src/main/kotlin/AdminConfigService.kt
+++ b/services/admin-config/src/main/kotlin/AdminConfigService.kt
@@ -31,8 +31,6 @@ import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.config.Context
 import org.eclipse.apoapsis.ortserver.config.Path
 import org.eclipse.apoapsis.ortserver.model.SourceCodeOrigin
-import org.eclipse.apoapsis.ortserver.shared.plugininfo.PluginInfo
-import org.eclipse.apoapsis.ortserver.shared.plugininfo.PluginType
 import org.eclipse.apoapsis.ortserver.utils.config.getBooleanOrDefault
 import org.eclipse.apoapsis.ortserver.utils.config.getConfigOrEmpty
 import org.eclipse.apoapsis.ortserver.utils.config.getIntOrDefault
@@ -95,9 +93,6 @@ class AdminConfigService(
 
         /** An object to obtain default values for the mail server configuration. */
         private val defaultMailServerConfig = MailServerConfiguration(fromAddress = "")
-
-        /** The type for reporter plugins. */
-        private val reporterPluginType = PluginType("org.ossreviewtoolkit.reporter.ReporterFactory")
 
         private val logger = LoggerFactory.getLogger(AdminConfigService::class.java)
 
@@ -257,7 +252,7 @@ class AdminConfigService(
             config: Config,
             globalAssets: GlobalReporterAssets
         ): Map<String, ReportDefinition> =
-            addDefinitionsForUnreferencedPlugins(
+            ReporterConfig.addDefinitionsForUnreferencedPlugins(
                 config.getObjectOrEmpty("reports").filterValues { it is ConfigObject }
                     .mapValues { entry ->
                         parseReportDefinition((entry.value as ConfigObject).toConfig(), globalAssets)
@@ -287,27 +282,6 @@ class AdminConfigService(
             )
 
         /**
-         * Create dummy [ReportDefinition]s for all reporter plugins that are not referenced in the given
-         * [definitions]. This makes sure that there is always a definition for each existing reporter plugin.
-         */
-        private fun addDefinitionsForUnreferencedPlugins(
-            definitions: Map<String, ReportDefinition>
-        ): Map<String, ReportDefinition> {
-            val allReporterPlugins = getReporterPluginIds()
-            val referencedPlugins = definitions.values.mapTo(mutableSetOf()) { it.pluginId.lowercase() }
-
-            return definitions + (allReporterPlugins.keys - referencedPlugins).associate { pluginId ->
-                val originalPluginId = allReporterPlugins.getValue(pluginId)
-                originalPluginId to ReportDefinition(
-                    pluginId = originalPluginId,
-                    assetFiles = emptyList(),
-                    assetDirectories = emptyList(),
-                    nameMapping = null
-                )
-            }
-        }
-
-        /**
          * Validate the given [reporterConfig]. Add found issues to the given [issues] list.
          */
         private fun validateReporterConfig(issues: MutableList<String>, reporterConfig: ReporterConfig) {
@@ -316,12 +290,7 @@ class AdminConfigService(
                     .filter { it.startsWith(UNRESOLVABLE_ASSET_PREFIX) }
             }.map { "Undefined reference to a reporter asset: '${it.removePrefix(UNRESOLVABLE_ASSET_PREFIX)}'." }
 
-            val reporterPlugins = getReporterPluginIds()
-            issues += reporterConfig.reportDefinitionNames.map { it to reporterConfig.getReportDefinition(it) }
-                .filter { it.second?.pluginId?.lowercase() !in reporterPlugins }
-                .map {
-                    "Unknown reporter plugin '${it.second?.pluginId}' referenced from report definition '${it.first}'."
-                }
+            reporterConfig.validateReportDefinitions(issues)
         }
 
         /**
@@ -424,15 +393,6 @@ class AdminConfigService(
         ): List<ReporterAsset> =
             this[assetRef]?.map { directoryAsset(it, isDirectory) }
                 ?: listOf(ReporterAsset(UNRESOLVABLE_ASSET_PREFIX + assetRef))
-
-        /**
-         * Return a map with the IDs of all available reporter plugins. The keys of the map are the IDs in lowercase
-         * to enable case-insensitive matching. The values are the IDs in original case.
-         */
-        private fun getReporterPluginIds(): Map<String, String> =
-            PluginInfo.pluginsForType(reporterPluginType)
-                .map { it.id.id }
-                .associateBy { it.lowercase() }
 
         private fun parseMavenCentralMirror(config: Config): MavenCentralMirror? =
             config.parseObjectOrDefault("mavenCentralMirror", null) {

--- a/services/admin-config/src/test/kotlin/AdminConfigServiceTest.kt
+++ b/services/admin-config/src/test/kotlin/AdminConfigServiceTest.kt
@@ -24,6 +24,7 @@ import com.typesafe.config.ConfigFactory
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containAll
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
@@ -654,6 +655,7 @@ class AdminConfigServiceTest : WordSpec({
             reporterConfig.howToFixTextProviderFile shouldBe ORT_HOW_TO_FIX_TEXT_PROVIDER_FILENAME
             reporterConfig.customLicenseTextDir should beNull()
             reporterConfig shouldBe AdminConfig.DEFAULT_REPORTER_CONFIG
+            reporterConfig.reportDefinitionNames should containAll("WebApp", "PdfTemplate")
         }
 
         "use default values for unspecified properties" {
@@ -667,6 +669,7 @@ class AdminConfigServiceTest : WordSpec({
 
             reporterConfig.howToFixTextProviderFile shouldBe ORT_HOW_TO_FIX_TEXT_PROVIDER_FILENAME
             reporterConfig.customLicenseTextDir should beNull()
+            reporterConfig.reportDefinitionNames should containAll("WebApp", "PdfTemplate")
         }
 
         "parse simple properties from the reporter section of the config file" {


### PR DESCRIPTION
Make sure that always report definitions for all existing reporter plugins are present even if there is no admin configuration, or the configuration does not contain a `reporter` section.