### PR TITLE
fix(ui): Show updated branding values correctly on edit

### DIFF
--- a/ui/src/routes/admin/content-management/branding/-components/favicon-form.tsx
+++ b/ui/src/routes/admin/content-management/branding/-components/favicon-form.tsx
@@ -77,7 +77,7 @@ export function FaviconForm() {
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
-    defaultValues: {
+    values: {
       faviconUrl: dbFavicon?.value || '',
       isEnabled: dbFavicon?.isEnabled || false,
     },

--- a/ui/src/routes/admin/content-management/branding/-components/footer-form.tsx
+++ b/ui/src/routes/admin/content-management/branding/-components/footer-form.tsx
@@ -75,7 +75,7 @@ export function FooterForm() {
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
-    defaultValues: {
+    values: {
       markdown: contentManagementSection?.markdown || '',
       isEnabled: contentManagementSection?.isEnabled || false,
     },

--- a/ui/src/routes/admin/content-management/branding/-components/home-icon-form.tsx
+++ b/ui/src/routes/admin/content-management/branding/-components/home-icon-form.tsx
@@ -87,7 +87,7 @@ export function HomeIconForm() {
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
-    defaultValues: {
+    values: {
       iconUrl: dbHomeIcon?.value || '',
       iconUrlDark: dbHomeIconDark?.value || '',
       isEnabled: dbHomeIcon?.isEnabled || false,

--- a/ui/src/routes/admin/content-management/branding/-components/product-name-form.tsx
+++ b/ui/src/routes/admin/content-management/branding/-components/product-name-form.tsx
@@ -76,7 +76,7 @@ export function ProductNameForm() {
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
-    defaultValues: {
+    values: {
       productName: dbProductName?.value || '',
       isEnabled: dbProductName?.isEnabled || false,
     },


### PR DESCRIPTION
The form for editing the different branding elements on Admin / Content Management / Branding page was using `defaultValues`, so when for example refreshing the page, updated values were not displayed correctly. 

Switching to `values` instead of `defaultValues` ensures that the form  always reflects the current values of the branding elements.