### PR TITLE
ui: Introduce a new card table

### DIFF
--- a/ui/.gitignore
+++ b/ui/.gitignore
@@ -8,3 +8,6 @@ dist
 
 src/api/
 src/routeTree.gen.ts
+
+# AI Agent related files and directories
+plans/

--- a/ui/src/components/data-table-cards/data-table-cards-header.tsx
+++ b/ui/src/components/data-table-cards/data-table-cards-header.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { LinkOptions } from '@tanstack/react-router';
+import { Table } from '@tanstack/react-table';
+
+import { DataTableCardsSort } from '@/components/data-table-cards/data-table-cards-sort';
+import { DataTableFilter } from '@/components/data-table/data-table-filter';
+
+interface DataTableCardsHeaderProps<TData> {
+  table: Table<TData>;
+  setSortingOptions?: (sorting: {
+    id: string;
+    desc: boolean | undefined;
+  }) => LinkOptions;
+}
+
+export function DataTableCardsHeader<TData>({
+  table,
+  setSortingOptions,
+}: DataTableCardsHeaderProps<TData>) {
+  // Determine which columns are used as invisible filtering columns.
+  // They will be shown as filtering components in the header.
+  const filterableColumns = table
+    .getAllColumns()
+    .filter((column) => !column.getIsVisible() && column.getCanFilter());
+
+  return (
+    <div className='mb-0 flex items-center justify-end gap-6 border-b p-2'>
+      {filterableColumns.map((column) => {
+        return (
+          <div className='flex items-center gap-2' key={column.id}>
+            <DataTableFilter column={column} showTitle />
+          </div>
+        );
+      })}
+
+      <DataTableCardsSort table={table} setSortingOptions={setSortingOptions} />
+    </div>
+  );
+}

