### PR TITLE
ui: Show the advisor that reported the vulnerability

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
@@ -124,6 +124,10 @@ const renderSubComponent = ({
         <AccordionTrigger className='font-semibold'>Details</AccordionTrigger>
         <AccordionContent>
           <div className='flex flex-col gap-4'>
+            <div>
+              This vulnerability was reported by{' '}
+              <b>{row.original.advisor.name}</b> advisor.
+            </div>
             <VulnerabilityMetrics vulnerability={vulnerability} />
             <div className='text-lg font-semibold'>Description</div>
             <MarkdownRenderer


### PR DESCRIPTION

<img width="972" height="617" alt="Screenshot from 2025-08-20 10-52-18" src="https://github.com/user-attachments/assets/8e878071-7320-44fa-aedb-31bdf706c285" />

Further improvements to this feature could be to change the reported advisor into a link to its homepage, but for now, it wasn't absolutely clear as to which pages to redirect to for each advisor.

Please see the commit for details.