### PR TITLE
ui: Show metadata and modified flags for packages

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
@@ -99,24 +99,47 @@ const renderSubComponent = ({
 
   return (
     <div className='flex flex-col gap-4'>
-      {pkg.isModified && (
-        <div>
-          <Tooltip>
-            <TooltipTrigger>
-              <Badge
-                className={`border ${getIssueSeverityBackgroundColor('HINT')}`}
-              >
-                MODIFIED
-              </Badge>
-            </TooltipTrigger>
-            <TooltipContent>
-              The source code of the package has been modified compared to the
-              original source code, e.g., in case of a fork of an upstream Open
-              Source project.
-            </TooltipContent>
-          </Tooltip>
-        </div>
-      )}
+      {pkg.isModified ||
+        (pkg.isMetadataOnly && (
+          <div className='flex gap-2'>
+            <div className='font-semibold'>Flags:</div>
+            {pkg.isModified && (
+              <div>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <Badge
+                      className={`border ${getIssueSeverityBackgroundColor('WARNING')}`}
+                    >
+                      MODIFIED
+                    </Badge>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    The package has been modified compared to the original
+                    package, e.g. in case of a fork of an upstream Open Source
+                    project.
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+            )}
+            {pkg.isMetadataOnly && (
+              <div>
+                <Tooltip>
+                  <TooltipTrigger>
+                    <Badge
+                      className={`border ${getIssueSeverityBackgroundColor('HINT')}`}
+                    >
+                      METADATA ONLY
+                    </Badge>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    This is a metadata-only package that has no source code
+                    associated to it.
+                  </TooltipContent>
+                </Tooltip>
+              </div>
+            )}
+          </div>
+        ))}
       <RenderProperty label='Authors' value={pkg.authors} />
       <RenderProperty
         label='Description'
@@ -153,30 +176,26 @@ const renderSubComponent = ({
           />
         </div>
       </div>
-      <div>
-        <div className='font-semibold'>Source Artifact</div>
-        <div className='ml-2'>
-          {pkg.isMetadataOnly ? (
-            <div>This is a metadata-only package.</div>
-          ) : (
-            <>
-              <RenderProperty
-                label='URL'
-                value={pkg.sourceArtifact.url}
-                type='url'
-              />
-              <RenderProperty
-                label='Hash value'
-                value={pkg.sourceArtifact.hashValue}
-              />
-              <RenderProperty
-                label='Hash algorithm'
-                value={pkg.sourceArtifact.hashAlgorithm}
-              />
-            </>
-          )}
-        </div>
-      </div>
+      {!pkg.isMetadataOnly && (
+        <>
+          <div className='font-semibold'>Source Artifact</div>
+          <div className='ml-2'>
+            <RenderProperty
+              label='URL'
+              value={pkg.sourceArtifact.url}
+              type='url'
+            />
+            <RenderProperty
+              label='Hash value'
+              value={pkg.sourceArtifact.hashValue}
+            />
+            <RenderProperty
+              label='Hash algorithm'
+              value={pkg.sourceArtifact.hashAlgorithm}
+            />
+          </div>
+        </>
+      )}
       {pkg.shortestDependencyPaths.length > 0 && (
         <div>
           <div className='font-semibold'>Shortest dependency paths</div>


### PR DESCRIPTION
<img width="1170" height="833" alt="Screenshot from 2025-09-19 10-44-56" src="https://github.com/user-attachments/assets/bee8bc82-c2d6-499a-a092-de94e7a2aed6" />

<img width="1406" height="833" alt="Screenshot from 2025-09-19 10-46-17" src="https://github.com/user-attachments/assets/790d11fb-15a6-4e1c-832c-53eb23e984b9" />

Please see the commit for details (and wording of the tooltips, which is subject to discussion).

After a lengthy discussion with the DoubleOpen team, it was decided _not_ so show these "exception" flags when they are `false`, after all, to not overwhelm the user with package data which is "normal" (i.e. most of the packages are probably non-modified and contain the source in some form).