### PR TITLE
fix(workers): Create `remotes.json` for both `Conan` versions

### DIFF
--- a/workers/common/src/main/kotlin/common/env/ConanGenerator.kt
+++ b/workers/common/src/main/kotlin/common/env/ConanGenerator.kt
@@ -28,33 +28,35 @@ import org.eclipse.apoapsis.ortserver.workers.common.env.definition.ConanDefinit
  */
 class ConanGenerator : EnvironmentConfigGenerator<ConanDefinition> {
     companion object {
-        /** The name of the configuration file created by this generator. */
-        private const val TARGET = ".conan/remotes.json"
+        /** The names of the configuration files created by this generator. */
+        private val TARGETS = listOf(".conan/remotes.json", ".conan2/remotes.json")
     }
 
     override val environmentDefinitionType: Class<ConanDefinition> = ConanDefinition::class.java
 
     override suspend fun generate(builder: ConfigFileBuilder, definitions: Collection<ConanDefinition>) {
-        builder.buildInUserHome(TARGET) {
-            println("{")
-            println("\"remotes\": [".prependIndent(INDENT_2_SPACES))
-            definitions.forEachIndexed { index, definition ->
-                if (index > 0) {
-                    // Print a comma and a line break before each definition for multi-definition remote.json files
-                    println(",")
+        TARGETS.forEach { target ->
+            builder.buildInUserHome(target) {
+                println("{")
+                println("\"remotes\": [".prependIndent(INDENT_2_SPACES))
+                definitions.forEachIndexed { index, definition ->
+                    if (index > 0) {
+                        // Print a comma and a line break before each definition for multi-definition remote.json files
+                        println(",")
+                    }
+
+                    println("{".prependIndent(INDENT_4_SPACES))
+
+                    println("\"name\": \"${definition.name}\",".prependIndent(INDENT_6_SPACES))
+                    println("\"url\": \"${definition.remoteUrl}\",".prependIndent(INDENT_6_SPACES))
+                    println("\"verify_ssl\": ${definition.verifySsl}".prependIndent(INDENT_6_SPACES))
+
+                    print("}".prependIndent(INDENT_4_SPACES))
                 }
-
-                println("{".prependIndent(INDENT_4_SPACES))
-
-                println("\"name\": \"${definition.name}\",".prependIndent(INDENT_6_SPACES))
-                println("\"url\": \"${definition.remoteUrl}\",".prependIndent(INDENT_6_SPACES))
-                println("\"verify_ssl\": ${definition.verifySsl}".prependIndent(INDENT_6_SPACES))
-
-                print("}".prependIndent(INDENT_4_SPACES))
+                println()
+                println("]".prependIndent(INDENT_2_SPACES))
+                println("}")
             }
-            println()
-            println("]".prependIndent(INDENT_2_SPACES))
-            println("}")
         }
     }
 }

--- a/workers/common/src/test/kotlin/common/env/ConanGeneratorTest.kt
+++ b/workers/common/src/test/kotlin/common/env/ConanGeneratorTest.kt
@@ -37,7 +37,7 @@ class ConanGeneratorTest : WordSpec({
     }
 
     "generate" should {
-        "generate the file at the correct location" {
+        "generate the files at the correct location" {
             val definition = ConanDefinition(
                 MockConfigFileBuilder.createInfrastructureService(REMOTE_URL),
                 emptySet(),
@@ -50,7 +50,26 @@ class ConanGeneratorTest : WordSpec({
 
             ConanGenerator().generate(mockBuilder.builder, listOf(definition))
 
-            mockBuilder.homeFileName shouldBe ".conan/remotes.json"
+            mockBuilder.homeFileNames shouldBe listOf(".conan/remotes.json", ".conan2/remotes.json")
+        }
+
+        "generate the same file for both versions" {
+            val definition = ConanDefinition(
+                MockConfigFileBuilder.createInfrastructureService(REMOTE_URL),
+                emptySet(),
+                REMOTE_NAME,
+                REMOTE_URL,
+                true
+            )
+
+            val mockBuilder = MockConfigFileBuilder()
+
+            ConanGenerator().generate(mockBuilder.builder, listOf(definition))
+
+            val conan1Lines = mockBuilder.generatedLinesFor(homeFileName = ".conan/remotes.json")
+            val conan2Lines = mockBuilder.generatedLinesFor(homeFileName = ".conan2/remotes.json")
+
+            conan2Lines shouldBe conan1Lines
         }
 
         "generate a file with a single remote" {
@@ -77,7 +96,7 @@ class ConanGeneratorTest : WordSpec({
                   ]
                 }
             """.trimIndent().lines()
-            val lines = mockBuilder.generatedLines()
+            val lines = mockBuilder.generatedLinesFor(homeFileName = ".conan/remotes.json")
             lines shouldContainExactly expectedLines
         }
 
@@ -119,7 +138,7 @@ class ConanGeneratorTest : WordSpec({
                   ]
                 }
             """.trimIndent().lines()
-            val lines = mockBuilder.generatedLines()
+            val lines = mockBuilder.generatedLinesFor(homeFileName = ".conan/remotes.json")
             lines shouldContainExactly expectedLines
         }
 
@@ -147,7 +166,7 @@ class ConanGeneratorTest : WordSpec({
                   ]
                 }
             """.trimIndent().lines()
-            val lines = mockBuilder.generatedLines()
+            val lines = mockBuilder.generatedLinesFor(homeFileName = ".conan/remotes.json")
             lines shouldContainExactly expectedLines
         }
 
@@ -175,7 +194,7 @@ class ConanGeneratorTest : WordSpec({
                   ]
                 }
             """.trimIndent().lines()
-            val lines = mockBuilder.generatedLines()
+            val lines = mockBuilder.generatedLinesFor(homeFileName = ".conan/remotes.json")
             lines shouldContainExactly expectedLines
         }
     }


### PR DESCRIPTION
The Analyzer worker has Conan 1.x and Conan 2.x installed, but they don't share the same configuration directory (~/.conan for Conan 1.x and ~/.conan2 for Conan 2.x). This commit generates the `remotes.json` file for both versions.