### PR TITLE
fix(core): Add missing project dependencies

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -63,6 +63,7 @@ repositories {
 dependencies {
     implementation(projects.api.v1.apiV1Mapping)
     implementation(projects.clients.keycloak)
+    implementation(projects.components.adminConfig.backend)
     implementation(projects.components.adminConfig.backend) {
         capabilities {
             requireCapability("$group:routes")
@@ -75,6 +76,7 @@ dependencies {
             requireCapability("$group:routes")
         }
     }
+    implementation(projects.components.secrets.backend)
     implementation(projects.components.secrets.backend) {
         capabilities {
             requireCapability("$group:routes")


### PR DESCRIPTION
Adding a dependency on a feature variant of a module does not automatically add a dependency to the main part of the module (see the example at [1]). Add the missing project dependencies to prevent class not found exceptions at runtime.

This is a fixup for bd3754f.

[1]: https://docs.gradle.org/current/userguide/how_to_create_feature_variants_of_a_library.html#sec::consuming_feature_variants