### PR TITLE
api: Align request objects with operation IDs in apiDocs

### DIFF
--- a/api/v1/client/src/commonMain/kotlin/api/RepositoriesApi.kt
+++ b/api/v1/client/src/commonMain/kotlin/api/RepositoriesApi.kt
@@ -25,8 +25,8 @@ import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRun
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostRepositoryRun
 
 /**
  * A client for the repositories API.
@@ -40,7 +40,7 @@ class RepositoriesApi(
     /**
      * Create a new [ORT run][ortRun] for the given [repository][repositoryId].
      */
-    suspend fun createOrtRun(repositoryId: Long, ortRun: CreateOrtRun): OrtRun =
+    suspend fun createOrtRun(repositoryId: Long, ortRun: PostRepositoryRun): OrtRun =
         client.post("api/v1/repositories/$repositoryId/runs") {
             setBody(ortRun)
         }.body()

--- a/api/v1/client/src/jvmTest/kotlin/RepositoriesApiTest.kt
+++ b/api/v1/client/src/jvmTest/kotlin/RepositoriesApiTest.kt
@@ -27,11 +27,11 @@ import io.ktor.http.HttpStatusCode
 
 import kotlinx.datetime.Instant
 
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.JobConfigurations
 import org.eclipse.apoapsis.ortserver.api.v1.model.Jobs
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatus
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostRepositoryRun
 import org.eclipse.apoapsis.ortserver.client.NotFoundException
 import org.eclipse.apoapsis.ortserver.client.api.RepositoriesApi
 import org.eclipse.apoapsis.ortserver.client.createOrtHttpClient
