### PR TITLE
ui: Move the Advisor info to a table column

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
@@ -124,10 +124,6 @@ const renderSubComponent = ({
         <AccordionTrigger className='font-semibold'>Details</AccordionTrigger>
         <AccordionContent>
           <div className='flex flex-col gap-4'>
-            <div>
-              This vulnerability was reported by{' '}
-              <b>{row.original.advisor.name}</b> advisor.
-            </div>
             <VulnerabilityMetrics vulnerability={vulnerability} />
             <div className='text-lg font-semibold'>Description</div>
             <MarkdownRenderer
@@ -346,6 +342,12 @@ const VulnerabilitiesComponent = () => {
           {row.getValue('externalId')}
         </Badge>
       ),
+      enableColumnFilter: false,
+    }),
+    columnHelper.accessor('advisor.name', {
+      id: 'advisorName',
+      header: 'Advisor',
+      cell: ({ row }) => <div>{row.getValue('advisorName')}</div>,
       enableColumnFilter: false,
     }),
     columnHelper.accessor(


### PR DESCRIPTION
Please note that I did not mark this PR as resolving #3403 yet, because the issue still needs some discussion between the teams as to how to properly deduplicate and filter the vulnerabilities reported by different advisors.

<img width="1354" height="613" alt="Screenshot from 2025-08-27 11-19-57" src="https://github.com/user-attachments/assets/b33e4ae0-a6bb-4faa-b20a-d2ff06a50dec" />
