### PR TITLE
refactor(ui): Refactor left-overs

### DIFF
--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -21,7 +21,6 @@ import { createRouter, RouterProvider } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 import { hasAuthParams } from 'react-oidc-context';
 
-import { OpenAPI } from '@/api/requests/index.ts';
 import { CopyToClipboard } from '@/components/copy-to-clipboard.tsx';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { Button } from '@/components/ui/button.tsx';
@@ -97,7 +96,6 @@ export const App = () => {
 
   useEffect(() => {
     if (auth.user?.access_token) {
-      OpenAPI.TOKEN = auth.user.access_token;
       setTokenIsSet(true);
     } else {
       setTokenIsSet(false);

--- a/ui/src/components/charts/cvss4-vector-card.tsx
+++ b/ui/src/components/charts/cvss4-vector-card.tsx
@@ -17,7 +17,6 @@
  * License-Filename: LICENSE
  */
 
-import { VulnerabilityRating } from '@/api/requests';
 import { Badge } from '@/components/ui/badge';
 import {
   Card,
@@ -33,6 +32,7 @@ import {
 } from '@/components/ui/tooltip';
 import { getVulnerabilityRatingBackgroundColor } from '@/helpers/get-status-class';
 import { Cvss4MacroVector } from '@/helpers/vulnerability-statistics';
+import { VulnerabilityRating } from '@/hey-api';
 
 type Cvss4VectorCardProps = { macroVector: Cvss4MacroVector };
 

--- a/ui/src/components/charts/job-durations.tsx
+++ b/ui/src/components/charts/job-durations.tsx
@@ -17,11 +17,11 @@
  * License-Filename: LICENSE
  */
 
+import { useQuery } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
 import { Bar, BarChart, CartesianGrid, XAxis } from 'recharts';
 
-import { useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdRuns } from '@/api/queries';
 import {
   DEFAULT_RUNS,
   RunsFilterForm,
@@ -46,6 +46,7 @@ import {
   convertDurationToHms,
   getDurationChartData,
 } from '@/helpers/calculate-duration';
+import { getOrtRunsByRepositoryIdOptions } from '@/hey-api/@tanstack/react-query.gen';
 import { toast } from '@/lib/toast';
 
 const chartConfig = {
@@ -109,18 +110,16 @@ export const JobDurations = ({
     error: runsError,
     isPending: runsIsPending,
     isError: runsIsError,
-  } = useRepositoriesServiceGetApiV1RepositoriesByRepositoryIdRuns(
-    {
-      repositoryId: Number.parseInt(repoId),
-      limit,
-      offset,
-      sort: '-index',
-    },
-    undefined,
-    {
-      refetchInterval: pollInterval,
-    }
-  );
+  } = useQuery({
+    ...getOrtRunsByRepositoryIdOptions({
+      path: {
+        repositoryId: Number.parseInt(repoId),
+      },
+      query: { limit, offset, sort: '-index' },
+    }),
+
+    refetchInterval: pollInterval,
+  });
 
   const chartData = getDurationChartData(runs, showInfrastructure);
 

--- a/ui/src/components/charts/vulnerability-metrics.tsx
+++ b/ui/src/components/charts/vulnerability-metrics.tsx
@@ -17,7 +17,6 @@
  * License-Filename: LICENSE
  */
 
-import { Vulnerability } from '@/api/requests';
 import { Cvss4RadarChart } from '@/components/charts/cvss4-radar-chart';
 import { Cvss4VectorCard } from '@/components/charts/cvss4-vector-card';
 import { Cvss23RadarChart } from '@/components/charts/cvss23-radar-chart';
@@ -28,6 +27,7 @@ import {
   findHighestCvssScore,
   findHighestEpssScore,
 } from '@/helpers/vulnerability-statistics';
+import { Vulnerability } from '@/hey-api';
 
 type VulnerabilityMetricsProps = {
   vulnerability: Vulnerability;

--- a/ui/src/components/dependency-paths.tsx
+++ b/ui/src/components/dependency-paths.tsx
@@ -19,11 +19,11 @@
 
 import { MoveRight } from 'lucide-react';
 
-import { Package, ShortestDependencyPath } from '@/api/requests';
 import {
   identifierToPurl,
   identifierToString,
 } from '@/helpers/identifier-conversion.ts';
+import { Package, ShortestDependencyPath } from '@/hey-api';
 import { cn } from '@/lib/utils';
 import { PackageIdType } from '@/schemas';
 

--- a/ui/src/components/ort-run-job-status.tsx
+++ b/ui/src/components/ort-run-job-status.tsx
@@ -19,7 +19,6 @@
 
 import { Link } from '@tanstack/react-router';
 
-import { PagedResponse_OrtRunSummary } from '@/api/requests';
 import {
   Tooltip,
   TooltipContent,
@@ -29,10 +28,11 @@ import {
   getStatusBackgroundColor,
   getStatusClass,
 } from '@/helpers/get-status-class';
+import { PagedResponseOrtRunSummary } from '@/hey-api';
 import { RunDuration } from './run-duration';
 
 type OrtRunJobStatusProps = {
-  jobs: PagedResponse_OrtRunSummary['data'][0]['jobs'];
+  jobs: PagedResponseOrtRunSummary['data'][0]['jobs'];
   orgId: string;
   productId: string;
   repoId: string;

--- a/ui/src/components/package-curation.tsx
+++ b/ui/src/components/package-curation.tsx
@@ -17,9 +17,9 @@
  * License-Filename: LICENSE
  */
 
-import { PackageCurationData } from '@/api/requests';
 import { RenderProperty } from '@/components/render-property';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { PackageCurationData } from '@/hey-api';
 
 type PackageCurationProps = {
   curation: PackageCurationData;

--- a/ui/src/components/providers.tsx
+++ b/ui/src/components/providers.tsx
@@ -22,14 +22,11 @@ import { Log } from 'oidc-client-ts';
 import { ReactNode } from 'react';
 import { AuthProvider } from 'react-oidc-context';
 
-import { OpenAPI as OpenAPIConfig } from '@/api/requests/core/OpenAPI';
 import { ThemeProvider } from '@/components/theme-provider';
 import { Toaster } from '@/components/ui/toaster';
 import { TooltipProvider } from '@/components/ui/tooltip';
 import { config } from '@/config';
 import { queryClient } from '@/lib/query-client';
-
-OpenAPIConfig.BASE = config.API_URL;
 
 const oidcConfig = config.oidcConfig;
 

--- a/ui/src/components/ui/user-group-row-actions.tsx
+++ b/ui/src/components/ui/user-group-row-actions.tsx
@@ -20,7 +20,6 @@
 import { Row } from '@tanstack/react-table';
 import { Eye, Pen, Shield } from 'lucide-react';
 
-import { UserGroup, UserWithGroups } from '@/api/requests';
 import { EllipsisIconButton } from '@/components/ellipsis-icon-button.tsx';
 import {
   DropdownMenu,
@@ -28,6 +27,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu.tsx';
+import { UserGroup, UserWithGroups } from '@/hey-api';
 
 type UserGroupRowActionsProps = {
   row: Row<UserWithGroups>;

--- a/ui/src/helpers/calculate-duration.ts
+++ b/ui/src/helpers/calculate-duration.ts
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-import { JobSummary, PagedResponse_OrtRunSummary } from '@/api/requests';
+import { JobSummary, PagedResponseOrtRunSummary } from '@/hey-api';
 
 function divmod(a: number, b: number): [number, number] {
   const remainder = a % b;
@@ -93,7 +93,7 @@ type DurationChartData = {
 };
 
 export function getDurationChartData(
-  runs: PagedResponse_OrtRunSummary | undefined,
+  runs: PagedResponseOrtRunSummary | undefined,
   showInfra: boolean
 ): DurationChartData[] | undefined {
   return runs?.data.map((run) => {

--- a/ui/src/helpers/get-status-class.ts
+++ b/ui/src/helpers/get-status-class.ts
@@ -22,7 +22,7 @@ import {
   OrtRunStatus,
   Severity,
   VulnerabilityRating,
-} from '@/api/requests';
+} from '@/hey-api';
 import { PackageManagerId } from '@/lib/types';
 import { ItemResolved } from '@/schemas';
 

--- a/ui/src/helpers/identifier-conversion.ts
+++ b/ui/src/helpers/identifier-conversion.ts
@@ -19,7 +19,7 @@
 
 import { PackageURL } from 'packageurl-js';
 
-import { Identifier } from '@/api/requests';
+import { Identifier } from '@/hey-api';
 
 export function identifierToPurl(pkg: Identifier | undefined | null): string {
   if (!pkg) {

--- a/ui/src/helpers/job-helpers.ts
+++ b/ui/src/helpers/job-helpers.ts
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-import { JobStatus } from '@/api/requests';
+import { JobStatus } from '@/hey-api';
 
 /**
  * Check if a job is finished, based on its status. The finished states are

--- a/ui/src/helpers/resolutions.ts
+++ b/ui/src/helpers/resolutions.ts
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-import { Issue, RuleViolation, VulnerabilityWithDetails } from '@/api/requests';
+import { Issue, RuleViolation, VulnerabilityWithDetails } from '@/hey-api';
 
 export type ItemWithResolutions =
   | Issue

--- a/ui/src/helpers/role-helpers.ts
+++ b/ui/src/helpers/role-helpers.ts
@@ -24,7 +24,7 @@ import {
   ProductRole,
   RepositoryRole,
   UserGroup,
-} from '@/api/requests';
+} from '@/hey-api';
 import { groupsSchema } from '@/schemas';
 
 // Temporary helper functions to help with migration from groups to roles.

--- a/ui/src/helpers/sorting-functions.ts
+++ b/ui/src/helpers/sorting-functions.ts
@@ -17,8 +17,8 @@
  * License-Filename: LICENSE
  */
 
-import { Severity, VulnerabilityRating } from '@/api/requests';
 import { vulnerabilityRatings } from '@/helpers/get-status-class';
+import { Severity, VulnerabilityRating } from '@/hey-api';
 
 /**
  * Compare two severities by their severity level. The severity levels are defined as follows:

--- a/ui/src/helpers/vulnerability-statistics.ts
+++ b/ui/src/helpers/vulnerability-statistics.ts
@@ -29,7 +29,7 @@ import {
   V4ScoreResult,
 } from 'ae-cvss-calculator/dist/types/src/CvssVector';
 
-import { Vulnerability } from '@/api/requests/types.gen';
+import { Vulnerability } from '@/hey-api';
 
 export type EpssData = {
   score: number;

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-violations-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-violations-statistics-card.tsx
@@ -20,9 +20,9 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Scale } from 'lucide-react';
 
-import { Severity } from '@/api/requests';
 import { StatisticsCard } from '@/components/statistics-card';
 import { getRuleViolationSeverityBackgroundColor } from '@/helpers/get-status-class';
+import { Severity } from '@/hey-api';
 import { getOrtRunStatisticsByProductIdOptions } from '@/hey-api/@tanstack/react-query.gen';
 import { cn } from '@/lib/utils';
 

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-vulnerabilities-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-vulnerabilities-statistics-card.tsx
@@ -20,9 +20,9 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { ShieldQuestion } from 'lucide-react';
 
-import { VulnerabilityRating } from '@/api/requests';
 import { StatisticsCard } from '@/components/statistics-card';
 import { getVulnerabilityRatingBackgroundColor } from '@/helpers/get-status-class';
+import { VulnerabilityRating } from '@/hey-api';
 import { getOrtRunStatisticsByProductIdOptions } from '@/hey-api/@tanstack/react-query.gen';
 import { cn } from '@/lib/utils';
 

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/advisor-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/advisor-fields.tsx
@@ -19,7 +19,6 @@
 
 import { UseFormReturn } from 'react-hook-form';
 
-import { PreconfiguredPluginDescriptor } from '@/api/requests';
 import { MultiSelectField } from '@/components/form/multi-select-field';
 import {
   AccordionContent,
@@ -34,6 +33,7 @@ import {
   FormLabel,
 } from '@/components/ui/form';
 import { Switch } from '@/components/ui/switch';
+import { PreconfiguredPluginDescriptor } from '@/hey-api';
 import { CreateRunFormValues } from '../_repo-layout/create-run/-create-run-utils';
 
 type AdvisorFieldsProps = {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/reporter-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/reporter-fields.tsx
@@ -19,7 +19,6 @@
 
 import { UseFormReturn } from 'react-hook-form';
 
-import { PreconfiguredPluginDescriptor } from '@/api/requests';
 import { MultiSelectField } from '@/components/form/multi-select-field';
 import {
   AccordionContent,
@@ -34,6 +33,7 @@ import {
   FormLabel,
 } from '@/components/ui/form';
 import { Switch } from '@/components/ui/switch';
+import { PreconfiguredPluginDescriptor } from '@/hey-api';
 import { CreateRunFormValues } from '../_repo-layout/create-run/-create-run-utils';
 
 type ReporterFieldsProps = {

--- a/ui/src/routes/runs/$runId/index.tsx
+++ b/ui/src/routes/runs/$runId/index.tsx
@@ -20,27 +20,23 @@
 import { createFileRoute, redirect } from '@tanstack/react-router';
 import { AlertCircle } from 'lucide-react';
 
-import { ApiError, RunsService } from '@/api/requests';
 import { NotFoundError } from '@/components/not-found-error';
 import { Card, CardContent, CardHeader } from '@/components/ui/card.tsx';
 import { Separator } from '@/components/ui/separator.tsx';
+import { getOrtRunById } from '@/hey-api';
 
 export const Route = createFileRoute('/runs/$runId/')({
   beforeLoad: async ({ params }) => {
-    let organizationId, productId, repositoryId, index;
-    try {
-      const ortRun = await RunsService.getApiV1RunsByRunId({
-        runId: Number.parseInt(params.runId),
-      });
-      organizationId = ortRun.organizationId.toString();
-      productId = ortRun.productId.toString();
-      repositoryId = ortRun.repositoryId.toString();
-      index = ortRun.index.toString();
-    } catch (error) {
-      if (error instanceof ApiError) {
-        throw new NotFoundError(params.runId);
-      }
-    }
+    const { data: ortRun, error } = await getOrtRunById({
+      path: { runId: Number.parseInt(params.runId) },
+    });
+    if (error) throw new NotFoundError(params.runId);
+
+    const organizationId = ortRun?.organizationId.toString();
+    const productId = ortRun?.productId.toString();
+    const repositoryId = ortRun?.repositoryId.toString();
+    const index = ortRun?.index.toString();
+
     if (organizationId && productId && repositoryId && index) {
       throw redirect({
         to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex',

--- a/ui/src/schemas/index.ts
+++ b/ui/src/schemas/index.ts
@@ -19,27 +19,12 @@
 
 import z from 'zod';
 
-import {
-  $OrtRunStatus,
-  $Severity,
-  $VulnerabilityRating,
-} from '@/api/requests/schemas.gen';
-
 // Enum schema for the groupId parameter of the Groups endpoints
 export const groupsSchema = z.enum(['admins', 'writers', 'readers']);
-
-// Enum schema for the possible values of the status parameter of the ORT run
-export const runStatusSchema = z.enum($OrtRunStatus.enum);
-
-// Enum schema for the possible values of the severities
-export const severitySchema = z.enum($Severity.enum);
 
 // Enum schema and type for the resolved statuses of issues, vulnerabilites, and rule violations
 export const itemResolvedSchema = z.enum(['Resolved', 'Unresolved']);
 export type ItemResolved = z.infer<typeof itemResolvedSchema>;
-
-// Enum schema for the possible values of the advisory overall vulnerability ratings
-export const vulnerabilityRatingSchema = z.enum($VulnerabilityRating.enum);
 
 // Enum schema and type for the possible values of the issue categories.
 export const issueCategorySchema = z.enum([
@@ -68,6 +53,27 @@ export const repositoryTypeSchema = z.enum([
   'GIT_REPO',
   'MERCURIAL',
   'SUBVERSION',
+]);
+
+// Enum schema for the possible values of the status parameter of the ORT run
+export const runStatusSchema = z.enum([
+  'CREATED',
+  'ACTIVE',
+  'FINISHED',
+  'FAILED',
+  'FINISHED_WITH_ISSUES',
+]);
+
+// Enum schema for the possible values of the severities
+export const severitySchema = z.enum(['HINT', 'WARNING', 'ERROR']);
+
+// Enum schema for the possible values of the advisory overall vulnerability ratings
+export const vulnerabilityRatingSchema = z.enum([
+  'NONE',
+  'LOW',
+  'MEDIUM',
+  'HIGH',
+  'CRITICAL',
 ]);
 
 // Search parameter validation schemas


### PR DESCRIPTION
After this PR, the only parts of the UI not yet refactored are the ones touching the plugins handling, so once that part is refactored as well, a follow-up PR can remove the old query client, clean up the UI code, and return error handling to the former, more informative type.

Please see the commits for details.