@@ -62,7 +62,7 @@ class RepositoriesApiTest : StringSpec({
 
             val actualOrtRun = repositoriesApi.createOrtRun(
                 repositoryId = 1,
-                ortRun = CreateOrtRun(revision = "main", jobConfigs = JobConfigurations())
+                ortRun = PostRepositoryRun(revision = "main", jobConfigs = JobConfigurations())
             )
 
             actualOrtRun shouldBe respondOrtRun
@@ -77,7 +77,7 @@ class RepositoriesApiTest : StringSpec({
             shouldThrow<NotFoundException> {
                 repositoriesApi.createOrtRun(
                     repositoryId = 1,
-                    ortRun = CreateOrtRun(revision = "main", jobConfigs = JobConfigurations())
+                    ortRun = PostRepositoryRun(revision = "main", jobConfigs = JobConfigurations())
                 )
             }
         }

--- a/api/v1/model/src/commonMain/kotlin/ContentManagementSection.kt
+++ b/api/v1/model/src/commonMain/kotlin/ContentManagementSection.kt
@@ -37,7 +37,7 @@ data class ContentManagementSection(
  * Request object for the update of a section.
  */
 @Serializable
-data class UpdateContentManagementSection(
+data class PatchSection(
     val isEnabled: Boolean,
     val markdown: String
 )

--- a/api/v1/model/src/commonMain/kotlin/Organization.kt
+++ b/api/v1/model/src/commonMain/kotlin/Organization.kt
@@ -52,14 +52,14 @@ data class Organization(
  * Request object for the create organization endpoint.
  */
 @Serializable
-data class CreateOrganization(
+data class PostOrganization(
     val name: String,
     val description: String? = null
 ) {
     companion object {
-        val validate: ValidatorFunc<CreateOrganization> = { obj ->
+        val validate: ValidatorFunc<PostOrganization> = { obj ->
             Validation {
-                CreateOrganization::name {
+                PostOrganization::name {
                     pattern(Organization.NAME_PATTERN_REGEX) hint Organization.NAME_PATTERN_MESSAGE
                 }
             }.invoke(obj)
@@ -71,14 +71,14 @@ data class CreateOrganization(
  * Request object for the update organization endpoint.
  */
 @Serializable
-data class UpdateOrganization(
+data class PatchOrganization(
     val name: OptionalValue<String> = OptionalValue.Absent,
     val description: OptionalValue<String?> = OptionalValue.Absent
 ) {
     companion object {
-        val validate: ValidatorFunc<UpdateOrganization> = { obj ->
+        val validate: ValidatorFunc<PatchOrganization> = { obj ->
             Validation {
-                UpdateOrganization::name {
+                PatchOrganization::name {
                     optionalPattern(Organization.NAME_PATTERN_REGEX) hint Organization.NAME_PATTERN_MESSAGE
                 }
             }.invoke(obj)

--- a/api/v1/model/src/commonMain/kotlin/OrtRun.kt
+++ b/api/v1/model/src/commonMain/kotlin/OrtRun.kt
@@ -143,7 +143,7 @@ data class OrtRun(
  * Request object for the create ort run endpoint.
  */
 @Serializable
-data class CreateOrtRun(
+data class PostRepositoryRun(
     /**
      * The repository revision used by this run.
      */

--- a/api/v1/model/src/commonMain/kotlin/Product.kt
+++ b/api/v1/model/src/commonMain/kotlin/Product.kt
@@ -74,14 +74,14 @@ data class PostProduct(
  * Request object for the update product endpoint.
  */
 @Serializable
-data class UpdateProduct(
+data class PatchProduct(
     val name: OptionalValue<String> = OptionalValue.Absent,
     val description: OptionalValue<String?> = OptionalValue.Absent
 ) {
     companion object {
-        val validate: ValidatorFunc<UpdateProduct> = { obj ->
+        val validate: ValidatorFunc<PatchProduct> = { obj ->
             Validation {
-                UpdateProduct::name {
+                PatchProduct::name {
                     optionalPattern(Product.NAME_PATTERN_REGEX) hint Product.NAME_PATTERN_MESSAGE
                 }
             }.invoke(obj)

--- a/api/v1/model/src/commonMain/kotlin/Product.kt
+++ b/api/v1/model/src/commonMain/kotlin/Product.kt
@@ -55,14 +55,14 @@ data class Product(
  * Request object for the create product endpoint.
  */
 @Serializable
-data class CreateProduct(
+data class PostProduct(
     val name: String,
     val description: String? = null
 ) {
     companion object {
-        val validate: ValidatorFunc<CreateProduct> = { obj ->
+        val validate: ValidatorFunc<PostProduct> = { obj ->
             Validation {
-                CreateProduct::name {
+                PostProduct::name {
                     pattern(Product.NAME_PATTERN_REGEX) hint Product.NAME_PATTERN_MESSAGE
                 }
             }.invoke(obj)

--- a/api/v1/model/src/commonMain/kotlin/Repository.kt
+++ b/api/v1/model/src/commonMain/kotlin/Repository.kt
@@ -70,15 +70,15 @@ private fun String.isValidHost() = all { it.isLetterOrDigit() || it == '.' || it
  * Request object for the create repository endpoint.
  */
 @Serializable
-data class CreateRepository(
+data class PostRepository(
     val type: RepositoryType,
     val url: String,
     val description: String? = null
 ) {
     companion object {
-        val validate: ValidatorFunc<CreateRepository> = { obj ->
+        val validate: ValidatorFunc<PostRepository> = { obj ->
             Validation {
-                CreateRepository::url {
+                PostRepository::url {
                     constrain("malformed URL") {
                         Repository.isValidUrl(it)
                     } hint Repository.INVALID_URL_MESSAGE

--- a/api/v1/model/src/commonMain/kotlin/Repository.kt
+++ b/api/v1/model/src/commonMain/kotlin/Repository.kt
@@ -96,15 +96,15 @@ data class PostRepository(
  * Request object for the update repository endpoint.
  */
 @Serializable
-data class UpdateRepository(
+data class PatchRepository(
     val type: OptionalValue<RepositoryType> = OptionalValue.Absent,
     val url: OptionalValue<String> = OptionalValue.Absent,
     val description: OptionalValue<String?> = OptionalValue.Absent
 ) {
     companion object {
-        val validate: ValidatorFunc<UpdateRepository> = { obj ->
+        val validate: ValidatorFunc<PatchRepository> = { obj ->
             Validation {
-                UpdateRepository::url {
+                PatchRepository::url {
                     constrain("malformed URL") {
                         when (it) {
                             is OptionalValue.Present -> Repository.isValidUrl(it.value)

--- a/api/v1/model/src/commonMain/kotlin/User.kt
+++ b/api/v1/model/src/commonMain/kotlin/User.kt
@@ -68,7 +68,7 @@ data class UserWithGroups(
 )
 
 @Serializable
-data class CreateUser(
+data class PostUser(
     val username: String,
     val firstName: String? = null,
     val lastName: String? = null,

--- a/cli/src/commonMain/kotlin/StartCommand.kt
+++ b/cli/src/commonMain/kotlin/StartCommand.kt
@@ -47,11 +47,11 @@ import kotlinx.coroutines.runBlocking
 
 import okio.Path.Companion.toPath
 
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.JobConfigurations
 import org.eclipse.apoapsis.ortserver.api.v1.model.Jobs
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatus
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostRepositoryRun
 import org.eclipse.apoapsis.ortserver.cli.model.AuthenticationError
 import org.eclipse.apoapsis.ortserver.cli.model.CliInputException
 import org.eclipse.apoapsis.ortserver.cli.model.RunFinishedWithIssuesException
@@ -116,7 +116,7 @@ class StartCommand : SuspendingCliktCommand(name = "start") {
 
     override suspend fun run() {
         val createOrtRun = runCatching {
-            json.decodeFromString(CreateOrtRun.serializer(), parameters)
+            json.decodeFromString(PostRepositoryRun.serializer(), parameters)
         }.getOrElse {
             throw CliInputException(
                 "Invalid run parameters: '$parameters'.",

--- a/core/src/main/kotlin/api/AdminRoute.kt
+++ b/core/src/main/kotlin/api/AdminRoute.kt
@@ -35,8 +35,8 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToApi
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateUser
-import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateContentManagementSection
+import org.eclipse.apoapsis.ortserver.api.v1.model.PatchSection
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostUser
 import org.eclipse.apoapsis.ortserver.components.authorization.requireAuthenticated
 import org.eclipse.apoapsis.ortserver.components.authorization.requireSuperuser
 import org.eclipse.apoapsis.ortserver.core.apiDocs.deleteUser
@@ -84,7 +84,7 @@ fun Route.admin() = route("admin") {
         post(postUser) {
             requireSuperuser()
 
-            val createUser = call.receive<CreateUser>()
+            val createUser = call.receive<PostUser>()
             userService.createUser(
                 username = createUser.username,
                 firstName = createUser.firstName,
@@ -129,7 +129,7 @@ fun Route.admin() = route("admin") {
                 requireSuperuser()
 
                 val id = call.requireParameter("sectionId")
-                val updateSection = call.receive<UpdateContentManagementSection>()
+                val updateSection = call.receive<PatchSection>()
 
                 val section = contentManagementService.updateSectionById(
                     id = id,

--- a/core/src/main/kotlin/api/AdminRoute.kt
+++ b/core/src/main/kotlin/api/AdminRoute.kt
@@ -43,7 +43,7 @@ import org.eclipse.apoapsis.ortserver.core.apiDocs.deleteUser
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getSection
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getUsers
 import org.eclipse.apoapsis.ortserver.core.apiDocs.patchSection
-import org.eclipse.apoapsis.ortserver.core.apiDocs.postUsers
+import org.eclipse.apoapsis.ortserver.core.apiDocs.postUser
 import org.eclipse.apoapsis.ortserver.core.apiDocs.runPermissionsSync
 import org.eclipse.apoapsis.ortserver.services.AuthorizationService
 import org.eclipse.apoapsis.ortserver.services.ContentManagementService
@@ -81,7 +81,7 @@ fun Route.admin() = route("admin") {
             call.respond(users)
         }
 
-        post(postUsers) {
+        post(postUser) {
             requireSuperuser()
 
             val createUser = call.receive<CreateUser>()

--- a/core/src/main/kotlin/api/OrganizationsRoute.kt
+++ b/core/src/main/kotlin/api/OrganizationsRoute.kt
@@ -33,10 +33,10 @@ import io.ktor.server.routing.route
 
 import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToApi
 import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToModel
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrganization
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateProduct
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatistics
-import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateOrganization
+import org.eclipse.apoapsis.ortserver.api.v1.model.PatchOrganization
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostOrganization
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostProduct
 import org.eclipse.apoapsis.ortserver.api.v1.model.Username
 import org.eclipse.apoapsis.ortserver.components.authorization.api.OrganizationRole
 import org.eclipse.apoapsis.ortserver.components.authorization.hasPermission
@@ -121,7 +121,7 @@ fun Route.organizations() = route("organizations") {
     post(postOrganization) {
         requireSuperuser()
 
-        val createOrganization = call.receive<CreateOrganization>()
+        val createOrganization = call.receive<PostOrganization>()
 
         val createdOrganization =
             organizationService.createOrganization(createOrganization.name, createOrganization.description)
@@ -145,7 +145,7 @@ fun Route.organizations() = route("organizations") {
             requirePermission(OrganizationPermission.WRITE)
 
             val organizationId = call.requireIdParameter("organizationId")
-            val org = call.receive<UpdateOrganization>()
+            val org = call.receive<PatchOrganization>()
 
             val updatedOrg = organizationService.updateOrganization(
                 organizationId,
@@ -189,7 +189,7 @@ fun Route.organizations() = route("organizations") {
             post(postProduct) {
                 requirePermission(OrganizationPermission.CREATE_PRODUCT)
 
-                val createProduct = call.receive<CreateProduct>()
+                val createProduct = call.receive<PostProduct>()
                 val orgId = call.requireIdParameter("organizationId")
 
                 val createdProduct =

--- a/core/src/main/kotlin/api/ProductsRoute.kt
+++ b/core/src/main/kotlin/api/ProductsRoute.kt
@@ -34,11 +34,11 @@ import io.ktor.server.routing.route
 
 import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToApi
 import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToModel
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.Jobs
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatistics
 import org.eclipse.apoapsis.ortserver.api.v1.model.PatchProduct
 import org.eclipse.apoapsis.ortserver.api.v1.model.PostRepository
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostRepositoryRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.Username
 import org.eclipse.apoapsis.ortserver.components.authorization.OrtPrincipal
 import org.eclipse.apoapsis.ortserver.components.authorization.api.ProductRole
@@ -352,7 +352,7 @@ fun Route.products() = route("products/{productId}") {
                 return@post
             }
 
-            val createOrtRun = call.receive<CreateOrtRun>()
+            val createOrtRun = call.receive<PostRepositoryRun>()
             val userDisplayName = call.principal<OrtPrincipal>()?.let { principal ->
                 UserDisplayName(principal.getUserId(), principal.getUsername(), principal.getFullName())
             }

--- a/core/src/main/kotlin/api/ProductsRoute.kt
+++ b/core/src/main/kotlin/api/ProductsRoute.kt
@@ -35,10 +35,10 @@ import io.ktor.server.routing.route
 import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToApi
 import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToModel
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateRepository
 import org.eclipse.apoapsis.ortserver.api.v1.model.Jobs
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatistics
-import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateProduct
+import org.eclipse.apoapsis.ortserver.api.v1.model.PatchProduct
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostRepository
 import org.eclipse.apoapsis.ortserver.api.v1.model.Username
 import org.eclipse.apoapsis.ortserver.components.authorization.OrtPrincipal
 import org.eclipse.apoapsis.ortserver.components.authorization.api.ProductRole
@@ -125,7 +125,7 @@ fun Route.products() = route("products/{productId}") {
         requirePermission(ProductPermission.WRITE)
 
         val id = call.requireIdParameter("productId")
-        val updateProduct = call.receive<UpdateProduct>()
+        val updateProduct = call.receive<PatchProduct>()
 
         val updatedProduct =
             productService.updateProduct(id, updateProduct.name.mapToModel(), updateProduct.description.mapToModel())
@@ -163,7 +163,7 @@ fun Route.products() = route("products/{productId}") {
             requirePermission(ProductPermission.CREATE_REPOSITORY)
 
             val id = call.requireIdParameter("productId")
-            val createRepository = call.receive<CreateRepository>()
+            val createRepository = call.receive<PostRepository>()
             val repository = productService.createRepository(
                 createRepository.type.mapToModel(),
                 createRepository.url,

--- a/core/src/main/kotlin/api/RepositoriesRoute.kt
+++ b/core/src/main/kotlin/api/RepositoriesRoute.kt
@@ -34,9 +34,9 @@ import io.ktor.server.routing.route
 
 import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToApi
 import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToModel
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.Jobs
-import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateRepository
+import org.eclipse.apoapsis.ortserver.api.v1.model.PatchRepository
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostRepositoryRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.Username
 import org.eclipse.apoapsis.ortserver.components.authorization.OrtPrincipal
 import org.eclipse.apoapsis.ortserver.components.authorization.api.RepositoryRole
@@ -105,7 +105,7 @@ fun Route.repositories() = route("repositories/{repositoryId}") {
         requirePermission(RepositoryPermission.WRITE)
 
         val id = call.requireIdParameter("repositoryId")
-        val updateRepository = call.receive<UpdateRepository>()
+        val updateRepository = call.receive<PatchRepository>()
 
         val updatedRepository = repositoryService.updateRepository(
             id,
@@ -145,7 +145,7 @@ fun Route.repositories() = route("repositories/{repositoryId}") {
             val repositoryId = call.requireIdParameter("repositoryId")
 
             repositoryService.getRepository(repositoryId)?.let {
-                val createOrtRun = call.receive<CreateOrtRun>()
+                val createOrtRun = call.receive<PostRepositoryRun>()
 
                 // Extract the user information from the principal.
                 val userDisplayName = call.principal<OrtPrincipal>()?.let { principal ->

--- a/core/src/main/kotlin/apiDocs/AdminDocs.kt
+++ b/core/src/main/kotlin/apiDocs/AdminDocs.kt
@@ -81,8 +81,8 @@ val getUsers: RouteConfig.() -> Unit = {
     }
 }
 
-val postUsers: RouteConfig.() -> Unit = {
-    operationId = "postUsers"
+val postUser: RouteConfig.() -> Unit = {
+    operationId = "postUser"
     summary = "Create a user, possibly with a password"
     tags = listOf("Admin")
 

--- a/core/src/main/kotlin/apiDocs/AdminDocs.kt
+++ b/core/src/main/kotlin/apiDocs/AdminDocs.kt
@@ -24,8 +24,8 @@ import io.github.smiley4.ktoropenapi.config.RouteConfig
 import io.ktor.http.HttpStatusCode
 
 import org.eclipse.apoapsis.ortserver.api.v1.model.ContentManagementSection
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateUser
-import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateContentManagementSection
+import org.eclipse.apoapsis.ortserver.api.v1.model.PatchSection
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostUser
 import org.eclipse.apoapsis.ortserver.api.v1.model.User
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.jsonBody
 
@@ -87,9 +87,9 @@ val postUser: RouteConfig.() -> Unit = {
     tags = listOf("Admin")
 
     request {
-        jsonBody<CreateUser> {
+        jsonBody<PostUser> {
             example("Create User") {
-                value = CreateUser(
+                value = PostUser(
                     username = "newUser",
                     firstName = "First",
                     lastName = "Last",
@@ -175,9 +175,9 @@ val patchSection: RouteConfig.() -> Unit = {
             description = "The section's ID."
         }
 
-        jsonBody<UpdateContentManagementSection> {
+        jsonBody<PatchSection> {
             example("Update Section") {
-                value = UpdateContentManagementSection(
+                value = PatchSection(
                     isEnabled = true,
                     markdown = "# This is a new footer"
                 )

--- a/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
@@ -24,17 +24,17 @@ import io.github.smiley4.ktoropenapi.config.RouteConfig
 import io.ktor.http.HttpStatusCode
 
 import org.eclipse.apoapsis.ortserver.api.v1.model.ComparisonOperator
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrganization
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateProduct
 import org.eclipse.apoapsis.ortserver.api.v1.model.EcosystemStats
 import org.eclipse.apoapsis.ortserver.api.v1.model.FilterOperatorAndValue
 import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
 import org.eclipse.apoapsis.ortserver.api.v1.model.Organization
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrganizationVulnerability
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatistics
+import org.eclipse.apoapsis.ortserver.api.v1.model.PatchOrganization
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostOrganization
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostProduct
 import org.eclipse.apoapsis.ortserver.api.v1.model.Product
 import org.eclipse.apoapsis.ortserver.api.v1.model.Severity
-import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateOrganization
 import org.eclipse.apoapsis.ortserver.api.v1.model.User
 import org.eclipse.apoapsis.ortserver.api.v1.model.UserGroup
 import org.eclipse.apoapsis.ortserver.api.v1.model.UserWithGroups
@@ -118,9 +118,9 @@ val postOrganization: RouteConfig.() -> Unit = {
     tags = listOf("Organizations")
 
     request {
-        jsonBody<CreateOrganization> {
+        jsonBody<PostOrganization> {
             example("Create Organization") {
-                value = CreateOrganization(name = "My Organization", description = "This is my organization.")
+                value = PostOrganization(name = "My Organization", description = "This is my organization.")
             }
         }
     }
@@ -146,10 +146,10 @@ val patchOrganization: RouteConfig.() -> Unit = {
         pathParameter<Long>("organizationId") {
             description = "The organization's ID."
         }
-        jsonBody<UpdateOrganization> {
+        jsonBody<PatchOrganization> {
             description = "Set the values that should be updated. To delete a value, set it explicitly to null."
             example("Update Organization") {
-                value = UpdateOrganization(
+                value = PatchOrganization(
                     name = "My updated Organization".asPresent(),
                     description = "Updated description".asPresent()
                 )
@@ -236,9 +236,9 @@ val postProduct: RouteConfig.() -> Unit = {
         pathParameter<Long>("organizationId") {
             description = "The organization's ID."
         }
-        jsonBody<CreateProduct> {
+        jsonBody<PostProduct> {
             example("Create product") {
-                value = CreateProduct(name = "My product", description = "Description")
+                value = PostProduct(name = "My product", description = "Description")
             }
         }
     }

--- a/core/src/main/kotlin/apiDocs/ProductsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/ProductsDocs.kt
@@ -27,7 +27,6 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.AdvisorJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.AnalyzerJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.ComparisonOperator
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateRepository
 import org.eclipse.apoapsis.ortserver.api.v1.model.EcosystemStats
 import org.eclipse.apoapsis.ortserver.api.v1.model.FilterOperatorAndValue
 import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
@@ -35,12 +34,13 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.JobConfigurations
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatistics
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatus
+import org.eclipse.apoapsis.ortserver.api.v1.model.PatchProduct
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostRepository
 import org.eclipse.apoapsis.ortserver.api.v1.model.Product
 import org.eclipse.apoapsis.ortserver.api.v1.model.ProductVulnerability
 import org.eclipse.apoapsis.ortserver.api.v1.model.Repository
 import org.eclipse.apoapsis.ortserver.api.v1.model.RepositoryType
 import org.eclipse.apoapsis.ortserver.api.v1.model.Severity
-import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateProduct
 import org.eclipse.apoapsis.ortserver.api.v1.model.User
 import org.eclipse.apoapsis.ortserver.api.v1.model.UserGroup
 import org.eclipse.apoapsis.ortserver.api.v1.model.UserWithGroups
@@ -91,10 +91,10 @@ val patchProduct: RouteConfig.() -> Unit = {
         pathParameter<Long>("productId") {
             description = "The product's ID."
         }
-        jsonBody<UpdateProduct> {
+        jsonBody<PatchProduct> {
             description = "Set the values that should be updated. To delete a value, set it explicitly to null."
             example("Update Product") {
-                value = UpdateProduct(name = "Update Product".asPresent(), description = "Updated product".asPresent())
+                value = PatchProduct(name = "Update Product".asPresent(), description = "Updated product".asPresent())
             }
         }
     }
@@ -195,9 +195,9 @@ val postRepository: RouteConfig.() -> Unit = {
         pathParameter<Long>("productId") {
             description = "The product's ID."
         }
-        jsonBody<CreateRepository> {
+        jsonBody<PostRepository> {
             example("Create repository") {
-                value = CreateRepository(
+                value = PostRepository(
                     type = RepositoryType.GIT,
                     url = "https://example.com/namspace/repo.git",
                 )

--- a/core/src/main/kotlin/apiDocs/ProductsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/ProductsDocs.kt
@@ -26,7 +26,6 @@ import io.ktor.http.HttpStatusCode
 import org.eclipse.apoapsis.ortserver.api.v1.model.AdvisorJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.AnalyzerJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.ComparisonOperator
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.EcosystemStats
 import org.eclipse.apoapsis.ortserver.api.v1.model.FilterOperatorAndValue
 import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
@@ -36,6 +35,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatistics
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatus
 import org.eclipse.apoapsis.ortserver.api.v1.model.PatchProduct
 import org.eclipse.apoapsis.ortserver.api.v1.model.PostRepository
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostRepositoryRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.Product
 import org.eclipse.apoapsis.ortserver.api.v1.model.ProductVulnerability
 import org.eclipse.apoapsis.ortserver.api.v1.model.Repository
@@ -484,16 +484,16 @@ val postProductRuns: RouteConfig.() -> Unit = {
             description = "The product's ID."
         }
 
-        jsonBody<CreateOrtRun> {
+        jsonBody<PostRepositoryRun> {
             example("Create ORT runs for all repositories using minimal job configurations") {
-                value = CreateOrtRun(
+                value = PostRepositoryRun(
                     revision = "main",
                     jobConfigs = minimalJobConfigurations
                 )
             }
 
             example("Create ORT runs for specific repositories using minimal job configurations") {
-                value = CreateOrtRun(
+                value = PostRepositoryRun(
                     revision = "main",
                     jobConfigs = minimalJobConfigurations,
                     repositoryIds = listOf(1, 2)

--- a/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
@@ -30,7 +30,6 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.AdvisorJob
 import org.eclipse.apoapsis.ortserver.api.v1.model.AdvisorJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.AnalyzerJob
 import org.eclipse.apoapsis.ortserver.api.v1.model.AnalyzerJobConfiguration
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.EnvironmentConfig
 import org.eclipse.apoapsis.ortserver.api.v1.model.EvaluatorJob
 import org.eclipse.apoapsis.ortserver.api.v1.model.EvaluatorJobConfiguration
@@ -45,6 +44,8 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatus
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunSummary
 import org.eclipse.apoapsis.ortserver.api.v1.model.PackageManagerConfiguration
+import org.eclipse.apoapsis.ortserver.api.v1.model.PatchRepository
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostRepositoryRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.ProviderPluginConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.ReporterJob
 import org.eclipse.apoapsis.ortserver.api.v1.model.ReporterJobConfiguration
@@ -53,7 +54,6 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.RepositoryType
 import org.eclipse.apoapsis.ortserver.api.v1.model.ScannerJob
 import org.eclipse.apoapsis.ortserver.api.v1.model.ScannerJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.SubmoduleFetchStrategy.FULLY_RECURSIVE
-import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateRepository
 import org.eclipse.apoapsis.ortserver.api.v1.model.User
 import org.eclipse.apoapsis.ortserver.api.v1.model.UserDisplayName
 import org.eclipse.apoapsis.ortserver.api.v1.model.UserGroup
@@ -248,10 +248,10 @@ val patchRepository: RouteConfig.() -> Unit = {
         pathParameter<Long>("repositoryId") {
             description = "The repository's ID."
         }
-        jsonBody<UpdateRepository> {
+        jsonBody<PatchRepository> {
             description = "Set the values that should be updated. To delete a value, set it explicitly to null."
             example("Update Repository") {
-                value = UpdateRepository(
+                value = PatchRepository(
                     type = RepositoryType.GIT_REPO.asPresent(),
                     url = "https://example.com/org/updated-repo.git".asPresent(),
                     description = "Updated repository description.".asPresent()
@@ -385,16 +385,16 @@ val postRepositoryRun: RouteConfig.() -> Unit = {
             description = "The repository's ID."
         }
 
-        jsonBody<CreateOrtRun> {
+        jsonBody<PostRepositoryRun> {
             example("Create ORT run using minimal job configurations (defaults)") {
-                value = CreateOrtRun(
+                value = PostRepositoryRun(
                     revision = "main",
                     jobConfigs = minimalJobConfigurations
                 )
             }
 
             example("Create ORT run using full job configurations") {
-                value = CreateOrtRun(
+                value = PostRepositoryRun(
                     revision = "main",
                     jobConfigs = fullJobConfigurations,
                     labels = mapOf("label key" to "label value"),

--- a/core/src/main/kotlin/plugins/Validation.kt
+++ b/core/src/main/kotlin/plugins/Validation.kt
@@ -25,10 +25,10 @@ import io.ktor.server.plugins.requestvalidation.RequestValidation
 
 import org.eclipse.apoapsis.ortserver.api.v1.model.PatchOrganization
 import org.eclipse.apoapsis.ortserver.api.v1.model.PatchProduct
+import org.eclipse.apoapsis.ortserver.api.v1.model.PatchRepository
 import org.eclipse.apoapsis.ortserver.api.v1.model.PostOrganization
 import org.eclipse.apoapsis.ortserver.api.v1.model.PostProduct
 import org.eclipse.apoapsis.ortserver.api.v1.model.PostRepository
-import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateRepository
 import org.eclipse.apoapsis.ortserver.components.infrastructureservices.infrastructureServicesValidations
 import org.eclipse.apoapsis.ortserver.components.secrets.secretsValidations
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.mapValidationResult
@@ -55,8 +55,8 @@ fun Application.configureValidation() {
             mapValidationResult(PostRepository.validate(create))
         }
 
-        validate<UpdateRepository> { update ->
-            mapValidationResult(UpdateRepository.validate(update))
+        validate<PatchRepository> { update ->
+            mapValidationResult(PatchRepository.validate(update))
         }
 
         infrastructureServicesValidations()

--- a/core/src/main/kotlin/plugins/Validation.kt
+++ b/core/src/main/kotlin/plugins/Validation.kt
@@ -23,10 +23,10 @@ import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.plugins.requestvalidation.RequestValidation
 
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrganization
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateProduct
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateRepository
-import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateOrganization
+import org.eclipse.apoapsis.ortserver.api.v1.model.PatchOrganization
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostOrganization
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostProduct
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateProduct
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateRepository
 import org.eclipse.apoapsis.ortserver.components.infrastructureservices.infrastructureServicesValidations
@@ -35,16 +35,16 @@ import org.eclipse.apoapsis.ortserver.shared.ktorutils.mapValidationResult
 
 fun Application.configureValidation() {
     install(RequestValidation) {
-        validate<CreateOrganization> { create ->
-            mapValidationResult(CreateOrganization.validate(create))
+        validate<PostOrganization> { create ->
+            mapValidationResult(PostOrganization.validate(create))
         }
 
-        validate<UpdateOrganization> { update ->
-            mapValidationResult(UpdateOrganization.validate(update))
+        validate<PatchOrganization> { update ->
+            mapValidationResult(PatchOrganization.validate(update))
         }
 
-        validate<CreateProduct> { create ->
-            mapValidationResult(CreateProduct.validate(create))
+        validate<PostProduct> { create ->
+            mapValidationResult(PostProduct.validate(create))
         }
 
         validate<UpdateProduct> { update ->

--- a/core/src/main/kotlin/plugins/Validation.kt
+++ b/core/src/main/kotlin/plugins/Validation.kt
@@ -23,11 +23,11 @@ import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.plugins.requestvalidation.RequestValidation
 
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateRepository
 import org.eclipse.apoapsis.ortserver.api.v1.model.PatchOrganization
+import org.eclipse.apoapsis.ortserver.api.v1.model.PatchProduct
 import org.eclipse.apoapsis.ortserver.api.v1.model.PostOrganization
 import org.eclipse.apoapsis.ortserver.api.v1.model.PostProduct
-import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateProduct
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostRepository
 import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateRepository
 import org.eclipse.apoapsis.ortserver.components.infrastructureservices.infrastructureServicesValidations
 import org.eclipse.apoapsis.ortserver.components.secrets.secretsValidations
@@ -47,12 +47,12 @@ fun Application.configureValidation() {
             mapValidationResult(PostProduct.validate(create))
         }
 
-        validate<UpdateProduct> { update ->
-            mapValidationResult(UpdateProduct.validate(update))
+        validate<PatchProduct> { update ->
+            mapValidationResult(PatchProduct.validate(update))
         }
 
-        validate<CreateRepository> { create ->
-            mapValidationResult(CreateRepository.validate(create))
+        validate<PostRepository> { create ->
+            mapValidationResult(PostRepository.validate(create))
         }
 
         validate<UpdateRepository> { update ->

--- a/core/src/main/kotlin/utils/Extensions.kt
+++ b/core/src/main/kotlin/utils/Extensions.kt
@@ -25,9 +25,9 @@ import io.ktor.server.config.tryGetString
 import kotlin.time.Duration.Companion.seconds
 
 import org.eclipse.apoapsis.ortserver.api.v1.model.ComparisonOperator
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.FilterOperatorAndValue
 import org.eclipse.apoapsis.ortserver.api.v1.model.PluginConfig
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostRepositoryRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityForRunsFilters
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityRating
 import org.eclipse.apoapsis.ortserver.clients.keycloak.KeycloakClientConfiguration
@@ -59,11 +59,11 @@ fun ConfigManager.createKeycloakClientConfiguration(): KeycloakClientConfigurati
 private val emptyPluginConfig = PluginConfig(options = emptyMap(), secrets = emptyMap())
 
 /**
- * Get all [PluginConfig]s from a [CreateOrtRun] object. The result is a map from [PluginType]s to maps of plugin IDs to
- * [PluginConfig]s. Some job configs allow to enable plugins without additional configuration, in this case an empty
- * [PluginConfig] is used as the value for the plugin ID in the map.
+ * Get all [PluginConfig]s from a [PostRepositoryRun] object. The result is a map from [PluginType]s to maps of plugin
+ * IDs to [PluginConfig]s. Some job configs allow to enable plugins without additional configuration, in this case an
+ * empty [PluginConfig] is used as the value for the plugin ID in the map.
  */
-fun CreateOrtRun.getPluginConfigs(): Map<PluginType, Map<String, PluginConfig>> =
+fun PostRepositoryRun.getPluginConfigs(): Map<PluginType, Map<String, PluginConfig>> =
     buildMap {
         jobConfigs.advisor?.let { jobConfig ->
             val allAdvisors = jobConfig.advisors + jobConfig.config?.keys.orEmpty()
@@ -141,7 +141,7 @@ fun CreateOrtRun.getPluginConfigs(): Map<PluginType, Map<String, PluginConfig>> 
     }.filterValues { it.isNotEmpty() }
 
 /** Return true if the `keepAliveWorker` flag is enabled in any job config. */
-fun CreateOrtRun.hasKeepAliveWorkerFlag() =
+fun PostRepositoryRun.hasKeepAliveWorkerFlag() =
     jobConfigs.advisor?.keepAliveWorker == true ||
     jobConfigs.analyzer.keepAliveWorker ||
     jobConfigs.evaluator?.keepAliveWorker == true ||

--- a/core/src/test/kotlin/api/AdminRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/AdminRouteIntegrationTest.kt
@@ -38,8 +38,8 @@ import io.ktor.http.HttpStatusCode
 import kotlinx.serialization.json.Json
 
 import org.eclipse.apoapsis.ortserver.api.v1.model.ContentManagementSection
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateUser
-import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateContentManagementSection
+import org.eclipse.apoapsis.ortserver.api.v1.model.PatchSection
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostUser
 import org.eclipse.apoapsis.ortserver.api.v1.model.User
 import org.eclipse.apoapsis.ortserver.components.authorization.roles.Superuser
 import org.eclipse.apoapsis.ortserver.core.SUPERUSER
@@ -98,7 +98,7 @@ class AdminRouteIntegrationTest : AbstractIntegrationTest({
     "POST /admin/users" should {
         "create a new user" {
             integrationTestApplication {
-                val user = CreateUser(
+                val user = PostUser(
                     username = testUsername,
                     firstName = testFirstName,
                     lastName = testLastName,
@@ -117,7 +117,7 @@ class AdminRouteIntegrationTest : AbstractIntegrationTest({
 
         "respond with an internal error if the user already exists" {
             integrationTestApplication {
-                val user = CreateUser(
+                val user = PostUser(
                     username = testUsername,
                     firstName = testFirstName,
                     lastName = testLastName,
@@ -141,7 +141,7 @@ class AdminRouteIntegrationTest : AbstractIntegrationTest({
             requestShouldRequireRole(Superuser.ROLE_NAME, HttpStatusCode.Created) {
                 post("/api/v1/admin/users") {
                     setBody(
-                        CreateUser(
+                        PostUser(
                             username = testUsername,
                             firstName = testFirstName,
                             lastName = testLastName,
@@ -224,7 +224,7 @@ class AdminRouteIntegrationTest : AbstractIntegrationTest({
     "PATCH /admin/content-management/sections/footer" should {
         "return 403 Forbidden for non-superuser" {
             integrationTestApplication {
-                val updateSectionRequest = UpdateContentManagementSection(
+                val updateSectionRequest = PatchSection(
                     isEnabled = true,
                     markdown = "This is a changed footer."
                 )
@@ -239,7 +239,7 @@ class AdminRouteIntegrationTest : AbstractIntegrationTest({
 
         "update the footer section" {
             integrationTestApplication {
-                val updateSectionRequest = UpdateContentManagementSection(
+                val updateSectionRequest = PatchSection(
                     isEnabled = true,
                     markdown = "empty"
                 )
@@ -261,7 +261,7 @@ class AdminRouteIntegrationTest : AbstractIntegrationTest({
 
         "return 404 NotFound for non-existing section" {
             integrationTestApplication {
-                val updateSectionRequest = UpdateContentManagementSection(
+                val updateSectionRequest = PatchSection(
                     isEnabled = true,
                     markdown = "empty"
                 )

--- a/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
@@ -55,7 +55,6 @@ import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToApi
 import org.eclipse.apoapsis.ortserver.api.v1.model.AdvisorJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.AnalyzerJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.ComparisonOperator
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.EcosystemStats
 import org.eclipse.apoapsis.ortserver.api.v1.model.EvaluatorJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.FilterOperatorAndValue
@@ -67,6 +66,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.PatchProduct
 import org.eclipse.apoapsis.ortserver.api.v1.model.PluginConfig
 import org.eclipse.apoapsis.ortserver.api.v1.model.PostOrganization
 import org.eclipse.apoapsis.ortserver.api.v1.model.PostRepository
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostRepositoryRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.Product
 import org.eclipse.apoapsis.ortserver.api.v1.model.ProductVulnerability
 import org.eclipse.apoapsis.ortserver.api.v1.model.ProviderPluginConfiguration
@@ -1531,7 +1531,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                     description = description
                 ).id
 
-                val createOrtRunAll = CreateOrtRun(
+                val createOrtRunAll = PostRepositoryRun(
                     revision = "main",
                     path = "",
                     jobConfigs = JobConfigurations(),
@@ -1555,7 +1555,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 }
                 repositoryIdsAll shouldContainExactlyInAnyOrder listOf(repository1Id, repository2Id)
 
-                val createOrtRunSpecific = CreateOrtRun(
+                val createOrtRunSpecific = PostRepositoryRun(
                     revision = "main",
                     path = "",
                     jobConfigs = JobConfigurations(),
@@ -1593,7 +1593,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 val scannerPluginId = "notInstalledScanner"
 
                 // Create a run with not installed plugins.
-                val createRun = CreateOrtRun(
+                val createRun = PostRepositoryRun(
                     revision = "main",
                     jobConfigs = JobConfigurations(
                         analyzer = AnalyzerJobConfiguration(
@@ -1657,7 +1657,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 disablePlugin(PluginType.SCANNER, scannerPluginId)
 
                 // Create a run with disabled plugins.
-                val createRun = CreateOrtRun(
+                val createRun = PostRepositoryRun(
                     revision = "main",
                     jobConfigs = JobConfigurations(
                         analyzer = AnalyzerJobConfiguration(
@@ -1724,7 +1724,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 superuserClient.post("/api/v1/admin/plugins/$pluginType/$pluginId/templates/test/enableGlobal")
 
                 // Create a run trying to overwrite the final option.
-                val createRun = CreateOrtRun(
+                val createRun = PostRepositoryRun(
                     "main",
                     null,
                     JobConfigurations(
@@ -1771,7 +1771,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
 
                 keepAliveJobConfigs.forAll {
                     val response = testUserClient.post("/api/v1/products/$productId/runs") {
-                        setBody(CreateOrtRun(revision = "main", jobConfigs = it))
+                        setBody(PostRepositoryRun(revision = "main", jobConfigs = it))
                     }
 
                     response shouldHaveStatus HttpStatusCode.Forbidden
@@ -1786,7 +1786,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
 
                 keepAliveJobConfigs.forAll {
                     val response = superuserClient.post("/api/v1/products/$productId/runs") {
-                        setBody(CreateOrtRun(revision = "main", jobConfigs = it))
+                        setBody(PostRepositoryRun(revision = "main", jobConfigs = it))
                     }
 
                     response shouldHaveStatus HttpStatusCode.Created
@@ -1834,7 +1834,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                     status = OrtRunStatus.FAILED.asPresent2()
                 )
 
-                val createOrtRunFailed = CreateOrtRun(
+                val createOrtRunFailed = PostRepositoryRun(
                     revision = "main",
                     path = "",
                     jobConfigs = JobConfigurations(),
@@ -1905,7 +1905,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                     status = OrtRunStatus.ACTIVE.asPresent2()
                 )
 
-                val createOrtRunFailed = CreateOrtRun(
+                val createOrtRunFailed = PostRepositoryRun(
                     revision = "main",
                     path = "",
                     jobConfigs = JobConfigurations(),
@@ -1935,7 +1935,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 ProductPermission.TRIGGER_ORT_RUN.roleName(createdProduct.id),
                 HttpStatusCode.Created
             ) {
-                val createOrtRun = CreateOrtRun(
+                val createOrtRun = PostRepositoryRun(
                     revision = "main",
                     path = "",
                     jobConfigs = JobConfigurations(),

--- a/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
@@ -56,7 +56,6 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.AdvisorJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.AnalyzerJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.ComparisonOperator
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateRepository
 import org.eclipse.apoapsis.ortserver.api.v1.model.EcosystemStats
 import org.eclipse.apoapsis.ortserver.api.v1.model.EvaluatorJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.FilterOperatorAndValue
@@ -64,8 +63,10 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.JobConfigurations
 import org.eclipse.apoapsis.ortserver.api.v1.model.NotifierJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatistics
+import org.eclipse.apoapsis.ortserver.api.v1.model.PatchProduct
 import org.eclipse.apoapsis.ortserver.api.v1.model.PluginConfig
 import org.eclipse.apoapsis.ortserver.api.v1.model.PostOrganization
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostRepository
 import org.eclipse.apoapsis.ortserver.api.v1.model.Product
 import org.eclipse.apoapsis.ortserver.api.v1.model.ProductVulnerability
 import org.eclipse.apoapsis.ortserver.api.v1.model.ProviderPluginConfiguration
@@ -74,7 +75,6 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.Repository
 import org.eclipse.apoapsis.ortserver.api.v1.model.RepositoryType as ApiRepositoryType
 import org.eclipse.apoapsis.ortserver.api.v1.model.ScannerJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.Severity as ApiSeverity
-import org.eclipse.apoapsis.ortserver.api.v1.model.UpdateProduct
 import org.eclipse.apoapsis.ortserver.api.v1.model.User as ApiUser
 import org.eclipse.apoapsis.ortserver.api.v1.model.UserGroup as ApiUserGroup
 import org.eclipse.apoapsis.ortserver.api.v1.model.UserWithGroups as ApiUserWithGroups
@@ -201,7 +201,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication {
                 val createdProduct = createProduct()
 
-                val updatedProduct = UpdateProduct(
+                val updatedProduct = PatchProduct(
                     "updatedProduct".asPresent(),
                     "updateDescription".asPresent()
                 )
@@ -222,7 +222,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
         "require ProductPermission.WRITE" {
             val createdProduct = createProduct()
             requestShouldRequireRole(ProductPermission.WRITE.roleName(createdProduct.id)) {
-                val updatedProduct = UpdateProduct("updatedName".asPresent(), "updatedDescription".asPresent())
+                val updatedProduct = PatchProduct("updatedName".asPresent(), "updatedDescription".asPresent())
                 patch("/api/v1/products/${createdProduct.id}") { setBody(updatedProduct) }
             }
         }
@@ -231,7 +231,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication {
                 val createdProduct = createProduct()
 
-                val updatedProduct = UpdateProduct(
+                val updatedProduct = PatchProduct(
                     " updatedProduct! ".asPresent(),
                     "updateDescription".asPresent()
                 )
@@ -243,7 +243,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
 
                 val body = response.body<ErrorResponse>()
                 body.message shouldBe "Request validation has failed."
-                body.cause shouldContain "Validation failed for UpdateProduct"
+                body.cause shouldContain "Validation failed for PatchProduct"
             }
         }
     }
@@ -386,7 +386,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication {
                 val createdProduct = createProduct()
 
-                val repository = CreateRepository(ApiRepositoryType.GIT, "https://example.com/repo.git", "description")
+                val repository = PostRepository(ApiRepositoryType.GIT, "https://example.com/repo.git", "description")
                 val response = superuserClient.post("/api/v1/products/${createdProduct.id}/repositories") {
                     setBody(repository)
                 }
@@ -401,7 +401,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication {
                 val createdProduct = createProduct()
 
-                val repository = CreateRepository(ApiRepositoryType.GIT, "https://git hub.com/org/repo.git")
+                val repository = PostRepository(ApiRepositoryType.GIT, "https://git hub.com/org/repo.git")
                 val response = superuserClient.post("/api/v1/products/${createdProduct.id}/repositories") {
                     setBody(repository)
                 }
@@ -410,7 +410,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
 
                 val body = response.body<ErrorResponse>()
                 body.message shouldBe "Request validation has failed."
-                body.cause shouldContain "Validation failed for CreateRepository"
+                body.cause shouldContain "Validation failed for PostRepository"
             }
         }
 
@@ -418,7 +418,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication {
                 val createdProduct = createProduct()
 
-                val repository = CreateRepository(ApiRepositoryType.GIT, "https://user:password@github.com")
+                val repository = PostRepository(ApiRepositoryType.GIT, "https://user:password@github.com")
                 val response = superuserClient.post("/api/v1/products/${createdProduct.id}/repositories") {
                     setBody(repository)
                 }
@@ -427,7 +427,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
 
                 val body = response.body<ErrorResponse>()
                 body.message shouldBe "Request validation has failed."
-                body.cause shouldContain "Validation failed for CreateRepository"
+                body.cause shouldContain "Validation failed for PostRepository"
             }
         }
 
@@ -435,7 +435,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication {
                 val createdProduct = createProduct()
 
-                val repository = CreateRepository(ApiRepositoryType.GIT, "https://example.com/repo.git")
+                val repository = PostRepository(ApiRepositoryType.GIT, "https://example.com/repo.git")
                 val createdRepository = superuserClient.post("/api/v1/products/${createdProduct.id}/repositories") {
                     setBody(repository)
                 }.body<Repository>()
@@ -457,7 +457,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 ProductPermission.CREATE_REPOSITORY.roleName(createdProduct.id),
                 HttpStatusCode.Created
             ) {
-                val repository = CreateRepository(ApiRepositoryType.GIT, "https://example.com/repo.git")
+                val repository = PostRepository(ApiRepositoryType.GIT, "https://example.com/repo.git")
                 post("/api/v1/products/${createdProduct.id}/repositories") { setBody(repository) }
             }
         }

--- a/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
@@ -55,7 +55,6 @@ import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToApi
 import org.eclipse.apoapsis.ortserver.api.v1.model.AdvisorJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.AnalyzerJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.ComparisonOperator
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrganization
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateRepository
 import org.eclipse.apoapsis.ortserver.api.v1.model.EcosystemStats
@@ -66,6 +65,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.NotifierJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatistics
 import org.eclipse.apoapsis.ortserver.api.v1.model.PluginConfig
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostOrganization
 import org.eclipse.apoapsis.ortserver.api.v1.model.Product
 import org.eclipse.apoapsis.ortserver.api.v1.model.ProductVulnerability
 import org.eclipse.apoapsis.ortserver.api.v1.model.ProviderPluginConfiguration
@@ -550,7 +550,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
             "respond with 'BadRequest' if the request body is invalid for method '${method.value}'" {
                 integrationTestApplication {
                     val createdProd = createProduct()
-                    val org = CreateOrganization(name = "name", description = "description") // Wrong request body
+                    val org = PostOrganization(name = "name", description = "description") // Wrong request body
 
                     val response = when (method) {
                         HttpMethod.Put -> superuserClient.put(

--- a/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
@@ -57,7 +57,6 @@ import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToApi
 import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToApiSummary
 import org.eclipse.apoapsis.ortserver.api.v1.model.AdvisorJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.AnalyzerJobConfiguration
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrganization
 import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.EnvironmentConfig
 import org.eclipse.apoapsis.ortserver.api.v1.model.EnvironmentVariableDeclaration as ApiEnvironmentVariableDeclaration
@@ -68,6 +67,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.Jobs
 import org.eclipse.apoapsis.ortserver.api.v1.model.NotifierJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.PluginConfig
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostOrganization
 import org.eclipse.apoapsis.ortserver.api.v1.model.ProviderPluginConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.ReporterJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.Repository
@@ -1038,7 +1038,7 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
             "respond with 'BadRequest' if the request body is invalid for method '${method.value}'" {
                 integrationTestApplication {
                     val createdRepo = createRepository()
-                    val org = CreateOrganization(name = "name", description = "description") // Wrong request body
+                    val org = PostOrganization(name = "name", description = "description") // Wrong request body
 
                     val response = when (method) {
                         HttpMethod.Put -> superuserClient.put(

--- a/core/src/test/kotlin/utils/ExtensionsTest.kt
+++ b/core/src/test/kotlin/utils/ExtensionsTest.kt
@@ -31,11 +31,11 @@ import kotlin.time.Duration.Companion.seconds
 
 import org.eclipse.apoapsis.ortserver.api.v1.model.AdvisorJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.AnalyzerJobConfiguration
-import org.eclipse.apoapsis.ortserver.api.v1.model.CreateOrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.EvaluatorJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.JobConfigurations
 import org.eclipse.apoapsis.ortserver.api.v1.model.PackageManagerConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.PluginConfig
+import org.eclipse.apoapsis.ortserver.api.v1.model.PostRepositoryRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.ProviderPluginConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.ReporterJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.ScannerJobConfiguration
@@ -43,9 +43,9 @@ import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 
 class ExtensionsTest : WordSpec({
-    "CreateOrtRun.getPluginConfigs()" should {
+    "PostRepositoryRun.getPluginConfigs()" should {
         "return an empty result when no plugins are configured" {
-            val createOrtRun = CreateOrtRun(
+            val createOrtRun = PostRepositoryRun(
                 revision = "revision",
                 jobConfigs = JobConfigurations()
             )
@@ -54,7 +54,7 @@ class ExtensionsTest : WordSpec({
         }
 
         "return all plugin configurations" {
-            val createOrtRun = CreateOrtRun(
+            val createOrtRun = PostRepositoryRun(
                 revision = "revision",
                 jobConfigs = JobConfigurations(
                     analyzer = AnalyzerJobConfiguration(
@@ -148,7 +148,7 @@ class ExtensionsTest : WordSpec({
         }
 
         "return empty configuration for plugins which are enabled but have no plugin config" {
-            val createOrtRun = CreateOrtRun(
+            val createOrtRun = PostRepositoryRun(
                 revision = "revision",
                 jobConfigs = JobConfigurations(
                     analyzer = AnalyzerJobConfiguration(
@@ -186,7 +186,7 @@ class ExtensionsTest : WordSpec({
         }
 
         "ignore package configuration providers from reporter job if evaluator job is configured" {
-            val createOrtRun = CreateOrtRun(
+            val createOrtRun = PostRepositoryRun(
                 revision = "revision",
                 jobConfigs = JobConfigurations(
                     evaluator = EvaluatorJobConfiguration(
@@ -221,7 +221,7 @@ class ExtensionsTest : WordSpec({
         }
 
         "return package configuration providers from reporter job if evaluator job is not configured" {
-            val createOrtRun = CreateOrtRun(
+            val createOrtRun = PostRepositoryRun(
                 revision = "revision",
                 jobConfigs = JobConfigurations(
                     reporter = ReporterJobConfiguration(

--- a/ui/src/routes/admin/users/create-user/index.tsx
+++ b/ui/src/routes/admin/users/create-user/index.tsx
@@ -26,7 +26,7 @@ import { z } from 'zod';
 
 import {
   getOrganizationsOptions,
-  postUsersMutation,
+  postUserMutation,
   putOrganizationRoleToUserMutation,
 } from '@/api/@tanstack/react-query.gen';
 import { asOptionalField } from '@/components/form/as-optional-field';
@@ -85,7 +85,7 @@ const CreateUser = () => {
 
   const { mutateAsync: createUser, isPending: isCreateUserPending } =
     useMutation({
-      ...postUsersMutation(),
+      ...postUserMutation(),
       onSuccess() {
         toast.info('Create User', {
           description: `User "${form.getValues().username}" created successfully.`,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
@@ -22,8 +22,8 @@ import { z } from 'zod';
 
 import {
   AnalyzerJobConfiguration,
-  CreateOrtRun,
   OrtRun,
+  PostRepositoryRun,
   ReporterJobConfiguration,
 } from '@/api';
 import { PackageManagerId, packageManagers } from '@/lib/types';
@@ -462,7 +462,7 @@ export function defaultValues(
  */
 export function formValuesToPayload(
   values: z.infer<typeof createRunFormSchema>
-): CreateOrtRun {
+): PostRepositoryRun {
   /**
    * A helper function to get the enabled package managers from the form values.
    *


### PR DESCRIPTION
As requested by @mnonnenmacher [here](https://github.com/eclipse-apoapsis/ort-server/pull/3647#pullrequestreview-3305080465), align the request objects with the new refactored operation IDs. This will make the `openapi.json` contract between the front-end and back-end even cleaner.

Please see the commits for details.