### PR TITLE
build: Enable Detekt's autoCorrect

### DIFF
--- a/buildSrc/src/main/kotlin/ort-server-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-kotlin-conventions.gradle.kts
@@ -61,6 +61,7 @@ detekt {
 }
 
 tasks.withType<Detekt>().configureEach {
+    autoCorrect = true
     exclude {
         "/build/generated/" in it.file.absolutePath
     }


### PR DESCRIPTION
This allows the developer to use `./gradle detekt --auto-correct` to fix trivial formatting issues.