### PR TITLE
feat(cli): Use exit code 2 for ORT runs finishing with issues

### DIFF
--- a/cli/src/commonMain/kotlin/OrtServerMain.kt
+++ b/cli/src/commonMain/kotlin/OrtServerMain.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.Json
 
 import org.eclipse.apoapsis.ortserver.cli.model.OrtServerCliException
+import org.eclipse.apoapsis.ortserver.cli.model.RunFinishedWithIssuesException
 import org.eclipse.apoapsis.ortserver.cli.utils.createAuthenticatedOrtServerClient
 import org.eclipse.apoapsis.ortserver.cli.utils.echoError
 import org.eclipse.apoapsis.ortserver.cli.utils.useJsonFormat
@@ -63,6 +64,7 @@ fun main(args: Array<String>) {
         when (e) {
             is AuthenticationException -> cli.echoError("Authentication failed. Please check your credentials.")
             is OrtServerCliException, is OrtServerException -> cli.echoError(e.message)
+            is RunFinishedWithIssuesException -> exitProcess(2)
             is CliktError -> {
                 // The jsonFormat flag is not supported for the help message.
                 cli.echoFormattedHelp(e)

--- a/cli/src/commonMain/kotlin/StartCommand.kt
+++ b/cli/src/commonMain/kotlin/StartCommand.kt
@@ -53,6 +53,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatus
 import org.eclipse.apoapsis.ortserver.cli.model.AuthenticationError
 import org.eclipse.apoapsis.ortserver.cli.model.CliInputException
+import org.eclipse.apoapsis.ortserver.cli.model.RunFinishedWithIssuesException
 import org.eclipse.apoapsis.ortserver.cli.model.printables.toPrintable
 import org.eclipse.apoapsis.ortserver.cli.utils.createAuthenticatedOrtServerClient
 import org.eclipse.apoapsis.ortserver.cli.utils.echoMessage
@@ -127,6 +128,10 @@ class StartCommand : SuspendingCliktCommand(name = "start") {
         }
 
         echoMessage(ortRun.toPrintable())
+
+        if (ortRun.status == OrtRunStatus.FAILED || ortRun.status == OrtRunStatus.FINISHED_WITH_ISSUES) {
+            throw RunFinishedWithIssuesException("The ORT run finished with status '${ortRun.status}'.")
+        }
     }
 
     private fun updateProgressBar(ortRun: OrtRun, client: OrtServerClient): OrtRun = runBlocking {

--- a/cli/src/commonMain/kotlin/model/Exceptions.kt
+++ b/cli/src/commonMain/kotlin/model/Exceptions.kt
@@ -36,3 +36,8 @@ class CliInputException(message: String, cause: Throwable? = null) : OrtServerCl
  */
 class AuthenticationError(message: String = "Authentication required. Please run '$COMMAND_NAME auth login'.") :
     OrtServerCliException(message, null)
+
+/**
+ * An exception thrown when a run has been completed but issues were found.
+ */
+class RunFinishedWithIssuesException(message: String) : Exception(message)


### PR DESCRIPTION
When using the CLI in CI/CD the user want to immediately know if the run was successful or not. Therefore the CLI should return a non-zero exit code when the run finished with issues.

This aligns the behavior of `osc` with the ORT CLI, that also uses exit code 2 for runs with issues.