### PR TITLE
fix(reporter): Make `CustomLicenseTextProvider` more robust

### DIFF
--- a/workers/reporter/src/main/kotlin/reporter/CustomLicenseTextProvider.kt
+++ b/workers/reporter/src/main/kotlin/reporter/CustomLicenseTextProvider.kt
@@ -48,11 +48,14 @@ internal class CustomLicenseTextProvider(
     val configurationContext: Context?,
 
     /** The [Path] to the directory in the configuration containing custom license texts. */
-    val licenseTextDir: Path,
+    rawLicenseTextDir: Path,
 
     /** A fallback [LicenseTextProvider] to query for license texts not available in the configuration. */
     val wrappedProvider: LicenseTextProvider = DefaultLicenseTextProvider()
 ) : LicenseTextProvider {
+    /** The sanitized [Path] to the directory in the configuration containing custom license texts. */
+    val licenseTextDir = Path(rawLicenseTextDir.path.removeSuffix("/"))
+
     /** Stores the IDs of the licenses that can be resolved from the config directory. */
     private val knownLicenseTexts by lazy {
         val directoryPrefix = "${licenseTextDir.path}/"

--- a/workers/reporter/src/test/kotlin/reporter/CustomLicenseTextProviderTest.kt
+++ b/workers/reporter/src/test/kotlin/reporter/CustomLicenseTextProviderTest.kt
@@ -89,6 +89,18 @@ class CustomLicenseTextProviderTest : WordSpec({
 
             reader?.invoke() shouldBe ""
         }
+
+        "handle a license text dir with a trailing slash" {
+            val configManager = createConfigManagerMock()
+            every {
+                configManager.getFileAsString(configContext, Path("${licenseDir.path}/$LICENSE_ID"))
+            } returns LICENSE_TEXT
+
+            val provider = CustomLicenseTextProvider(configManager, configContext, Path("${licenseDir.path}/"), mockk())
+            val reader = provider.getLicenseTextReader(LICENSE_ID)
+
+            reader?.invoke() shouldBe LICENSE_TEXT
+        }
     }
 
     "hasLicenseText" should {


### PR DESCRIPTION
The implementation could not handle a license text directory parameter with a trailing slash. This is problematic, since the directory is now defined in the admin configuration which expects that directory paths end on a slash.