### PR TITLE
fix(plugin-manager): Reset the deleted flag when creating a template

### DIFF
--- a/components/plugin-manager/backend/src/main/kotlin/PluginTemplateState.kt
+++ b/components/plugin-manager/backend/src/main/kotlin/PluginTemplateState.kt
@@ -45,7 +45,10 @@ internal class PluginTemplateState(
             is Deleted -> isDeleted = true
             is GlobalDisabled -> isGlobal = false
             is GlobalEnabled -> isGlobal = true
-            is OptionsUpdated -> options = event.payload.options
+            is OptionsUpdated -> {
+                options = event.payload.options
+                isDeleted = false
+            }
             is OrganizationAdded -> organizationIds += event.payload.organizationId
             is OrganizationRemoved -> organizationIds -= event.payload.organizationId
         }

--- a/components/plugin-manager/backend/src/test/kotlin/routes/DeleteTemplateIntegrationTest.kt
+++ b/components/plugin-manager/backend/src/test/kotlin/routes/DeleteTemplateIntegrationTest.kt
@@ -46,6 +46,19 @@ class DeleteTemplateIntegrationTest : PluginManagerIntegrationTest({
             }
         }
 
+        "delete a template that was previously recreated" {
+            pluginManagerTestApplication { client ->
+                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
+                pluginTemplateService.delete("template1", pluginType, pluginId, "test-user")
+                pluginTemplateService.create("template1", pluginType, pluginId, "test-user", emptyList())
+
+                client.delete("/admin/plugins/$pluginType/$pluginId/templates/template1") shouldHaveStatus
+                        HttpStatusCode.OK
+
+                pluginTemplateService.getTemplate("template1", pluginType, pluginId).isErr shouldBe true
+            }
+        }
+
         "return NotFound if the template does not exist" {
             pluginManagerTestApplication { client ->
                 client.delete("/admin/plugins/$pluginType/$pluginId/templates/non-existing") shouldHaveStatus


### PR DESCRIPTION
Make sure that the `isDeleted` flag is set to `false` if a plugin template is recreated that was previously deleted.