### PR TITLE
build(gradle): Remove the `versions` plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,8 +17,6 @@
  * License-Filename: LICENSE
  */
 
-import com.github.benmanes.gradle.versions.updates.DependencyUpdatesTask
-
 import git.semver.plugin.gradle.PrintTask
 
 val dockerBaseBuildArgs: String by project
@@ -29,7 +27,6 @@ val containerEngineCommand: String by project
 plugins {
     alias(libs.plugins.gitSemver)
     alias(libs.plugins.jib) apply false
-    alias(libs.plugins.versions)
 }
 
 semver {
@@ -59,21 +56,6 @@ if (version == Project.DEFAULT_VERSION) {
 }
 
 logger.lifecycle("Building ORT Server version $version.")
-
-tasks.named<DependencyUpdatesTask>("dependencyUpdates").configure {
-    gradleReleaseChannel = "current"
-    outputFormatter = "json"
-
-    val nonFinalQualifiers = listOf(
-        "alpha", "b", "beta", "cr", "dev", "ea", "eap", "m", "milestone", "pr", "preview", "rc", "\\d{14}"
-    ).joinToString("|", "(", ")")
-
-    val nonFinalQualifiersRegex = Regex(".*[.-]$nonFinalQualifiers[.\\d-+]*", RegexOption.IGNORE_CASE)
-
-    rejectVersionIf {
-        candidate.version.matches(nonFinalQualifiersRegex)
-    }
-}
 
 // Gradle's "dependencies" task selector only executes on a single / the current project [1]. However, sometimes viewing
 // all dependencies at once is beneficial, e.g., for debugging version conflict resolution.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,7 +32,6 @@ kotlinxDatetime = "0.6.2"
 kotlinxSerialization = "1.9.0"
 kspPlugin = "2.2.10-2.0.2"
 mavenPublishPlugin = "0.34.0"
-versionsPlugin = "0.52.0"
 
 # Gradle dependencies
 aedile = "3.0.1"
@@ -82,7 +81,6 @@ gitSemver = { id = "com.github.jmongard.git-semver-plugin", version.ref = "gitSe
 jib = { id = "com.google.cloud.tools.jib", version.ref = "jibPlugin" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlinPlugin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "kspPlugin" }
-versions = { id = "com.github.ben-manes.versions", version.ref = "versionsPlugin" }
 
 [libraries]
 # These are Maven coordinates for Gradle plugins, which is necessary to use them in precompiled plugin scripts.


### PR DESCRIPTION
Follow ORT in removing the `versions` plugin as the task to update dependencies has been fully taken over by Renovate. Local users may want to give [1] a try instead.

[1]: https://github.com/bishiboosh/caupain