### PR TITLE
build(gradle): Remove enforcing the OkHttp version

### DIFF
--- a/buildSrc/src/main/kotlin/ort-server-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-kotlin-conventions.gradle.kts
@@ -33,13 +33,6 @@ plugins {
     id("io.gitlab.arturbosch.detekt")
 }
 
-configurations.all {
-    resolutionStrategy {
-        // Required until the AWS SDK for Kotlin is updated to use the stable release of OkHttp.
-        force("com.squareup.okhttp3:okhttp:5.0.0-alpha.14")
-    }
-}
-
 dependencies {
     detektPlugins("io.gitlab.arturbosch.detekt:detekt-formatting:${rootProject.libs.versions.detektPlugin.get()}")
     detektPlugins("org.ossreviewtoolkit:detekt-rules:${rootProject.libs.versions.ort.get()}")


### PR DESCRIPTION
This is not needed anymore. Also see [1].

[1]: https://github.com/smithy-lang/smithy-kotlin/tree/main/runtime/protocol/http-client-engines/http-client-engine-okhttp4