### PR TITLE
refactor(services): Don't load file lists for result on IssueService

### DIFF
--- a/services/ort-run/src/main/kotlin/IssueService.kt
+++ b/services/ort-run/src/main/kotlin/IssueService.kt
@@ -63,7 +63,7 @@ class IssueService(private val db: Database, private val ortRunService: OrtRunSe
             "ORT run with ID $ortRunId not found."
         )
 
-        val ortResult = ortRunService.generateOrtResult(ortRun, failIfRepoInfoMissing = false)
+        val ortResult = ortRunService.generateOrtResult(ortRun, failIfRepoInfoMissing = false, loadFileLists = false)
 
         val issues = collectIssues(ortRunId, ortResult)
 


### PR DESCRIPTION
Loading the file lists is not necessary in order to access the needed functions in the `OrtResult` in this particular case. Add a `loadFileLists` flag for the `generateOrtResult` function to allow skipping the loading of the file lists, while still allowing to fetch other data from the database for the `ScannerRun` object.