### PR TITLE
feat: Implement filtering functionality across repositories: organization, product, repository

### DIFF
--- a/core/src/main/kotlin/api/ProductsRoute.kt
+++ b/core/src/main/kotlin/api/ProductsRoute.kt
@@ -84,6 +84,7 @@ import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToModel
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse
 import org.eclipse.apoapsis.ortserver.shared.apimodel.SortDirection
 import org.eclipse.apoapsis.ortserver.shared.apimodel.SortProperty
+import org.eclipse.apoapsis.ortserver.shared.ktorutils.filterParameter
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.pagingOptions
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireEnumParameter
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireIdParameter
@@ -144,12 +145,13 @@ fun Route.products() = route("products/{productId}") {
     route("repositories") {
         get(getRepositoriesByProductId) {
             requirePermission(ProductPermission.READ_REPOSITORIES)
+            val filter = call.filterParameter("filter")
 
             val productId = call.requireIdParameter("productId")
             val pagingOptions = call.pagingOptions(SortProperty("url", SortDirection.ASCENDING))
 
             val repositoriesForProduct =
-                productService.listRepositoriesForProduct(productId, pagingOptions.mapToModel())
+                productService.listRepositoriesForProduct(productId, pagingOptions.mapToModel(), filter?.mapToModel())
 
             val pagedResponse = repositoriesForProduct.mapToApi(Repository::mapToApi)
 

--- a/dao/src/main/kotlin/repositories/product/DaoProductRepository.kt
+++ b/dao/src/main/kotlin/repositories/product/DaoProductRepository.kt
@@ -21,13 +21,17 @@ package org.eclipse.apoapsis.ortserver.dao.repositories.product
 
 import org.eclipse.apoapsis.ortserver.dao.blockingQuery
 import org.eclipse.apoapsis.ortserver.dao.entityQuery
+import org.eclipse.apoapsis.ortserver.dao.utils.applyRegex
 import org.eclipse.apoapsis.ortserver.dao.utils.listQuery
 import org.eclipse.apoapsis.ortserver.model.repositories.ProductRepository
+import org.eclipse.apoapsis.ortserver.model.util.FilterParameter
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.OptionalValue
 
 import org.jetbrains.exposed.sql.Database
+import org.jetbrains.exposed.sql.Op
 import org.jetbrains.exposed.sql.SqlExpressionBuilder.eq
+import org.jetbrains.exposed.sql.and
 
 class DaoProductRepository(private val db: Database) : ProductRepository {
     override fun create(name: String, description: String?, organizationId: Long) = db.blockingQuery {
@@ -40,14 +44,31 @@ class DaoProductRepository(private val db: Database) : ProductRepository {
 
     override fun get(id: Long) = db.entityQuery { ProductDao[id].mapToModel() }
 
-    override fun list(parameters: ListQueryParameters) =
-        db.blockingQuery { ProductDao.list(parameters).map { it.mapToModel() } }
+    override fun list(parameters: ListQueryParameters, filter: FilterParameter?) =
+        db.blockingQuery {
+            ProductDao.listQuery(parameters, ProductDao::mapToModel) {
+                var condition: Op<Boolean> = Op.TRUE
+                filter?.let {
+                    condition = condition and ProductsTable.name.applyRegex(
+                        it.value
+                    )
+                }
+                condition
+            }
+        }
 
     override fun countForOrganization(organizationId: Long) =
         ProductDao.count(ProductsTable.organizationId eq organizationId)
 
-    override fun listForOrganization(organizationId: Long, parameters: ListQueryParameters) = db.blockingQuery {
-        ProductDao.listQuery(parameters, ProductDao::mapToModel) { ProductsTable.organizationId eq organizationId }
+    override fun listForOrganization(organizationId: Long, parameters: ListQueryParameters, filter: FilterParameter?) =
+        db.blockingQuery {
+        ProductDao.listQuery(parameters, ProductDao::mapToModel) {
+            if (filter != null) {
+                ProductsTable.organizationId eq organizationId and ProductsTable.name.applyRegex(filter.value)
+            } else {
+                ProductsTable.organizationId eq organizationId
+            }
+        }
     }
 
     override fun update(id: Long, name: OptionalValue<String>, description: OptionalValue<String?>) = db.blockingQuery {

--- a/dao/src/main/kotlin/utils/Extensions.kt
+++ b/dao/src/main/kotlin/utils/Extensions.kt
@@ -185,10 +185,21 @@ fun <T : Comparable<T>> Column<T>.applyFilter(operator: ComparisonOperator, valu
 class InsensitiveLikeOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, "ILIKE")
 
 /**
+*  Represents a regex operation. This is an extension of the [ComparisonOp] class that uses the REGEX operator,
+* */
+class RegexOp(expr1: Expression<*>, expr2: Expression<*>) : ComparisonOp(expr1, expr2, "~")
+
+/**
  * Apply the given [value] to filter this column by using the ILIKE operator.
  */
 fun Expression<String>.applyILike(value: String): Op<Boolean> =
     InsensitiveLikeOp(this, QueryParameter("%$value%", TextColumnType()))
+
+/*
+*  Apply the given [value] to filter this column by using the REGEX operator.
+*/
+fun Expression<String>.applyRegex(value: String): Op<Boolean> =
+    RegexOp(this, QueryParameter(value, TextColumnType()))
 
 /**
  * Apply the given [operator] and filter [values] to filter this column by. This is an overload of the

--- a/model/src/commonMain/kotlin/repositories/OrganizationRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/OrganizationRepository.kt
@@ -20,7 +20,9 @@
 package org.eclipse.apoapsis.ortserver.model.repositories
 
 import org.eclipse.apoapsis.ortserver.model.Organization
+import org.eclipse.apoapsis.ortserver.model.util.FilterParameter
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
+import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
 import org.eclipse.apoapsis.ortserver.model.util.OptionalValue
 
 /**
@@ -40,7 +42,10 @@ interface OrganizationRepository {
     /**
      * List all organizations according to the given [parameters].
      */
-    fun list(parameters: ListQueryParameters = ListQueryParameters.DEFAULT): List<Organization>
+    fun list(
+        parameters: ListQueryParameters = ListQueryParameters.DEFAULT,
+        filter: FilterParameter? = null
+    ): ListQueryResult<Organization>
 
     /**
      * Update an organization by [id] with the [present][OptionalValue.Present] values.

--- a/model/src/commonMain/kotlin/repositories/ProductRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/ProductRepository.kt
@@ -20,6 +20,7 @@
 package org.eclipse.apoapsis.ortserver.model.repositories
 
 import org.eclipse.apoapsis.ortserver.model.Product
+import org.eclipse.apoapsis.ortserver.model.util.FilterParameter
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
 import org.eclipse.apoapsis.ortserver.model.util.OptionalValue
@@ -41,14 +42,18 @@ interface ProductRepository {
     /**
      * List all products according to the given [parameters].
      */
-    fun list(parameters: ListQueryParameters = ListQueryParameters.DEFAULT): List<Product>
+    fun list(
+        parameters: ListQueryParameters = ListQueryParameters.DEFAULT,
+        filter: FilterParameter? = null
+    ): ListQueryResult<Product>
 
     /**
      * List all products for an [organization][organizationId] according to the given [parameters].
      */
     fun listForOrganization(
         organizationId: Long,
-        parameters: ListQueryParameters = ListQueryParameters.DEFAULT
+        parameters: ListQueryParameters = ListQueryParameters.DEFAULT,
+        filter: FilterParameter? = null
     ): ListQueryResult<Product>
 
     /**

--- a/model/src/commonMain/kotlin/repositories/RepositoryRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/RepositoryRepository.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.model.repositories
 import org.eclipse.apoapsis.ortserver.model.Hierarchy
 import org.eclipse.apoapsis.ortserver.model.Repository
 import org.eclipse.apoapsis.ortserver.model.RepositoryType
+import org.eclipse.apoapsis.ortserver.model.util.FilterParameter
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
 import org.eclipse.apoapsis.ortserver.model.util.OptionalValue
@@ -49,14 +50,18 @@ interface RepositoryRepository {
     /**
      * List all repositories according to the given [parameters].
      */
-    fun list(parameters: ListQueryParameters = ListQueryParameters.DEFAULT): List<Repository>
+    fun list(
+        parameters: ListQueryParameters = ListQueryParameters.DEFAULT,
+        filter: FilterParameter? = null
+    ): ListQueryResult<Repository>
 
     /**
      * List all repositories for a [product][productId] according to the given [parameters].
      */
     fun listForProduct(
         productId: Long,
-        parameters: ListQueryParameters = ListQueryParameters.DEFAULT
+        parameters: ListQueryParameters = ListQueryParameters.DEFAULT,
+        filter: FilterParameter? = null
     ): ListQueryResult<Repository>
 
     /**

--- a/model/src/commonMain/kotlin/util/FilterOperatorAndValue.kt
+++ b/model/src/commonMain/kotlin/util/FilterOperatorAndValue.kt
@@ -41,3 +41,7 @@ enum class ComparisonOperator {
     GREATER_OR_EQUAL,
     LESS_OR_EQUAL
 }
+
+data class FilterParameter(
+    val value: String,
+)

--- a/services/authorization/src/main/kotlin/KeycloakAuthorizationService.kt
+++ b/services/authorization/src/main/kotlin/KeycloakAuthorizationService.kt
@@ -212,7 +212,7 @@ class KeycloakAuthorizationService(
         logger.info("Synchronizing Keycloak roles for organization permissions.")
 
         runCatching {
-            val organizationIds = db.dbQuery { organizationRepository.list() }.mapTo(mutableSetOf()) { it.id }
+            val organizationIds = db.dbQuery { organizationRepository.list().data }.mapTo(mutableSetOf()) { it.id }
 
             organizationIds.forEach { organizationId ->
                 val requiredRoles = OrganizationPermission.getRolesForOrganization(organizationId)
@@ -241,7 +241,7 @@ class KeycloakAuthorizationService(
         logger.info("Synchronizing Keycloak roles for product permissions.")
 
         runCatching {
-            val productIds = db.dbQuery { productRepository.list() }.mapTo(mutableSetOf()) { it.id }
+            val productIds = db.dbQuery { productRepository.list().data }.mapTo(mutableSetOf()) { it.id }
 
             productIds.forEach { productId ->
                 val requiredRoles = ProductPermission.getRolesForProduct(productId)
@@ -270,7 +270,7 @@ class KeycloakAuthorizationService(
         logger.info("Synchronizing Keycloak roles for repository permissions.")
 
         runCatching {
-            val repositoryIds = db.dbQuery { repositoryRepository.list() }.mapTo(mutableSetOf()) { it.id }
+            val repositoryIds = db.dbQuery { repositoryRepository.list().data }.mapTo(mutableSetOf()) { it.id }
 
             repositoryIds.forEach { repository ->
                 val requiredRoles = RepositoryPermission.getRolesForRepository(repository)
@@ -329,7 +329,7 @@ class KeycloakAuthorizationService(
         logger.info("Synchronizing Keycloak roles for organization roles.")
 
         runCatching {
-            val organizationIds = db.dbQuery { organizationRepository.list().mapTo(mutableSetOf()) { it.id } }
+            val organizationIds = db.dbQuery { organizationRepository.list().data.mapTo(mutableSetOf()) { it.id } }
 
             organizationIds.forEach { organizationId ->
                 // Make sure that all roles exist.
@@ -375,7 +375,7 @@ class KeycloakAuthorizationService(
         logger.info("Synchronizing Keycloak roles for product roles.")
 
         runCatching {
-            val products = db.dbQuery { productRepository.list() }
+            val products = db.dbQuery { productRepository.list().data }
 
             products.forEach { product ->
                 // Make sure that all roles exist.
@@ -439,7 +439,7 @@ class KeycloakAuthorizationService(
         logger.info("Synchronizing Keycloak roles for repository roles.")
 
         runCatching {
-            val repositories = db.dbQuery { repositoryRepository.list() }
+            val repositories = db.dbQuery { repositoryRepository.list().data }
 
             repositories.forEach { repository ->
                 // Make sure that all roles exist.
@@ -501,7 +501,7 @@ class KeycloakAuthorizationService(
         logger.info("Synchronizing Keycloak groups for organization roles.")
 
         runCatching {
-            val organizationIds = db.dbQuery { organizationRepository.list().mapTo(mutableSetOf()) { it.id } }
+            val organizationIds = db.dbQuery { organizationRepository.list().data.mapTo(mutableSetOf()) { it.id } }
 
             organizationIds.forEach { organizationId ->
                 // Make sure that all groups exist.
@@ -542,7 +542,7 @@ class KeycloakAuthorizationService(
         logger.info("Synchronizing Keycloak groups for product roles.")
 
         runCatching {
-            val productIds = db.dbQuery { productRepository.list().mapTo(mutableSetOf()) { it.id } }
+            val productIds = db.dbQuery { productRepository.list().data.mapTo(mutableSetOf()) { it.id } }
 
             productIds.forEach { productId ->
                 // Make sure that all groups exist.
@@ -583,7 +583,7 @@ class KeycloakAuthorizationService(
         logger.info("Synchronizing Keycloak groups for repository roles.")
 
         runCatching {
-            val repositoryIds = db.dbQuery { repositoryRepository.list().mapTo(mutableSetOf()) { it.id } }
+            val repositoryIds = db.dbQuery { repositoryRepository.list().data.mapTo(mutableSetOf()) { it.id } }
 
             repositoryIds.forEach { repositoryId ->
                 // Make sure that all groups exist.

--- a/services/authorization/src/test/kotlin/KeycloakAuthorizationServiceTest.kt
+++ b/services/authorization/src/test/kotlin/KeycloakAuthorizationServiceTest.kt
@@ -81,13 +81,13 @@ class KeycloakAuthorizationServiceTest : WordSpec({
 
     val organizationRepository = mockk<OrganizationRepository> {
         every { this@mockk.get(organizationId) } returns Organization(id = organizationId, name = "organization")
-        every { list(any()) } returns listOf(organization)
+        every { list(any()).data } returns listOf(organization)
     }
 
     val productRepository = mockk<ProductRepository> {
         every { this@mockk.get(productId) } returns
                 Product(id = productId, organizationId = organizationId, name = "product")
-        every { list(any()) } returns listOf(product)
+        every { list(any()).data } returns listOf(product)
     }
 
     val repositoryRepository = mockk<RepositoryRepository> {
@@ -99,7 +99,7 @@ class KeycloakAuthorizationServiceTest : WordSpec({
                     type = RepositoryType.GIT,
                     url = "https://example.com/repo.git"
                 )
-        every { list(any()) } returns listOf(repository)
+        every { list(any()).data } returns listOf(repository)
     }
 
     fun createService(keycloakClient: KeycloakClient) =

--- a/services/hierarchy/src/main/kotlin/OrganizationService.kt
+++ b/services/hierarchy/src/main/kotlin/OrganizationService.kt
@@ -26,7 +26,9 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.repository.RepositoriesTa
 import org.eclipse.apoapsis.ortserver.model.Organization
 import org.eclipse.apoapsis.ortserver.model.repositories.OrganizationRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.ProductRepository
+import org.eclipse.apoapsis.ortserver.model.util.FilterParameter
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
+import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
 import org.eclipse.apoapsis.ortserver.model.util.OptionalValue
 
 import org.jetbrains.exposed.sql.Database
@@ -103,9 +105,10 @@ class OrganizationService(
      * List all organizations according to the given [parameters].
      */
     suspend fun listOrganizations(
-        parameters: ListQueryParameters = ListQueryParameters.DEFAULT
-    ): List<Organization> = db.dbQuery {
-        organizationRepository.list(parameters)
+        parameters: ListQueryParameters = ListQueryParameters.DEFAULT,
+        filter: FilterParameter? = null
+    ): ListQueryResult<Organization> = db.dbQuery {
+        organizationRepository.list(parameters, filter)
     }
 
     /**
@@ -113,9 +116,10 @@ class OrganizationService(
      */
     suspend fun listProductsForOrganization(
         organizationId: Long,
-        parameters: ListQueryParameters = ListQueryParameters.DEFAULT
+        parameters: ListQueryParameters = ListQueryParameters.DEFAULT,
+        filter: FilterParameter? = null
     ) = db.dbQuery {
-        productRepository.listForOrganization(organizationId, parameters)
+        productRepository.listForOrganization(organizationId, parameters, filter)
     }
 
     /**

--- a/services/hierarchy/src/main/kotlin/ProductService.kt
+++ b/services/hierarchy/src/main/kotlin/ProductService.kt
@@ -31,6 +31,7 @@ import org.eclipse.apoapsis.ortserver.model.RepositoryType
 import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.ProductRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.RepositoryRepository
+import org.eclipse.apoapsis.ortserver.model.util.FilterParameter
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
 import org.eclipse.apoapsis.ortserver.model.util.OptionalValue
@@ -102,9 +103,10 @@ class ProductService(
      */
     suspend fun listRepositoriesForProduct(
         productId: Long,
-        parameters: ListQueryParameters = ListQueryParameters.DEFAULT
+        parameters: ListQueryParameters = ListQueryParameters.DEFAULT,
+        filter: FilterParameter? = null
     ): ListQueryResult<Repository> = db.dbQuery {
-        repositoryRepository.listForProduct(productId, parameters)
+        repositoryRepository.listForProduct(productId, parameters, filter)
     }
 
     /**

--- a/shared/api-mappings/src/commonMain/kotlin/PagedResponseMappings.kt
+++ b/shared/api-mappings/src/commonMain/kotlin/PagedResponseMappings.kt
@@ -19,10 +19,12 @@
 
 package org.eclipse.apoapsis.ortserver.shared.apimappings
 
+import org.eclipse.apoapsis.ortserver.model.util.FilterParameter
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
 import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
 import org.eclipse.apoapsis.ortserver.model.util.OrderField
+import org.eclipse.apoapsis.ortserver.shared.apimodel.FilterOptions
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagingOptions
 import org.eclipse.apoapsis.ortserver.shared.apimodel.SortDirection
@@ -41,6 +43,8 @@ fun ListQueryParameters.mapToApi() =
         sortProperties = sortFields.map { it.mapToApi() }
     )
 
+fun FilterParameter.mapToApi() = FilterOptions(value)
+
 fun OrderField.mapToApi() = SortProperty(name, direction.mapToApi())
 
 fun OrderDirection.mapToApi() =
@@ -55,6 +59,8 @@ fun PagingOptions.mapToModel() =
         limit = limit,
         offset = offset
     )
+
+fun FilterOptions.mapToModel() = FilterParameter(value)
 
 fun SortProperty.mapToModel() = OrderField(name, direction.mapToModel())
 

--- a/shared/api-model/src/commonMain/kotlin/PagedResponse.kt
+++ b/shared/api-model/src/commonMain/kotlin/PagedResponse.kt
@@ -119,3 +119,9 @@ enum class SortDirection {
     /** Constant for _descending_ sort direction. */
     DESCENDING
 }
+
+@Serializable
+data class FilterOptions(
+    /** The filter string, interpreted as a regular expression. */
+    val value: String
+)

--- a/shared/ktor-utils/src/main/kotlin/ParameterHelpers.kt
+++ b/shared/ktor-utils/src/main/kotlin/ParameterHelpers.kt
@@ -23,6 +23,8 @@ import io.ktor.server.application.ApplicationCall
 import io.ktor.server.plugins.MissingRequestParameterException
 import io.ktor.server.plugins.ParameterConversionException
 
+import org.eclipse.apoapsis.ortserver.shared.apimodel.FilterOptions
+
 /**
  * Return the numeric value of the parameter with the given [name] or throw an exception if it cannot be converted to a
  * number.
@@ -46,6 +48,16 @@ fun ApplicationCall.requireIdParameter(name: String): Long {
     val id = requireParameter(name).toLongOrNull()
 
     return if (id != null && id > 0) id else throw ParameterConversionException(name, "ID")
+}
+
+/**
+ * Get the filter parameter from this [ApplicationCall] or return null if the parameter is null.
+ */
+fun ApplicationCall.filterParameter(name: String): FilterOptions? {
+    val filter = parameters[name]?.let { filter ->
+        FilterOptions(filter)
+    }
+    return filter
 }
 
 inline fun <reified T : Enum<T>> ApplicationCall.requireEnumParameter(name: String): T =


### PR DESCRIPTION
Hi,
this PR is related to the implementation of a name filter using regular expressions (regex) #3428.
The changes introduced are as follows:

Added a filter parameter (nullable) that allows filtering by the entity name or, in the case of a repository, by its URL.

The filter supports regex-based searches for greater flexibility.

Updated the organizationRepository.list method, which now returns a ListQueryResult instead of the previous list.

Additionally, the corresponding tests were implemented for both the repositories and the routes to ensure the correct functionality of the new feature.
