### PR TITLE
fix(dao): Add a missing ON DELETE CASCADE constraint

### DIFF
--- a/dao/src/main/resources/db/migration/V116__deleteInfrastructureServiceDeclarationsCascade.sql
+++ b/dao/src/main/resources/db/migration/V116__deleteInfrastructureServiceDeclarationsCascade.sql
@@ -1,0 +1,7 @@
+-- This migration script adds a missing ON DELETE CASCADE to the infrastructure_service_declarations_ort_runs table.
+-- This is required to successfully delete ORT runs that have associated infrastructure service declarations.
+
+ALTER TABLE infrastructure_service_declarations_ort_runs
+  DROP CONSTRAINT infrastructure_service_declarations_ort_runs_ort_run_id_fkey,
+  ADD CONSTRAINT infrastructure_service_declarations_ort_runs_ort_run_id_fkey
+    FOREIGN KEY (ort_run_id) REFERENCES ort_runs (id) ON DELETE CASCADE;

--- a/dao/src/test/kotlin/repositories/ortrun/DaoOrtRunRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/ortrun/DaoOrtRunRepositoryTest.kt
@@ -47,6 +47,7 @@ import org.eclipse.apoapsis.ortserver.dao.tables.shared.OrtRunsIssuesTable
 import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
 import org.eclipse.apoapsis.ortserver.model.ActiveOrtRun
 import org.eclipse.apoapsis.ortserver.model.AnalyzerJobConfiguration
+import org.eclipse.apoapsis.ortserver.model.InfrastructureServiceDeclaration
 import org.eclipse.apoapsis.ortserver.model.JobConfigurations
 import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.OrtRunFilters
@@ -833,6 +834,14 @@ class DaoOrtRunRepositoryTest : WordSpec({
                     "Analyzer"
                 )
                 ortRunRepository.update(ortRun.id, issues = listOf(issue).asPresent())
+
+                val serviceDeclaration = InfrastructureServiceDeclaration(
+                    name = "Test Service",
+                    url = "https://example.com",
+                    usernameSecret = "user-secret",
+                    passwordSecret = "password"
+                )
+                infrastructureServiceDeclarationRepository.getOrCreateForRun(serviceDeclaration, ortRun.id)
 
                 ortRunRepository.delete(ortRun.id)
 


### PR DESCRIPTION
This constraint was missing for the
`infrastructure_service_declarations_ort_runs` table preventing the deletion of runs with associated infrastructure service declarations.