### PR TITLE
ci(github): Upgrade to the `windows-2025` image

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -49,7 +49,7 @@ jobs:
             buildPath: 'cli/build/bin/macosX64/releaseExecutable/osc.kexe'
             binName: 'osc'
           - name: 'Windows x64'
-            os: windows-2022
+            os: windows-2025
             task: 'linkReleaseExecutableMingwX64'
             artifact: 'osc-cli-windows-x64'
             buildPath: 'cli/build/bin/mingwX64/releaseExecutable/osc.exe'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
           binName: osc
           archiveExt: tar.gz
         - name: "Windows x64"
-          os: windows-2022
+          os: windows-2025
           task: :cli:linkReleaseExecutableMingwX64
           artifact: osc-cli-windows-x64
           buildPath: cli/build/bin/mingwX64/releaseExecutable/osc.exe


### PR DESCRIPTION
By September 30, 2025, GitHub will make `windows-latest` point to `windows-2025` as the recommended Windows image. Get access to more modern tools already now by upgrading the image explicitly.