### PR TITLE
ci: Add names for the CLI build jobs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -55,6 +55,7 @@ jobs:
             buildPath: 'cli/build/bin/mingwX64/releaseExecutable/osc.exe'
             binName: 'osc.exe'
 
+    name: Build ${{ matrix.target.name }} CLI
     runs-on: ${{ matrix.target.os }}
     steps:
     - name: Checkout Repository


### PR DESCRIPTION
This makes it easier to configure them as required checks with Otterdog, otherwise the job names contain all matrix parameters.