### PR TITLE
chore: Use Kotest's `withEnvironment` again

### DIFF
--- a/orchestrator/src/test/kotlin/OrchestratorEndpointTest.kt
+++ b/orchestrator/src/test/kotlin/OrchestratorEndpointTest.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.orchestrator
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.core.test.TestCase
 import io.kotest.engine.test.TestResult
+import io.kotest.extensions.system.withEnvironment
 
 import io.mockk.every
 import io.mockk.just
@@ -65,8 +66,6 @@ import org.koin.test.KoinTest
 import org.koin.test.inject
 import org.koin.test.mock.MockProvider
 import org.koin.test.mock.declareMock
-
-import org.ossreviewtoolkit.utils.test.withEnvironment
 
 class OrchestratorEndpointTest : KoinTest, StringSpec() {
     private val msgHeader = MessageHeader(

--- a/tasks/src/test/kotlin/TaskRunnerTest.kt
+++ b/tasks/src/test/kotlin/TaskRunnerTest.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.tasks
 import com.typesafe.config.ConfigFactory
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.should
@@ -56,8 +57,6 @@ import org.koin.core.module.Module
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 import org.koin.test.KoinTest
-
-import org.ossreviewtoolkit.utils.test.withEnvironment
 
 class TaskRunnerTest : KoinTest, WordSpec() {
     init {

--- a/tasks/src/test/kotlin/impl/DeleteOldOrtRunsTaskTest.kt
+++ b/tasks/src/test/kotlin/impl/DeleteOldOrtRunsTaskTest.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.tasks.impl
 import com.typesafe.config.ConfigFactory
 
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.comparables.shouldBeLessThan
 
 import io.mockk.coEvery
@@ -39,8 +40,6 @@ import kotlinx.datetime.Instant
 
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.services.ortrun.OrtRunService
-
-import org.ossreviewtoolkit.utils.test.withEnvironment
 
 class DeleteOldOrtRunsTaskTest : StringSpec({
     "Old ORT runs should be deleted according to the configured retention policy" {

--- a/tasks/src/test/kotlin/impl/kubernetes/MonitorConfigTest.kt
+++ b/tasks/src/test/kotlin/impl/kubernetes/MonitorConfigTest.kt
@@ -22,14 +22,13 @@ package org.eclipse.apoapsis.ortserver.tasks.impl.kubernetes
 import com.typesafe.config.ConfigFactory
 
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.shouldBe
 
 import kotlin.time.Duration.Companion.minutes
 import kotlin.time.Duration.Companion.seconds
 
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
-
-import org.ossreviewtoolkit.utils.test.withEnvironment
 
 class MonitorConfigTest : StringSpec({
     "The configuration should be loaded correctly" {

--- a/transport/kubernetes/src/test/kotlin/KubernetesMessageReceiverFactoryTest.kt
+++ b/transport/kubernetes/src/test/kotlin/KubernetesMessageReceiverFactoryTest.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.transport.kubernetes
 import com.typesafe.config.ConfigFactory
 
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 
@@ -40,8 +41,6 @@ import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessageHeader
 import org.eclipse.apoapsis.ortserver.transport.RUN_ID_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.TRACE_PROPERTY
-
-import org.ossreviewtoolkit.utils.test.withEnvironment
 
 class KubernetesMessageReceiverFactoryTest : StringSpec({
     beforeAny {

--- a/transport/kubernetes/src/test/kotlin/KubernetesMessageSenderFactoryTest.kt
+++ b/transport/kubernetes/src/test/kotlin/KubernetesMessageSenderFactoryTest.kt
@@ -23,6 +23,7 @@ import com.typesafe.config.ConfigFactory
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.engine.spec.tempfile
+import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldContainInOrder
 import io.kotest.matchers.maps.shouldContainExactly
@@ -34,8 +35,6 @@ import io.kotest.matchers.types.shouldBeTypeOf
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.transport.AnalyzerEndpoint
 import org.eclipse.apoapsis.ortserver.transport.MessageSenderFactory
-
-import org.ossreviewtoolkit.utils.test.withEnvironment
 
 private const val NAMESPACE = "test-namespace"
 private const val IMAGE_NAME = "busybox"

--- a/transport/kubernetes/src/test/kotlin/KubernetesMessageSenderTest.kt
+++ b/transport/kubernetes/src/test/kotlin/KubernetesMessageSenderTest.kt
@@ -23,6 +23,7 @@ import com.typesafe.config.ConfigFactory
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.extensions.system.OverrideMode
+import io.kotest.extensions.system.withEnvironment
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainOnly
@@ -51,8 +52,6 @@ import org.eclipse.apoapsis.ortserver.transport.Message
 import org.eclipse.apoapsis.ortserver.transport.MessageHeader
 import org.eclipse.apoapsis.ortserver.transport.RUN_ID_PROPERTY
 import org.eclipse.apoapsis.ortserver.transport.TRACE_PROPERTY
-
-import org.ossreviewtoolkit.utils.test.withEnvironment
 
 class KubernetesMessageSenderTest : StringSpec({
     "Kubernetes jobs are created via the sender" {

--- a/utils/test/build.gradle.kts
+++ b/utils/test/build.gradle.kts
@@ -35,7 +35,7 @@ kotlin {
 
         jvmMain {
             dependencies {
-                api(ortLibs.utils.test)
+                api(libs.kotestExtensions)
 
                 // Transitively export this to consumers so they do not have to declare a logger implementation.
                 api(libs.logback)

--- a/workers/advisor/src/test/kotlin/AdvisorEndpointTest.kt
+++ b/workers/advisor/src/test/kotlin/AdvisorEndpointTest.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.workers.advisor
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.core.test.TestCase
 import io.kotest.engine.test.TestResult
+import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
@@ -50,8 +51,6 @@ import org.koin.test.KoinTest
 import org.koin.test.inject
 import org.koin.test.mock.MockProvider
 import org.koin.test.mock.declareMock
-
-import org.ossreviewtoolkit.utils.test.withEnvironment
 
 private const val ADVISOR_JOB_ID = 1L
 private const val TRACE_ID = "42"

--- a/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
@@ -26,6 +26,7 @@ import io.kotest.core.test.TestCase
 import io.kotest.engine.spec.tempdir
 import io.kotest.engine.test.TestResult
 import io.kotest.extensions.system.OverrideMode
+import io.kotest.extensions.system.withEnvironment
 import io.kotest.extensions.system.withSystemProperties
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.shouldBe
@@ -85,8 +86,6 @@ import org.koin.test.KoinTest
 import org.koin.test.inject
 import org.koin.test.mock.MockProvider
 import org.koin.test.mock.declareMock
-
-import org.ossreviewtoolkit.utils.test.withEnvironment
 
 private const val JOB_ID = 1L
 private const val TRACE_ID = "42"

--- a/workers/common/src/test/kotlin/common/auth/UserInfoSecretAuthenticatorTest.kt
+++ b/workers/common/src/test/kotlin/common/auth/UserInfoSecretAuthenticatorTest.kt
@@ -20,6 +20,7 @@
 package org.eclipse.apoapsis.ortserver.workers.common.auth
 
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
@@ -28,8 +29,6 @@ import io.kotest.matchers.shouldBe
 import java.net.Authenticator
 import java.net.PasswordAuthentication
 import java.net.URI
-
-import org.ossreviewtoolkit.utils.test.withEnvironment
 
 class UserInfoSecretAuthenticatorTest : StringSpec({
     "A URL with credentials defined in a 'URL' variable should be handled correctly" {

--- a/workers/common/src/test/kotlin/common/env/ConfigFileBuilderTest.kt
+++ b/workers/common/src/test/kotlin/common/env/ConfigFileBuilderTest.kt
@@ -23,6 +23,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.engine.spec.tempdir
 import io.kotest.engine.spec.tempfile
 import io.kotest.extensions.system.OverrideMode
+import io.kotest.extensions.system.withEnvironment
 import io.kotest.extensions.system.withSystemProperties
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
@@ -36,8 +37,6 @@ import org.eclipse.apoapsis.ortserver.workers.common.auth.undefinedCredentialRes
 import org.eclipse.apoapsis.ortserver.workers.common.auth.undefinedInfraSecretResolver
 import org.eclipse.apoapsis.ortserver.workers.common.env.ConfigFileBuilder.Companion.printLines
 import org.eclipse.apoapsis.ortserver.workers.common.env.ConfigFileBuilder.Companion.printProxySettings
-
-import org.ossreviewtoolkit.utils.test.withEnvironment
 
 class ConfigFileBuilderTest : StringSpec({
     "A PrintWriter is exposed" {

--- a/workers/common/src/test/kotlin/common/env/NpmRcGeneratorTest.kt
+++ b/workers/common/src/test/kotlin/common/env/NpmRcGeneratorTest.kt
@@ -20,6 +20,7 @@
 package org.eclipse.apoapsis.ortserver.workers.common.env
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldContain
@@ -28,8 +29,6 @@ import io.mockk.every
 
 import org.eclipse.apoapsis.ortserver.workers.common.env.definition.NpmAuthMode
 import org.eclipse.apoapsis.ortserver.workers.common.env.definition.NpmDefinition
-
-import org.ossreviewtoolkit.utils.test.withEnvironment
 
 class NpmRcGeneratorTest : WordSpec({
     "environmentDefinitionType" should {

--- a/workers/common/src/test/kotlin/common/env/YarnRcGeneratorTest.kt
+++ b/workers/common/src/test/kotlin/common/env/YarnRcGeneratorTest.kt
@@ -21,6 +21,7 @@ package org.eclipse.apoapsis.ortserver.workers.common.common.env
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.extensions.system.OverrideMode
+import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.shouldBe
 
@@ -28,8 +29,6 @@ import org.eclipse.apoapsis.ortserver.workers.common.env.MockConfigFileBuilder
 import org.eclipse.apoapsis.ortserver.workers.common.env.YarnRcGenerator
 import org.eclipse.apoapsis.ortserver.workers.common.env.definition.YarnAuthMode
 import org.eclipse.apoapsis.ortserver.workers.common.env.definition.YarnDefinition
-
-import org.ossreviewtoolkit.utils.test.withEnvironment
 
 class YarnRcGeneratorTest : WordSpec({
     "environmentDefinitionType" should {

--- a/workers/config/src/test/kotlin/EndpointTest.kt
+++ b/workers/config/src/test/kotlin/EndpointTest.kt
@@ -20,6 +20,7 @@
 package org.eclipse.apoapsis.ortserver.workers.config
 
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
@@ -48,8 +49,6 @@ import org.koin.test.KoinTest
 import org.koin.test.inject
 import org.koin.test.mock.MockProvider
 import org.koin.test.mock.declareMock
-
-import org.ossreviewtoolkit.utils.test.withEnvironment
 
 class EndpointTest : KoinTest, StringSpec() {
     init {

--- a/workers/evaluator/src/test/kotlin/EvaluatorEndpointTest.kt
+++ b/workers/evaluator/src/test/kotlin/EvaluatorEndpointTest.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.workers.evaluator
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.core.test.TestCase
 import io.kotest.engine.test.TestResult
+import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
@@ -50,8 +51,6 @@ import org.koin.core.context.stopKoin
 import org.koin.test.KoinTest
 import org.koin.test.mock.MockProvider
 import org.koin.test.mock.declareMock
-
-import org.ossreviewtoolkit.utils.test.withEnvironment
 
 private const val EVALUATOR_JOB_ID = 1L
 private const val TRACE_ID = "42"

--- a/workers/notifier/src/test/kotlin/NotifierEndpointTest.kt
+++ b/workers/notifier/src/test/kotlin/NotifierEndpointTest.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.workers.notifier
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.core.test.TestCase
 import io.kotest.engine.test.TestResult
+import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
@@ -50,8 +51,6 @@ import org.koin.test.KoinTest
 import org.koin.test.inject
 import org.koin.test.mock.MockProvider
 import org.koin.test.mock.declareMock
-
-import org.ossreviewtoolkit.utils.test.withEnvironment
 
 private const val NOTIFIER_JOB_ID = 1L
 private const val TRACE_ID = "42"

--- a/workers/reporter/src/test/kotlin/reporter/ReporterComponentTest.kt
+++ b/workers/reporter/src/test/kotlin/reporter/ReporterComponentTest.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.workers.reporter
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.core.test.TestCase
 import io.kotest.engine.test.TestResult
+import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
@@ -51,8 +52,6 @@ import org.koin.test.KoinTest
 import org.koin.test.inject
 import org.koin.test.mock.MockProvider
 import org.koin.test.mock.declareMock
-
-import org.ossreviewtoolkit.utils.test.withEnvironment
 
 private const val REPORTER_JOB_ID = 1L
 private const val TRACE_ID = "42"

--- a/workers/reporter/src/test/kotlin/reporter/ReporterEndpointTest.kt
+++ b/workers/reporter/src/test/kotlin/reporter/ReporterEndpointTest.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.workers.reporter
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.core.test.TestCase
 import io.kotest.engine.test.TestResult
+import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
@@ -50,8 +51,6 @@ import org.koin.test.KoinTest
 import org.koin.test.inject
 import org.koin.test.mock.MockProvider
 import org.koin.test.mock.declareMock
-
-import org.ossreviewtoolkit.utils.test.withEnvironment
 
 private const val REPORTER_JOB_ID = 1L
 private const val TRACE_ID = "42"

--- a/workers/scanner/src/test/kotlin/ScannerEndpointTest.kt
+++ b/workers/scanner/src/test/kotlin/ScannerEndpointTest.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.workers.scanner
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.core.test.TestCase
 import io.kotest.engine.test.TestResult
+import io.kotest.extensions.system.withEnvironment
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
@@ -50,8 +51,6 @@ import org.koin.test.KoinTest
 import org.koin.test.inject
 import org.koin.test.mock.MockProvider
 import org.koin.test.mock.declareMock
-
-import org.ossreviewtoolkit.utils.test.withEnvironment
 
 private const val SCANNER_JOB_ID = 1L
 private const val TRACE_ID = "42"


### PR DESCRIPTION
This was re-introduced in Kotest 6.0.3.