### PR TITLE
ui: Remove hover color from non-functional statistics cards

### DIFF
--- a/ui/src/routes/organizations/$orgId/index.tsx
+++ b/ui/src/routes/organizations/$orgId/index.tsx
@@ -139,6 +139,7 @@ const OrganizationComponent = () => {
           >
             <OrganizationIssuesStatisticsCard
               organizationId={organization.id}
+              className='hover:bg-muted/0'
             />
           </Suspense>
           <Suspense
@@ -153,6 +154,7 @@ const OrganizationComponent = () => {
           >
             <OrganizationViolationsStatisticsCard
               organizationId={organization.id}
+              className='hover:bg-muted/0'
             />
           </Suspense>
           <Suspense
@@ -167,6 +169,7 @@ const OrganizationComponent = () => {
           >
             <OrganizationPackagesStatisticsCard
               organizationId={organization.id}
+              className='hover:bg-muted/0'
             />
           </Suspense>
         </div>

--- a/ui/src/routes/organizations/$orgId/products/$productId/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/index.tsx
@@ -130,7 +130,10 @@ const ProductComponent = () => {
             />
           }
         >
-          <ProductIssuesStatisticsCard productId={product.id} />
+          <ProductIssuesStatisticsCard
+            productId={product.id}
+            className='hover:bg-muted/0'
+          />
         </Suspense>
         <Suspense
           fallback={
@@ -142,7 +145,10 @@ const ProductComponent = () => {
             />
           }
         >
-          <ProductViolationsStatisticsCard productId={product.id} />
+          <ProductViolationsStatisticsCard
+            productId={product.id}
+            className='hover:bg-muted/0'
+          />
         </Suspense>
         <Suspense
           fallback={
@@ -154,7 +160,10 @@ const ProductComponent = () => {
             />
           }
         >
-          <ProductPackagesStatisticsCard productId={product.id} />
+          <ProductPackagesStatisticsCard
+            productId={product.id}
+            className='hover:bg-muted/0'
+          />
         </Suspense>
       </div>
       <Card>


### PR DESCRIPTION
Please see the commit for details.

(@sschuberth Unfortunately, this couldn't be demonstrated with pictures, as my screenshot tool removes the hovering color when the screenshot is taken.)