### PR TITLE
fix(admin-config): Support case-insensitive plugin IDs

### DIFF
--- a/services/admin-config/src/main/kotlin/ReporterConfig.kt
+++ b/services/admin-config/src/main/kotlin/ReporterConfig.kt
@@ -258,10 +258,11 @@ data class ReporterConfig(
      */
     fun pluginOptionsForDefinition(name: String, optionsMap: Map<String, PluginConfig>): PluginConfig? =
         getReportDefinition(name)?.pluginId?.let { pluginId ->
-            val pluginConfig = optionsMap[pluginId]
+            val pluginConfig = optionsMap.entries.find { it.key.equals(pluginId, ignoreCase = true) }?.value
             val definitionConfig = optionsMap.entries.find {
                 val components = it.key.split(PLUGIN_REFERENCE_SEPARATOR)
-                components.size == 2 && components[0] == pluginId && components[1].equals(name, ignoreCase = true)
+                components.size == 2 && components[0].equals(pluginId, ignoreCase = true) &&
+                        components[1].equals(name, ignoreCase = true)
             }?.value
 
             if (pluginConfig != null && definitionConfig != null) {

--- a/services/admin-config/src/test/kotlin/ReporterConfigTest.kt
+++ b/services/admin-config/src/test/kotlin/ReporterConfigTest.kt
@@ -62,6 +62,13 @@ class ReporterConfigTest : WordSpec({
             ) shouldBe templatePluginOptions
         }
 
+        "use case-insensitive comparison for the plugin ID" {
+            reporterConfig.pluginOptionsForDefinition(
+                REPORT_DEFINITION_NAME,
+                mapOf(PLUGIN_ID.lowercase() to templatePluginOptions)
+            ) shouldBe templatePluginOptions
+        }
+
         "merge the configurations from the plugin and the report definition" {
             val definitionConfig = PluginConfig(
                 options = mapOf("mode" to "fast", "template" to "disclosure-document.ftl"),
@@ -73,6 +80,30 @@ class ReporterConfigTest : WordSpec({
                 mapOf(
                     PLUGIN_ID to templatePluginOptions,
                     "$PLUGIN_ID:$REPORT_DEFINITION_NAME" to definitionConfig
+                )
+            ) shouldNotBeNull {
+                options["style"] shouldBe "nice"
+                options["branding"] shouldBe "special"
+                options["template"] shouldBe "disclosure-document.ftl"
+                options["mode"] shouldBe "fast"
+
+                secrets["testSecret1"] shouldBe "overriddenSecretValue"
+                secrets["testSecret2"] shouldBe "testSecretValue2"
+                secrets["testSecret3"] shouldBe "testSecretValue3"
+            }
+        }
+
+        "use case-insensitive comparison when merging configurations" {
+            val definitionConfig = PluginConfig(
+                options = mapOf("mode" to "fast", "template" to "disclosure-document.ftl"),
+                secrets = mapOf("testSecret1" to "overriddenSecretValue", "testSecret3" to "testSecretValue3")
+            )
+
+            reporterConfig.pluginOptionsForDefinition(
+                REPORT_DEFINITION_NAME,
+                mapOf(
+                    PLUGIN_ID.lowercase() to templatePluginOptions,
+                    "${PLUGIN_ID.lowercase()}:${REPORT_DEFINITION_NAME.uppercase()}" to definitionConfig
                 )
             ) shouldNotBeNull {
                 options["style"] shouldBe "nice"


### PR DESCRIPTION
Compare plugin IDs specified in report definitions in a case-insensitive way. This simplifies the configuration and prevents hard-to-diagnose errors when plugin options cannot be assigned correctly.