### PR TITLE
docs(user-guide): Move CLI getting-started documentation to user-guide

### DIFF
--- a/website/docs/user-guide/cli/_category_.yml
+++ b/website/docs/user-guide/cli/_category_.yml
@@ -1,0 +1,2 @@
+position: 2
+label: CLI

--- a/website/docs/user-guide/cli/getting-started.md
+++ b/website/docs/user-guide/cli/getting-started.md
@@ -1,4 +1,4 @@
-# ORT Server Client CLI (`osc`)
+# Getting Started
 
 The ORT Server Client CLI (`osc`) is a command-line interface designed to interact with the ORT Server. It provides essential functionality for managing ORT runs and retrieving results.
 


### PR DESCRIPTION
The CLI documentation is intended for end users and should be part of the user guide.