### PR TITLE
build: Configure maven central for plugin management

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -25,6 +25,7 @@ plugins {
 }
 
 repositories {
+    mavenCentral()
     // Allow resolving external plugins from precompiled script plugins.
     gradlePluginPortal()
 }

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -17,6 +17,13 @@
  * License-Filename: LICENSE
  */
 
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
 rootProject.name = "buildSrc"
 
 dependencyResolutionManagement {

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -114,6 +114,13 @@ project(":storage:spi").name = "storage-spi"
 project(":transport:spi").name = "transport-spi"
 project(":workers:config").name = "config-worker"
 
+pluginManagement {
+    repositories {
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
 plugins {
     // Gradle cannot access the version catalog from here, so hard-code the dependency.
     id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")


### PR DESCRIPTION
By default, Gradle uses `plugins.gradle.ort/m2` in order to download plugins. Unfortunately, this might result to forwarding the request to Maven Central for artifacts that cannot be found on `plugins.gradle.org`.
This forwarding causes rate limiting for corporations trying to scan the ORT Server with the ORT Server which will then try to download artifacts from Maven Central [1].

More information can be found in [2].

Specifically, adding `mavenCentral()` as plugin repository will trigger the workaround implemented in [3] where `mavenCentral()` will be replaced by a corporate mirror of Maven Central.

[1]: https://www.sonatype.com/blog/beyond-ips-addressing-organizational-overconsumption-in-maven-central
[2]: https://blog.gradle.org/maven-central-mirror
[3]: https://github.com/eclipse-apoapsis/ort-server/pull/3304