### PR TITLE
Return purls for issues, rule violations and vulnerabilities of a run

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
@@ -282,7 +282,8 @@ fun Issue.mapToApi() =
         affectedPath = affectedPath,
         identifier = identifier?.mapToApi(),
         worker = worker,
-        resolutions = resolutions.map { it.mapToApi() }
+        resolutions = resolutions.map { it.mapToApi() },
+        purl = purl
     )
 
 fun ApiIssue.mapToModel() =

--- a/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
@@ -602,7 +602,8 @@ fun VulnerabilityWithDetails.mapToApi() =
         identifier = identifier.mapToApi(),
         rating = rating.mapToApi(),
         resolutions = resolutions.map { it.mapToApi() },
-        advisor = advisor.mapToApi()
+        advisor = advisor.mapToApi(),
+        purl = purl
     )
 
 fun Vulnerability.mapToApi() = ApiVulnerability(

--- a/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
@@ -620,7 +620,8 @@ fun RuleViolation.mapToApi() = ApiRuleViolation(
     severity = severity.mapToApi(),
     message = message,
     howToFix = howToFix,
-    resolutions = resolutions.map { it.mapToApi() }
+    resolutions = resolutions.map { it.mapToApi() },
+    purl = purl
 )
 
 fun Identifier.mapToApi() = ApiIdentifier(type = type, namespace = namespace, name = name, version = version)

--- a/api/v1/model/src/commonMain/kotlin/Issue.kt
+++ b/api/v1/model/src/commonMain/kotlin/Issue.kt
@@ -49,5 +49,10 @@ data class Issue(
     val worker: String? = null,
 
     /** The [IssueResolution]s that have been applied to this issue. */
-    val resolutions: List<IssueResolution> = emptyList()
+    val resolutions: List<IssueResolution> = emptyList(),
+
+    /**
+     * The purl of the [Package] this issue is related to. Null if the issue originates from a [Project] or elsewhere.
+     */
+    val purl: String? = null
 )

--- a/api/v1/model/src/commonMain/kotlin/RuleViolation.kt
+++ b/api/v1/model/src/commonMain/kotlin/RuleViolation.kt
@@ -30,7 +30,12 @@ data class RuleViolation(
     val severity: Severity,
     val message: String,
     val howToFix: String,
-    val resolutions: List<RuleViolationResolution> = emptyList()
+    val resolutions: List<RuleViolationResolution> = emptyList(),
+    /**
+     * The purl of the [Package] this rule violation stems from. Null if the rule violation comes from a [Project] or
+     * elsewhere.
+     */
+    val purl: String? = null
 )
 
 /**

--- a/api/v1/model/src/commonMain/kotlin/VulnerabilityWithDetails.kt
+++ b/api/v1/model/src/commonMain/kotlin/VulnerabilityWithDetails.kt
@@ -35,5 +35,8 @@ data class VulnerabilityWithDetails(
     val resolutions: List<VulnerabilityResolution> = emptyList(),
 
     /** Details of the used advisor. */
-    val advisor: AdvisorDetails
+    val advisor: AdvisorDetails,
+
+    /** The purl of the [Package] this vulnerability originates from. */
+    val purl: String
 )

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -308,7 +308,8 @@ val getVulnerabilitiesByRunId: RouteConfig.() -> Unit = {
                                 advisor = AdvisorDetails(
                                     name = "VulnerableCode",
                                     capabilities = setOf(AdvisorCapability.VULNERABILITIES)
-                                )
+                                ),
+                                purl = "pkg:maven/org.namespace/name@1.0"
                             )
                         ),
                         PagingData(

--- a/model/src/commonMain/kotlin/VulnerabilityWithDetails.kt
+++ b/model/src/commonMain/kotlin/VulnerabilityWithDetails.kt
@@ -37,7 +37,10 @@ data class VulnerabilityWithDetails(
     val resolutions: List<VulnerabilityResolution> = emptyList(),
 
     /** Details about the used advisor. */
-    val advisor: AdvisorDetails
+    val advisor: AdvisorDetails,
+
+    /** The purl of the [Package] this vulnerability originates from. */
+    val purl: String
 )
 
 /**

--- a/model/src/commonMain/kotlin/runs/Issue.kt
+++ b/model/src/commonMain/kotlin/runs/Issue.kt
@@ -52,7 +52,12 @@ data class Issue(
     val worker: String? = null,
 
     /** The [IssueResolution]s that have been applied to this issue. */
-    val resolutions: List<IssueResolution> = emptyList()
+    val resolutions: List<IssueResolution> = emptyList(),
+
+    /**
+     * The purl of the [Package] this issue is related to. Null if the issue originates from a [Project] or elsewhere.
+     */
+    val purl: String? = null
 )
 
 /**

--- a/model/src/commonMain/kotlin/runs/RuleViolation.kt
+++ b/model/src/commonMain/kotlin/runs/RuleViolation.kt
@@ -33,7 +33,12 @@ data class RuleViolation(
     val severity: Severity,
     val message: String,
     val howToFix: String,
-    val resolutions: List<RuleViolationResolution> = emptyList()
+    val resolutions: List<RuleViolationResolution> = emptyList(),
+    /**
+     * The purl of the [Package] this rule violation stems from. Null if the rule violation comes from a [Project] or
+     * elsewhere.
+     */
+    val purl: String? = null
 )
 
 /**

--- a/services/ort-run/src/main/kotlin/IssueService.kt
+++ b/services/ort-run/src/main/kotlin/IssueService.kt
@@ -73,7 +73,12 @@ class IssueService(private val db: Database, private val ortRunService: OrtRunSe
                 resolutionPattern.containsMatchIn(issue.message)
             }
 
-            issue.copy(resolutions = matchingResolutions.map { it.mapToModel() })
+            issue.copy(
+                resolutions = matchingResolutions.map { it.mapToModel() },
+                purl = issue.identifier?.mapToOrt()?.let {
+                    ortResult.getPackage(it)?.metadata?.purl
+                }
+            )
         }
 
         val filteredResult = issuesWithResolutions.applyResultFilter(issuesFilter)

--- a/services/ort-run/src/main/kotlin/RuleViolationService.kt
+++ b/services/ort-run/src/main/kotlin/RuleViolationService.kt
@@ -89,7 +89,12 @@ class RuleViolationService(private val db: Database, private val ortRunService: 
 
         val ruleViolationsWithResolutions = limitedResults.map { ruleViolation ->
             val matchingResolutions = resolutions.filter { it.matches(ruleViolation.mapToOrt()) }
-            ruleViolation.copy(resolutions = matchingResolutions.map { it.mapToModel() })
+            ruleViolation.copy(
+                resolutions = matchingResolutions.map { it.mapToModel() },
+                purl = ruleViolation.id?.mapToOrt()?.let {
+                    ortResult.getPackage(it)?.metadata?.purl
+                }
+            )
         }
 
         return ListQueryResult(

--- a/services/ort-run/src/main/kotlin/VulnerabilityService.kt
+++ b/services/ort-run/src/main/kotlin/VulnerabilityService.kt
@@ -64,6 +64,7 @@ import org.jetbrains.exposed.sql.castTo
 import org.jetbrains.exposed.sql.stringLiteral
 
 import org.ossreviewtoolkit.model.config.VulnerabilityResolution
+import org.ossreviewtoolkit.model.utils.toPurl
 
 /**
  * A service to interact with vulnerabilities.
@@ -103,7 +104,8 @@ class VulnerabilityService(private val db: Database, private val ortRunService: 
                             identifier = entry.key.mapToModel(),
                             rating = VulnerabilityRating.fromString(maxSeverity)
                                 ?: VulnerabilityRating.NONE,
-                            advisor = advisorResult.advisor.mapToModel()
+                            advisor = advisorResult.advisor.mapToModel(),
+                            purl = ortResult.getPackage(entry.key)?.metadata?.purl ?: entry.key.toPurl()
                         )
                     }
                 }

--- a/services/ort-run/src/test/kotlin/IssueServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/IssueServiceTest.kt
@@ -38,12 +38,16 @@ import org.eclipse.apoapsis.ortserver.model.AnalyzerJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.JobConfigurations
 import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.Severity
+import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.PackageCurationProviderConfig
+import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.ResolvedPackageCurations
 import org.eclipse.apoapsis.ortserver.model.runs.AnalyzerConfiguration
 import org.eclipse.apoapsis.ortserver.model.runs.Environment
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
 import org.eclipse.apoapsis.ortserver.model.runs.IssueFilter
 import org.eclipse.apoapsis.ortserver.model.runs.repository.IssueResolution
+import org.eclipse.apoapsis.ortserver.model.runs.repository.PackageCuration
+import org.eclipse.apoapsis.ortserver.model.runs.repository.PackageCurationData
 import org.eclipse.apoapsis.ortserver.model.runs.repository.Resolutions
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
@@ -277,6 +281,102 @@ class IssueServiceTest : WordSpec() {
 
                 val unresolvedIssue = result.data.single { it.message.contains("unresolved npm issue") }
                 unresolvedIssue.resolutions.size shouldBe 0
+            }
+
+            "return purl for issues that are related to packages" {
+                val repositoryId = fixtures.createRepository().id
+
+                val pkg1 = fixtures.generatePackage(Identifier("Maven", "com.example", "example-lib", "1.0.0"))
+                val pkg2 = fixtures.generatePackage(Identifier("Maven", "com.example", "scanner-test", "2.0.0"))
+                val pkg3 = fixtures.generatePackage(Identifier("Maven", "com.example", "unresolved-lib", "3.0.0"))
+                val project = fixtures.getProject()
+
+                val issues = listOf(
+                    Issue(
+                        timestamp = Clock.System.now(),
+                        source = "Gradle Inspector",
+                        message = "could not resolve org.example:example-tool:1.0.0 from project :example",
+                        severity = Severity.ERROR,
+                        affectedPath = "example",
+                        identifier = project.identifier
+                    ),
+                    Issue(
+                        timestamp = Clock.System.now().plus(1.seconds),
+                        source = "Maven",
+                        message = "dependency not found: example-lib",
+                        severity = Severity.ERROR,
+                        affectedPath = "build.gradle.kts",
+                        identifier = pkg1.identifier
+                    ),
+                    Issue(
+                        timestamp = Clock.System.now().plus(2.seconds),
+                        source = "NPM",
+                        message = "timeout while scanning package",
+                        severity = Severity.WARNING,
+                        affectedPath = "src/main/kotlin",
+                        identifier = pkg2.identifier
+                    ),
+                    Issue(
+                        timestamp = Clock.System.now().plus(3.seconds),
+                        source = "Scanner",
+                        message = "unresolved npm issue",
+                        severity = Severity.WARNING,
+                        affectedPath = "src/test/kotlin",
+                        identifier = pkg3.identifier
+                    )
+                )
+
+                val ortRun = createOrtRunWithIssues(repositoryId, issues)
+
+                val analyzerJob = fixtures.createAnalyzerJob(ortRun.id)
+
+                fixtures.createAnalyzerRun(analyzerJob.id, setOf(project), setOf(pkg1, pkg2, pkg3))
+
+                val higherPriorityCurations = ResolvedPackageCurations(
+                    provider = PackageCurationProviderConfig("provider1"),
+                    curations = listOf(
+                        PackageCuration(
+                            id = pkg2.identifier,
+                            data = PackageCurationData(purl = "curated")
+                        ),
+                        PackageCuration(
+                            id = pkg3.identifier,
+                            data = PackageCurationData(purl = "curated-higher")
+                        )
+                    )
+                )
+
+                val lowerPriorityCurations = ResolvedPackageCurations(
+                    provider = PackageCurationProviderConfig("provider2"),
+                    curations = listOf(
+                        PackageCuration(
+                            id = pkg3.identifier,
+                            data = PackageCurationData(purl = "curated-lower")
+                        )
+                    )
+                )
+
+                fixtures.resolvedConfigurationRepository.addPackageCurations(
+                    ortRun.id,
+                    listOf(higherPriorityCurations, lowerPriorityCurations)
+                )
+
+                val result = service.listForOrtRunId(ortRun.id)
+
+                result.data.size shouldBe 4
+                result.totalCount shouldBe 4
+
+                val couldNotResolveIssue = result.data.single { it.message.contains("could not resolve") }
+                couldNotResolveIssue.purl shouldBe null
+
+                val dependencyIssue = result.data.single { it.message.contains("dependency not found") }
+                dependencyIssue.purl shouldBe pkg1.purl
+
+                val timeoutIssue = result.data.single { it.message.contains("timeout while scanning") }
+                timeoutIssue.purl shouldBe "curated"
+
+                val unresolvedIssue = result.data.single { it.message.contains("unresolved npm issue") }
+                unresolvedIssue.purl shouldBe "curated-higher"
             }
         }
 

--- a/services/ort-run/src/test/kotlin/VulnerabilityServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/VulnerabilityServiceTest.kt
@@ -40,6 +40,8 @@ import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.PluginConfig
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityFilters
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityRating
+import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.PackageCurationProviderConfig
+import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.ResolvedPackageCurations
 import org.eclipse.apoapsis.ortserver.model.runs.Environment
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.AdvisorCapability
@@ -47,6 +49,8 @@ import org.eclipse.apoapsis.ortserver.model.runs.advisor.AdvisorConfiguration
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.AdvisorResult
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.Vulnerability
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.VulnerabilityReference
+import org.eclipse.apoapsis.ortserver.model.runs.repository.PackageCuration
+import org.eclipse.apoapsis.ortserver.model.runs.repository.PackageCurationData
 import org.eclipse.apoapsis.ortserver.model.runs.repository.Resolutions
 import org.eclipse.apoapsis.ortserver.model.runs.repository.VulnerabilityResolution
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
@@ -522,6 +526,74 @@ class VulnerabilityServiceTest : WordSpec() {
                     vulnerability.externalId shouldBe "CVE-2022-14345"
                     vulnerability.references shouldContainExactlyInAnyOrder references2
                     rating shouldBe VulnerabilityRating.CRITICAL
+                }
+            }
+
+            "return the purl of the package the vulnerability originates from" {
+                val ortRun = fixtures.createOrtRun(fixtures.createRepository().id)
+
+                val analyzerJob = fixtures.createAnalyzerJob(ortRun.id)
+
+                val pkg1 = fixtures.generatePackage(
+                    Identifier("Maven", "org.apache.logging.log4j", "log4j-core", "2.14.0")
+                )
+
+                val pkg2 = fixtures.generatePackage(
+                    Identifier("Maven", "com.fasterxml.jackson.core", "jackson-databind", "2.9.6")
+                )
+
+                fixtures.createAnalyzerRun(analyzerJobId = analyzerJob.id, packages = setOf(pkg1, pkg2))
+
+                val curations = ResolvedPackageCurations(
+                    provider = PackageCurationProviderConfig("test"),
+                    curations = listOf(
+                        PackageCuration(
+                            id = pkg2.identifier,
+                            data = PackageCurationData(purl = "curated")
+                        )
+                    )
+                )
+
+                fixtures.resolvedConfigurationRepository.addPackageCurations(
+                    ortRun.id,
+                    listOf(curations)
+                )
+
+                val vulnerabilities = createVulnerabilities(
+                    Triple(
+                        pkg1.identifier,
+                        listOf("CVE-2021-45046"),
+                        listOf(10.0)
+                    ),
+                    Triple(
+                        pkg2.identifier,
+                        listOf("CVE-2018-14721"),
+                        listOf(4.2)
+                    )
+                )
+
+                val advisorJobId = fixtures.createAdvisorJob(
+                    ortRunId = ortRun.id,
+                    configuration = AdvisorJobConfiguration(config = advisorConfig())
+                ).id
+
+                fixtures.createAdvisorRun(
+                    advisorJobId,
+                    createAdvisorResults(vulnerabilities)
+                )
+
+                val results = service.listForOrtRunId(ortRun.id)
+
+                results.data.size shouldBe 2
+
+                with(results.data.first()) {
+                    vulnerability.externalId shouldBe "CVE-2018-14721"
+                    purl shouldBe "curated"
+                }
+
+                with(results.data.last()) {
+                    vulnerability.externalId shouldBe "CVE-2021-45046"
+                    purl shouldBe pkg1.purl
                 }
             }
         }


### PR DESCRIPTION
Add the purls in the responses for the run specific items if the item is related to a package. This doesn't yet contain returning purls for the organization and product vulnerabilities endpoints, as they need to be handled a bit differently.