### PR TITLE
ui: Refactor all tables in ORT run details pages

### DIFF
--- a/ui/src/components/data-table/data-table-body.tsx
+++ b/ui/src/components/data-table/data-table-body.tsx
@@ -47,7 +47,10 @@ export function DataTableBody<TData>({
               {row.getVisibleCells().map((cell) => (
                 <TableCell
                   key={cell.id}
-                  style={{ minWidth: cell.column.columnDef.size }}
+                  style={{
+                    minWidth: cell.column.columnDef.size,
+                    maxWidth: cell.column.columnDef.size,
+                  }}
                 >
                   {cell.getIsPlaceholder()
                     ? null

--- a/ui/src/lib/constants.ts
+++ b/ui/src/lib/constants.ts
@@ -28,3 +28,5 @@ export const ALL_ITEMS = 100000;
 // The base download URL for the downloadable assets of the latest ORT Server release.
 export const GITHUB_LATEST_RELEASE_DOWNLOAD_URL =
   'https://github.com/eclipse-apoapsis/ort-server/releases/latest/download';
+
+export const ACTION_COLUMN_SIZE = 20;

--- a/ui/src/routes/organizations/$orgId/-components/organization-product-table.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-product-table.tsx
@@ -87,6 +87,7 @@ export const OrganizationProductTable = () => {
       columnHelper.accessor('name', {
         id: 'product',
         header: 'Products',
+        size: 300,
         cell: ({ row }) => (
           <>
             <Link

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repository-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repository-table.tsx
@@ -83,6 +83,7 @@ export const ProductRepositoryTable = () => {
       columnHelper.accessor('url', {
         id: 'repository',
         header: 'Repositories',
+        size: 300,
         cell: ({ row }) => (
           <>
             <Link

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues/index.tsx
@@ -72,7 +72,7 @@ import { updateColumnSorting } from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-conversion';
 import { getResolvedStatus } from '@/helpers/resolutions';
 import { compareSeverity } from '@/helpers/sorting-functions';
-import { ALL_ITEMS } from '@/lib/constants';
+import { ACTION_COLUMN_SIZE, ALL_ITEMS } from '@/lib/constants';
 import { toast } from '@/lib/toast';
 import {
   IssueCategory,
@@ -181,7 +181,7 @@ const IssuesComponent = () => {
     columnHelper.display({
       id: 'details',
       header: 'Details',
-      size: 20,
+      size: ACTION_COLUMN_SIZE,
       cell: function CellComponent({ row }) {
         return row.getCanExpand() ? (
           <div className='flex items-center gap-1'>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
@@ -71,6 +71,7 @@ import {
   updateColumnSorting,
 } from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-conversion';
+import { ACTION_COLUMN_SIZE } from '@/lib/constants';
 import { toast } from '@/lib/toast';
 import { getRepositoryTypeLabel } from '@/lib/types';
 import {
@@ -365,7 +366,7 @@ const PackagesComponent = () => {
     columnHelper.display({
       id: 'details',
       header: 'Details',
-      size: 20,
+      size: ACTION_COLUMN_SIZE,
       cell: function CellComponent({ row }) {
         return row.getCanExpand() ? (
           <div className='flex items-center gap-1'>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
@@ -91,11 +91,19 @@ const columnHelper = createColumnHelper<Package>();
 const PackageCard = ({ pkg }: { pkg: Package }) => {
   const packageIdType = useUserSettingsStore((state) => state.packageIdType);
   const id =
-    packageIdType === 'ORT_ID' ? identifierToString(pkg.identifier) : pkg.purl;
+    packageIdType === 'PURL' && pkg.purl
+      ? pkg.purl
+      : identifierToString(pkg.identifier);
+  const declaredLicenses = [
+    ...(pkg.processedDeclaredLicense.spdxExpression
+      ? [pkg.processedDeclaredLicense.spdxExpression]
+      : []),
+    ...(pkg.processedDeclaredLicense.unmappedLicenses ?? []),
+  ];
 
   return (
     <div className='flex flex-col gap-1'>
-      <div className='flex justify-between'>
+      <div className='flex items-center justify-between'>
         <div className='font-semibold'>
           <BreakableString text={id} />
         </div>
@@ -108,10 +116,15 @@ const PackageCard = ({ pkg }: { pkg: Package }) => {
           {pkg.homepageUrl}
         </a>
       </div>
-      <div className='text-sm'>
-        <span className='font-semibold'>Declared License: </span>
-        {pkg.processedDeclaredLicense.spdxExpression || 'N/A'}
-      </div>
+      {declaredLicenses.length > 0 ? (
+        <div className='flex gap-2 text-sm'>
+          <div className='text-muted-foreground'>Declared License:</div>
+          <div className='break-words'>{declaredLicenses.join(',')}</div>
+        </div>
+      ) : (
+        <div className='text-muted-foreground italic'>No declared license</div>
+      )}
+
       <div className='flex gap-2'>
         {pkg.curations.length > 0 && (
           <Tooltip>
@@ -352,7 +365,7 @@ const PackagesComponent = () => {
     columnHelper.display({
       id: 'details',
       header: 'Details',
-      size: 50,
+      size: 20,
       cell: function CellComponent({ row }) {
         return row.getCanExpand() ? (
           <div className='flex items-center gap-1'>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
@@ -55,7 +55,7 @@ import {
 } from '@/components/ui/card';
 import { updateColumnSorting } from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-conversion';
-import { ALL_ITEMS } from '@/lib/constants';
+import { ACTION_COLUMN_SIZE, ALL_ITEMS } from '@/lib/constants';
 import { toast } from '@/lib/toast';
 import { getRepositoryTypeLabel } from '@/lib/types';
 import {
@@ -277,7 +277,7 @@ const ProjectsComponent = () => {
     columnHelper.display({
       id: 'details',
       header: 'Details',
-      size: 20,
+      size: ACTION_COLUMN_SIZE,
       cell: function CellComponent({ row }) {
         return row.getCanExpand() ? (
           <div className='flex items-center gap-1'>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
@@ -70,7 +70,7 @@ import { updateColumnSorting } from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-conversion';
 import { getResolvedStatus } from '@/helpers/resolutions';
 import { compareSeverity } from '@/helpers/sorting-functions';
-import { ALL_ITEMS } from '@/lib/constants';
+import { ACTION_COLUMN_SIZE, ALL_ITEMS } from '@/lib/constants';
 import {
   ItemResolved,
   itemResolvedSchema,
@@ -192,7 +192,7 @@ const RuleViolationsComponent = () => {
     columnHelper.display({
       id: 'details',
       header: 'Details',
-      size: 20,
+      size: ACTION_COLUMN_SIZE,
       cell: function CellComponent({ row }) {
         return row.getCanExpand() ? (
           <div className='flex items-center gap-1'>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
@@ -79,7 +79,7 @@ import { updateColumnSorting } from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-conversion';
 import { getResolvedStatus } from '@/helpers/resolutions';
 import { compareVulnerabilityRating } from '@/helpers/sorting-functions';
-import { ALL_ITEMS } from '@/lib/constants';
+import { ACTION_COLUMN_SIZE, ALL_ITEMS } from '@/lib/constants';
 import { toast } from '@/lib/toast';
 import {
   ItemResolved,
@@ -233,7 +233,7 @@ const VulnerabilitiesComponent = () => {
     columnHelper.display({
       id: 'details',
       header: 'Details',
-      size: 20,
+      size: ACTION_COLUMN_SIZE,
       cell: function CellComponent({ row }) {
         return row.getCanExpand() ? (
           <div className='flex items-center gap-1'>


### PR DESCRIPTION
Change all tables to use the new card layout, to fit more data to the tables and present them in a nicer form.


<img width="1120" height="424" alt="Screenshot from 2025-09-30 15-20-35" src="https://github.com/user-attachments/assets/a9dadb98-5398-4859-92cc-eeed475129bf" />
<img width="1120" height="444" alt="Screenshot from 2025-09-30 15-19-57" src="https://github.com/user-attachments/assets/a6120a19-7aeb-4178-8f10-9e566c1ecbd9" />
<img width="1120" height="419" alt="Screenshot from 2025-09-30 15-19-44" src="https://github.com/user-attachments/assets/9086c307-e8fc-4ae1-852e-81eed749d6f5" />
<img width="1120" height="428" alt="Screenshot from 2025-09-30 15-19-26" src="https://github.com/user-attachments/assets/2f8ae750-f869-4c48-8c1c-31f006773e79" />
<img width="1120" height="411" alt="Screenshot from 2025-09-30 15-19-11" src="https://github.com/user-attachments/assets/407bb480-56c1-4549-ac87-7539b3af0e35" />


Please see the commits for details.