### PR TITLE
Align endpoint naming in apiDocs

### DIFF
--- a/core/src/main/kotlin/api/AdminRoute.kt
+++ b/core/src/main/kotlin/api/AdminRoute.kt
@@ -39,10 +39,10 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.CreateUser
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateContentManagementSection
 import org.eclipse.apoapsis.ortserver.components.authorization.requireAuthenticated
 import org.eclipse.apoapsis.ortserver.components.authorization.requireSuperuser
-import org.eclipse.apoapsis.ortserver.core.apiDocs.deleteUserByUsername
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getSectionById
+import org.eclipse.apoapsis.ortserver.core.apiDocs.deleteUser
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getSection
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getUsers
-import org.eclipse.apoapsis.ortserver.core.apiDocs.patchSectionById
+import org.eclipse.apoapsis.ortserver.core.apiDocs.patchSection
 import org.eclipse.apoapsis.ortserver.core.apiDocs.postUsers
 import org.eclipse.apoapsis.ortserver.core.apiDocs.runPermissionsSync
 import org.eclipse.apoapsis.ortserver.services.AuthorizationService
@@ -97,7 +97,7 @@ fun Route.admin() = route("admin") {
             call.respond(HttpStatusCode.Created)
         }
 
-        delete(deleteUserByUsername) {
+        delete(deleteUser) {
             requireSuperuser()
 
             val username = call.requireParameter("username")
@@ -114,7 +114,7 @@ fun Route.admin() = route("admin") {
         val contentManagementService by inject<ContentManagementService>()
 
         route("sections/{sectionId}") {
-            get(getSectionById) {
+            get(getSection) {
                 requireAuthenticated()
 
                 val id = call.requireParameter("sectionId")
@@ -125,7 +125,7 @@ fun Route.admin() = route("admin") {
                 call.respond(HttpStatusCode.OK, section.mapToApi())
             }
 
-            patch(patchSectionById) {
+            patch(patchSection) {
                 requireSuperuser()
 
                 val id = call.requireParameter("sectionId")

--- a/core/src/main/kotlin/api/DownloadsRoute.kt
+++ b/core/src/main/kotlin/api/DownloadsRoute.kt
@@ -25,7 +25,7 @@ import io.ktor.server.response.respondOutputStream
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.route
 
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getReportByRunIdAndToken
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunReportByToken
 import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
 import org.eclipse.apoapsis.ortserver.services.ReportStorageService
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireParameter
@@ -43,7 +43,7 @@ fun Route.downloads() = route("runs/{runId}/downloads") {
     route("report/{token}") {
         val reportStorageService by inject<ReportStorageService>()
 
-        get(getReportByRunIdAndToken) {
+        get(getRunReportByToken) {
             call.forRun(ortRunRepository) { ortRun ->
                 val token = call.requireParameter("token")
 

--- a/core/src/main/kotlin/api/OrganizationsRoute.kt
+++ b/core/src/main/kotlin/api/OrganizationsRoute.kt
@@ -46,16 +46,16 @@ import org.eclipse.apoapsis.ortserver.components.authorization.requirePermission
 import org.eclipse.apoapsis.ortserver.components.authorization.requireSuperuser
 import org.eclipse.apoapsis.ortserver.core.api.UserWithGroupsHelper.mapToApi
 import org.eclipse.apoapsis.ortserver.core.api.UserWithGroupsHelper.sortAndPage
-import org.eclipse.apoapsis.ortserver.core.apiDocs.deleteOrganizationById
+import org.eclipse.apoapsis.ortserver.core.apiDocs.deleteOrganization
 import org.eclipse.apoapsis.ortserver.core.apiDocs.deleteOrganizationRoleFromUser
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getOrganizationById
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getOrganization
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getOrganizationProducts
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getOrganizationRunStatistics
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getOrganizationUsers
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getOrganizationVulnerabilities
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getOrganizations
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getOrtRunStatisticsByOrganizationId
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getUsersForOrganization
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getVulnerabilitiesAcrossRepositoriesByOrganizationId
-import org.eclipse.apoapsis.ortserver.core.apiDocs.patchOrganizationById
-import org.eclipse.apoapsis.ortserver.core.apiDocs.postOrganizations
+import org.eclipse.apoapsis.ortserver.core.apiDocs.patchOrganization
+import org.eclipse.apoapsis.ortserver.core.apiDocs.postOrganization
 import org.eclipse.apoapsis.ortserver.core.apiDocs.postProduct
 import org.eclipse.apoapsis.ortserver.core.apiDocs.putOrganizationRoleToUser
 import org.eclipse.apoapsis.ortserver.core.utils.vulnerabilityForRunsFilters
@@ -118,7 +118,7 @@ fun Route.organizations() = route("organizations") {
         call.respond(HttpStatusCode.OK, pagedResponse)
     }
 
-    post(postOrganizations) {
+    post(postOrganization) {
         requireSuperuser()
 
         val createOrganization = call.receive<CreateOrganization>()
@@ -130,7 +130,7 @@ fun Route.organizations() = route("organizations") {
     }
 
     route("{organizationId}") {
-        get(getOrganizationById) {
+        get(getOrganization) {
             requirePermission(OrganizationPermission.READ)
 
             val id = call.requireIdParameter("organizationId")
@@ -141,7 +141,7 @@ fun Route.organizations() = route("organizations") {
                 ?: call.respond(HttpStatusCode.NotFound)
         }
 
-        patch(patchOrganizationById) {
+        patch(patchOrganization) {
             requirePermission(OrganizationPermission.WRITE)
 
             val organizationId = call.requireIdParameter("organizationId")
@@ -156,7 +156,7 @@ fun Route.organizations() = route("organizations") {
             call.respond(HttpStatusCode.OK, updatedOrg.mapToApi())
         }
 
-        delete(deleteOrganizationById) {
+        delete(deleteOrganization) {
             requirePermission(OrganizationPermission.DELETE)
 
             val id = call.requireIdParameter("organizationId")
@@ -236,7 +236,7 @@ fun Route.organizations() = route("organizations") {
         }
 
         route("vulnerabilities") {
-            get(getVulnerabilitiesAcrossRepositoriesByOrganizationId) {
+            get(getOrganizationVulnerabilities) {
                 requirePermission(OrganizationPermission.READ)
 
                 val organizationId = call.requireIdParameter("organizationId")
@@ -265,7 +265,7 @@ fun Route.organizations() = route("organizations") {
 
         route("statistics") {
             route("runs") {
-                get(getOrtRunStatisticsByOrganizationId) {
+                get(getOrganizationRunStatistics) {
                     requirePermission(OrganizationPermission.READ)
 
                     val orgId = call.requireIdParameter("organizationId")
@@ -364,7 +364,7 @@ fun Route.organizations() = route("organizations") {
         }
 
         route("users") {
-            get(getUsersForOrganization) {
+            get(getOrganizationUsers) {
                 requirePermission(OrganizationPermission.READ)
 
                 val orgId = call.requireIdParameter("organizationId")

--- a/core/src/main/kotlin/api/ProductsRoute.kt
+++ b/core/src/main/kotlin/api/ProductsRoute.kt
@@ -53,15 +53,15 @@ import org.eclipse.apoapsis.ortserver.components.authorization.roles.Superuser
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplateService
 import org.eclipse.apoapsis.ortserver.core.api.UserWithGroupsHelper.mapToApi
 import org.eclipse.apoapsis.ortserver.core.api.UserWithGroupsHelper.sortAndPage
-import org.eclipse.apoapsis.ortserver.core.apiDocs.deleteProductById
+import org.eclipse.apoapsis.ortserver.core.apiDocs.deleteProduct
 import org.eclipse.apoapsis.ortserver.core.apiDocs.deleteProductRoleFromUser
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getOrtRunStatisticsByProductId
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getProductById
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getRepositoriesByProductId
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getUsersForProduct
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getVulnerabilitiesAcrossRepositoriesByProductId
-import org.eclipse.apoapsis.ortserver.core.apiDocs.patchProductById
-import org.eclipse.apoapsis.ortserver.core.apiDocs.postOrtRunsForProduct
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getProduct
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getProductRepositories
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getProductRunStatistics
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getProductUsers
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getProductVulnerabilities
+import org.eclipse.apoapsis.ortserver.core.apiDocs.patchProduct
+import org.eclipse.apoapsis.ortserver.core.apiDocs.postProductRuns
 import org.eclipse.apoapsis.ortserver.core.apiDocs.postRepository
 import org.eclipse.apoapsis.ortserver.core.apiDocs.putProductRoleToUser
 import org.eclipse.apoapsis.ortserver.core.services.OrchestratorService
@@ -107,7 +107,7 @@ fun Route.products() = route("products/{productId}") {
     val userService by inject<UserService>()
     val orchestratorService by inject<OrchestratorService>()
 
-    get(getProductById) {
+    get(getProduct) {
         requirePermission(ProductPermission.READ)
 
         val id = call.requireIdParameter("productId")
@@ -121,7 +121,7 @@ fun Route.products() = route("products/{productId}") {
         }
     }
 
-    patch(patchProductById) {
+    patch(patchProduct) {
         requirePermission(ProductPermission.WRITE)
 
         val id = call.requireIdParameter("productId")
@@ -133,7 +133,7 @@ fun Route.products() = route("products/{productId}") {
         call.respond(HttpStatusCode.OK, updatedProduct.mapToApi())
     }
 
-    delete(deleteProductById) {
+    delete(deleteProduct) {
         requirePermission(ProductPermission.DELETE)
 
         val id = call.requireIdParameter("productId")
@@ -144,7 +144,7 @@ fun Route.products() = route("products/{productId}") {
     }
 
     route("repositories") {
-        get(getRepositoriesByProductId) {
+        get(getProductRepositories) {
             requirePermission(ProductPermission.READ_REPOSITORIES)
             val filter = call.filterParameter("filter")
 
@@ -215,7 +215,7 @@ fun Route.products() = route("products/{productId}") {
     }
 
     route("vulnerabilities") {
-        get(getVulnerabilitiesAcrossRepositoriesByProductId) {
+        get(getProductVulnerabilities) {
             requirePermission(ProductPermission.READ)
 
             val productId = call.requireIdParameter("productId")
@@ -241,7 +241,7 @@ fun Route.products() = route("products/{productId}") {
 
     route("statistics") {
         route("runs") {
-            get(getOrtRunStatisticsByProductId) {
+            get(getProductRunStatistics) {
                 requirePermission(ProductPermission.READ)
 
                 val productId = call.requireIdParameter("productId")
@@ -340,7 +340,7 @@ fun Route.products() = route("products/{productId}") {
     }
 
     route("runs") {
-        post(postOrtRunsForProduct) {
+        post(postProductRuns) {
             requirePermission(ProductPermission.TRIGGER_ORT_RUN)
 
             val productId = call.requireIdParameter("productId")
@@ -432,7 +432,7 @@ fun Route.products() = route("products/{productId}") {
     }
 
     route("users") {
-        get(getUsersForProduct) {
+        get(getProductUsers) {
             requirePermission(ProductPermission.READ)
 
             val productId = call.requireIdParameter("productId")

--- a/core/src/main/kotlin/api/RepositoriesRoute.kt
+++ b/core/src/main/kotlin/api/RepositoriesRoute.kt
@@ -51,15 +51,15 @@ import org.eclipse.apoapsis.ortserver.components.authorization.roles.Superuser
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplateService
 import org.eclipse.apoapsis.ortserver.core.api.UserWithGroupsHelper.mapToApi
 import org.eclipse.apoapsis.ortserver.core.api.UserWithGroupsHelper.sortAndPage
-import org.eclipse.apoapsis.ortserver.core.apiDocs.deleteOrtRunByIndex
-import org.eclipse.apoapsis.ortserver.core.apiDocs.deleteRepositoryById
+import org.eclipse.apoapsis.ortserver.core.apiDocs.deleteRepository
 import org.eclipse.apoapsis.ortserver.core.apiDocs.deleteRepositoryRoleFromUser
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getOrtRunByIndex
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getOrtRunsByRepositoryId
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getRepositoryById
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getUsersForRepository
-import org.eclipse.apoapsis.ortserver.core.apiDocs.patchRepositoryById
-import org.eclipse.apoapsis.ortserver.core.apiDocs.postOrtRun
+import org.eclipse.apoapsis.ortserver.core.apiDocs.deleteRepositoryRun
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getRepository
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getRepositoryRun
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getRepositoryRuns
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getRepositoryUsers
+import org.eclipse.apoapsis.ortserver.core.apiDocs.patchRepository
+import org.eclipse.apoapsis.ortserver.core.apiDocs.postRepositoryRun
 import org.eclipse.apoapsis.ortserver.core.apiDocs.putRepositoryRoleToUser
 import org.eclipse.apoapsis.ortserver.core.services.OrchestratorService
 import org.eclipse.apoapsis.ortserver.core.utils.getPluginConfigs
@@ -92,7 +92,7 @@ fun Route.repositories() = route("repositories/{repositoryId}") {
     val repositoryService by inject<RepositoryService>()
     val userService by inject<UserService>()
 
-    get(getRepositoryById) {
+    get(getRepository) {
         requirePermission(RepositoryPermission.READ)
 
         val id = call.requireIdParameter("repositoryId")
@@ -101,7 +101,7 @@ fun Route.repositories() = route("repositories/{repositoryId}") {
             ?: call.respond(HttpStatusCode.NotFound)
     }
 
-    patch(patchRepositoryById) {
+    patch(patchRepository) {
         requirePermission(RepositoryPermission.WRITE)
 
         val id = call.requireIdParameter("repositoryId")
@@ -117,7 +117,7 @@ fun Route.repositories() = route("repositories/{repositoryId}") {
         call.respond(HttpStatusCode.OK, updatedRepository.mapToApi())
     }
 
-    delete(deleteRepositoryById) {
+    delete(deleteRepository) {
         requirePermission(RepositoryPermission.DELETE)
 
         val id = call.requireIdParameter("repositoryId")
@@ -128,7 +128,7 @@ fun Route.repositories() = route("repositories/{repositoryId}") {
     }
 
     route("runs") {
-        get(getOrtRunsByRepositoryId) {
+        get(getRepositoryRuns) {
             requirePermission(RepositoryPermission.READ_ORT_RUNS)
 
             val repositoryId = call.requireIdParameter("repositoryId")
@@ -139,7 +139,7 @@ fun Route.repositories() = route("repositories/{repositoryId}") {
             call.respond(HttpStatusCode.OK, pagedResponse)
         }
 
-        post(postOrtRun) {
+        post(postRepositoryRun) {
             requirePermission(RepositoryPermission.TRIGGER_ORT_RUN)
 
             val repositoryId = call.requireIdParameter("repositoryId")
@@ -195,7 +195,7 @@ fun Route.repositories() = route("repositories/{repositoryId}") {
         }
 
         route("{ortRunIndex}") {
-            get(getOrtRunByIndex) {
+            get(getRepositoryRun) {
                 requirePermission(RepositoryPermission.READ_ORT_RUNS)
 
                 val repositoryId = call.requireIdParameter("repositoryId")
@@ -208,7 +208,7 @@ fun Route.repositories() = route("repositories/{repositoryId}") {
                 } ?: call.respond(HttpStatusCode.NotFound)
             }
 
-            delete(deleteOrtRunByIndex) {
+            delete(deleteRepositoryRun) {
                 val repositoryId = call.requireIdParameter("repositoryId")
                 val ortRunIndex = call.requireIdParameter("ortRunIndex")
 
@@ -259,7 +259,7 @@ fun Route.repositories() = route("repositories/{repositoryId}") {
     }
 
     route("users") {
-        get(getUsersForRepository) {
+        get(getRepositoryUsers) {
             requirePermission(RepositoryPermission.READ)
 
             val repositoryId = call.requireIdParameter("repositoryId")

--- a/core/src/main/kotlin/api/RunsRoute.kt
+++ b/core/src/main/kotlin/api/RunsRoute.kt
@@ -53,18 +53,18 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityFilters
 import org.eclipse.apoapsis.ortserver.components.authorization.permissions.RepositoryPermission
 import org.eclipse.apoapsis.ortserver.components.authorization.requirePermission
 import org.eclipse.apoapsis.ortserver.components.authorization.requireSuperuser
-import org.eclipse.apoapsis.ortserver.core.apiDocs.deleteOrtRunById
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getIssuesByRunId
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getLicensesForPackagesByRunId
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getLogsByRunId
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getOrtRunById
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getOrtRunStatistics
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getOrtRuns
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getPackagesByRunId
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getProjectsByRunId
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getReportByRunIdAndFileName
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getRuleViolationsByRunId
-import org.eclipse.apoapsis.ortserver.core.apiDocs.getVulnerabilitiesByRunId
+import org.eclipse.apoapsis.ortserver.core.apiDocs.deleteRun
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getRun
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunIssues
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunLogs
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunPackageLicenses
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunPackages
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunProjects
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunReport
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunRuleViolations
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunStatistics
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunVulnerabilities
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getRuns
 import org.eclipse.apoapsis.ortserver.core.utils.findByName
 import org.eclipse.apoapsis.ortserver.logaccess.LogFileService
 import org.eclipse.apoapsis.ortserver.model.JobStatus
@@ -110,7 +110,7 @@ fun Route.runs() = route("runs") {
     val projectService by inject<ProjectService>()
     val ortRunService by inject<OrtRunService>()
 
-    get(getOrtRuns) {
+    get(getRuns) {
         requireSuperuser()
 
         val pagingOptions = call.pagingOptions(SortProperty("createdAt", SortDirection.DESCENDING))
@@ -134,7 +134,7 @@ fun Route.runs() = route("runs") {
     }
 
     route("{runId}") {
-        get(getOrtRunById) {
+        get(getRun) {
             val ortRunId = call.requireIdParameter("runId")
 
             ortRunRepository.get(ortRunId)?.let { ortRun ->
@@ -146,7 +146,7 @@ fun Route.runs() = route("runs") {
             } ?: call.respond(HttpStatusCode.NotFound)
         }
 
-        delete(deleteOrtRunById) {
+        delete(deleteRun) {
             val ortRunId = call.requireIdParameter("runId")
 
             ortRunRepository.get(ortRunId)?.let { ortRun ->
@@ -160,7 +160,7 @@ fun Route.runs() = route("runs") {
         route("logs") {
             val logFileService by inject<LogFileService>()
 
-            get(getLogsByRunId) {
+            get(getRunLogs) {
                 call.forRun(ortRunRepository) { ortRun ->
                     requirePermission(RepositoryPermission.READ_ORT_RUNS.roleName(ortRun.repositoryId))
 
@@ -188,7 +188,7 @@ fun Route.runs() = route("runs") {
         }
 
         route("issues") {
-            get(getIssuesByRunId) {
+            get(getRunIssues) {
                 call.forRun(ortRunRepository) { ortRun ->
                     requirePermission(RepositoryPermission.READ_ORT_RUNS.roleName(ortRun.repositoryId))
 
@@ -205,7 +205,7 @@ fun Route.runs() = route("runs") {
         }
 
         route("vulnerabilities") {
-            get(getVulnerabilitiesByRunId) {
+            get(getRunVulnerabilities) {
                 call.forRun(ortRunRepository) { ortRun ->
                     requirePermission(RepositoryPermission.READ_ORT_RUNS.roleName(ortRun.repositoryId))
 
@@ -227,7 +227,7 @@ fun Route.runs() = route("runs") {
         }
 
         route("rule-violations") {
-            get(getRuleViolationsByRunId) {
+            get(getRunRuleViolations) {
                 call.forRun(ortRunRepository) { ortRun ->
                     requirePermission(RepositoryPermission.READ_ORT_RUNS.roleName(ortRun.repositoryId))
 
@@ -251,7 +251,7 @@ fun Route.runs() = route("runs") {
         }
 
         route("packages") {
-            get(getPackagesByRunId) {
+            get(getRunPackages) {
                 call.forRun(ortRunRepository) { ortRun ->
                     requirePermission(RepositoryPermission.READ_ORT_RUNS.roleName(ortRun.repositoryId))
 
@@ -271,7 +271,7 @@ fun Route.runs() = route("runs") {
             }
 
             route("licenses") {
-                get(getLicensesForPackagesByRunId) {
+                get(getRunPackageLicenses) {
                     call.forRun(ortRunRepository) { ortRun ->
                         requirePermission(RepositoryPermission.READ_ORT_RUNS.roleName(ortRun.repositoryId))
 
@@ -288,7 +288,7 @@ fun Route.runs() = route("runs") {
         route("reporter/{fileName}") {
             val reportStorageService by inject<ReportStorageService>()
 
-            get(getReportByRunIdAndFileName) {
+            get(getRunReport) {
                 call.forRun(ortRunRepository) { ortRun ->
                     val fileName = call.requireParameter("fileName")
 
@@ -314,7 +314,7 @@ fun Route.runs() = route("runs") {
         }
 
         route("statistics") {
-            get(getOrtRunStatistics) {
+            get(getRunStatistics) {
                 call.forRun(ortRunRepository) { ortRun ->
                     requirePermission(RepositoryPermission.READ_ORT_RUNS.roleName(ortRun.repositoryId))
 
@@ -380,7 +380,7 @@ fun Route.runs() = route("runs") {
         }
 
         route("projects") {
-            get(getProjectsByRunId) {
+            get(getRunProjects) {
                 call.forRun(ortRunRepository) { ortRun ->
                     requirePermission(RepositoryPermission.READ_ORT_RUNS.roleName(ortRun.repositoryId))
 

--- a/core/src/main/kotlin/apiDocs/AdminDocs.kt
+++ b/core/src/main/kotlin/apiDocs/AdminDocs.kt
@@ -115,8 +115,8 @@ val postUsers: RouteConfig.() -> Unit = {
     }
 }
 
-val deleteUserByUsername: RouteConfig.() -> Unit = {
-    operationId = "deleteUserByUsername"
+val deleteUser: RouteConfig.() -> Unit = {
+    operationId = "deleteUser"
     summary = "Delete a user from the server"
     tags = listOf("Admin")
 
@@ -137,8 +137,8 @@ val deleteUserByUsername: RouteConfig.() -> Unit = {
     }
 }
 
-val getSectionById: RouteConfig.() -> Unit = {
-    operationId = "GetSectionById"
+val getSection: RouteConfig.() -> Unit = {
+    operationId = "getSection"
     summary = "Get a dynamic UI text section by ID."
     tags = listOf("Admin")
 
@@ -165,8 +165,8 @@ val getSectionById: RouteConfig.() -> Unit = {
     }
 }
 
-val patchSectionById: RouteConfig.() -> Unit = {
-    operationId = "PatchSectionById"
+val patchSection: RouteConfig.() -> Unit = {
+    operationId = "patchSection"
     summary = "Update a dynamic UI text section by ID."
     tags = listOf("Admin")
 

--- a/core/src/main/kotlin/apiDocs/DownloadsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/DownloadsDocs.kt
@@ -23,8 +23,8 @@ import io.github.smiley4.ktoropenapi.config.RouteConfig
 
 import io.ktor.http.HttpStatusCode
 
-val getReportByRunIdAndToken: RouteConfig.() -> Unit = {
-    operationId = "GetReportByRunIdAndToken"
+val getRunReportByToken: RouteConfig.() -> Unit = {
+    operationId = "getRunReportByToken"
     summary = "Download a report of an ORT run using a token"
     description = "This endpoint does not require authentication."
     tags = listOf("Runs")

--- a/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
@@ -53,8 +53,8 @@ import org.eclipse.apoapsis.ortserver.shared.apimodel.asPresent
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.jsonBody
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.standardListQueryParameters
 
-val getOrganizationById: RouteConfig.() -> Unit = {
-    operationId = "GetOrganizationById"
+val getOrganization: RouteConfig.() -> Unit = {
+    operationId = "getOrganization"
     summary = "Get details of an organization"
     tags = listOf("Organizations")
 
@@ -77,7 +77,7 @@ val getOrganizationById: RouteConfig.() -> Unit = {
 }
 
 val getOrganizations: RouteConfig.() -> Unit = {
-    operationId = "GetOrganizations"
+    operationId = "getOrganizations"
     summary = "Get all organizations"
     tags = listOf("Organizations")
 
@@ -112,8 +112,8 @@ val getOrganizations: RouteConfig.() -> Unit = {
     }
 }
 
-val postOrganizations: RouteConfig.() -> Unit = {
-    operationId = "PostOrganizations"
+val postOrganization: RouteConfig.() -> Unit = {
+    operationId = "postOrganization"
     summary = "Create an organization"
     tags = listOf("Organizations")
 
@@ -137,8 +137,8 @@ val postOrganizations: RouteConfig.() -> Unit = {
     }
 }
 
-val patchOrganizationById: RouteConfig.() -> Unit = {
-    operationId = "PatchOrganizationById"
+val patchOrganization: RouteConfig.() -> Unit = {
+    operationId = "patchOrganization"
     summary = "Update an organization"
     tags = listOf("Organizations")
 
@@ -169,8 +169,8 @@ val patchOrganizationById: RouteConfig.() -> Unit = {
     }
 }
 
-val deleteOrganizationById: RouteConfig.() -> Unit = {
-    operationId = "DeleteOrganizationById"
+val deleteOrganization: RouteConfig.() -> Unit = {
+    operationId = "deleteOrganization"
     summary = "Delete an organization"
     tags = listOf("Organizations")
 
@@ -188,7 +188,7 @@ val deleteOrganizationById: RouteConfig.() -> Unit = {
 }
 
 val getOrganizationProducts: RouteConfig.() -> Unit = {
-    operationId = "GetOrganizationProducts"
+    operationId = "getOrganizationProducts"
     summary = "Get all products of an organization"
     tags = listOf("Organizations")
 
@@ -228,7 +228,7 @@ val getOrganizationProducts: RouteConfig.() -> Unit = {
 }
 
 val postProduct: RouteConfig.() -> Unit = {
-    operationId = "PostProduct"
+    operationId = "postProduct"
     summary = "Create a product for an organization"
     tags = listOf("Organizations")
 
@@ -256,7 +256,7 @@ val postProduct: RouteConfig.() -> Unit = {
 }
 
 val putOrganizationRoleToUser: RouteConfig.() -> Unit = {
-    operationId = "PutOrganizationRoleToUser"
+    operationId = "putOrganizationRoleToUser"
     summary = "Assign an organization role to a user"
     description = "Assign an organization role to a user. If the user already has another role for the same " +
             "organization, it will be replaced with the new one."
@@ -289,7 +289,7 @@ val putOrganizationRoleToUser: RouteConfig.() -> Unit = {
 }
 
 val deleteOrganizationRoleFromUser: RouteConfig.() -> Unit = {
-    operationId = "DeleteOrganizationRoleFromUser"
+    operationId = "deleteOrganizationRoleFromUser"
     summary = "Remove an organization role from a user"
     tags = listOf("Organizations")
 
@@ -317,8 +317,8 @@ val deleteOrganizationRoleFromUser: RouteConfig.() -> Unit = {
     }
 }
 
-val getVulnerabilitiesAcrossRepositoriesByOrganizationId: RouteConfig.() -> Unit = {
-    operationId = "GetVulnerabilitiesAcrossRepositoriesByOrganizationId"
+val getOrganizationVulnerabilities: RouteConfig.() -> Unit = {
+    operationId = "getOrganizationVulnerabilities"
     summary = "Get vulnerabilities from an organization"
     description = "Get the vulnerabilities from latest successful advisor runs across the repositories in an " +
             " organization."
@@ -398,8 +398,8 @@ val getVulnerabilitiesAcrossRepositoriesByOrganizationId: RouteConfig.() -> Unit
     }
 }
 
-val getOrtRunStatisticsByOrganizationId: RouteConfig.() -> Unit = {
-    operationId = "GetOrtRunStatisticsByOrganizationId"
+val getOrganizationRunStatistics: RouteConfig.() -> Unit = {
+    operationId = "getOrganizationRunStatistics"
     summary = "Get statistics about ORT runs across the repositories of an organization"
     tags = listOf("Organizations")
 
@@ -446,8 +446,8 @@ val getOrtRunStatisticsByOrganizationId: RouteConfig.() -> Unit = {
     }
 }
 
-val getUsersForOrganization: RouteConfig.() -> Unit = {
-    operationId = "GetUsersForOrganization"
+val getOrganizationUsers: RouteConfig.() -> Unit = {
+    operationId = "getOrganizationUsers"
     summary = "Get all users for an organization"
     description = "Get all users that have access rights for an organization, including the user privileges (groups) " +
             "the user has within the organization. Fields available for sorting: 'username', 'firstName', " +

--- a/core/src/main/kotlin/apiDocs/ProductsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/ProductsDocs.kt
@@ -59,8 +59,8 @@ import org.eclipse.apoapsis.ortserver.shared.apimodel.asPresent
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.jsonBody
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.standardListQueryParameters
 
-val getProductById: RouteConfig.() -> Unit = {
-    operationId = "GetProductById"
+val getProduct: RouteConfig.() -> Unit = {
+    operationId = "getProduct"
     summary = "Get details of a product"
     tags = listOf("Products")
 
@@ -82,8 +82,8 @@ val getProductById: RouteConfig.() -> Unit = {
     }
 }
 
-val patchProductById: RouteConfig.() -> Unit = {
-    operationId = "PatchProductById"
+val patchProduct: RouteConfig.() -> Unit = {
+    operationId = "patchProduct"
     summary = "Update a product"
     tags = listOf("Products")
 
@@ -116,8 +116,8 @@ val patchProductById: RouteConfig.() -> Unit = {
     }
 }
 
-val deleteProductById: RouteConfig.() -> Unit = {
-    operationId = "DeleteProductById"
+val deleteProduct: RouteConfig.() -> Unit = {
+    operationId = "deleteProduct"
     summary = "Delete a product"
     tags = listOf("Products")
 
@@ -134,8 +134,8 @@ val deleteProductById: RouteConfig.() -> Unit = {
     }
 }
 
-val getRepositoriesByProductId: RouteConfig.() -> Unit = {
-    operationId = "GetRepositoriesByProductId"
+val getProductRepositories: RouteConfig.() -> Unit = {
+    operationId = "getProductRepositories"
     summary = "Get all repositories of a product"
     tags = listOf("Products")
 
@@ -187,7 +187,7 @@ val getRepositoriesByProductId: RouteConfig.() -> Unit = {
 }
 
 val postRepository: RouteConfig.() -> Unit = {
-    operationId = "CreateRepository"
+    operationId = "postRepository"
     summary = "Create a repository for a product"
     tags = listOf("Products")
 
@@ -224,7 +224,7 @@ val postRepository: RouteConfig.() -> Unit = {
 }
 
 val putProductRoleToUser: RouteConfig.() -> Unit = {
-    operationId = "PutProductRoleToUser"
+    operationId = "putProductRoleToUser"
     summary = "Assign a product role to a user"
     description = "Assign a product role to a user. If the user already has another role for the same product, it " +
             "will be replaced with the new one."
@@ -257,7 +257,7 @@ val putProductRoleToUser: RouteConfig.() -> Unit = {
 }
 
 val deleteProductRoleFromUser: RouteConfig.() -> Unit = {
-    operationId = "DeleteProductRoleFromUser"
+    operationId = "deleteProductRoleFromUser"
     summary = "Remove a product role from a user"
     tags = listOf("Products")
 
@@ -285,8 +285,8 @@ val deleteProductRoleFromUser: RouteConfig.() -> Unit = {
     }
 }
 
-val getVulnerabilitiesAcrossRepositoriesByProductId: RouteConfig.() -> Unit = {
-    operationId = "GetVulnerabilitiesAcrossRepositoriesByProductId"
+val getProductVulnerabilities: RouteConfig.() -> Unit = {
+    operationId = "getProductVulnerabilities"
     summary = "Get vulnerabilities from a product"
     description = "Get the vulnerabilities from latest successful advisor runs across the repositories in a product."
     tags = listOf("Products")
@@ -365,8 +365,8 @@ val getVulnerabilitiesAcrossRepositoriesByProductId: RouteConfig.() -> Unit = {
     }
 }
 
-val getOrtRunStatisticsByProductId: RouteConfig.() -> Unit = {
-    operationId = "GetOrtRunStatisticsByProductId"
+val getProductRunStatistics: RouteConfig.() -> Unit = {
+    operationId = "getProductRunStatistics"
     summary = "Get statistics about ORT runs across the repositories of a product"
     tags = listOf("Products")
 
@@ -414,8 +414,8 @@ val getOrtRunStatisticsByProductId: RouteConfig.() -> Unit = {
     }
 }
 
-val getUsersForProduct: RouteConfig.() -> Unit = {
-    operationId = "GetUsersForProduct"
+val getProductUsers: RouteConfig.() -> Unit = {
+    operationId = "getProductUsers"
     summary = "Get all users for a product"
     description = "Get all users that have access rights for a product, including the user privileges (groups) " +
             "the user has within the product. Fields available for sorting: 'username', 'firstName', " +
@@ -473,8 +473,8 @@ private val minimalJobConfigurations = JobConfigurations(
     )
 )
 
-val postOrtRunsForProduct: RouteConfig.() -> Unit = {
-    operationId = "postOrtRunsForProduct"
+val postProductRuns: RouteConfig.() -> Unit = {
+    operationId = "postProductRuns"
     summary = "Create ORT runs for repositories under a product"
     description = "Create ORT runs for all repositories under a product or specific repositories"
     tags = listOf("Products")

--- a/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
@@ -210,8 +210,8 @@ fun createJobSummary(offset: Duration, status: JobStatus = JobStatus.FINISHED): 
     )
 }
 
-val getRepositoryById: RouteConfig.() -> Unit = {
-    operationId = "GetRepositoryById"
+val getRepository: RouteConfig.() -> Unit = {
+    operationId = "getRepository"
     summary = "Get details of a repository"
     tags = listOf("Repositories")
 
@@ -239,8 +239,8 @@ val getRepositoryById: RouteConfig.() -> Unit = {
     }
 }
 
-val patchRepositoryById: RouteConfig.() -> Unit = {
-    operationId = "PatchRepositoryById"
+val patchRepository: RouteConfig.() -> Unit = {
+    operationId = "patchRepository"
     summary = "Update a repository"
     tags = listOf("Repositories")
 
@@ -279,8 +279,8 @@ val patchRepositoryById: RouteConfig.() -> Unit = {
     }
 }
 
-val deleteRepositoryById: RouteConfig.() -> Unit = {
-    operationId = "DeleteRepositoryById"
+val deleteRepository: RouteConfig.() -> Unit = {
+    operationId = "deleteRepository"
     summary = "Delete a repository"
     tags = listOf("Repositories")
 
@@ -297,8 +297,8 @@ val deleteRepositoryById: RouteConfig.() -> Unit = {
     }
 }
 
-val getOrtRunsByRepositoryId: RouteConfig.() -> Unit = {
-    operationId = "getOrtRunsByRepositoryId"
+val getRepositoryRuns: RouteConfig.() -> Unit = {
+    operationId = "getRepositoryRuns"
     summary = "Get all ORT runs of a repository"
     tags = listOf("Repositories")
 
@@ -375,8 +375,8 @@ val getOrtRunsByRepositoryId: RouteConfig.() -> Unit = {
     }
 }
 
-val postOrtRun: RouteConfig.() -> Unit = {
-    operationId = "postOrtRun"
+val postRepositoryRun: RouteConfig.() -> Unit = {
+    operationId = "postRepositoryRun"
     summary = "Create an ORT run for a repository"
     tags = listOf("Repositories")
 
@@ -435,8 +435,8 @@ val postOrtRun: RouteConfig.() -> Unit = {
     }
 }
 
-val getOrtRunByIndex: RouteConfig.() -> Unit = {
-    operationId = "getOrtRunByIndex"
+val getRepositoryRun: RouteConfig.() -> Unit = {
+    operationId = "getRepositoryRun"
     summary = "Get details of an ORT run of a repository"
     tags = listOf("Repositories")
 
@@ -481,8 +481,8 @@ val getOrtRunByIndex: RouteConfig.() -> Unit = {
     }
 }
 
-val deleteOrtRunByIndex: RouteConfig.() -> Unit = {
-    operationId = "deleteOrtRunByIndex"
+val deleteRepositoryRun: RouteConfig.() -> Unit = {
+    operationId = "deleteRepositoryRun"
     summary = "Delete an ORT run of a repository"
     description = "This operation deletes an ORT run and all generated data, including the generated reports."
     tags = listOf("Repositories")
@@ -509,7 +509,7 @@ val deleteOrtRunByIndex: RouteConfig.() -> Unit = {
 }
 
 val putRepositoryRoleToUser: RouteConfig.() -> Unit = {
-    operationId = "PutRepositoryRoleToUser"
+    operationId = "putRepositoryRoleToUser"
     summary = "Assign a repository role to a user"
     description = "Assign a repository role to a user. If the user already has another role for the same repository, " +
             "it will be replaced with the new one."
@@ -542,7 +542,7 @@ val putRepositoryRoleToUser: RouteConfig.() -> Unit = {
 }
 
 val deleteRepositoryRoleFromUser: RouteConfig.() -> Unit = {
-    operationId = "DeleteRepositoryRoleFromUser"
+    operationId = "deleteRepositoryRoleFromUser"
     summary = "Remove a repository role from a user"
     tags = listOf("Repositories")
 
@@ -570,8 +570,8 @@ val deleteRepositoryRoleFromUser: RouteConfig.() -> Unit = {
     }
 }
 
-val getUsersForRepository: RouteConfig.() -> Unit = {
-    operationId = "GetUsersForRepository"
+val getRepositoryUsers: RouteConfig.() -> Unit = {
+    operationId = "getRepositoryUsers"
     summary = "Get all users for a repository"
     description = "Get all users that have access rights for a repository, including the user privileges (groups) " +
             "the user has within the repository. Fields available for sorting: 'username', 'firstName', " +

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -67,8 +67,8 @@ import org.eclipse.apoapsis.ortserver.shared.apimodel.SortProperty
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.jsonBody
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.standardListQueryParameters
 
-val getOrtRunById: RouteConfig.() -> Unit = {
-    operationId = "getOrtRunById"
+val getRun: RouteConfig.() -> Unit = {
+    operationId = "getRun"
     summary = "Get details of an ORT run"
     tags = listOf("Runs")
 
@@ -110,8 +110,8 @@ val getOrtRunById: RouteConfig.() -> Unit = {
     }
 }
 
-val deleteOrtRunById: RouteConfig.() -> Unit = {
-    operationId = "deleteOrtRunById"
+val deleteRun: RouteConfig.() -> Unit = {
+    operationId = "deleteRun"
     summary = "Delete an ORT run"
     description = "This operation deletes an ORT run and all generated data, including the generated reports."
     tags = listOf("Runs")
@@ -133,8 +133,8 @@ val deleteOrtRunById: RouteConfig.() -> Unit = {
     }
 }
 
-val getReportByRunIdAndFileName: RouteConfig.() -> Unit = {
-    operationId = "GetReportByRunIdAndFileName"
+val getRunReport: RouteConfig.() -> Unit = {
+    operationId = "getRunReport"
     summary = "Download a report of an ORT run"
     tags = listOf("Runs")
 
@@ -161,8 +161,8 @@ val getReportByRunIdAndFileName: RouteConfig.() -> Unit = {
     }
 }
 
-val getLogsByRunId: RouteConfig.() -> Unit = {
-    operationId = "GetLogsByRunId"
+val getRunLogs: RouteConfig.() -> Unit = {
+    operationId = "getRunLogs"
     summary = "Download an archive with selected logs of an ORT run"
     tags = listOf("Runs")
 
@@ -199,8 +199,8 @@ val getLogsByRunId: RouteConfig.() -> Unit = {
     }
 }
 
-val getIssuesByRunId: RouteConfig.() -> Unit = {
-    operationId = "GetIssuesByRunId"
+val getRunIssues: RouteConfig.() -> Unit = {
+    operationId = "getRunIssues"
     summary = "Get the issues of an ORT run"
     tags = listOf("Runs")
 
@@ -251,8 +251,8 @@ val getIssuesByRunId: RouteConfig.() -> Unit = {
     }
 }
 
-val getVulnerabilitiesByRunId: RouteConfig.() -> Unit = {
-    operationId = "GetVulnerabilitiesByRunId"
+val getRunVulnerabilities: RouteConfig.() -> Unit = {
+    operationId = "getRunVulnerabilities"
     summary = "Get the vulnerabilities found in an ORT run"
     tags = listOf("Runs")
 
@@ -327,8 +327,8 @@ val getVulnerabilitiesByRunId: RouteConfig.() -> Unit = {
     }
 }
 
-val getRuleViolationsByRunId: RouteConfig.() -> Unit = {
-    operationId = "GetRuleViolationsByRunId"
+val getRunRuleViolations: RouteConfig.() -> Unit = {
+    operationId = "getRunRuleViolations"
     summary = "Get the rule violations found in an ORT run"
     tags = listOf("Runs")
 
@@ -412,8 +412,8 @@ val getRuleViolationsByRunId: RouteConfig.() -> Unit = {
     }
 }
 
-val getPackagesByRunId: RouteConfig.() -> Unit = {
-    operationId = "GetPackagesByRunId"
+val getRunPackages: RouteConfig.() -> Unit = {
+    operationId = "getRunPackages"
     summary = "Get the packages found in an ORT run"
     tags = listOf("Runs")
 
@@ -527,8 +527,8 @@ val getPackagesByRunId: RouteConfig.() -> Unit = {
     }
 }
 
-val getProjectsByRunId: RouteConfig.() -> Unit = {
-    operationId = "GetProjectsByRunId"
+val getRunProjects: RouteConfig.() -> Unit = {
+    operationId = "getRunProjects"
     summary = "Get the projects found in an ORT run"
     tags = listOf("Runs")
 
@@ -582,8 +582,8 @@ val getProjectsByRunId: RouteConfig.() -> Unit = {
     }
 }
 
-val getOrtRuns: RouteConfig.() -> Unit = {
-    operationId = "getOrtRuns"
+val getRuns: RouteConfig.() -> Unit = {
+    operationId = "getRuns"
     summary = "Get all ORT runs"
     tags = listOf("Runs")
 
@@ -647,8 +647,8 @@ val getOrtRuns: RouteConfig.() -> Unit = {
     }
 }
 
-val getOrtRunStatistics: RouteConfig.() -> Unit = {
-    operationId = "getOrtRunStatistics"
+val getRunStatistics: RouteConfig.() -> Unit = {
+    operationId = "getRunStatistics"
     summary = "Get statistics about an ORT run"
     tags = listOf("Runs")
 
@@ -696,8 +696,8 @@ val getOrtRunStatistics: RouteConfig.() -> Unit = {
     }
 }
 
-val getLicensesForPackagesByRunId: RouteConfig.() -> Unit = {
-    operationId = "GetLicensesForPackagesByRunId"
+val getRunPackageLicenses: RouteConfig.() -> Unit = {
+    operationId = "getRunPackageLicenses"
     summary = "Get the licenses for packages found in an ORT run"
     tags = listOf("Runs")
 

--- a/services/authorization/src/test/kotlin/UserServiceTest.kt
+++ b/services/authorization/src/test/kotlin/UserServiceTest.kt
@@ -68,7 +68,7 @@ class UserServiceTest : WordSpec({
         )
     }
 
-    "getUsersForOrganization" should {
+    "getOrganizationUsers" should {
         "return empty list when no users are found for organization" {
             // Given
             val orgId = 7L

--- a/services/authorization/src/test/kotlin/UserServiceTest.kt
+++ b/services/authorization/src/test/kotlin/UserServiceTest.kt
@@ -134,7 +134,7 @@ class UserServiceTest : WordSpec({
         }
     }
 
-    "getUsersForRepository" should {
+    "getRepositoryUsers" should {
         "return empty list when no users are found for repository" {
             // Given
             val repoId = 2L

--- a/services/authorization/src/test/kotlin/UserServiceTest.kt
+++ b/services/authorization/src/test/kotlin/UserServiceTest.kt
@@ -101,7 +101,7 @@ class UserServiceTest : WordSpec({
         }
     }
 
-    "getUsersForProduct" should {
+    "getProductUsers" should {
         "return empty list when no users are found for product" {
             // Given
             val prodId = 4L

--- a/ui/src/components/charts/job-durations.tsx
+++ b/ui/src/components/charts/job-durations.tsx
@@ -22,7 +22,7 @@ import { useNavigate } from '@tanstack/react-router';
 import { useState } from 'react';
 import { Bar, BarChart, CartesianGrid, XAxis } from 'recharts';
 
-import { getOrtRunsByRepositoryIdOptions } from '@/api/@tanstack/react-query.gen';
+import { getRepositoryRunsOptions } from '@/api/@tanstack/react-query.gen';
 import {
   DEFAULT_RUNS,
   RunsFilterForm,
@@ -111,7 +111,7 @@ export const JobDurations = ({
     isPending: runsIsPending,
     isError: runsIsError,
   } = useQuery({
-    ...getOrtRunsByRepositoryIdOptions({
+    ...getRepositoryRunsOptions({
       path: {
         repositoryId: Number.parseInt(repoId),
       },

--- a/ui/src/components/footer.tsx
+++ b/ui/src/components/footer.tsx
@@ -19,7 +19,7 @@
 
 import { useQuery } from '@tanstack/react-query';
 
-import { getSectionByIdOptions } from '@/api/@tanstack/react-query.gen';
+import { getSectionOptions } from '@/api/@tanstack/react-query.gen';
 import { MarkdownRenderer } from '@/components/markdown-renderer.tsx';
 
 function extractColumns(
@@ -44,7 +44,7 @@ function extractColumns(
 
 export function Footer() {
   const { data } = useQuery({
-    ...getSectionByIdOptions({ path: { sectionId: 'footer' } }),
+    ...getSectionOptions({ path: { sectionId: 'footer' } }),
   });
 
   const markdown = data?.markdown || '';

--- a/ui/src/components/siblings.tsx
+++ b/ui/src/components/siblings.tsx
@@ -25,7 +25,7 @@ import {
   getOrganizationProductsOptions,
   getOrganizationsOptions,
   getOrtRunsByRepositoryIdOptions,
-  getRepositoriesByProductIdOptions,
+  getProductRepositoriesOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { BreadcrumbItem, BreadcrumbLink } from '@/components/ui/breadcrumb';
 import {
@@ -88,7 +88,7 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
     isError: isRepositoriesError,
     error: repositoriesError,
   } = useQuery({
-    ...getRepositoriesByProductIdOptions({
+    ...getProductRepositoriesOptions({
       path: { productId: Number(params.productId) ?? '' },
       query: { limit: ALL_ITEMS },
     }),

--- a/ui/src/components/siblings.tsx
+++ b/ui/src/components/siblings.tsx
@@ -24,8 +24,8 @@ import { Check, ChevronDown } from 'lucide-react';
 import {
   getOrganizationProductsOptions,
   getOrganizationsOptions,
-  getOrtRunsByRepositoryIdOptions,
   getProductRepositoriesOptions,
+  getRepositoryRunsOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { BreadcrumbItem, BreadcrumbLink } from '@/components/ui/breadcrumb';
 import {
@@ -102,7 +102,7 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
     isError: isRunsError,
     error: runsError,
   } = useQuery({
-    ...getOrtRunsByRepositoryIdOptions({
+    ...getRepositoryRunsOptions({
       path: { repositoryId: Number(params.repoId) ?? '' },
       query: { limit: ALL_ITEMS, sort: '-index' },
     }),

--- a/ui/src/routes/admin/content-management/branding/-components/footer-form.tsx
+++ b/ui/src/routes/admin/content-management/branding/-components/footer-form.tsx
@@ -24,9 +24,9 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import {
-  getSectionByIdOptions,
-  getSectionByIdQueryKey,
-  patchSectionByIdMutation,
+  getSectionOptions,
+  getSectionQueryKey,
+  patchSectionMutation,
 } from '@/api/@tanstack/react-query.gen';
 import { LoadingIndicator } from '@/components/loading-indicator.tsx';
 import { ToastError } from '@/components/toast-error.tsx';
@@ -70,7 +70,7 @@ export function FooterForm() {
     error,
     isError,
   } = useQuery({
-    ...getSectionByIdOptions({ path: { sectionId: 'footer' } }),
+    ...getSectionOptions({ path: { sectionId: 'footer' } }),
   });
 
   const form = useForm<z.infer<typeof formSchema>>({
@@ -82,10 +82,10 @@ export function FooterForm() {
   });
 
   const { mutateAsync, isPending } = useMutation({
-    ...patchSectionByIdMutation(),
+    ...patchSectionMutation(),
     onSuccess() {
       queryClient.invalidateQueries({
-        queryKey: getSectionByIdQueryKey({ path: { sectionId: 'footer' } }),
+        queryKey: getSectionQueryKey({ path: { sectionId: 'footer' } }),
       });
       toast.info('Footer saved', {
         description: `Footer saved successfully.`,

--- a/ui/src/routes/admin/index.tsx
+++ b/ui/src/routes/admin/index.tsx
@@ -23,7 +23,7 @@ import { AudioWaveform, List, ListVideo, Loader2 } from 'lucide-react';
 
 import {
   getOrganizationsOptions,
-  getOrtRunsOptions,
+  getRunsOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { zOrtRunStatus } from '@/api/zod.gen';
 import { StatisticsCard } from '@/components/statistics-card';
@@ -44,7 +44,7 @@ const OverviewContent = () => {
     isLoading: runsIsLoading,
     error: runsIsError,
   } = useQuery({
-    ...getOrtRunsOptions({ query: { limit: 1 } }),
+    ...getRunsOptions({ query: { limit: 1 } }),
   });
 
   const {
@@ -52,7 +52,7 @@ const OverviewContent = () => {
     isLoading: activeRunsIsLoading,
     error: activeRunsIsError,
   } = useQuery({
-    ...getOrtRunsOptions({
+    ...getRunsOptions({
       query: { limit: 1, status: 'active' },
     }),
   });

--- a/ui/src/routes/admin/runs/index.tsx
+++ b/ui/src/routes/admin/runs/index.tsx
@@ -32,7 +32,7 @@ import {
   getOrganizationOptions,
   getOrtRunsOptions,
   getProductOptions,
-  getRepositoryByIdOptions,
+  getRepositoryOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { zOrtRunStatus } from '@/api/zod.gen';
 import { DataTable } from '@/components/data-table/data-table';
@@ -83,7 +83,7 @@ const RunsComponent = () => {
       header: 'Repository',
       cell: function CellComponent({ row }) {
         const { data: repo } = useQuery({
-          ...getRepositoryByIdOptions({
+          ...getRepositoryOptions({
             path: { repositoryId: row.original.repositoryId },
           }),
         });

--- a/ui/src/routes/admin/runs/index.tsx
+++ b/ui/src/routes/admin/runs/index.tsx
@@ -29,7 +29,7 @@ import z from 'zod';
 
 import { OrtRunStatus, OrtRunSummary } from '@/api';
 import {
-  getOrganizationByIdOptions,
+  getOrganizationOptions,
   getOrtRunsOptions,
   getProductByIdOptions,
   getRepositoryByIdOptions,
@@ -89,7 +89,7 @@ const RunsComponent = () => {
         });
 
         const { data: org } = useQuery({
-          ...getOrganizationByIdOptions({
+          ...getOrganizationOptions({
             path: { organizationId: row.original.organizationId },
           }),
         });

--- a/ui/src/routes/admin/runs/index.tsx
+++ b/ui/src/routes/admin/runs/index.tsx
@@ -30,9 +30,9 @@ import z from 'zod';
 import { OrtRunStatus, OrtRunSummary } from '@/api';
 import {
   getOrganizationOptions,
-  getOrtRunsOptions,
   getProductOptions,
   getRepositoryOptions,
+  getRunsOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { zOrtRunStatus } from '@/api/zod.gen';
 import { DataTable } from '@/components/data-table/data-table';
@@ -248,14 +248,14 @@ const RunsComponent = () => {
   ];
 
   const { data: runs } = useQuery({
-    ...getOrtRunsOptions({
+    ...getRunsOptions({
       query: { limit: 1 },
     }),
     refetchInterval: pollInterval,
   });
 
   const { data, error } = useQuery({
-    ...getOrtRunsOptions({
+    ...getRunsOptions({
       query: {
         limit: pageSize,
         offset: pageIndex * pageSize,
@@ -343,7 +343,7 @@ export const Route = createFileRoute('/admin/runs/')({
     deps: { page, pageSize, status },
   }) => {
     queryClient.prefetchQuery({
-      ...getOrtRunsOptions({
+      ...getRunsOptions({
         query: {
           limit: pageSize || defaultPageSize,
           offset: page ? (page - 1) * (pageSize || defaultPageSize) : 0,

--- a/ui/src/routes/admin/runs/index.tsx
+++ b/ui/src/routes/admin/runs/index.tsx
@@ -31,7 +31,7 @@ import { OrtRunStatus, OrtRunSummary } from '@/api';
 import {
   getOrganizationOptions,
   getOrtRunsOptions,
-  getProductByIdOptions,
+  getProductOptions,
   getRepositoryByIdOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { zOrtRunStatus } from '@/api/zod.gen';
@@ -95,7 +95,7 @@ const RunsComponent = () => {
         });
 
         const { data: prod } = useQuery({
-          ...getProductByIdOptions({
+          ...getProductOptions({
             path: { productId: row.original.productId },
           }),
         });

--- a/ui/src/routes/admin/users/index.tsx
+++ b/ui/src/routes/admin/users/index.tsx
@@ -33,7 +33,7 @@ import { UserPlus } from 'lucide-react';
 
 import { User } from '@/api';
 import {
-  deleteUserByUsernameMutation,
+  deleteUserMutation,
   getUsersOptions,
   getUsersQueryKey,
 } from '@/api/@tanstack/react-query.gen';
@@ -88,7 +88,7 @@ const columns = [
       const queryClient = useQueryClient();
 
       const { mutateAsync: delUser } = useMutation({
-        ...deleteUserByUsernameMutation(),
+        ...deleteUserMutation(),
         onSuccess() {
           toast.info('Delete User', {
             description: `User "${row.original.username}" deleted successfully.`,

--- a/ui/src/routes/create-organization/index.tsx
+++ b/ui/src/routes/create-organization/index.tsx
@@ -24,7 +24,7 @@ import { Loader2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
-import { postOrganizationsMutation } from '@/api/@tanstack/react-query.gen';
+import { postOrganizationMutation } from '@/api/@tanstack/react-query.gen';
 import { asOptionalField } from '@/components/form/as-optional-field';
 import { OptionalInput } from '@/components/form/optional-input';
 import { ToastError } from '@/components/toast-error';
@@ -56,7 +56,7 @@ const CreateOrganizationPage = () => {
   const navigate = useNavigate();
 
   const { mutateAsync, isPending } = useMutation({
-    ...postOrganizationsMutation(),
+    ...postOrganizationMutation(),
     onSuccess(data) {
       toast.info('Add Organization', {
         description: `Organization "${data.name}" added successfully.`,

--- a/ui/src/routes/organizations/$orgId/-components/organization-issues-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-issues-statistics-card.tsx
@@ -21,7 +21,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { Bug } from 'lucide-react';
 
 import { Severity } from '@/api';
-import { getOrtRunStatisticsByOrganizationIdOptions } from '@/api/@tanstack/react-query.gen';
+import { getOrganizationRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
 import { StatisticsCard } from '@/components/statistics-card';
 import { getIssueSeverityBackgroundColor } from '@/helpers/get-status-class';
 import { cn } from '@/lib/utils';
@@ -36,7 +36,7 @@ export const OrganizationIssuesStatisticsCard = ({
   className,
 }: OrganizationIssuesStatisticsCardProps) => {
   const data = useSuspenseQuery({
-    ...getOrtRunStatisticsByOrganizationIdOptions({
+    ...getOrganizationRunStatisticsOptions({
       path: { organizationId: organizationId },
     }),
   });

--- a/ui/src/routes/organizations/$orgId/-components/organization-packages-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-packages-statistics-card.tsx
@@ -20,7 +20,7 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Boxes } from 'lucide-react';
 
-import { getOrtRunStatisticsByOrganizationIdOptions } from '@/api/@tanstack/react-query.gen';
+import { getOrganizationRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
 import { StatisticsCard } from '@/components/statistics-card';
 import { getEcosystemBackgroundColor } from '@/helpers/get-status-class';
 import { cn } from '@/lib/utils';
@@ -35,7 +35,7 @@ export const OrganizationPackagesStatisticsCard = ({
   className,
 }: OrganizationPackagesStatisticsCardProps) => {
   const data = useSuspenseQuery({
-    ...getOrtRunStatisticsByOrganizationIdOptions({
+    ...getOrganizationRunStatisticsOptions({
       path: { organizationId: organizationId },
     }),
   });

--- a/ui/src/routes/organizations/$orgId/-components/organization-product-table.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-product-table.tsx
@@ -30,7 +30,7 @@ import { useMemo } from 'react';
 import { Product } from '@/api';
 import {
   getOrganizationProductsOptions,
-  getRepositoriesByProductIdOptions,
+  getProductRepositoriesOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { DataTable } from '@/components/data-table/data-table';
 import { LoadingIndicator } from '@/components/loading-indicator';
@@ -122,7 +122,7 @@ export const OrganizationProductTable = () => {
         size: 60,
         cell: function CellComponent({ row }) {
           const { data, isPending, isError } = useQuery({
-            ...getRepositoriesByProductIdOptions({
+            ...getProductRepositoriesOptions({
               path: { productId: row.original.id },
               query: { limit: 1 },
             }),
@@ -149,7 +149,7 @@ export const OrganizationProductTable = () => {
         header: 'Last Run Status',
         cell: function CellComponent({ row }) {
           const { data, isPending, isError } = useQuery({
-            ...getRepositoriesByProductIdOptions({
+            ...getProductRepositoriesOptions({
               path: { productId: row.original.id },
               query: { limit: 1 },
             }),
@@ -179,7 +179,7 @@ export const OrganizationProductTable = () => {
         header: 'Last Run Date',
         cell: function CellComponent({ row }) {
           const { data, isPending, isError } = useQuery({
-            ...getRepositoriesByProductIdOptions({
+            ...getProductRepositoriesOptions({
               path: { productId: row.original.id },
               query: { limit: 1 },
             }),
@@ -206,7 +206,7 @@ export const OrganizationProductTable = () => {
         header: 'Last Job Status',
         cell: function CellComponent({ row }) {
           const { data, isPending, isError } = useQuery({
-            ...getRepositoriesByProductIdOptions({
+            ...getProductRepositoriesOptions({
               path: { productId: row.original.id },
               query: { limit: 1 },
             }),

--- a/ui/src/routes/organizations/$orgId/-components/organization-violations-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-violations-statistics-card.tsx
@@ -21,7 +21,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { Scale } from 'lucide-react';
 
 import { Severity } from '@/api';
-import { getOrtRunStatisticsByOrganizationIdOptions } from '@/api/@tanstack/react-query.gen';
+import { getOrganizationRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
 import { StatisticsCard } from '@/components/statistics-card';
 import { getRuleViolationSeverityBackgroundColor } from '@/helpers/get-status-class';
 import { cn } from '@/lib/utils';
@@ -36,7 +36,7 @@ export const OrganizationViolationsStatisticsCard = ({
   className,
 }: OrganizationViolationsStatisticsCardProps) => {
   const data = useSuspenseQuery({
-    ...getOrtRunStatisticsByOrganizationIdOptions({
+    ...getOrganizationRunStatisticsOptions({
       path: { organizationId: organizationId },
     }),
   });

--- a/ui/src/routes/organizations/$orgId/-components/organization-vulnerabilities-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-vulnerabilities-statistics-card.tsx
@@ -21,7 +21,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { ShieldQuestion } from 'lucide-react';
 
 import { VulnerabilityRating } from '@/api';
-import { getOrtRunStatisticsByOrganizationIdOptions } from '@/api/@tanstack/react-query.gen';
+import { getOrganizationRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
 import { StatisticsCard } from '@/components/statistics-card';
 import { getVulnerabilityRatingBackgroundColor } from '@/helpers/get-status-class';
 import { cn } from '@/lib/utils';
@@ -36,7 +36,7 @@ export const OrganizationVulnerabilitiesStatisticsCard = ({
   className,
 }: OrganizationVulnerabilitiesStatisticsCardProps) => {
   const data = useSuspenseQuery({
-    ...getOrtRunStatisticsByOrganizationIdOptions({
+    ...getOrganizationRunStatisticsOptions({
       path: { organizationId: organizationId },
     }),
   });

--- a/ui/src/routes/organizations/$orgId/index.tsx
+++ b/ui/src/routes/organizations/$orgId/index.tsx
@@ -23,7 +23,7 @@ import { Boxes, Bug, Scale, ShieldQuestion } from 'lucide-react';
 import { Suspense } from 'react';
 import z from 'zod';
 
-import { getOrganizationByIdOptions } from '@/api/@tanstack/react-query.gen';
+import { getOrganizationOptions } from '@/api/@tanstack/react-query.gen';
 import { ErrorComponent } from '@/components/error-component';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { StatisticsCard } from '@/components/statistics-card';
@@ -56,7 +56,7 @@ const OrganizationComponent = () => {
     isPending: orgIsPending,
     isError: orgIsError,
   } = useQuery({
-    ...getOrganizationByIdOptions({
+    ...getOrganizationOptions({
       path: { organizationId: Number.parseInt(params.orgId) },
     }),
   });
@@ -187,7 +187,7 @@ export const Route = createFileRoute('/organizations/$orgId/')({
   }),
   loader: async ({ context: { queryClient }, params }) => {
     await queryClient.prefetchQuery({
-      ...getOrganizationByIdOptions({
+      ...getOrganizationOptions({
         path: { organizationId: Number.parseInt(params.orgId) },
       }),
     });

--- a/ui/src/routes/organizations/$orgId/infrastructure-services/index.tsx
+++ b/ui/src/routes/organizations/$orgId/infrastructure-services/index.tsx
@@ -32,7 +32,7 @@ import {
   deleteInfrastructureServiceForOrganizationIdAndNameMutation,
   getInfrastructureServicesByOrganizationIdOptions,
   getInfrastructureServicesByOrganizationIdQueryKey,
-  getOrganizationByIdOptions,
+  getOrganizationOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { DataTable } from '@/components/data-table/data-table';
 import { DeleteDialog } from '@/components/delete-dialog';
@@ -132,7 +132,7 @@ const InfrastructureServices = () => {
     isPending: orgIsPending,
     isError: orgIsError,
   } = useQuery({
-    ...getOrganizationByIdOptions({
+    ...getOrganizationOptions({
       path: { organizationId: Number.parseInt(params.orgId) },
     }),
   });
@@ -295,7 +295,7 @@ export const Route = createFileRoute(
   }) => {
     await Promise.allSettled([
       queryClient.prefetchQuery({
-        ...getOrganizationByIdOptions({
+        ...getOrganizationOptions({
           path: { organizationId: Number.parseInt(params.orgId) },
         }),
       }),

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/last-job-status.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/last-job-status.tsx
@@ -20,7 +20,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { Loader2 } from 'lucide-react';
 
-import { getOrtRunsByRepositoryIdOptions } from '@/api/@tanstack/react-query.gen';
+import { getRepositoryRunsOptions } from '@/api/@tanstack/react-query.gen';
 import { OrtRunJobStatus } from '@/components/ort-run-job-status';
 import { config } from '@/config';
 
@@ -30,7 +30,7 @@ export const LastJobStatus = ({ repoId }: { repoId: number }) => {
     isPending: runsIsPending,
     isError: runsIsError,
   } = useQuery({
-    ...getOrtRunsByRepositoryIdOptions({
+    ...getRepositoryRunsOptions({
       path: { repositoryId: repoId },
       query: { limit: 1, sort: '-index' },
     }),

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/last-run-date.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/last-run-date.tsx
@@ -20,7 +20,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { Loader2 } from 'lucide-react';
 
-import { getOrtRunsByRepositoryIdOptions } from '@/api/@tanstack/react-query.gen';
+import { getRepositoryRunsOptions } from '@/api/@tanstack/react-query.gen';
 import { TimestampWithUTC } from '@/components/timestamp-with-utc';
 import {
   Tooltip,
@@ -35,7 +35,7 @@ export const LastRunDate = ({ repoId }: { repoId: number }) => {
     isPending: runsIsPending,
     isError: runsIsError,
   } = useQuery({
-    ...getOrtRunsByRepositoryIdOptions({
+    ...getRepositoryRunsOptions({
       path: { repositoryId: repoId },
       query: { limit: 1, sort: '-index' },
     }),

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/last-run-status.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/last-run-status.tsx
@@ -20,7 +20,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { Loader2 } from 'lucide-react';
 
-import { getOrtRunsByRepositoryIdOptions } from '@/api/@tanstack/react-query.gen';
+import { getRepositoryRunsOptions } from '@/api/@tanstack/react-query.gen';
 import { Badge } from '@/components/ui/badge';
 import { config } from '@/config';
 import { getStatusBackgroundColor } from '@/helpers/get-status-class';
@@ -31,7 +31,7 @@ export const LastRunStatus = ({ repoId }: { repoId: number }) => {
     isPending: runsIsPending,
     isError: runsIsError,
   } = useQuery({
-    ...getOrtRunsByRepositoryIdOptions({
+    ...getRepositoryRunsOptions({
       path: { repositoryId: repoId },
       query: { limit: 1, sort: '-index' },
     }),

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-issues-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-issues-statistics-card.tsx
@@ -21,7 +21,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { Bug } from 'lucide-react';
 
 import { Severity } from '@/api';
-import { getOrtRunStatisticsByProductIdOptions } from '@/api/@tanstack/react-query.gen';
+import { getProductRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
 import { StatisticsCard } from '@/components/statistics-card';
 import { getIssueSeverityBackgroundColor } from '@/helpers/get-status-class';
 import { cn } from '@/lib/utils';
@@ -36,7 +36,7 @@ export const ProductIssuesStatisticsCard = ({
   className,
 }: ProductIssuesStatisticsCardProps) => {
   const data = useSuspenseQuery({
-    ...getOrtRunStatisticsByProductIdOptions({
+    ...getProductRunStatisticsOptions({
       path: { productId: productId },
     }),
   });

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-packages-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-packages-statistics-card.tsx
@@ -20,7 +20,7 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Boxes } from 'lucide-react';
 
-import { getOrtRunStatisticsByProductIdOptions } from '@/api/@tanstack/react-query.gen';
+import { getProductRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
 import { StatisticsCard } from '@/components/statistics-card';
 import { getEcosystemBackgroundColor } from '@/helpers/get-status-class';
 import { cn } from '@/lib/utils';
@@ -35,7 +35,7 @@ export const ProductPackagesStatisticsCard = ({
   className,
 }: ProductPackagesStatisticsCardProps) => {
   const data = useSuspenseQuery({
-    ...getOrtRunStatisticsByProductIdOptions({
+    ...getProductRunStatisticsOptions({
       path: { productId: productId },
     }),
   });

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repositories-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repositories-statistics-card.tsx
@@ -21,7 +21,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { Files, PlusIcon } from 'lucide-react';
 
-import { getRepositoriesByProductIdOptions } from '@/api/@tanstack/react-query.gen';
+import { getProductRepositoriesOptions } from '@/api/@tanstack/react-query.gen';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { StatisticsCard } from '@/components/statistics-card';
 import { ToastError } from '@/components/toast-error';
@@ -46,7 +46,7 @@ export const ProductRepositoriesStatisticsCard = ({
   className,
 }: ProductRepositoriesStatisticsCardProps) => {
   const { data, isPending, isError, error } = useQuery({
-    ...getRepositoriesByProductIdOptions({
+    ...getProductRepositoriesOptions({
       path: { productId: Number.parseInt(productId) },
       query: { limit: 1 },
     }),

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repository-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repository-table.tsx
@@ -27,7 +27,7 @@ import {
 import { useMemo } from 'react';
 
 import { Repository } from '@/api';
-import { getRepositoriesByProductIdOptions } from '@/api/@tanstack/react-query.gen';
+import { getProductRepositoriesOptions } from '@/api/@tanstack/react-query.gen';
 import { DataTable } from '@/components/data-table/data-table';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { ToastError } from '@/components/toast-error';
@@ -68,7 +68,7 @@ export const ProductRepositoryTable = () => {
     isPending: reposIsPending,
     isError: reposIsError,
   } = useQuery({
-    ...getRepositoriesByProductIdOptions({
+    ...getProductRepositoriesOptions({
       path: { productId: Number.parseInt(params.productId) },
       query: {
         limit: pageSize,

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-violations-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-violations-statistics-card.tsx
@@ -21,7 +21,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { Scale } from 'lucide-react';
 
 import { Severity } from '@/api';
-import { getOrtRunStatisticsByProductIdOptions } from '@/api/@tanstack/react-query.gen';
+import { getProductRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
 import { StatisticsCard } from '@/components/statistics-card';
 import { getRuleViolationSeverityBackgroundColor } from '@/helpers/get-status-class';
 import { cn } from '@/lib/utils';
@@ -36,7 +36,7 @@ export const ProductViolationsStatisticsCard = ({
   className,
 }: ProductViolationsStatisticsCardProps) => {
   const data = useSuspenseQuery({
-    ...getOrtRunStatisticsByProductIdOptions({
+    ...getProductRunStatisticsOptions({
       path: { productId: productId },
     }),
   });

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-vulnerabilities-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-vulnerabilities-statistics-card.tsx
@@ -21,7 +21,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { ShieldQuestion } from 'lucide-react';
 
 import { VulnerabilityRating } from '@/api';
-import { getOrtRunStatisticsByProductIdOptions } from '@/api/@tanstack/react-query.gen';
+import { getProductRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
 import { StatisticsCard } from '@/components/statistics-card';
 import { getVulnerabilityRatingBackgroundColor } from '@/helpers/get-status-class';
 import { cn } from '@/lib/utils';
@@ -36,7 +36,7 @@ export const ProductVulnerabilitiesStatisticsCard = ({
   className,
 }: ProductVulnerabilitiesStatisticsCardProps) => {
   const data = useSuspenseQuery({
-    ...getOrtRunStatisticsByProductIdOptions({
+    ...getProductRunStatisticsOptions({
       path: { productId: productId },
     }),
   });

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/total-runs.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/total-runs.tsx
@@ -20,7 +20,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { Loader2 } from 'lucide-react';
 
-import { getOrtRunsByRepositoryIdOptions } from '@/api/@tanstack/react-query.gen';
+import { getRepositoryRunsOptions } from '@/api/@tanstack/react-query.gen';
 import { config } from '@/config';
 
 export const TotalRuns = ({ repoId }: { repoId: number }) => {
@@ -29,7 +29,7 @@ export const TotalRuns = ({ repoId }: { repoId: number }) => {
     isPending: runsIsPending,
     isError: runsIsError,
   } = useQuery({
-    ...getOrtRunsByRepositoryIdOptions({
+    ...getRepositoryRunsOptions({
       path: { repositoryId: repoId },
       query: { limit: 1, sort: '-index' },
     }),

--- a/ui/src/routes/organizations/$orgId/products/$productId/create-repository/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/create-repository/index.tsx
@@ -24,7 +24,7 @@ import { Loader2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
-import { createRepositoryMutation } from '@/api/@tanstack/react-query.gen';
+import { postRepositoryMutation } from '@/api/@tanstack/react-query.gen';
 import { zRepositoryType } from '@/api/zod.gen';
 import { asOptionalField } from '@/components/form/as-optional-field.ts';
 import { OptionalInput } from '@/components/form/optional-input.tsx';
@@ -70,7 +70,7 @@ const CreateRepositoryPage = () => {
   const { refreshUser } = useUser();
 
   const { mutateAsync, isPending } = useMutation({
-    ...createRepositoryMutation(),
+    ...postRepositoryMutation(),
     onSuccess(data) {
       // Refresh the user token and data to get the new roles after creating a new repository.
       refreshUser();

--- a/ui/src/routes/organizations/$orgId/products/$productId/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/index.tsx
@@ -23,7 +23,7 @@ import { Boxes, Bug, Scale, ShieldQuestion } from 'lucide-react';
 import { Suspense } from 'react';
 import z from 'zod';
 
-import { getProductByIdOptions } from '@/api/@tanstack/react-query.gen';
+import { getProductOptions } from '@/api/@tanstack/react-query.gen';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { StatisticsCard } from '@/components/statistics-card';
 import { ToastError } from '@/components/toast-error';
@@ -55,7 +55,7 @@ const ProductComponent = () => {
     isPending: prodIsPending,
     isError: prodIsError,
   } = useQuery({
-    ...getProductByIdOptions({
+    ...getProductOptions({
       path: { productId: Number.parseInt(params.productId) },
     }),
   });
@@ -175,7 +175,7 @@ export const Route = createFileRoute(
   }),
   loader: async ({ context: { queryClient }, params }) => {
     await queryClient.prefetchQuery({
-      ...getProductByIdOptions({
+      ...getProductOptions({
         path: { productId: Number.parseInt(params.productId) },
       }),
     });

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/repository-runs-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/repository-runs-table.tsx
@@ -33,10 +33,10 @@ import { Repeat, View } from 'lucide-react';
 
 import { OrtRunSummary } from '@/api';
 import {
-  deleteOrtRunByIndexMutation,
-  getOrtRunsByRepositoryIdOptions,
-  getOrtRunsByRepositoryIdQueryKey,
-  getRepositoryByIdOptions,
+  deleteRepositoryRunMutation,
+  getRepositoryOptions,
+  getRepositoryRunsOptions,
+  getRepositoryRunsQueryKey,
 } from '@/api/@tanstack/react-query.gen';
 import { DataTable } from '@/components/data-table/data-table';
 import { DeleteDialog } from '@/components/delete-dialog';
@@ -165,7 +165,7 @@ const columns = [
       const queryClient = useQueryClient();
 
       const repository = useSuspenseQuery({
-        ...getRepositoryByIdOptions({
+        ...getRepositoryOptions({
           path: {
             repositoryId: row.original.repositoryId,
           },
@@ -173,13 +173,13 @@ const columns = [
       });
 
       const { mutateAsync: deleteRun } = useMutation({
-        ...deleteOrtRunByIndexMutation(),
+        ...deleteRepositoryRunMutation(),
         onSuccess() {
           toast.info('Delete Run', {
             description: `Run "${row.original.index}" deleted successfully.`,
           });
           queryClient.invalidateQueries({
-            queryKey: getOrtRunsByRepositoryIdQueryKey({
+            queryKey: getRepositoryRunsQueryKey({
               path: {
                 repositoryId: row.original.repositoryId,
               },
@@ -282,7 +282,7 @@ export const RepositoryRunsTable = ({
     isPending: runsIsPending,
     isError: runsIsError,
   } = useQuery({
-    ...getOrtRunsByRepositoryIdOptions({
+    ...getRepositoryRunsOptions({
       path: {
         repositoryId: Number.parseInt(repoId),
       },

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -25,8 +25,8 @@ import { useState } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 import { z } from 'zod';
 
-import { postOrtRunMutation } from '@/api/@tanstack/react-query.gen';
-import { getOrtRunByIndex, getPluginsForRepository } from '@/api/sdk.gen';
+import { postRepositoryRunMutation } from '@/api/@tanstack/react-query.gen';
+import { getPluginsForRepository, getRepositoryRun } from '@/api/sdk.gen';
 import { CopyToClipboard } from '@/components/copy-to-clipboard';
 import { ToastError } from '@/components/toast-error';
 import { InlineCode } from '@/components/typography.tsx';
@@ -103,7 +103,7 @@ const CreateRunPage = () => {
   };
 
   const { mutateAsync, isPending } = useMutation({
-    ...postOrtRunMutation(),
+    ...postRepositoryRunMutation(),
     onSuccess(response) {
       toast.info('Create Run', {
         description: 'New run created successfully for this repository.',
@@ -552,7 +552,7 @@ export const Route = createFileRoute(
   loader: async ({ params, deps: { rerunIndex } }) => {
     const [ortRun, plugins] = await Promise.all([
       rerunIndex !== undefined
-        ? getOrtRunByIndex({
+        ? getRepositoryRun({
             path: {
               repositoryId: Number.parseInt(params.repoId),
               ortRunIndex: rerunIndex,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/infrastructure-services/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/infrastructure-services/index.tsx
@@ -32,7 +32,7 @@ import {
   deleteInfrastructureServiceForRepositoryIdAndNameMutation,
   getInfrastructureServicesByRepositoryIdOptions,
   getInfrastructureServicesByRepositoryIdQueryKey,
-  getRepositoryByIdOptions,
+  getRepositoryOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { DataTable } from '@/components/data-table/data-table';
 import { DeleteDialog } from '@/components/delete-dialog';
@@ -139,7 +139,7 @@ const InfrastructureServices = () => {
     isPending: repositoryIsPending,
     isError: repositoryIsError,
   } = useQuery({
-    ...getRepositoryByIdOptions({
+    ...getRepositoryOptions({
       path: {
         repositoryId: Number.parseInt(params.repoId),
       },
@@ -308,7 +308,7 @@ export const Route = createFileRoute(
   }) => {
     await Promise.allSettled([
       queryClient.prefetchQuery({
-        ...getRepositoryByIdOptions({
+        ...getRepositoryOptions({
           path: { repositoryId: Number.parseInt(params.repoId) },
         }),
       }),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/runs/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/runs/index.tsx
@@ -22,8 +22,8 @@ import { createFileRoute, Link } from '@tanstack/react-router';
 import { PlusIcon } from 'lucide-react';
 
 import {
-  getOrtRunsByRepositoryIdOptions,
-  getRepositoryByIdOptions,
+  getRepositoryOptions,
+  getRepositoryRunsOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { JobDurations } from '@/components/charts/job-durations';
 import { LoadingIndicator } from '@/components/loading-indicator';
@@ -57,7 +57,7 @@ const RepositoryRunsComponent = () => {
     isPending: repoIsPending,
     isError: repoIsError,
   } = useQuery({
-    ...getRepositoryByIdOptions({
+    ...getRepositoryOptions({
       path: { repositoryId: Number.parseInt(params.repoId) },
     }),
   });
@@ -155,12 +155,12 @@ export const Route = createFileRoute(
   }) => {
     await Promise.allSettled([
       queryClient.prefetchQuery({
-        ...getRepositoryByIdOptions({
+        ...getRepositoryOptions({
           path: { repositoryId: Number.parseInt(params.repoId) },
         }),
       }),
       queryClient.prefetchQuery({
-        ...getOrtRunsByRepositoryIdOptions({
+        ...getRepositoryRunsOptions({
           path: { repositoryId: Number.parseInt(params.repoId) },
           query: {
             limit: pageSize || defaultPageSize,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/index.tsx
@@ -38,7 +38,7 @@ import {
   deleteSecretByRepositoryIdAndNameMutation,
   getOrganizationOptions,
   getProductOptions,
-  getRepositoryByIdOptions,
+  getRepositoryOptions,
   getSecretsByOrganizationIdOptions,
   getSecretsByProductIdOptions,
   getSecretsByRepositoryIdOptions,
@@ -79,7 +79,7 @@ const ActionCell = ({ row }: CellContext<Secret, unknown>) => {
   const queryClient = useQueryClient();
 
   const { data: repo } = useSuspenseQuery({
-    ...getRepositoryByIdOptions({
+    ...getRepositoryOptions({
       path: { repositoryId: Number.parseInt(params.repoId) },
     }),
   });
@@ -181,7 +181,7 @@ const RepositorySecrets = () => {
     isPending: repoIsPending,
     isError: repoIsError,
   } = useQuery({
-    ...getRepositoryByIdOptions({
+    ...getRepositoryOptions({
       path: { repositoryId: Number.parseInt(params.repoId) },
     }),
   });
@@ -502,7 +502,7 @@ export const Route = createFileRoute(
   }) => {
     await Promise.allSettled([
       queryClient.prefetchQuery({
-        ...getRepositoryByIdOptions({
+        ...getRepositoryOptions({
           path: { repositoryId: Number.parseInt(params.repoId) },
         }),
       }),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/index.tsx
@@ -36,7 +36,7 @@ import z from 'zod';
 import { Secret } from '@/api';
 import {
   deleteSecretByRepositoryIdAndNameMutation,
-  getOrganizationByIdOptions,
+  getOrganizationOptions,
   getProductByIdOptions,
   getRepositoryByIdOptions,
   getSecretsByOrganizationIdOptions,
@@ -203,7 +203,7 @@ const RepositorySecrets = () => {
     isPending: orgIsPending,
     isError: orgIsError,
   } = useQuery({
-    ...getOrganizationByIdOptions({
+    ...getOrganizationOptions({
       path: { organizationId: Number.parseInt(params.orgId) },
     }),
   });
@@ -512,7 +512,7 @@ export const Route = createFileRoute(
         }),
       }),
       queryClient.prefetchQuery({
-        ...getOrganizationByIdOptions({
+        ...getOrganizationOptions({
           path: { organizationId: Number.parseInt(params.orgId) },
         }),
       }),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/index.tsx
@@ -37,7 +37,7 @@ import { Secret } from '@/api';
 import {
   deleteSecretByRepositoryIdAndNameMutation,
   getOrganizationOptions,
-  getProductByIdOptions,
+  getProductOptions,
   getRepositoryByIdOptions,
   getSecretsByOrganizationIdOptions,
   getSecretsByProductIdOptions,
@@ -192,7 +192,7 @@ const RepositorySecrets = () => {
     isPending: productIsPending,
     isError: productIsError,
   } = useQuery({
-    ...getProductByIdOptions({
+    ...getProductOptions({
       path: { productId: Number.parseInt(params.productId) },
     }),
   });
@@ -507,7 +507,7 @@ export const Route = createFileRoute(
         }),
       }),
       queryClient.prefetchQuery({
-        ...getProductByIdOptions({
+        ...getProductOptions({
           path: { productId: Number.parseInt(params.productId) },
         }),
       }),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/settings/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/settings/index.tsx
@@ -29,9 +29,9 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import {
-  deleteRepositoryByIdMutation,
-  getRepositoryByIdOptions,
-  patchRepositoryByIdMutation,
+  deleteRepositoryMutation,
+  getRepositoryOptions,
+  patchRepositoryMutation,
 } from '@/api/@tanstack/react-query.gen';
 import { zRepositoryType } from '@/api/zod.gen';
 import { DeleteDialog } from '@/components/delete-dialog';
@@ -78,7 +78,7 @@ const RepositorySettingsPage = () => {
   const repositoryId = Number.parseInt(params.repoId);
 
   const { data: repository } = useSuspenseQuery({
-    ...getRepositoryByIdOptions({
+    ...getRepositoryOptions({
       path: {
         repositoryId,
       },
@@ -86,7 +86,7 @@ const RepositorySettingsPage = () => {
   });
 
   const { mutateAsync, isPending } = useMutation({
-    ...patchRepositoryByIdMutation(),
+    ...patchRepositoryMutation(),
     onSuccess(data) {
       toast.info('Edit repository', {
         description: `Repository "${data.url}" updated successfully.`,
@@ -137,7 +137,7 @@ const RepositorySettingsPage = () => {
   }
 
   const { mutateAsync: deleteRepository } = useMutation({
-    ...deleteRepositoryByIdMutation(),
+    ...deleteRepositoryMutation(),
     onSuccess() {
       toast.info('Delete Repository', {
         description: `Repository "${repository?.url}" deleted successfully.`,
@@ -290,7 +290,7 @@ export const Route = createFileRoute(
   loader: async ({ context: { queryClient }, params }) => {
     const repositoryId = Number.parseInt(params.repoId);
     await queryClient.prefetchQuery({
-      ...getRepositoryByIdOptions({
+      ...getRepositoryOptions({
         path: { repositoryId },
       }),
     });

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/-components/repository-users-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/-components/repository-users-table.tsx
@@ -29,8 +29,8 @@ import { Eye, FileOutput, Pen, Shield } from 'lucide-react';
 import { UserWithGroups } from '@/api';
 import {
   deleteRepositoryRoleFromUserMutation,
-  getUsersForRepositoryOptions,
-  getUsersForRepositoryQueryKey,
+  getRepositoryUsersOptions,
+  getRepositoryUsersQueryKey,
   putRepositoryRoleToUserMutation,
 } from '@/api/@tanstack/react-query.gen';
 import { DataTable } from '@/components/data-table/data-table.tsx';
@@ -110,7 +110,7 @@ const columns = [
           ...putRepositoryRoleToUserMutation(),
           onSuccess(_response, parameters) {
             queryClient.invalidateQueries({
-              queryKey: getUsersForRepositoryQueryKey({
+              queryKey: getRepositoryUsersQueryKey({
                 path: { repositoryId: repoId },
               }),
             });
@@ -207,7 +207,7 @@ const columns = [
           // Upon successful removal of the user, invalidate the users query
           // to refresh the data in the table.
           queryClient.invalidateQueries({
-            queryKey: getUsersForRepositoryQueryKey({
+            queryKey: getRepositoryUsersQueryKey({
               path: { repositoryId: repoId },
             }),
           });
@@ -277,7 +277,7 @@ export const RepositoryUsersTable = () => {
   const pageIndex = page - 1;
 
   const { data: usersWithGroups } = useQuery({
-    ...getUsersForRepositoryOptions({
+    ...getRepositoryUsersOptions({
       path: { repositoryId: Number.parseInt(repoId) },
       query: {
         limit: pageSize,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/index.tsx
@@ -29,8 +29,8 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import {
-  getRepositoryByIdOptions,
-  getUsersForRepositoryQueryKey,
+  getRepositoryOptions,
+  getRepositoryUsersQueryKey,
   putRepositoryRoleToUserMutation,
 } from '@/api/@tanstack/react-query.gen';
 import { ToastError } from '@/components/toast-error';
@@ -81,7 +81,7 @@ const ManageUsers = () => {
   });
 
   const { data: repository } = useSuspenseQuery({
-    ...getRepositoryByIdOptions({
+    ...getRepositoryOptions({
       path: {
         repositoryId: Number.parseInt(params.repoId),
       },
@@ -94,7 +94,7 @@ const ManageUsers = () => {
     ...putRepositoryRoleToUserMutation(),
     onSuccess() {
       queryClient.invalidateQueries({
-        queryKey: getUsersForRepositoryQueryKey({
+        queryKey: getRepositoryUsersQueryKey({
           path: {
             repositoryId: Number.parseInt(params.repoId),
           },

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/route.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/route.tsx
@@ -19,7 +19,7 @@
 
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
 
-import { getUsersForRepositoryOptions } from '@/api/@tanstack/react-query.gen';
+import { getRepositoryUsersOptions } from '@/api/@tanstack/react-query.gen';
 import { paginationSearchParameterSchema } from '@/schemas';
 
 export const Route = createFileRoute(
@@ -40,7 +40,7 @@ export const Route = createFileRoute(
 
     // Ensure the data is available in the query cache when the component is rendered.
     await queryClient.ensureQueryData({
-      ...getUsersForRepositoryOptions({
+      ...getRepositoryUsersOptions({
         path: {
           repositoryId: Number.parseInt(repoId),
         },

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/index.tsx
@@ -20,7 +20,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 
-import { getOrtRunsByRepositoryIdOptions } from '@/api/@tanstack/react-query.gen';
+import { getRepositoryRunsOptions } from '@/api/@tanstack/react-query.gen';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { ToastError } from '@/components/toast-error';
 import { toast } from '@/lib/toast';
@@ -35,7 +35,7 @@ const RunRedirectComponent = () => {
     isError,
     error,
   } = useQuery({
-    ...getOrtRunsByRepositoryIdOptions({
+    ...getRepositoryRunsOptions({
       path: {
         repositoryId: Number.parseInt(params.repoId),
       },

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/route.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/route.tsx
@@ -19,7 +19,7 @@
 
 import { createFileRoute, Outlet } from '@tanstack/react-router';
 
-import { getRepositoryByIdOptions } from '@/api/@tanstack/react-query.gen';
+import { getRepositoryOptions } from '@/api/@tanstack/react-query.gen';
 
 const Layout = () => {
   return <Outlet />;
@@ -30,7 +30,7 @@ export const Route = createFileRoute(
 )({
   loader: async ({ context, params }) => {
     const repo = await context.queryClient.ensureQueryData({
-      ...getRepositoryByIdOptions({
+      ...getRepositoryOptions({
         path: {
           repositoryId: Number.parseInt(params.repoId),
         },

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/issues-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/issues-statistics-card.tsx
@@ -21,7 +21,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Bug } from 'lucide-react';
 
 import { JobStatus, Severity } from '@/api';
-import { getOrtRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
+import { getRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { StatisticsCard } from '@/components/statistics-card';
 import { ToastError } from '@/components/toast-error';
@@ -44,7 +44,7 @@ export const IssuesStatisticsCard = ({
   runId,
 }: IssuesStatisticsCardProps) => {
   const { data, isPending, isError, error } = useQuery({
-    ...getOrtRunStatisticsOptions({
+    ...getRunStatisticsOptions({
       path: { runId: runId },
     }),
     enabled: isJobFinished(status),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/packages-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/packages-statistics-card.tsx
@@ -21,7 +21,7 @@ import { useQuery } from '@tanstack/react-query';
 import { ListTree } from 'lucide-react';
 
 import { JobStatus } from '@/api';
-import { getOrtRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
+import { getRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { StatisticsCard } from '@/components/statistics-card';
 import { ToastError } from '@/components/toast-error';
@@ -44,7 +44,7 @@ export const PackagesStatisticsCard = ({
   runId,
 }: PackagesStatisticsCardProps) => {
   const { data, isPending, isError, error } = useQuery({
-    ...getOrtRunStatisticsOptions({
+    ...getRunStatisticsOptions({
       path: { runId: runId },
     }),
     enabled: isJobFinished(status),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/rule-violations-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/rule-violations-statistics-card.tsx
@@ -21,7 +21,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Scale } from 'lucide-react';
 
 import { JobStatus, Severity } from '@/api';
-import { getOrtRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
+import { getRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { StatisticsCard } from '@/components/statistics-card';
 import { ToastError } from '@/components/toast-error';
@@ -44,7 +44,7 @@ export const RuleViolationsStatisticsCard = ({
   runId,
 }: RuleViolationsStatisticsCardProps) => {
   const { data, isPending, isError, error } = useQuery({
-    ...getOrtRunStatisticsOptions({
+    ...getRunStatisticsOptions({
       path: { runId: runId },
     }),
     enabled: isJobFinished(status),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/run-details-bar.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/run-details-bar.tsx
@@ -21,7 +21,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { getRouteApi, Link } from '@tanstack/react-router';
 import { ArrowBigLeft, Repeat } from 'lucide-react';
 
-import { getOrtRunByIndexOptions } from '@/api/@tanstack/react-query.gen';
+import { getRepositoryRunOptions } from '@/api/@tanstack/react-query.gen';
 import { OrtRunJobStatus } from '@/components/ort-run-job-status';
 import { RunDuration } from '@/components/run-duration';
 import { TimestampWithUTC } from '@/components/timestamp-with-utc';
@@ -50,7 +50,7 @@ export const RunDetailsBar = ({ className }: RunDetailsBarProps) => {
   const pollInterval = config.pollInterval;
 
   const { data: ortRun } = useSuspenseQuery({
-    ...getOrtRunByIndexOptions({
+    ...getRepositoryRunOptions({
       path: {
         repositoryId: Number.parseInt(params.repoId),
         ortRunIndex: Number.parseInt(params.runIndex),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/vulnerabilities-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/vulnerabilities-statistics-card.tsx
@@ -21,7 +21,7 @@ import { useQuery } from '@tanstack/react-query';
 import { ShieldQuestion } from 'lucide-react';
 
 import { JobStatus, VulnerabilityRating } from '@/api';
-import { getOrtRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
+import { getRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { StatisticsCard } from '@/components/statistics-card';
 import { ToastError } from '@/components/toast-error';
@@ -44,7 +44,7 @@ export const VulnerabilitiesStatisticsCard = ({
   runId,
 }: VulnerabilitiesStatisticsCardProps) => {
   const { data, isPending, isError, error } = useQuery({
-    ...getOrtRunStatisticsOptions({
+    ...getRunStatisticsOptions({
       path: { runId: runId },
     }),
     enabled: isJobFinished(status),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/index.tsx
@@ -20,7 +20,7 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
 
-import { getOrtRunByIndexOptions } from '@/api/@tanstack/react-query.gen';
+import { getRepositoryRunOptions } from '@/api/@tanstack/react-query.gen';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
@@ -35,7 +35,7 @@ const ConfigComponent = () => {
   const params = Route.useParams();
 
   const { data: ortRun } = useSuspenseQuery({
-    ...getOrtRunByIndexOptions({
+    ...getRepositoryRunOptions({
       path: {
         repositoryId: Number.parseInt(params.repoId),
         ortRunIndex: Number.parseInt(params.runIndex),
@@ -122,7 +122,7 @@ export const Route = createFileRoute(
 )({
   loader: async ({ context: { queryClient }, params }) => {
     await queryClient.prefetchQuery({
-      ...getOrtRunByIndexOptions({
+      ...getRepositoryRunOptions({
         path: {
           repositoryId: Number.parseInt(params.repoId),
           ortRunIndex: Number.parseInt(params.runIndex),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/index.tsx
@@ -20,7 +20,7 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
 
-import { getOrtRunByIndexOptions } from '@/api/@tanstack/react-query.gen';
+import { getRepositoryRunOptions } from '@/api/@tanstack/react-query.gen';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { config } from '@/config';
 import { IssuesStatisticsCard } from './-components/issues-statistics-card';
@@ -33,7 +33,7 @@ const RunComponent = () => {
   const pollInterval = config.pollInterval;
 
   const { data: ortRun } = useSuspenseQuery({
-    ...getOrtRunByIndexOptions({
+    ...getRepositoryRunOptions({
       path: {
         repositoryId: Number.parseInt(params.repoId),
         ortRunIndex: Number.parseInt(params.runIndex),
@@ -137,7 +137,7 @@ export const Route = createFileRoute(
 )({
   loader: async ({ context: { queryClient }, params }) => {
     await queryClient.prefetchQuery({
-      ...getOrtRunByIndexOptions({
+      ...getRepositoryRunOptions({
         path: {
           repositoryId: Number.parseInt(params.repoId),
           ortRunIndex: Number.parseInt(params.runIndex),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues/index.tsx
@@ -36,8 +36,8 @@ import z from 'zod';
 
 import { Issue, Severity } from '@/api';
 import {
-  getIssuesByRunIdOptions,
   getRepositoryRunOptions,
+  getRunIssuesOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { zSeverity } from '@/api/zod.gen';
 import { BreakableString } from '@/components/breakable-string';
@@ -418,7 +418,7 @@ const IssuesComponent = () => {
     isError,
     error,
   } = useQuery({
-    ...getIssuesByRunIdOptions({
+    ...getRunIssuesOptions({
       path: { runId: ortRun.id },
       query: { limit: ALL_ITEMS },
     }),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues/index.tsx
@@ -37,7 +37,7 @@ import z from 'zod';
 import { Issue, Severity } from '@/api';
 import {
   getIssuesByRunIdOptions,
-  getOrtRunByIndexOptions,
+  getRepositoryRunOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { zSeverity } from '@/api/zod.gen';
 import { BreakableString } from '@/components/breakable-string';
@@ -404,7 +404,7 @@ const IssuesComponent = () => {
   );
 
   const { data: ortRun } = useSuspenseQuery({
-    ...getOrtRunByIndexOptions({
+    ...getRepositoryRunOptions({
       path: {
         repositoryId: Number.parseInt(params.repoId),
         ortRunIndex: Number.parseInt(params.runIndex),
@@ -538,7 +538,7 @@ export const Route = createFileRoute(
   }),
   loader: async ({ context: { queryClient }, params }) => {
     await queryClient.prefetchQuery({
-      ...getOrtRunByIndexOptions({
+      ...getRepositoryRunOptions({
         path: {
           repositoryId: Number.parseInt(params.repoId),
           ortRunIndex: Number.parseInt(params.runIndex),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/logs/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/logs/index.tsx
@@ -22,7 +22,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { ChevronDownIcon, Loader2 } from 'lucide-react';
 import { useState } from 'react';
 
-import { getOrtRunByIndexOptions } from '@/api/@tanstack/react-query.gen';
+import { getRepositoryRunOptions } from '@/api/@tanstack/react-query.gen';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { ToastError } from '@/components/toast-error';
 import { Button } from '@/components/ui/button';
@@ -52,7 +52,7 @@ const ReportComponent = () => {
   const { user } = useUser();
 
   const { data: ortRun } = useSuspenseQuery({
-    ...getOrtRunByIndexOptions({
+    ...getRepositoryRunOptions({
       path: {
         repositoryId: Number.parseInt(params.repoId),
         ortRunIndex: Number.parseInt(params.runIndex),
@@ -195,7 +195,7 @@ export const Route = createFileRoute(
 )({
   loader: async ({ context: { queryClient }, params }) => {
     await queryClient.prefetchQuery({
-      ...getOrtRunByIndexOptions({
+      ...getRepositoryRunOptions({
         path: {
           repositoryId: Number.parseInt(params.repoId),
           ortRunIndex: Number.parseInt(params.runIndex),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
@@ -34,8 +34,8 @@ import z from 'zod';
 import { Package } from '@/api';
 import {
   getLicensesForPackagesByRunIdOptions,
-  getOrtRunByIndexOptions,
   getPackagesByRunIdOptions,
+  getRepositoryRunOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { BreakableString } from '@/components/breakable-string';
 import { DataTableCards } from '@/components/data-table-cards/data-table-cards';
@@ -318,7 +318,7 @@ const PackagesComponent = () => {
   const packageIdType = useUserSettingsStore((state) => state.packageIdType);
 
   const { data: ortRun } = useSuspenseQuery({
-    ...getOrtRunByIndexOptions({
+    ...getRepositoryRunOptions({
       path: {
         repositoryId: Number.parseInt(params.repoId),
         ortRunIndex: Number.parseInt(params.runIndex),
@@ -574,7 +574,7 @@ export const Route = createFileRoute(
   }),
   loader: async ({ context: { queryClient }, params }) => {
     await queryClient.prefetchQuery({
-      ...getOrtRunByIndexOptions({
+      ...getRepositoryRunOptions({
         path: {
           repositoryId: Number.parseInt(params.repoId),
           ortRunIndex: Number.parseInt(params.runIndex),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
@@ -33,9 +33,9 @@ import z from 'zod';
 
 import { Package } from '@/api';
 import {
-  getLicensesForPackagesByRunIdOptions,
-  getPackagesByRunIdOptions,
   getRepositoryRunOptions,
+  getRunPackageLicensesOptions,
+  getRunPackagesOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { BreakableString } from '@/components/breakable-string';
 import { DataTableCards } from '@/components/data-table-cards/data-table-cards';
@@ -327,14 +327,14 @@ const PackagesComponent = () => {
   });
 
   const { data: totalPackages } = useSuspenseQuery({
-    ...getPackagesByRunIdOptions({
+    ...getRunPackagesOptions({
       path: { runId: ortRun.id },
       query: { limit: 1 },
     }),
   });
 
   const { data: declaredLicensesOptions } = useSuspenseQuery({
-    ...getLicensesForPackagesByRunIdOptions({
+    ...getRunPackageLicensesOptions({
       path: { runId: ortRun.id },
     }),
   });
@@ -345,7 +345,7 @@ const PackagesComponent = () => {
     isError,
     error,
   } = useSuspenseQuery({
-    ...getPackagesByRunIdOptions({
+    ...getRunPackagesOptions({
       path: {
         runId: ortRun.id,
       },

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
@@ -36,8 +36,8 @@ import z from 'zod';
 
 import { Project } from '@/api';
 import {
-  getOrtRunByIndexOptions,
   getProjectsByRunIdOptions,
+  getRepositoryRunOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { BreakableString } from '@/components/breakable-string';
 import { DataTableCards } from '@/components/data-table-cards/data-table-cards';
@@ -229,7 +229,7 @@ const ProjectsComponent = () => {
   );
 
   const { data: ortRun } = useSuspenseQuery({
-    ...getOrtRunByIndexOptions({
+    ...getRepositoryRunOptions({
       path: {
         repositoryId: Number.parseInt(params.repoId),
         ortRunIndex: Number.parseInt(params.runIndex),
@@ -489,7 +489,7 @@ export const Route = createFileRoute(
   }),
   loader: async ({ context: { queryClient }, params }) => {
     await queryClient.prefetchQuery({
-      ...getOrtRunByIndexOptions({
+      ...getRepositoryRunOptions({
         path: {
           repositoryId: Number.parseInt(params.repoId),
           ortRunIndex: Number.parseInt(params.runIndex),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
@@ -36,8 +36,8 @@ import z from 'zod';
 
 import { Project } from '@/api';
 import {
-  getProjectsByRunIdOptions,
   getRepositoryRunOptions,
+  getRunProjectsOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { BreakableString } from '@/components/breakable-string';
 import { DataTableCards } from '@/components/data-table-cards/data-table-cards';
@@ -243,7 +243,7 @@ const ProjectsComponent = () => {
     isError,
     error,
   } = useQuery({
-    ...getProjectsByRunIdOptions({
+    ...getRunProjectsOptions({
       path: { runId: ortRun.id },
       query: { limit: ALL_ITEMS },
     }),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/reports/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/reports/index.tsx
@@ -20,7 +20,7 @@
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
 
-import { getOrtRunByIndexOptions } from '@/api/@tanstack/react-query.gen';
+import { getRepositoryRunOptions } from '@/api/@tanstack/react-query.gen';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { ToastError } from '@/components/toast-error';
 import { Button } from '@/components/ui/button';
@@ -42,7 +42,7 @@ const ReportComponent = () => {
   const { user } = useUser();
 
   const { data: ortRun } = useSuspenseQuery({
-    ...getOrtRunByIndexOptions({
+    ...getRepositoryRunOptions({
       path: {
         repositoryId: Number.parseInt(params.repoId),
         ortRunIndex: Number.parseInt(params.runIndex),
@@ -140,7 +140,7 @@ export const Route = createFileRoute(
 )({
   loader: async ({ context: { queryClient }, params }) => {
     await queryClient.prefetchQuery({
-      ...getOrtRunByIndexOptions({
+      ...getRepositoryRunOptions({
         path: {
           repositoryId: Number.parseInt(params.repoId),
           ortRunIndex: Number.parseInt(params.runIndex),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/route.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/route.tsx
@@ -33,7 +33,7 @@ import {
 } from 'lucide-react';
 import { Suspense } from 'react';
 
-import { getOrtRunByIndexOptions } from '@/api/@tanstack/react-query.gen';
+import { getRepositoryRunOptions } from '@/api/@tanstack/react-query.gen';
 import { PageLayout } from '@/components/page-layout';
 import { SidebarNavProps } from '@/components/sidebar';
 import { RunDetailsBar } from './-components/run-details-bar';
@@ -159,7 +159,7 @@ export const Route = createFileRoute(
 )({
   loader: async ({ context, params }) => {
     const run = await context.queryClient.ensureQueryData({
-      ...getOrtRunByIndexOptions({
+      ...getRepositoryRunOptions({
         path: {
           repositoryId: Number.parseInt(params.repoId),
           ortRunIndex: Number.parseInt(params.runIndex),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
@@ -36,7 +36,7 @@ import z from 'zod';
 
 import { RuleViolation, Severity } from '@/api';
 import {
-  getOrtRunByIndexOptions,
+  getRepositoryRunOptions,
   getRuleViolationsByRunIdOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { zSeverity } from '@/api/zod.gen';
@@ -371,7 +371,7 @@ const RuleViolationsComponent = () => {
   );
 
   const { data: ortRun } = useSuspenseQuery({
-    ...getOrtRunByIndexOptions({
+    ...getRepositoryRunOptions({
       path: {
         repositoryId: Number.parseInt(params.repoId),
         ortRunIndex: Number.parseInt(params.runIndex),
@@ -475,7 +475,7 @@ export const Route = createFileRoute(
   }),
   loader: async ({ context: { queryClient }, params }) => {
     await queryClient.prefetchQuery({
-      ...getOrtRunByIndexOptions({
+      ...getRepositoryRunOptions({
         path: {
           repositoryId: Number.parseInt(params.repoId),
           ortRunIndex: Number.parseInt(params.runIndex),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
@@ -37,7 +37,7 @@ import z from 'zod';
 import { RuleViolation, Severity } from '@/api';
 import {
   getRepositoryRunOptions,
-  getRuleViolationsByRunIdOptions,
+  getRunRuleViolationsOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { zSeverity } from '@/api/zod.gen';
 import { BreakableString } from '@/components/breakable-string';
@@ -380,7 +380,7 @@ const RuleViolationsComponent = () => {
   });
 
   const { data: ruleViolations } = useSuspenseQuery({
-    ...getRuleViolationsByRunIdOptions({
+    ...getRunRuleViolationsOptions({
       path: { runId: ortRun.id },
       query: { limit: ALL_ITEMS },
     }),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/sbom/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/sbom/index.tsx
@@ -21,7 +21,7 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
 import { Download } from 'lucide-react';
 
-import { getOrtRunByIndexOptions } from '@/api/@tanstack/react-query.gen';
+import { getRepositoryRunOptions } from '@/api/@tanstack/react-query.gen';
 import CycloneDXDark from '@/assets/cyclonedx-logo-black.svg';
 import CycloneDXLight from '@/assets/cyclonedx-logo-white.svg';
 import SPDX from '@/assets/spdx-logo-color.svg';
@@ -51,7 +51,7 @@ const SBOMComponent = () => {
   const { user } = useUser();
 
   const { data: ortRun } = useSuspenseQuery({
-    ...getOrtRunByIndexOptions({
+    ...getRepositoryRunOptions({
       path: {
         repositoryId: Number.parseInt(params.repoId),
         ortRunIndex: Number.parseInt(params.runIndex),
@@ -233,7 +233,7 @@ export const Route = createFileRoute(
 )({
   loader: async ({ context: { queryClient }, params }) => {
     await queryClient.prefetchQuery({
-      ...getOrtRunByIndexOptions({
+      ...getRepositoryRunOptions({
         path: {
           repositoryId: Number.parseInt(params.repoId),
           ortRunIndex: Number.parseInt(params.runIndex),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
@@ -36,7 +36,7 @@ import z from 'zod';
 
 import { VulnerabilityRating, VulnerabilityWithDetails } from '@/api';
 import {
-  getOrtRunByIndexOptions,
+  getRepositoryRunOptions,
   getVulnerabilitiesByRunIdOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { zVulnerabilityRating } from '@/api/zod.gen';
@@ -430,7 +430,7 @@ const VulnerabilitiesComponent = () => {
   );
 
   const { data: ortRun } = useSuspenseQuery({
-    ...getOrtRunByIndexOptions({
+    ...getRepositoryRunOptions({
       path: {
         repositoryId: Number.parseInt(params.repoId),
         ortRunIndex: Number.parseInt(params.runIndex),
@@ -561,7 +561,7 @@ export const Route = createFileRoute(
   }),
   loader: async ({ context: { queryClient }, params }) => {
     await queryClient.prefetchQuery({
-      ...getOrtRunByIndexOptions({
+      ...getRepositoryRunOptions({
         path: {
           repositoryId: Number.parseInt(params.repoId),
           ortRunIndex: Number.parseInt(params.runIndex),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
@@ -37,7 +37,7 @@ import z from 'zod';
 import { VulnerabilityRating, VulnerabilityWithDetails } from '@/api';
 import {
   getRepositoryRunOptions,
-  getVulnerabilitiesByRunIdOptions,
+  getRunVulnerabilitiesOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { zVulnerabilityRating } from '@/api/zod.gen';
 import { BreakableString } from '@/components/breakable-string';
@@ -444,7 +444,7 @@ const VulnerabilitiesComponent = () => {
     isError,
     error,
   } = useQuery({
-    ...getVulnerabilitiesByRunIdOptions({
+    ...getRunVulnerabilitiesOptions({
       path: { runId: ortRun.id },
       query: { limit: ALL_ITEMS },
     }),

--- a/ui/src/routes/organizations/$orgId/products/$productId/route.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/route.tsx
@@ -21,7 +21,7 @@ import { createFileRoute, Outlet, useParams } from '@tanstack/react-router';
 import { AxiosError } from 'axios';
 import { BookLock, Eye, Settings, ShieldQuestion, User } from 'lucide-react';
 
-import { getProductByIdOptions } from '@/api/@tanstack/react-query.gen';
+import { getProductOptions } from '@/api/@tanstack/react-query.gen';
 import { PageLayout } from '@/components/page-layout';
 import { SidebarNavProps } from '@/components/sidebar';
 import { useUser } from '@/hooks/use-user';
@@ -109,7 +109,7 @@ export const Route = createFileRoute(
   loader: async ({ context, params }) => {
     try {
       const product = await context.queryClient.ensureQueryData({
-        ...getProductByIdOptions({
+        ...getProductOptions({
           path: { productId: Number.parseInt(params.productId) },
         }),
       });

--- a/ui/src/routes/organizations/$orgId/products/$productId/secrets/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/secrets/index.tsx
@@ -37,7 +37,7 @@ import { Secret } from '@/api';
 import {
   deleteSecretByProductIdAndNameMutation,
   getOrganizationOptions,
-  getProductByIdOptions,
+  getProductOptions,
   getSecretsByOrganizationIdOptions,
   getSecretsByProductIdOptions,
   getSecretsByProductIdQueryKey,
@@ -76,7 +76,7 @@ const ActionCell = ({ row }: CellContext<Secret, unknown>) => {
   const queryClient = useQueryClient();
 
   const { data: product } = useSuspenseQuery({
-    ...getProductByIdOptions({
+    ...getProductOptions({
       path: { productId: Number.parseInt(params.productId) },
     }),
   });
@@ -176,7 +176,7 @@ const ProductSecrets = () => {
     isPending: prodIsPending,
     isError: prodIsError,
   } = useQuery({
-    ...getProductByIdOptions({
+    ...getProductOptions({
       path: { productId: Number.parseInt(params.productId) },
     }),
   });
@@ -378,7 +378,7 @@ export const Route = createFileRoute(
   }) => {
     await Promise.allSettled([
       queryClient.prefetchQuery({
-        ...getProductByIdOptions({
+        ...getProductOptions({
           path: { productId: Number.parseInt(params.productId) },
         }),
       }),

--- a/ui/src/routes/organizations/$orgId/products/$productId/secrets/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/secrets/index.tsx
@@ -36,7 +36,7 @@ import z from 'zod';
 import { Secret } from '@/api';
 import {
   deleteSecretByProductIdAndNameMutation,
-  getOrganizationByIdOptions,
+  getOrganizationOptions,
   getProductByIdOptions,
   getSecretsByOrganizationIdOptions,
   getSecretsByProductIdOptions,
@@ -187,7 +187,7 @@ const ProductSecrets = () => {
     isPending: orgIsPending,
     isError: orgIsError,
   } = useQuery({
-    ...getOrganizationByIdOptions({
+    ...getOrganizationOptions({
       path: { organizationId: Number.parseInt(params.orgId) },
     }),
   });
@@ -383,7 +383,7 @@ export const Route = createFileRoute(
         }),
       }),
       queryClient.prefetchQuery({
-        ...getOrganizationByIdOptions({
+        ...getOrganizationOptions({
           path: { organizationId: Number.parseInt(params.orgId) },
         }),
       }),

--- a/ui/src/routes/organizations/$orgId/products/$productId/settings/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/settings/index.tsx
@@ -29,9 +29,9 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import {
-  deleteProductByIdMutation,
-  getProductByIdOptions,
-  patchProductByIdMutation,
+  deleteProductMutation,
+  getProductOptions,
+  patchProductMutation,
 } from '@/api/@tanstack/react-query.gen';
 import { DeleteDialog } from '@/components/delete-dialog';
 import { ToastError } from '@/components/toast-error';
@@ -68,7 +68,7 @@ const ProductSettingsPage = () => {
   const productId = Number.parseInt(params.productId);
 
   const { data: product } = useSuspenseQuery({
-    ...getProductByIdOptions({
+    ...getProductOptions({
       path: {
         productId,
       },
@@ -76,7 +76,7 @@ const ProductSettingsPage = () => {
   });
 
   const { mutateAsync, isPending } = useMutation({
-    ...patchProductByIdMutation(),
+    ...patchProductMutation(),
     onSuccess(data) {
       toast.info('Edit Product', {
         description: `Product "${data.name}" updated successfully.`,
@@ -121,7 +121,7 @@ const ProductSettingsPage = () => {
   }
 
   const { mutateAsync: deleteProduct } = useMutation({
-    ...deleteProductByIdMutation(),
+    ...deleteProductMutation(),
     onSuccess() {
       toast.info('Delete Product', {
         description: `Product "${product.name}" deleted successfully.`,
@@ -243,7 +243,7 @@ export const Route = createFileRoute(
   loader: async ({ context: { queryClient }, params }) => {
     const productId = Number.parseInt(params.productId);
     await queryClient.prefetchQuery({
-      ...getProductByIdOptions({
+      ...getProductOptions({
         path: { productId },
       }),
     });

--- a/ui/src/routes/organizations/$orgId/products/$productId/users/-components/product-users-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/users/-components/product-users-table.tsx
@@ -29,8 +29,8 @@ import { Eye, FileOutput, Pen, Shield } from 'lucide-react';
 import { UserWithGroups } from '@/api';
 import {
   deleteProductRoleFromUserMutation,
-  getUsersForProductOptions,
-  getUsersForProductQueryKey,
+  getProductUsersOptions,
+  getProductUsersQueryKey,
   putProductRoleToUserMutation,
 } from '@/api/@tanstack/react-query.gen';
 import { DataTable } from '@/components/data-table/data-table.tsx';
@@ -110,7 +110,7 @@ const columns = [
           ...putProductRoleToUserMutation(),
           onSuccess(_response, parameters) {
             queryClient.invalidateQueries({
-              queryKey: getUsersForProductQueryKey({
+              queryKey: getProductUsersQueryKey({
                 path: { productId: productId },
               }),
             });
@@ -198,7 +198,7 @@ const columns = [
           // Upon successful removal of the user, invalidate the users query
           // to refresh the data in the table.
           queryClient.invalidateQueries({
-            queryKey: getUsersForProductQueryKey({
+            queryKey: getProductUsersQueryKey({
               path: { productId: productId },
             }),
           });
@@ -266,7 +266,7 @@ export const ProductUsersTable = () => {
   const pageIndex = page - 1;
 
   const { data: usersWithGroups } = useQuery({
-    ...getUsersForProductOptions({
+    ...getProductUsersOptions({
       path: { productId: Number.parseInt(productId) },
       query: {
         limit: pageSize,

--- a/ui/src/routes/organizations/$orgId/products/$productId/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/users/index.tsx
@@ -29,8 +29,8 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import {
-  getProductByIdOptions,
-  getUsersForProductQueryKey,
+  getProductOptions,
+  getProductUsersQueryKey,
   putProductRoleToUserMutation,
 } from '@/api/@tanstack/react-query.gen';
 import { ToastError } from '@/components/toast-error';
@@ -81,7 +81,7 @@ const ManageUsers = () => {
   });
 
   const { data: product } = useSuspenseQuery({
-    ...getProductByIdOptions({
+    ...getProductOptions({
       path: {
         productId: Number.parseInt(params.productId),
       },
@@ -94,7 +94,7 @@ const ManageUsers = () => {
     ...putProductRoleToUserMutation(),
     onSuccess() {
       queryClient.invalidateQueries({
-        queryKey: getUsersForProductQueryKey({
+        queryKey: getProductUsersQueryKey({
           path: {
             productId: Number.parseInt(params.productId),
           },

--- a/ui/src/routes/organizations/$orgId/products/$productId/users/route.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/users/route.tsx
@@ -19,7 +19,7 @@
 
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
 
-import { getUsersForProductOptions } from '@/api/@tanstack/react-query.gen';
+import { getProductUsersOptions } from '@/api/@tanstack/react-query.gen';
 import { paginationSearchParameterSchema } from '@/schemas';
 
 export const Route = createFileRoute(
@@ -40,7 +40,7 @@ export const Route = createFileRoute(
 
     // Ensure the data is available in the query cache when the component is rendered.
     await queryClient.ensureQueryData({
-      ...getUsersForProductOptions({
+      ...getProductUsersOptions({
         path: {
           productId: Number.parseInt(productId),
         },

--- a/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
@@ -33,8 +33,8 @@ import z from 'zod';
 
 import { ProductVulnerability, VulnerabilityRating } from '@/api';
 import {
-  getProductByIdOptions,
-  getVulnerabilitiesAcrossRepositoriesByProductIdOptions,
+  getProductOptions,
+  getProductVulnerabilitiesOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { zVulnerabilityRating } from '@/api/zod.gen';
 import { BreakableString } from '@/components/breakable-string';
@@ -368,7 +368,7 @@ const ProductVulnerabilitiesComponent = () => {
     isError: totIsError,
     error: totError,
   } = useQuery({
-    ...getVulnerabilitiesAcrossRepositoriesByProductIdOptions({
+    ...getProductVulnerabilitiesOptions({
       path: { productId: Number.parseInt(params.productId) },
       query: { limit: 1 },
     }),
@@ -380,7 +380,7 @@ const ProductVulnerabilitiesComponent = () => {
     isError,
     error,
   } = useQuery({
-    ...getVulnerabilitiesAcrossRepositoriesByProductIdOptions({
+    ...getProductVulnerabilitiesOptions({
       path: { productId: Number.parseInt(params.productId) },
       query: {
         limit: pageSize,
@@ -510,7 +510,7 @@ export const Route = createFileRoute(
   }),
   loader: async ({ context: { queryClient }, params }) => {
     await queryClient.prefetchQuery({
-      ...getProductByIdOptions({
+      ...getProductOptions({
         path: { productId: Number.parseInt(params.productId) },
       }),
     });

--- a/ui/src/routes/organizations/$orgId/route.tsx
+++ b/ui/src/routes/organizations/$orgId/route.tsx
@@ -28,7 +28,7 @@ import {
   User,
 } from 'lucide-react';
 
-import { getOrganizationByIdOptions } from '@/api/@tanstack/react-query.gen';
+import { getOrganizationOptions } from '@/api/@tanstack/react-query.gen';
 import { PageLayout } from '@/components/page-layout';
 import { SidebarNavProps } from '@/components/sidebar';
 import { useUser } from '@/hooks/use-user';
@@ -123,7 +123,7 @@ export const Route = createFileRoute('/organizations/$orgId')({
   loader: async ({ context, params }) => {
     try {
       const organization = await context.queryClient.ensureQueryData({
-        ...getOrganizationByIdOptions({
+        ...getOrganizationOptions({
           path: { organizationId: Number.parseInt(params.orgId) },
         }),
       });

--- a/ui/src/routes/organizations/$orgId/secrets/index.tsx
+++ b/ui/src/routes/organizations/$orgId/secrets/index.tsx
@@ -35,7 +35,7 @@ import { EditIcon, PlusIcon } from 'lucide-react';
 import { Secret } from '@/api';
 import {
   deleteSecretByOrganizationIdAndNameMutation,
-  getOrganizationByIdOptions,
+  getOrganizationOptions,
   getSecretsByOrganizationIdOptions,
   getSecretsByOrganizationIdQueryKey,
 } from '@/api/@tanstack/react-query.gen';
@@ -70,7 +70,7 @@ const ActionCell = ({ row }: CellContext<Secret, unknown>) => {
   const queryClient = useQueryClient();
 
   const { data: organization } = useSuspenseQuery({
-    ...getOrganizationByIdOptions({
+    ...getOrganizationOptions({
       path: { organizationId: Number.parseInt(params.orgId) },
     }),
   });
@@ -160,7 +160,7 @@ const OrganizationSecrets = () => {
     isPending: orgIsPending,
     isError: orgIsError,
   } = useQuery({
-    ...getOrganizationByIdOptions({
+    ...getOrganizationOptions({
       path: { organizationId: Number.parseInt(params.orgId) },
     }),
   });
@@ -264,7 +264,7 @@ export const Route = createFileRoute('/organizations/$orgId/secrets/')({
   }) => {
     await Promise.allSettled([
       queryClient.prefetchQuery({
-        ...getOrganizationByIdOptions({
+        ...getOrganizationOptions({
           path: { organizationId: Number.parseInt(params.orgId) },
         }),
       }),

--- a/ui/src/routes/organizations/$orgId/settings/index.tsx
+++ b/ui/src/routes/organizations/$orgId/settings/index.tsx
@@ -29,9 +29,9 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import {
-  deleteOrganizationByIdMutation,
-  getOrganizationByIdOptions,
-  patchOrganizationByIdMutation,
+  deleteOrganizationMutation,
+  getOrganizationOptions,
+  patchOrganizationMutation,
 } from '@/api/@tanstack/react-query.gen';
 import { DeleteDialog } from '@/components/delete-dialog';
 import { ToastError } from '@/components/toast-error';
@@ -68,7 +68,7 @@ const OrganizationSettingsPage = () => {
   const organizationId = Number.parseInt(params.orgId);
 
   const { data: organization } = useSuspenseQuery({
-    ...getOrganizationByIdOptions({
+    ...getOrganizationOptions({
       path: {
         organizationId,
       },
@@ -76,7 +76,7 @@ const OrganizationSettingsPage = () => {
   });
 
   const { mutateAsync, isPending } = useMutation({
-    ...patchOrganizationByIdMutation(),
+    ...patchOrganizationMutation(),
     onSuccess(data) {
       toast.info('Edit Organization', {
         description: `Organization "${data.name}" updated successfully.`,
@@ -121,7 +121,7 @@ const OrganizationSettingsPage = () => {
   }
 
   const { mutateAsync: deleteOrganization } = useMutation({
-    ...deleteOrganizationByIdMutation(),
+    ...deleteOrganizationMutation(),
     onSuccess() {
       toast.info('Delete Organization', {
         description: `Organization "${organization.name}" deleted successfully.`,
@@ -240,7 +240,7 @@ export const Route = createFileRoute('/organizations/$orgId/settings/')({
   loader: async ({ context: { queryClient }, params }) => {
     const organizationId = Number.parseInt(params.orgId);
     await queryClient.prefetchQuery({
-      ...getOrganizationByIdOptions({
+      ...getOrganizationOptions({
         path: {
           organizationId,
         },

--- a/ui/src/routes/organizations/$orgId/users/-components/organization-users-table.tsx
+++ b/ui/src/routes/organizations/$orgId/users/-components/organization-users-table.tsx
@@ -29,8 +29,8 @@ import { Eye, FileOutput, Pen, Shield } from 'lucide-react';
 import { UserWithGroups } from '@/api';
 import {
   deleteOrganizationRoleFromUserMutation,
-  getUsersForOrganizationOptions,
-  getUsersForOrganizationQueryKey,
+  getOrganizationUsersOptions,
+  getOrganizationUsersQueryKey,
   putOrganizationRoleToUserMutation,
 } from '@/api/@tanstack/react-query.gen';
 import { DataTable } from '@/components/data-table/data-table.tsx';
@@ -110,7 +110,7 @@ const columns = [
           ...putOrganizationRoleToUserMutation(),
           onSuccess(_response, parameters) {
             queryClient.invalidateQueries({
-              queryKey: getUsersForOrganizationQueryKey({
+              queryKey: getOrganizationUsersQueryKey({
                 path: {
                   organizationId: organizationId,
                 },
@@ -200,7 +200,7 @@ const columns = [
           // Upon successful removal of the user, invalidate the users query
           // to refresh the data in the table.
           queryClient.invalidateQueries({
-            queryKey: getUsersForOrganizationQueryKey({
+            queryKey: getOrganizationUsersQueryKey({
               path: {
                 organizationId: organizationId,
               },
@@ -270,7 +270,7 @@ export const OrganizationUsersTable = () => {
   const pageIndex = page - 1;
 
   const { data: usersWithGroups } = useQuery({
-    ...getUsersForOrganizationOptions({
+    ...getOrganizationUsersOptions({
       path: {
         organizationId: Number.parseInt(orgId),
       },

--- a/ui/src/routes/organizations/$orgId/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/users/index.tsx
@@ -29,8 +29,8 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import {
-  getOrganizationByIdOptions,
-  getUsersForOrganizationQueryKey,
+  getOrganizationOptions,
+  getOrganizationUsersQueryKey,
   putOrganizationRoleToUserMutation,
 } from '@/api/@tanstack/react-query.gen';
 import { ToastError } from '@/components/toast-error';
@@ -81,7 +81,7 @@ const ManageUsers = () => {
   });
 
   const { data: organization } = useSuspenseQuery({
-    ...getOrganizationByIdOptions({
+    ...getOrganizationOptions({
       path: {
         organizationId: Number.parseInt(params.orgId),
       },
@@ -94,7 +94,7 @@ const ManageUsers = () => {
     ...putOrganizationRoleToUserMutation(),
     onSuccess() {
       queryClient.invalidateQueries({
-        queryKey: getUsersForOrganizationQueryKey({
+        queryKey: getOrganizationUsersQueryKey({
           path: {
             organizationId: Number.parseInt(params.orgId),
           },

--- a/ui/src/routes/organizations/$orgId/users/route.tsx
+++ b/ui/src/routes/organizations/$orgId/users/route.tsx
@@ -19,7 +19,7 @@
 
 import { createFileRoute, Outlet, redirect } from '@tanstack/react-router';
 
-import { getUsersForOrganizationOptions } from '@/api/@tanstack/react-query.gen';
+import { getOrganizationUsersOptions } from '@/api/@tanstack/react-query.gen';
 import { paginationSearchParameterSchema } from '@/schemas';
 
 export const Route = createFileRoute('/organizations/$orgId/users')({
@@ -38,7 +38,7 @@ export const Route = createFileRoute('/organizations/$orgId/users')({
 
     // Ensure the data is available in the query cache when the component is rendered.
     await queryClient.ensureQueryData({
-      ...getUsersForOrganizationOptions({
+      ...getOrganizationUsersOptions({
         path: {
           organizationId: Number.parseInt(orgId),
         },

--- a/ui/src/routes/organizations/$orgId/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/vulnerabilities/index.tsx
@@ -33,8 +33,8 @@ import z from 'zod';
 
 import { OrganizationVulnerability, VulnerabilityRating } from '@/api';
 import {
-  getOrganizationByIdOptions,
-  getVulnerabilitiesAcrossRepositoriesByOrganizationIdOptions,
+  getOrganizationOptions,
+  getOrganizationVulnerabilitiesOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { zVulnerabilityRating } from '@/api/zod.gen';
 import { BreakableString } from '@/components/breakable-string';
@@ -245,7 +245,7 @@ const OrganizationVulnerabilitiesComponent = () => {
     isPending: totPending,
     isError: totError,
   } = useQuery({
-    ...getVulnerabilitiesAcrossRepositoriesByOrganizationIdOptions({
+    ...getOrganizationVulnerabilitiesOptions({
       path: { organizationId: Number.parseInt(params.orgId) },
       query: {
         limit: 1,
@@ -259,7 +259,7 @@ const OrganizationVulnerabilitiesComponent = () => {
     isPending,
     isError,
   } = useQuery({
-    ...getVulnerabilitiesAcrossRepositoriesByOrganizationIdOptions({
+    ...getOrganizationVulnerabilitiesOptions({
       path: { organizationId: Number.parseInt(params.orgId) },
       query: {
         limit: pageSize,
@@ -513,7 +513,7 @@ export const Route = createFileRoute('/organizations/$orgId/vulnerabilities/')({
   }),
   loader: async ({ context: { queryClient }, params }) => {
     await queryClient.prefetchQuery({
-      ...getOrganizationByIdOptions({
+      ...getOrganizationOptions({
         path: { organizationId: Number.parseInt(params.orgId) },
       }),
     });

--- a/ui/src/routes/runs/$runId/index.tsx
+++ b/ui/src/routes/runs/$runId/index.tsx
@@ -20,14 +20,14 @@
 import { createFileRoute, redirect } from '@tanstack/react-router';
 import { AlertCircle } from 'lucide-react';
 
-import { getOrtRunById } from '@/api';
+import { getRun } from '@/api';
 import { NotFoundError } from '@/components/not-found-error';
 import { Card, CardContent, CardHeader } from '@/components/ui/card.tsx';
 import { Separator } from '@/components/ui/separator.tsx';
 
 export const Route = createFileRoute('/runs/$runId/')({
   beforeLoad: async ({ params }) => {
-    const { data: ortRun, error } = await getOrtRunById({
+    const { data: ortRun, error } = await getRun({
       path: { runId: Number.parseInt(params.runId) },
     });
     if (error) throw new NotFoundError(params.runId);


### PR DESCRIPTION
As discussed in #3577, the naming of most of the API endpoints is misaligned and doesn't comply with the [naming conventions of the OpenAPI operation IDs](https://www.apimatic.io/openapi/operationid). This leads to problems especially for the UI development, because the names of the query functions are automatically generated from the operation IDs in `openapi.json`, and the inconsistencies in names makes it sometimes very hard to find the correct query function for the task.

This PR aligns and greatly simplifies most endpoints; as a start, it is targeted to the endpoints in `/core`, and endpoints in `/components` will be aligned with the same naming principles in a follow-up PR, once this is discussed.

The following principles have been used for renaming of the operation IDs:
1. Keep all operation IDs unique.
2. Camel case used (some were using camel case, some pascal case).
3. Avoid binding words (`For`, `By`, `And` etc.) where possible (to shorten and simplify the operation IDs).
4. `CreateSomething` -> `postSomething` (it doesn't make sense to use two different verbs for the same action).
5. Use the hierarchy of the entities (`Organization`, `Product`, `Repository`, `Run` etc.) when naming: `getVulnerabilitiesAcrossRepositoriesByOrganizationId` -> `getOrganizationVulnerabilities`, `getLicensesForPackagesByRunId` -> `getRunPackageLicenses`
6. `OrtRun` -> `Run` (we have no other types of runs).

As I have received no comments from back-end team to this PR, I decided to amend the UI changes to it and mark it for review. Each of the commits now include changes to endpoints, accompanied with the corresponding changes in the UI, to keep the project buildable after each refactoring commit.