--- a/ui/src/components/data-table-cards/data-table-cards-sort.tsx
+++ b/ui/src/components/data-table-cards/data-table-cards-sort.tsx
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { Link, LinkOptions } from '@tanstack/react-router';
+import { Table } from '@tanstack/react-table';
+import { ChevronDown, ChevronsUpDown, ChevronUp } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+interface DataTableCardsSortProps<TData> {
+  table: Table<TData>;
+  setSortingOptions?: (sorting: {
+    id: string;
+    desc: boolean | undefined;
+  }) => LinkOptions;
+}
+
+export function DataTableCardsSort<TData>({
+  table,
+  setSortingOptions,
+}: DataTableCardsSortProps<TData>) {
+  const isSortingActive = table.getState().sorting?.length > 0;
+  // Determine which columns are used as invisible sorting columns.
+  // They will be shown in the sorting dropdown in the header.
+  const sortableColumns = table
+    .getAllColumns()
+    .filter((column) => !column.getIsVisible() && column.getCanSort());
+
+  if (!setSortingOptions || sortableColumns.length === 0) {
+    return null;
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <div className='flex items-center gap-2'>
+          <Button variant='ghost' size='narrow' className='text-sm font-medium'>
+            <div className='text-sm font-medium'>Sort</div>
+            <ChevronDown
+              className={cn('size-4', isSortingActive && 'text-blue-500')}
+            />
+          </Button>
+        </div>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align='end'>
+        <DropdownMenuGroup>
+          {sortableColumns.map((column) => {
+            const isSorted = column.getIsSorted();
+
+            return (
+              <Tooltip key={column.id}>
+                <TooltipTrigger asChild>
+                  <Link
+                    {...setSortingOptions({
+                      id: column.id,
+                      desc:
+                        isSorted === 'desc' ? undefined : isSorted === 'asc',
+                    })}
+                  >
+                    <DropdownMenuItem>
+                      {isSorted === 'asc' ? (
+                        <ChevronUp className='mr-2 h-4 w-4 text-blue-500' />
+                      ) : isSorted === 'desc' ? (
+                        <ChevronDown className='mr-2 h-4 w-4 text-blue-500' />
+                      ) : (
+                        <ChevronsUpDown className='mr-2 h-4 w-4' />
+                      )}
+                      <div>{column.columnDef.header?.toString()}</div>
+                    </DropdownMenuItem>
+                  </Link>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {column.getCanSort()
+                    ? column.getIsSorted() === 'asc'
+                      ? 'Sort descending'
+                      : column.getIsSorted() === 'desc'
+                        ? 'Clear sorting'
+                        : 'Sort ascending'
+                    : undefined}
+                </TooltipContent>
+              </Tooltip>
+            );
+          })}
+        </DropdownMenuGroup>
+        {isSortingActive && (
+          <DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem className='justify-center text-center' asChild>
+              <Link {...setSortingOptions({ id: '', desc: undefined })}>
+                Clear Sorting
+              </Link>
+            </DropdownMenuItem>
+          </DropdownMenuGroup>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/ui/src/components/data-table-cards/data-table-cards.tsx
+++ b/ui/src/components/data-table-cards/data-table-cards.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { LinkOptions } from '@tanstack/react-router';
+import { Row, type Table as TanstackTable } from '@tanstack/react-table';
+import React from 'react';
+
+import { DataTableCardsHeader } from '@/components/data-table-cards/data-table-cards-header';
+import { DataTableBody } from '@/components/data-table/data-table-body';
+import { DataTablePagination } from '@/components/data-table/data-table-pagination';
+import { Table } from '@/components/ui/table';
+import { cn } from '@/lib/utils';
+
+interface DataTableCardsProps<TData>
+  extends React.HTMLAttributes<HTMLDivElement> {
+  table: TanstackTable<TData>;
+  renderSubComponent?: (props: { row: Row<TData> }) => React.ReactElement;
+  setCurrentPageOptions: (page: number) => LinkOptions;
+  setPageSizeOptions: (pageSize: number) => LinkOptions;
+  setSortingOptions?: (sorting: {
+    id: string;
+    desc: boolean | undefined;
+  }) => LinkOptions;
+}
+
+export function DataTableCards<TData>({
+  table,
+  renderSubComponent,
+  className,
+  setCurrentPageOptions,
+  setPageSizeOptions,
+  setSortingOptions,
+  ...props
+}: DataTableCardsProps<TData>) {
+  const pagination = table.getState().pagination;
+  const totalPages = table.getPageCount();
+
+  return (
+    <div
+      className={cn('w-full space-y-2.5 overflow-auto', className)}
+      {...props}
+    >
+      <DataTableCardsHeader
+        table={table}
+        setSortingOptions={setSortingOptions}
+      />
+      <Table>
+        <DataTableBody
+          rows={table.getRowModel().rows}
+          renderSubComponent={renderSubComponent}
+        />
+      </Table>
+      {table.getRowModel().rows?.length > 0 && (
+        <div className='flex flex-col gap-2.5'>
+          <DataTablePagination
+            currentPage={pagination.pageIndex + 1}
+            pageSize={pagination.pageSize}
+            totalPages={totalPages}
+            setCurrentPageOptions={setCurrentPageOptions}
+            setPageSizeOptions={setPageSizeOptions}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/data-table/data-table-filter.tsx
+++ b/ui/src/components/data-table/data-table-filter.tsx
@@ -28,20 +28,27 @@ import { FilterMultiSelect } from '@/components/data-table/filter-multi-select';
 import { FilterRegex } from '@/components/data-table/filter-regex';
 import { FilterText } from '@/components/data-table/filter-text';
 
+interface DataTableFilterProps<TData, TValue> {
+  column: Column<TData, TValue>;
+  showTitle?: boolean; // Whether to show the title next to the filter icon
+}
+
 export function DataTableFilter<TData, TValue>({
   column,
-}: {
-  column: Column<TData, TValue>;
-}) {
+  showTitle,
+}: DataTableFilterProps<TData, TValue>) {
   const filterVariant = column.columnDef.meta?.filter?.filterVariant;
 
   const columnFilterValue = column.getFilterValue();
+  const title = column.columnDef.header?.toString();
 
   if (filterVariant === 'text') {
     const { setFilterValue } = column.columnDef.meta?.filter as TextFilter;
 
     return (
       <FilterText
+        title={title}
+        showTitle={showTitle}
         filterValue={(columnFilterValue as string) || ''}
         setFilterValue={setFilterValue}
       />
@@ -53,6 +60,8 @@ export function DataTableFilter<TData, TValue>({
 
     return (
       <FilterRegex
+        title={title}
+        showTitle={showTitle}
         filterValue={(columnFilterValue as string) || ''}
         setFilterValue={setFilterValue}
       />
@@ -66,7 +75,8 @@ export function DataTableFilter<TData, TValue>({
 
     return (
       <FilterMultiSelect
-        title={column.columnDef.header?.toString()}
+        title={title}
+        showTitle={showTitle}
         options={selectOptions}
         selected={(columnFilterValue as TValue[]) ?? []}
         setSelected={setSelected}

--- a/ui/src/components/data-table/filter-multi-select.tsx
+++ b/ui/src/components/data-table/filter-multi-select.tsx
@@ -39,6 +39,7 @@ import { cn } from '@/lib/utils';
 
 interface FilterMultiSelectProps<TValue> {
   title?: string;
+  showTitle?: boolean; // Whether to show the title next to the filter icon
   options: {
     label: string;
     value: TValue;
@@ -51,6 +52,7 @@ interface FilterMultiSelectProps<TValue> {
 
 export function FilterMultiSelect<TValue>({
   title,
+  showTitle,
   options,
   selected,
   setSelected,
@@ -59,11 +61,12 @@ export function FilterMultiSelect<TValue>({
   return (
     <Popover>
       <PopoverTrigger asChild>
-        <Button variant='ghost' size='narrow'>
+        <Button variant='ghost' size='narrow' className='font-medium'>
+          {showTitle && <span className='text-sm'>{title}</span>}
           <Filter
             className={cn(
-              selected.length > 0 ? 'text-blue-500' : undefined,
-              'h-4 w-4'
+              'size-4',
+              selected.length > 0 ? 'text-blue-500' : undefined
             )}
           />
         </Button>

--- a/ui/src/components/data-table/filter-regex.tsx
+++ b/ui/src/components/data-table/filter-regex.tsx
@@ -54,11 +54,15 @@ const regexSchema = z
   .optional();
 
 interface FilterRegexProps {
+  title?: string;
+  showTitle?: boolean; // Whether to show the title next to the filter icon
   filterValue: string;
   setFilterValue: (value: string | undefined) => void;
 }
 
 export function FilterRegex({
+  title,
+  showTitle,
   filterValue: initialValue,
   setFilterValue,
 }: FilterRegexProps) {
@@ -76,8 +80,9 @@ export function FilterRegex({
     <Popover open={filterOpen} onOpenChange={setFilterOpen}>
       <PopoverTrigger asChild>
         <Button variant='ghost' size='narrow'>
+          {showTitle && <span className='text-sm'>{title}</span>}
           <Filter
-            className={cn(value.length > 0 && 'text-blue-500', 'h-4 w-4')}
+            className={cn('size-4', value.length > 0 && 'text-blue-500')}
           />
         </Button>
       </PopoverTrigger>

--- a/ui/src/components/data-table/filter-text.tsx
+++ b/ui/src/components/data-table/filter-text.tsx
@@ -30,11 +30,15 @@ import {
 import { cn } from '@/lib/utils';
 
 interface FilterTextProps {
+  title?: string;
+  showTitle?: boolean; // Whether to show the title next to the filter icon
   filterValue: string;
   setFilterValue: (value: string | undefined) => void;
 }
 
 export function FilterText({
+  title,
+  showTitle,
   filterValue: initialValue,
   setFilterValue,
 }: FilterTextProps) {
@@ -49,8 +53,9 @@ export function FilterText({
     <Popover open={filterOpen} onOpenChange={setFilterOpen}>
       <PopoverTrigger asChild>
         <Button variant='ghost' size='narrow'>
+          {showTitle && <span className='text-sm'>{title}</span>}
           <Filter
-            className={cn(value.length > 0 && 'text-blue-500', 'h-4 w-4')}
+            className={cn('size-4', value.length > 0 && 'text-blue-500')}
           />
         </Button>
       </PopoverTrigger>

--- a/ui/src/components/ui/badge-variants.ts
+++ b/ui/src/components/ui/badge-variants.ts
@@ -22,6 +22,8 @@ export const badgeVariants = cva(
           'border-transparent bg-destructive text-white [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60',
         outline:
           'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground',
+        small:
+          'border-transparent bg-primary h-4 px-1.5 py-1 font-medium text-[0.625rem] leading-3 text-primary-foreground',
       },
     },
     defaultVariants: {

--- a/ui/src/helpers/handle-multisort.ts
+++ b/ui/src/helpers/handle-multisort.ts
@@ -36,6 +36,13 @@ export const updateColumnSorting = (
     desc: boolean | undefined; // For column removal to work, the type must be extended from ColumnSort
   }
 ): SortingState | undefined => {
+  // If column id is empty, clear all sorting. This is a handy way
+  // to reset all sorting with one action, when using the card-like tables,
+  // where the sorting state is handled in one menu with multiple sorting options.
+  if (column.id === '') {
+    return undefined;
+  }
+
   // When no sorting is applied, do early return with the column
   if (!columns) {
     return [{ ...column, desc: column.desc ?? false }];


### PR DESCRIPTION
This PR starts implementation of #3587, by introducing a new "card table" component along with providing refactorization of packages table into the new layout as an example.

Card table is implemented with minimal changes to the column tables, by 
1. Rendering all data in one column
2. Implementing sorting and filtering of that column by retaining the sorting and filtering properties of sorted/filtered columns in `columns` object
3. Hiding the sorting/filtering columns
 
As those columns don't render any data and are marked as hidden, performance impact will be negligible.

Reviewers of the PR are kindly asked to concentrate more to the table and component structure than the details of the cards themselves, as those can very easily be changed in follow-up PRs. Packages is not the most "flashy" one as a target of refactoring; some other tables have more data in them and will show more advantages when refactored.

<img width="1184" height="456" alt="Screenshot from 2025-09-26 09-18-28" src="https://github.com/user-attachments/assets/7d113cad-a6e5-4378-aad2-565938526846" />

<img width="1184" height="506" alt="Screenshot from 2025-09-26 09-22-30" src="https://github.com/user-attachments/assets/c3a1af58-8027-4c7a-9610-b15981ee5ecc" />



Please see the commits for details.