### PR TITLE
feat(docker): Add cargo-credential-netrc to the Docker image

### DIFF
--- a/workers/analyzer/docker/Analyzer.Dockerfile
+++ b/workers/analyzer/docker/Analyzer.Dockerfile
@@ -552,4 +552,7 @@ RUN sudo chgrp -R 0 /home/ort && sudo chmod -R g+rwX /home/ort
 USER $USERNAME
 WORKDIR $HOMEDIR
 
+# Install cargo-credential-netrc late in the build to prevent an error accessing /opt/rust/cargo/registry/.
+RUN $CARGO_HOME/bin/cargo install cargo-credential-netrc
+
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
Some projects may have a hard build dependency on this crate (see [1]).

[1]: https://crates.io/crates/cargo-credential-netrc

See also https://github.com/oss-review-toolkit/ort/pull/10808.