### PR TITLE
fix(gradle): Add a version to the routes capability

### DIFF
--- a/buildSrc/src/main/kotlin/ort-server-kotlin-component-backend-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-kotlin-component-backend-conventions.gradle.kts
@@ -27,7 +27,7 @@ plugins {
 java {
     registerFeature("routes") {
         usingSourceSet(sourceSets.create("routes"))
-        capability(group.toString(), "routes", "")
+        capability(group.toString(), "routes", version.toString())
     }
 }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -66,20 +66,20 @@ dependencies {
     implementation(projects.components.adminConfig.backend)
     implementation(projects.components.adminConfig.backend) {
         capabilities {
-            requireCapability("$group:routes")
+            requireCapability("$group:routes:$version")
         }
     }
     implementation(projects.components.authorization.backend)
     implementation(projects.components.pluginManager.backend)
     implementation(projects.components.pluginManager.backend) {
         capabilities {
-            requireCapability("$group:routes")
+            requireCapability("$group:routes:$version")
         }
     }
     implementation(projects.components.secrets.backend)
     implementation(projects.components.secrets.backend) {
         capabilities {
-            requireCapability("$group:routes")
+            requireCapability("$group:routes:$version")
         }
     }
     implementation(projects.config.configSpi)


### PR DESCRIPTION
While the version is not required for the local build, the module file published to Maven Central cannot be parsed if the version is missing.