### PR TITLE
fix(docker): Change access rights for the `$CARGO_HOME` directory

### DIFF
--- a/workers/analyzer/docker/Analyzer.Dockerfile
+++ b/workers/analyzer/docker/Analyzer.Dockerfile
@@ -555,4 +555,7 @@ WORKDIR $HOMEDIR
 # Install cargo-credential-netrc late in the build to prevent an error accessing /opt/rust/cargo/registry/.
 RUN $CARGO_HOME/bin/cargo install cargo-credential-netrc
 
+# Make sure the user executing the container has access rights in the $CARGO_HOME directory.
+RUN sudo chgrp -R 0 $CARGO_HOME && sudo chmod -R g+rwX $CARGO_HOME
+
 ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
In some environments, Cargo is not able to write to $CARGO_HOME due to missing write permissions. This change ensures that the user running the container can access and modify the $CARGO_HOME directory.