### PR TITLE
ui: Show PURL from back-end directly in the UI

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
@@ -73,10 +73,7 @@ import {
   getVulnerabilityRatingBackgroundColor,
 } from '@/helpers/get-status-class';
 import { updateColumnSorting } from '@/helpers/handle-multisort';
-import {
-  identifierToPurl,
-  identifierToString,
-} from '@/helpers/identifier-conversion';
+import { identifierToString } from '@/helpers/identifier-conversion';
 import { getResolvedStatus } from '@/helpers/resolutions';
 import { compareVulnerabilityRating } from '@/helpers/sorting-functions';
 import { ALL_ITEMS } from '@/lib/constants';
@@ -304,18 +301,14 @@ const VulnerabilitiesComponent = () => {
     ),
     columnHelper.accessor(
       (vuln) => {
-        // TODO: This is a temporary front-end only solution to support PURL
-        //       identifiers. The backend endpoints should be updated to return
-        //       PURL identifiers natively so this will need to be removed
-        //       in the future.
         if (packageIdType === 'PURL') {
-          return identifierToPurl(vuln.identifier);
+          return vuln.purl;
         } else {
           return identifierToString(vuln.identifier);
         }
       },
       {
-        id: 'packageIdentifier',
+        id: `${packageIdType === 'ORT_ID' ? 'identifier' : 'purl'}`,
         header: 'Package ID',
         cell: ({ getValue }) => {
           return (
@@ -397,19 +390,21 @@ const VulnerabilitiesComponent = () => {
     [search.rating]
   );
 
+  const columnId = packageIdType === 'ORT_ID' ? 'identifier' : 'purl';
+
   const columnFilters = useMemo(() => {
     const filters = [];
     if (itemStatus) {
       filters.push({ id: 'itemStatus', value: itemStatus });
     }
     if (packageIdentifier) {
-      filters.push({ id: 'packageIdentifier', value: packageIdentifier });
+      filters.push({ id: columnId, value: packageIdentifier });
     }
     if (rating) {
       filters.push({ id: 'rating', value: rating });
     }
     return filters;
-  }, [itemStatus, packageIdentifier, rating]);
+  }, [itemStatus, packageIdentifier, columnId, rating]);
 
   const sortBy = useMemo(
     () => (search.sortBy ? search.sortBy : undefined),


### PR DESCRIPTION
This PR is the UI counterpart for #3425.

1. In case ORT IDs have been chosen for the UI in Preferences, show them in every table.
2. If PURL has been chosen in the preferences, show it where applicable. This means that rule violations and issues arising from packages show PURL, and ORT ID is still shown for those arising from projects.

This picture shows the logic of 2. in the UI. I have also selected a text filter "ts" for the Package ID column, since it matches both some projects and packages, to show that the text filtering in the column still works:

<img width="1157" height="580" alt="Screenshot from 2025-09-02 14-11-10" src="https://github.com/user-attachments/assets/b3bfba20-edf4-49c8-9828-53d96ae63219" />

