### PR TITLE
build(gradle): Use Kotest 6 extensions

### DIFF
--- a/clients/keycloak/build.gradle.kts
+++ b/clients/keycloak/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     implementation(libs.kotlinxSerializationJson)
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestExtensionsTestContainer)
+    testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
 
     testFixturesApi(libs.kotestFrameworkEngine)

--- a/config/spi/build.gradle.kts
+++ b/config/spi/build.gradle.kts
@@ -34,7 +34,7 @@ dependencies {
     implementation(projects.utils.config)
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestExtensionsTestContainer)
+    testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
 

--- a/dao/build.gradle.kts
+++ b/dao/build.gradle.kts
@@ -65,9 +65,10 @@ dependencies {
     testFixturesImplementation(projects.config.configSpi)
 
     testFixturesImplementation(libs.flywayCore)
+    testFixturesImplementation(libs.hikari)
     testFixturesImplementation(libs.jacksonModuleKotlin)
     testFixturesImplementation(libs.koinTest)
-    testFixturesImplementation(libs.kotestExtensionsTestContainer)
+    testFixturesImplementation(libs.kotestExtensionsTestcontainers)
     testFixturesImplementation(libs.kotestRunnerJunit5)
     testFixturesImplementation(libs.mockk)
     testFixturesImplementation(libs.testContainers)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,7 +55,6 @@ konform = "0.11.1"
 kotest = "6.0.3"
 kotestAssertionsKotlinxDatetime = "1.1.0"
 kotestAssertionsKtor = "2.0.0"
-kotestExtensionTestContainers = "2.0.2"
 kotlinResult = "2.1.0"
 ktorOpenApi = "5.2.0"
 kubernetesClient = "23.0.0"
@@ -117,7 +116,7 @@ kotestAssertionsKotlinxDatetime = { module = "io.kotest.extensions:kotest-assert
 kotestAssertionsKtor = { module = "io.kotest.extensions:kotest-assertions-ktor", version.ref = "kotestAssertionsKtor" }
 kotestAssertionsTable = { module = "io.kotest:kotest-assertions-table", version.ref = "kotest" }
 kotestExtensions = { module = "io.kotest:kotest-extensions", version.ref = "kotest" }
-kotestExtensionsTestContainer = { module = "io.kotest.extensions:kotest-extensions-testcontainers", version.ref = "kotestExtensionTestContainers" }
+kotestExtensionsTestcontainers = { module = "io.kotest:kotest-extensions-testcontainers", version.ref = "kotest" }
 kotestFrameworkEngine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
 kotestRunnerJunit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 kotlinResult = { module = "com.michael-bull.kotlin-result:kotlin-result", version.ref = "kotlinResult" }

--- a/logaccess/spi/build.gradle.kts
+++ b/logaccess/spi/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
     implementation(ortLibs.utils.common)
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestExtensionsTestContainer)
+    testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
 

--- a/secrets/spi/build.gradle.kts
+++ b/secrets/spi/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
     api(projects.model)
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestExtensionsTestContainer)
+    testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
 

--- a/secrets/vault/build.gradle.kts
+++ b/secrets/vault/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
     testImplementation(testFixtures(projects.config.configSpi))
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestExtensionsTestContainer)
+    testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
     testImplementation(libs.testContainersVault)

--- a/storage/azure-blob/build.gradle.kts
+++ b/storage/azure-blob/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
     implementation(libs.azureStorageBlob)
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestExtensionsTestContainer)
+    testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.testContainers)
 }

--- a/storage/database/build.gradle.kts
+++ b/storage/database/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     testImplementation(testFixtures(projects.dao))
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestExtensionsTestContainer)
+    testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
 }

--- a/storage/s3/build.gradle.kts
+++ b/storage/s3/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
     implementation(ortLibs.utils.ort)
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestExtensionsTestContainer)
+    testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.testContainersLocalStack)
 

--- a/storage/spi/build.gradle.kts
+++ b/storage/spi/build.gradle.kts
@@ -36,7 +36,7 @@ dependencies {
     implementation(libs.kotlinxCoroutinesSlf4j)
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestExtensionsTestContainer)
+    testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
 

--- a/transport/activemqartemis/build.gradle.kts
+++ b/transport/activemqartemis/build.gradle.kts
@@ -41,7 +41,7 @@ dependencies {
     testImplementation(testFixtures(projects.transport.transportSpi))
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestExtensionsTestContainer)
+    testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
     testImplementation(libs.testContainers)

--- a/transport/rabbitmq/build.gradle.kts
+++ b/transport/rabbitmq/build.gradle.kts
@@ -40,7 +40,7 @@ dependencies {
     testImplementation(testFixtures(projects.transport.transportSpi))
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestExtensionsTestContainer)
+    testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
     testImplementation(libs.testContainers)

--- a/transport/spi/build.gradle.kts
+++ b/transport/spi/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
     api(libs.koinCore)
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestExtensionsTestContainer)
+    testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
 

--- a/transport/sqs/build.gradle.kts
+++ b/transport/sqs/build.gradle.kts
@@ -44,7 +44,7 @@ dependencies {
     testImplementation(testFixtures(projects.transport.transportSpi))
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestExtensionsTestContainer)
+    testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
     testImplementation(libs.testContainers)

--- a/utils/config/build.gradle.kts
+++ b/utils/config/build.gradle.kts
@@ -30,6 +30,6 @@ dependencies {
     implementation(ortLibs.utils.common)
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestExtensionsTestContainer)
+    testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
 }


### PR DESCRIPTION
As of Kotest 6 all extensions follow the main versioning again, see [1]. Also fix the Testcontainers catalog name while at it.

Note that DAO `testFixtures` now require an explicit dependency on Hikari. Also, some deprecated extension can only be updated once [2] is released.

[1]: https://kotest.io/docs/extensions/test_containers.html#dependencies
[2]: https://github.com/kotest/kotest/pull/5079