### PR TITLE
refactor(ui): Refactor plugins handling

### DIFF
--- a/ui/src/routes/admin/plugins/route.tsx
+++ b/ui/src/routes/admin/plugins/route.tsx
@@ -19,14 +19,12 @@
 
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 
-import { usePluginsServiceGetApiV1AdminPluginsKey } from '@/api/queries';
-import { PluginsService } from '@/api/requests';
+import { getInstalledPluginsOptions } from '@/hey-api/@tanstack/react-query.gen';
 
 export const Route = createFileRoute('/admin/plugins')({
-  loader: async ({ context }) => {
-    const plugins = await context.queryClient.ensureQueryData({
-      queryKey: [usePluginsServiceGetApiV1AdminPluginsKey],
-      queryFn: () => PluginsService.getApiV1AdminPlugins(),
+  loader: async ({ context: { queryClient } }) => {
+    const plugins = await queryClient.ensureQueryData({
+      ...getInstalledPluginsOptions(),
     });
     return { plugins };
   },

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -25,7 +25,7 @@ import { useState } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 import { z } from 'zod';
 
-import { ApiError, RepositoriesService } from '@/api/requests';
+import { ApiError } from '@/api/requests';
 import { CopyToClipboard } from '@/components/copy-to-clipboard';
 import { ToastError } from '@/components/toast-error';
 import { InlineCode } from '@/components/typography.tsx';
@@ -52,7 +52,7 @@ import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
 import { postOrtRunMutation } from '@/hey-api/@tanstack/react-query.gen';
-import { getOrtRunByIndex } from '@/hey-api/sdk.gen';
+import { getOrtRunByIndex, getPluginsForRepository } from '@/hey-api/sdk.gen';
 import { useUser } from '@/hooks/use-user.ts';
 import { toast } from '@/lib/toast';
 import { AdvisorFields } from '../../-components/advisor-fields';
@@ -78,9 +78,9 @@ const CreateRunPage = () => {
   const isSuperuser = user.hasRole(['superuser']);
 
   const advisorPlugins =
-    plugins?.filter((plugin) => plugin.type === 'ADVISOR') || [];
+    plugins?.data?.filter((plugin) => plugin.type === 'ADVISOR') || [];
   const reporterPlugins =
-    plugins?.filter((plugin) => plugin.type === 'REPORTER') || [];
+    plugins?.data?.filter((plugin) => plugin.type === 'REPORTER') || [];
 
   type AccordionSection =
     | 'analyzer'
@@ -558,8 +558,10 @@ export const Route = createFileRoute(
             },
           })
         : Promise.resolve(null as null),
-      RepositoriesService.getApiV1RepositoriesByRepositoryIdPlugins({
-        repositoryId: Number.parseInt(params.repoId),
+      getPluginsForRepository({
+        path: {
+          repositoryId: Number.parseInt(params.repoId),
+        },
       }),
     ]);
 


### PR DESCRIPTION
This PR concludes the refactoring of the query client to use the hey-api instead of the old one.

After this PR and #3541 are merged, the old query client will be removed, and the error handling will be returned to have the more informative error messaged from back-end again.

This picture shows that the only import from the old query client is the `ApiError` which will be the topic of the final refactoring follow-up PR.
<img width="251" height="869" alt="Screenshot from 2025-09-17 07-28-27" src="https://github.com/user-attachments/assets/0f54c6ab-12ad-40cd-a6e8-ab870c873672" />
