### PR TITLE
ui: Add support for theming

### DIFF
--- a/ui/src/components/charts/cvss23-radar-chart.tsx
+++ b/ui/src/components/charts/cvss23-radar-chart.tsx
@@ -90,7 +90,7 @@ export const Cvss23RadarChart = ({ cvssScore }: Cvss23RadarChartProps) => {
   const chartConfig = {
     score: {
       label: 'Score',
-      color: 'hsl(var(--chart-1))',
+      color: 'var(--chart-1)',
     },
   } satisfies ChartConfig;
 
@@ -152,9 +152,9 @@ export const Cvss23RadarChart = ({ cvssScore }: Cvss23RadarChartProps) => {
             <PolarGrid radialLines={false} />
             <Radar
               dataKey='score'
-              fill='hsl(var(--chart-1))'
+              fill='var(--chart-1)'
               fillOpacity={0.2}
-              stroke='hsl(var(--chart-1))'
+              stroke='var(--chart-1)'
               strokeWidth={2}
               dot={(props) => {
                 const { payload } = props;
@@ -165,7 +165,7 @@ export const Cvss23RadarChart = ({ cvssScore }: Cvss23RadarChartProps) => {
                     cx={payload.x}
                     cy={payload.y}
                     r='4'
-                    fill='hsl(var(--chart-1))'
+                    fill='var(--chart-1)'
                   />
                 );
               }}

--- a/ui/src/components/charts/cvss4-radar-chart.tsx
+++ b/ui/src/components/charts/cvss4-radar-chart.tsx
@@ -79,7 +79,7 @@ export const Cvss4RadarChart = ({ cvssScore }: Cvss4RadarChartProps) => {
   const chartConfig = {
     score: {
       label: 'Score',
-      color: 'hsl(var(--chart-1))',
+      color: 'var(--chart-1)',
     },
   } satisfies ChartConfig;
 
@@ -141,9 +141,9 @@ export const Cvss4RadarChart = ({ cvssScore }: Cvss4RadarChartProps) => {
             <PolarGrid radialLines={false} />
             <Radar
               dataKey='score'
-              fill='hsl(var(--chart-1))'
+              fill='var(--chart-1)'
               fillOpacity={0.2}
-              stroke='hsl(var(--chart-1))'
+              stroke='var(--chart-1)'
               strokeWidth={2}
               dot={(props) => {
                 const { payload } = props;
@@ -154,7 +154,7 @@ export const Cvss4RadarChart = ({ cvssScore }: Cvss4RadarChartProps) => {
                     cx={payload.x}
                     cy={payload.y}
                     r='4'
-                    fill='hsl(var(--chart-1))'
+                    fill='var(--chart-1)'
                   />
                 );
               }}

--- a/ui/src/components/charts/epss-chart.tsx
+++ b/ui/src/components/charts/epss-chart.tsx
@@ -46,11 +46,11 @@ export const EpssChart = ({ epssData }: EpssChartProps) => {
   const chartConfig = {
     score: {
       label: 'Score',
-      color: 'hsl(var(--chart-1))',
+      color: 'var(--chart-1)',
     },
     percentile: {
       label: 'Percentile',
-      color: 'hsl(var(--chart-1))',
+      color: 'var(--chart-1)',
     },
   } satisfies ChartConfig;
 

--- a/ui/src/components/color-theme-toggle.tsx
+++ b/ui/src/components/color-theme-toggle.tsx
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { Check } from 'lucide-react';
+
+import { useTheme } from '@/components/theme-provider-context';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { colorThemes } from '@/lib/types';
+
+/**
+ * 2×2 color chip preview for a SPECIFIC theme.
+ * It scopes CSS variables by placing `data-theme={themeId}` on a wrapper,
+ * so the preview uses that theme's colors only inside the chip.
+ */
+function ThemeChip({
+  themeId,
+  vars = ['--primary', '--secondary', '--card', '--destructive'],
+  className = '',
+}: {
+  themeId: string;
+  vars?: [string, string, string, string];
+  className?: string;
+}) {
+  return (
+    <div
+      data-theme={themeId}
+      className={`grid grid-cols-2 grid-rows-2 overflow-hidden rounded-[0.25rem] ${className}`}
+      aria-hidden
+      // a tiny ring so chips are visible on very light/dark menus
+      style={{ boxShadow: '0 0 0 1px rgb(0 0 0 / 0.08) inset' }}
+    >
+      {vars.map((cssVar, i) => (
+        <div
+          key={i}
+          className='border border-black/10'
+          style={{ backgroundColor: `var(${cssVar})` }}
+          title={`${themeId} ${cssVar}`}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function ColorThemeToggle() {
+  const { colorTheme, setColorTheme } = useTheme();
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant='outline' size='icon' className='relative'>
+          {/* Show chip of the CURRENT theme in the button */}
+          <ThemeChip themeId={colorTheme} className='size-4' />
+          <span className='sr-only'>Toggle color theme</span>
+        </Button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align='end'>
+        {colorThemes.map((theme) => {
+          const label = (
+            theme.charAt(0).toUpperCase() + theme.slice(1)
+          ).replace('-', ' ');
+          const isActive = theme === colorTheme;
+
+          return (
+            <DropdownMenuItem
+              key={theme}
+              onClick={() => setColorTheme(theme)}
+              className='flex items-center justify-between gap-3'
+            >
+              <div className='flex items-center gap-3'>
+                {/* Preview chip for THIS option only */}
+                <ThemeChip themeId={theme} className='size-4' />
+                <span>{label}</span>
+              </div>
+              {isActive ? (
+                <Check className='size-4 opacity-80' />
+              ) : (
+                <span className='size-4' />
+              )}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/ui/src/components/header.tsx
+++ b/ui/src/components/header.tsx
@@ -27,6 +27,7 @@ import { z } from 'zod';
 
 import { getConfigByKeyOptions } from '@/api/@tanstack/react-query.gen';
 import homeIcon from '@/assets/home-icon.svg';
+import { ColorThemeToggle } from '@/components/color-theme-toggle';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { ModeToggle } from '@/components/mode-toggle';
 import { Siblings } from '@/components/siblings';
@@ -356,6 +357,7 @@ export const Header = () => {
           </form>
         </Form>
         <ModeToggle />
+        <ColorThemeToggle />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button

--- a/ui/src/components/header.tsx
+++ b/ui/src/components/header.tsx
@@ -68,7 +68,7 @@ const formSchema = z.object({
 export const Header = () => {
   const user = useUser();
   const navigate = useNavigate();
-  const theme = useTheme().theme;
+  const mode = useTheme().mode;
 
   const {
     data: dbHomeIcon,
@@ -225,7 +225,7 @@ export const Header = () => {
   //   the configured or default product name instead
   let homeIconSrc;
   if (dbHomeIcon.isEnabled) {
-    if (theme === 'light') {
+    if (mode === 'light') {
       homeIconSrc = dbHomeIcon.value || dbHomeIconDark.value || homeIcon;
     } else {
       homeIconSrc = dbHomeIconDark.value || dbHomeIcon.value || homeIcon;

--- a/ui/src/components/header.tsx
+++ b/ui/src/components/header.tsx
@@ -68,7 +68,7 @@ const formSchema = z.object({
 export const Header = () => {
   const user = useUser();
   const navigate = useNavigate();
-  const activeTheme = useTheme().activeTheme;
+  const theme = useTheme().theme;
 
   const {
     data: dbHomeIcon,
@@ -225,7 +225,7 @@ export const Header = () => {
   //   the configured or default product name instead
   let homeIconSrc;
   if (dbHomeIcon.isEnabled) {
-    if (activeTheme === 'light') {
+    if (theme === 'light') {
       homeIconSrc = dbHomeIcon.value || dbHomeIconDark.value || homeIcon;
     } else {
       homeIconSrc = dbHomeIconDark.value || dbHomeIcon.value || homeIcon;

--- a/ui/src/components/mode-toggle.tsx
+++ b/ui/src/components/mode-toggle.tsx
@@ -29,7 +29,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 
 export function ModeToggle() {
-  const { setTheme } = useTheme();
+  const { setMode } = useTheme();
 
   return (
     <DropdownMenu>
@@ -41,13 +41,13 @@ export function ModeToggle() {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align='end'>
-        <DropdownMenuItem onClick={() => setTheme('light')}>
+        <DropdownMenuItem onClick={() => setMode('light')}>
           Light
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme('dark')}>
+        <DropdownMenuItem onClick={() => setMode('dark')}>
           Dark
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setTheme('system')}>
+        <DropdownMenuItem onClick={() => setMode('system')}>
           System
         </DropdownMenuItem>
       </DropdownMenuContent>

--- a/ui/src/components/mode-toggle.tsx
+++ b/ui/src/components/mode-toggle.tsx
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-import { Moon, Sun } from 'lucide-react';
+import { Check, Moon, Sun } from 'lucide-react';
 
 import { useTheme } from '@/components/theme-provider-context';
 import { Button } from '@/components/ui/button';
@@ -29,7 +29,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 
 export function ModeToggle() {
-  const { setMode } = useTheme();
+  const { mode, setMode } = useTheme();
 
   return (
     <DropdownMenu>
@@ -41,14 +41,38 @@ export function ModeToggle() {
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align='end'>
-        <DropdownMenuItem onClick={() => setMode('light')}>
+        <DropdownMenuItem
+          onClick={() => setMode('light')}
+          className='flex items-center justify-between gap-3'
+        >
           Light
+          {mode === 'light' ? (
+            <Check className='size-4' />
+          ) : (
+            <div className='size-4' />
+          )}
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setMode('dark')}>
+        <DropdownMenuItem
+          onClick={() => setMode('dark')}
+          className='flex items-center justify-between gap-3'
+        >
           Dark
+          {mode === 'dark' ? (
+            <Check className='size-4' />
+          ) : (
+            <div className='size-4' />
+          )}
         </DropdownMenuItem>
-        <DropdownMenuItem onClick={() => setMode('system')}>
+        <DropdownMenuItem
+          onClick={() => setMode('system')}
+          className='flex items-center justify-between gap-3'
+        >
           System
+          {mode === 'system' ? (
+            <Check className='size-4' />
+          ) : (
+            <div className='size-4' />
+          )}
         </DropdownMenuItem>
       </DropdownMenuContent>
     </DropdownMenu>

--- a/ui/src/components/providers.tsx
+++ b/ui/src/components/providers.tsx
@@ -39,7 +39,12 @@ export const Providers = ({ children }: { children: ReactNode }) => {
   return (
     <AuthProvider {...oidcConfig}>
       <QueryClientProvider client={queryClient}>
-        <ThemeProvider defaultMode='light' storageKey='vite-ui-theme'>
+        <ThemeProvider
+          defaultMode='light'
+          storageKeyMode='vite-ui-theme'
+          defaultColorTheme='default'
+          storageKeyColorTheme='vite-ui-theme-color'
+        >
           <TooltipProvider>{children}</TooltipProvider>
         </ThemeProvider>
       </QueryClientProvider>

--- a/ui/src/components/providers.tsx
+++ b/ui/src/components/providers.tsx
@@ -39,7 +39,7 @@ export const Providers = ({ children }: { children: ReactNode }) => {
   return (
     <AuthProvider {...oidcConfig}>
       <QueryClientProvider client={queryClient}>
-        <ThemeProvider defaultTheme='light' storageKey='vite-ui-theme'>
+        <ThemeProvider defaultMode='light' storageKey='vite-ui-theme'>
           <TooltipProvider>{children}</TooltipProvider>
         </ThemeProvider>
       </QueryClientProvider>

--- a/ui/src/components/theme-provider-state.tsx
+++ b/ui/src/components/theme-provider-state.tsx
@@ -17,14 +17,14 @@
  * License-Filename: LICENSE
  */
 
-import { Theme } from '@/components/theme-provider';
+import { Mode } from '@/components/theme-provider';
 
 export type ThemeProviderState = {
-  theme: Theme;
-  setTheme: (theme: Theme) => void;
+  mode: Mode;
+  setMode: (mode: Mode) => void;
 };
 
 export const initialState: ThemeProviderState = {
-  theme: 'light',
-  setTheme: () => null,
+  mode: 'light',
+  setMode: () => null,
 };

--- a/ui/src/components/theme-provider-state.tsx
+++ b/ui/src/components/theme-provider-state.tsx
@@ -18,13 +18,18 @@
  */
 
 import { Mode } from '@/components/theme-provider';
+import { ColorTheme } from '@/lib/types';
 
 export type ThemeProviderState = {
   mode: Mode;
+  colorTheme: ColorTheme;
   setMode: (mode: Mode) => void;
+  setColorTheme: (theme: ColorTheme) => void;
 };
 
 export const initialState: ThemeProviderState = {
   mode: 'light',
+  colorTheme: 'default',
   setMode: () => null,
+  setColorTheme: () => null,
 };

--- a/ui/src/components/theme-provider-state.tsx
+++ b/ui/src/components/theme-provider-state.tsx
@@ -17,16 +17,14 @@
  * License-Filename: LICENSE
  */
 
-import { SelectedTheme, Theme } from '@/components/theme-provider';
+import { Theme } from '@/components/theme-provider';
 
 export type ThemeProviderState = {
-  activeTheme: Theme;
-  selectedTheme: SelectedTheme;
-  setTheme: (theme: SelectedTheme) => void;
+  theme: Theme;
+  setTheme: (theme: Theme) => void;
 };
 
 export const initialState: ThemeProviderState = {
-  activeTheme: 'light',
-  selectedTheme: 'light',
+  theme: 'light',
   setTheme: () => null,
 };

--- a/ui/src/components/theme-provider.tsx
+++ b/ui/src/components/theme-provider.tsx
@@ -21,8 +21,7 @@ import { useEffect, useState } from 'react';
 
 import { ThemeProviderContext } from '@/components/theme-provider-context';
 
-export type Theme = 'dark' | 'light';
-export type SelectedTheme = 'dark' | 'light' | 'system';
+export type Theme = 'dark' | 'light' | 'system';
 
 type ThemeProviderProps = {
   children: React.ReactNode;
@@ -36,37 +35,33 @@ export function ThemeProvider({
   storageKey = 'vite-ui-theme',
   ...props
 }: ThemeProviderProps) {
-  const [selectedTheme, setSelectedTheme] = useState<SelectedTheme>(
-    () => (localStorage.getItem(storageKey) as SelectedTheme) || defaultTheme
+  const [theme, setTheme] = useState<Theme>(
+    () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
   );
-  const [activeTheme, setActiveTheme] = useState<Theme>('light');
 
   useEffect(() => {
     const root = window.document.documentElement;
 
     root.classList.remove('light', 'dark');
 
-    if (selectedTheme === 'system') {
+    if (theme === 'system') {
       const systemTheme = window.matchMedia('(prefers-color-scheme: dark)')
         .matches
         ? 'dark'
         : 'light';
 
       root.classList.add(systemTheme);
-      setActiveTheme(systemTheme);
       return;
     }
 
-    root.classList.add(selectedTheme);
-    setActiveTheme(selectedTheme);
-  }, [selectedTheme]);
+    root.classList.add(theme);
+  }, [theme]);
 
   const value = {
-    activeTheme: activeTheme,
-    selectedTheme,
-    setTheme: (theme: SelectedTheme) => {
+    theme,
+    setTheme: (theme: Theme) => {
       localStorage.setItem(storageKey, theme);
-      setSelectedTheme(theme);
+      setTheme(theme);
     },
   };
 

--- a/ui/src/components/theme-provider.tsx
+++ b/ui/src/components/theme-provider.tsx
@@ -20,25 +20,36 @@
 import { useEffect, useState } from 'react';
 
 import { ThemeProviderContext } from '@/components/theme-provider-context';
+import { ColorTheme } from '@/lib/types';
 
 export type Mode = 'dark' | 'light' | 'system';
 
 type ThemeProviderProps = {
   children: React.ReactNode;
   defaultMode?: Mode;
-  storageKey?: string;
+  defaultColorTheme?: ColorTheme;
+  storageKeyMode?: string;
+  storageKeyColorTheme?: string;
 };
 
 export function ThemeProvider({
   children,
   defaultMode = 'light',
-  storageKey = 'vite-ui-theme',
+  defaultColorTheme = 'default',
+  storageKeyMode = 'vite-ui-theme',
+  storageKeyColorTheme = 'vite-ui-theme-color',
   ...props
 }: ThemeProviderProps) {
   const [mode, setMode] = useState<Mode>(
-    () => (localStorage.getItem(storageKey) as Mode) || defaultMode
+    () => (localStorage.getItem(storageKeyMode) as Mode) || defaultMode
+  );
+  const [colorTheme, setColorTheme] = useState<ColorTheme>(
+    () =>
+      (localStorage.getItem(storageKeyColorTheme) as ColorTheme) ||
+      defaultColorTheme
   );
 
+  // Set mode classes.
   useEffect(() => {
     const root = window.document.documentElement;
 
@@ -57,11 +68,28 @@ export function ThemeProvider({
     root.classList.add(mode);
   }, [mode]);
 
+  // Set color theme classes.
+  useEffect(() => {
+    const root = window.document.documentElement;
+
+    // If color theme is 'default', remove all color theme classes.
+    if (colorTheme === 'default') {
+      root.removeAttribute('data-theme');
+    } else {
+      root.setAttribute('data-theme', colorTheme);
+    }
+  }, [colorTheme]);
+
   const value = {
     mode,
     setMode: (mode: Mode) => {
-      localStorage.setItem(storageKey, mode);
+      localStorage.setItem(storageKeyMode, mode);
       setMode(mode);
+    },
+    colorTheme,
+    setColorTheme: (colorTheme: ColorTheme) => {
+      localStorage.setItem(storageKeyColorTheme, colorTheme);
+      setColorTheme(colorTheme);
     },
   };
 

--- a/ui/src/components/theme-provider.tsx
+++ b/ui/src/components/theme-provider.tsx
@@ -21,22 +21,22 @@ import { useEffect, useState } from 'react';
 
 import { ThemeProviderContext } from '@/components/theme-provider-context';
 
-export type Theme = 'dark' | 'light' | 'system';
+export type Mode = 'dark' | 'light' | 'system';
 
 type ThemeProviderProps = {
   children: React.ReactNode;
-  defaultTheme?: Theme;
+  defaultMode?: Mode;
   storageKey?: string;
 };
 
 export function ThemeProvider({
   children,
-  defaultTheme = 'light',
+  defaultMode = 'light',
   storageKey = 'vite-ui-theme',
   ...props
 }: ThemeProviderProps) {
-  const [theme, setTheme] = useState<Theme>(
-    () => (localStorage.getItem(storageKey) as Theme) || defaultTheme
+  const [mode, setMode] = useState<Mode>(
+    () => (localStorage.getItem(storageKey) as Mode) || defaultMode
   );
 
   useEffect(() => {
@@ -44,24 +44,24 @@ export function ThemeProvider({
 
     root.classList.remove('light', 'dark');
 
-    if (theme === 'system') {
-      const systemTheme = window.matchMedia('(prefers-color-scheme: dark)')
+    if (mode === 'system') {
+      const systemMode = window.matchMedia('(prefers-color-scheme: dark)')
         .matches
         ? 'dark'
         : 'light';
 
-      root.classList.add(systemTheme);
+      root.classList.add(systemMode);
       return;
     }
 
-    root.classList.add(theme);
-  }, [theme]);
+    root.classList.add(mode);
+  }, [mode]);
 
   const value = {
-    theme,
-    setTheme: (theme: Theme) => {
-      localStorage.setItem(storageKey, theme);
-      setTheme(theme);
+    mode,
+    setMode: (mode: Mode) => {
+      localStorage.setItem(storageKey, mode);
+      setMode(mode);
     },
   };
 

--- a/ui/src/globals.css
+++ b/ui/src/globals.css
@@ -40,91 +40,120 @@
   }
 }
 
-@layer base {
-  :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+@theme inline {
+  --color-background: var(--background);
+  --color-foreground: var(--foreground);
+  --color-card: var(--card);
+  --color-card-foreground: var(--card-foreground);
+  --color-popover: var(--popover);
+  --color-popover-foreground: var(--popover-foreground);
+  --color-primary: var(--primary);
+  --color-primary-foreground: var(--primary-foreground);
+  --color-secondary: var(--secondary);
+  --color-secondary-foreground: var(--secondary-foreground);
+  --color-muted: var(--muted);
+  --color-muted-foreground: var(--muted-foreground);
+  --color-accent: var(--accent);
+  --color-accent-foreground: var(--accent-foreground);
+  --color-destructive: var(--destructive);
+  --color-border: var(--border);
+  --color-input: var(--input);
+  --color-ring: var(--ring);
+  --color-chart-1: var(--chart-1);
+  --color-chart-2: var(--chart-2);
+  --color-chart-3: var(--chart-3);
+  --color-chart-4: var(--chart-4);
+  --color-chart-5: var(--chart-5);
+  --color-sidebar: var(--sidebar);
+  --color-sidebar-foreground: var(--sidebar-foreground);
+  --color-sidebar-primary: var(--sidebar-primary);
+  --color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+  --color-sidebar-accent: var(--sidebar-accent);
+  --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+  --color-sidebar-border: var(--sidebar-border);
+  --color-sidebar-ring: var(--sidebar-ring);
 
-    --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+  --font-sans: var(--font-sans);
+  --font-mono: var(--font-mono);
+  --font-serif: var(--font-serif);
 
-    --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
+  --radius-sm: calc(var(--radius) - 4px);
+  --radius-md: calc(var(--radius) - 2px);
+  --radius-lg: var(--radius);
+  --radius-xl: calc(var(--radius) + 4px);
+}
 
-    --primary: 222.2 47.4% 11.2%;
-    --primary-foreground: 210 40% 98%;
+/* 
+ * Default theme (shadcn-ui original from 2024) 
+ */
 
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
+:root {
+  --background: hsl(0 0% 100%);
+  --foreground: hsl(222.2 84% 4.9%);
+  --card: hsl(0 0% 100%);
+  --card-foreground: hsl(222.2 84% 4.9%);
+  --popover: hsl(0 0% 100%);
+  --popover-foreground: hsl(222.2 84% 4.9%);
+  --primary: hsl(222.2 47.4% 11.2%);
+  --primary-foreground: hsl(210 40% 98%);
+  --secondary: hsl(210 40% 96.1%);
+  --secondary-foreground: hsl(222.2 47.4% 11.2%);
+  --muted: hsl(210 40% 96.1%);
+  --muted-foreground: hsl(215.4 16.3% 46.9%);
+  --accent: hsl(210 40% 96.1%);
+  --accent-foreground: hsl(222.2 47.4% 11.2%);
+  --destructive: hsl(0 84.2% 60.2%);
+  --destructive-foreground: hsl(210 40% 98%);
+  --border: hsl(214.3 31.8% 91.4%);
+  --input: hsl(214.3 31.8% 91.4%);
+  --ring: hsl(222.2 84% 4.9%);
 
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
+  --chart-1: hsl(12 76% 61%);
+  --chart-2: hsl(173 58% 39%);
+  --chart-3: hsl(197 37% 24%);
+  --chart-4: hsl(43 74% 66%);
+  --chart-5: hsl(27 87% 67%);
 
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
+  /* Custom colors for workers, taken from ORT brand colors */
+  /* https://oss-review-toolkit.org/ort/                    */
+  --analyzer: rgb(0, 175, 170);
+  --advisor: rgb(153, 123, 183);
+  --scanner: rgb(209, 78, 96);
+  --evaluator: rgb(51, 153, 204);
+  --reporter: rgb(242, 144, 86);
+  --traffic-light-green: rgb(0, 164, 0);
+  --traffic-light-yellow: rgb(255, 186, 0);
+  --traffic-light-red: rgb(250, 56, 62);
 
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
+  --radius: 0.5rem;
+}
 
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 222.2 84% 4.9%;
+.dark {
+  --background: hsl(222.2 84% 4.9%);
+  --foreground: hsl(210 40% 98%);
+  --card: hsl(222.2 84% 4.9%);
+  --card-foreground: hsl(210 40% 98%);
+  --popover: hsl(222.2 84% 4.9%);
+  --popover-foreground: hsl(210 40% 98%);
+  --primary: hsl(210 40% 98%);
+  --primary-foreground: hsl(222.2 47.4% 11.2%);
+  --secondary: hsl(217.2 32.6% 17.5%);
+  --secondary-foreground: hsl(210 40% 98%);
+  --muted: hsl(217.2 32.6% 17.5%);
+  --muted-foreground: hsl(215 20.2% 65.1%);
+  --accent: hsl(217.2 32.6% 17.5%);
+  --accent-foreground: hsl(210 40% 98%);
+  --destructive: hsl(0 62.8% 30.6%);
+  --destructive-foreground: hsl(210 40% 98%);
+  --border: hsl(217.2 32.6% 30%);
+  --input: hsl(217.2 32.6% 30%);
+  --ring: hsl(212.7 26.8% 83.9%);
 
-    --radius: 0.5rem;
-
-    --chart-1: 12 76% 61%;
-    --chart-2: 173 58% 39%;
-    --chart-3: 197 37% 24%;
-    --chart-4: 43 74% 66%;
-    --chart-5: 27 87% 67%;
-
-    /* Custom colors for workers, taken from ORT brand colors */
-    /* https://oss-review-toolkit.org/ort/                    */
-    --analyzer: rgb(0, 175, 170);
-    --advisor: rgb(153, 123, 183);
-    --scanner: rgb(209, 78, 96);
-    --evaluator: rgb(51, 153, 204);
-    --reporter: rgb(242, 144, 86);
-    --traffic-light-green: rgb(0, 164, 0);
-    --traffic-light-yellow: rgb(255, 186, 0);
-    --traffic-light-red: rgb(250, 56, 62);
-  }
-
-  .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-
-    --border: 217.2 32.6% 30%;
-    --input: 217.2 32.6% 30%;
-    --ring: 212.7 26.8% 83.9%;
-
-    --chart-1: 220 70% 50%;
-    --chart-2: 160 60% 45%;
-    --chart-3: 30 80% 55%;
-    --chart-4: 280 65% 60%;
-    --chart-5: 340 75% 55%;
-  }
+  --chart-1: hsl(220 70% 50%);
+  --chart-2: hsl(160 60% 45%);
+  --chart-3: hsl(30 80% 55%);
+  --chart-4: hsl(280 65% 60%);
+  --chart-5: hsl(340 75% 55%);
 }
 
 @layer base {

--- a/ui/src/globals.css
+++ b/ui/src/globals.css
@@ -156,6 +156,172 @@
   --chart-5: hsl(340 75% 55%);
 }
 
+/* 
+ * Current shadcn-ui theme (as of 7.10.2025) 
+ */
+
+[data-theme='shadcn'] {
+  --background: oklch(1 0 0);
+  --foreground: oklch(0.14 0 285.86);
+  --card: oklch(1 0 0);
+  --card-foreground: oklch(0.14 0 285.86);
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.14 0 285.86);
+  --primary: oklch(0.21 0.01 285.93);
+  --primary-foreground: oklch(0.99 0 0);
+  --secondary: oklch(0.97 0 0);
+  --secondary-foreground: oklch(0.21 0.01 285.93);
+  --muted: oklch(0.97 0 0);
+  --muted-foreground: oklch(0.55 0.02 285.93);
+  --accent: oklch(0.97 0 0);
+  --accent-foreground: oklch(0.21 0.01 285.93);
+  --destructive: oklch(0.58 0.24 28.48);
+  --border: oklch(0.92 0 286.61);
+  --input: oklch(0.92 0 286.61);
+  --ring: oklch(0.71 0.01 286.09);
+  --chart-1: oklch(0.65 0.22 36.85);
+  --chart-2: oklch(0.6 0.11 184.15);
+  --chart-3: oklch(0.4 0.07 227.18);
+  --chart-4: oklch(0.83 0.17 81.03);
+  --chart-5: oklch(0.77 0.17 65.36);
+  --sidebar: oklch(0.99 0 0);
+  --sidebar-foreground: oklch(0.14 0 285.86);
+  --sidebar-primary: oklch(0.21 0.01 285.93);
+  --sidebar-primary-foreground: oklch(0.99 0 0);
+  --sidebar-accent: oklch(0.97 0 0);
+  --sidebar-accent-foreground: oklch(0.21 0.01 285.93);
+  --sidebar-border: oklch(0.92 0 286.61);
+  --sidebar-ring: oklch(0.71 0.01 286.09);
+
+  --font-sans:
+    'Geist', 'Geist Fallback', ui-sans-serif, system-ui, -apple-system,
+    BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial,
+    'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
+  --font-serif:
+    'Geist', 'Geist Fallback', ui-serif, Georgia, Cambria, 'Times New Roman',
+    Times, serif;
+  --font-mono:
+    'Geist Mono', 'Geist Mono Fallback', ui-monospace, SFMono-Regular, Menlo,
+    Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+
+  --radius: 0.625rem;
+}
+
+.dark[data-theme='shadcn'] {
+  --background: oklch(0.14 0 285.86);
+  --foreground: oklch(0.99 0 0);
+  --card: oklch(0.21 0.01 285.93);
+  --card-foreground: oklch(0.99 0 0);
+  --popover: oklch(0.21 0.01 285.93);
+  --popover-foreground: oklch(0.99 0 0);
+  --primary: oklch(0.92 0 286.61);
+  --primary-foreground: oklch(0.21 0.01 285.93);
+  --secondary: oklch(0.27 0.01 286.1);
+  --secondary-foreground: oklch(0.99 0 0);
+  --muted: oklch(0.27 0.01 286.1);
+  --muted-foreground: oklch(0.71 0.01 286.09);
+  --accent: oklch(0.27 0.01 286.1);
+  --accent-foreground: oklch(0.99 0 0);
+  --destructive: oklch(0.7 0.19 22.23);
+  --border: oklch(1 0 0 / 10%);
+  --input: oklch(1 0 0 / 15%);
+  --ring: oklch(0.55 0.02 285.93);
+  --chart-1: oklch(0.49 0.24 264.4);
+  --chart-2: oklch(0.7 0.16 160.43);
+  --chart-3: oklch(0.77 0.17 65.36);
+  --chart-4: oklch(0.62 0.26 305.32);
+  --chart-5: oklch(0.64 0.25 16.51);
+  --sidebar: oklch(0.21 0.01 285.93);
+  --sidebar-foreground: oklch(0.99 0 0);
+  --sidebar-primary: oklch(0.49 0.24 264.4);
+  --sidebar-primary-foreground: oklch(0.99 0 0);
+  --sidebar-accent: oklch(0.27 0.01 286.1);
+  --sidebar-accent-foreground: oklch(0.99 0 0);
+  --sidebar-border: oklch(1 0 0 / 10%);
+  --sidebar-ring: oklch(0.55 0.02 285.93);
+}
+
+/* 
+ * Material design theme 
+ */
+
+[data-theme='material-design'] {
+  --background: oklch(0.98 0.01 335.69);
+  --foreground: oklch(0.22 0 0);
+  --card: oklch(0.96 0.01 335.69);
+  --card-foreground: oklch(0.14 0 0);
+  --popover: oklch(0.95 0.01 316.67);
+  --popover-foreground: oklch(0.4 0.04 309.35);
+  --primary: oklch(0.51 0.21 286.5);
+  --primary-foreground: oklch(1 0 0);
+  --secondary: oklch(0.49 0.04 300.23);
+  --secondary-foreground: oklch(1 0 0);
+  --muted: oklch(0.96 0.01 335.69);
+  --muted-foreground: oklch(0.14 0 0);
+  --accent: oklch(0.92 0.04 303.47);
+  --accent-foreground: oklch(0.14 0 0);
+  --destructive: oklch(0.57 0.23 29.21);
+  --border: oklch(0.83 0.02 308.26);
+  --input: oklch(0.57 0.02 309.68);
+  --ring: oklch(0.5 0.13 293.77);
+  --chart-1: oklch(0.61 0.21 279.42);
+  --chart-2: oklch(0.72 0.15 157.67);
+  --chart-3: oklch(0.66 0.17 324.24);
+  --chart-4: oklch(0.81 0.15 127.91);
+  --chart-5: oklch(0.68 0.17 258.25);
+  --sidebar: oklch(0.99 0 0);
+  --sidebar-foreground: oklch(0.15 0 0);
+  --sidebar-primary: oklch(0.56 0.11 228.27);
+  --sidebar-primary-foreground: oklch(0.98 0 0);
+  --sidebar-accent: oklch(0.95 0 0);
+  --sidebar-accent-foreground: oklch(0.25 0 0);
+  --sidebar-border: oklch(0.9 0 0);
+  --sidebar-ring: oklch(0.56 0.11 228.27);
+
+  --font-sans: Roboto, sans-serif;
+  --font-serif: Merriweather, serif;
+  --font-mono:
+    'Geist Mono', 'Geist Mono Fallback', ui-monospace, SFMono-Regular, Menlo,
+    Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+
+  --radius: 1rem;
+}
+
+.dark[data-theme='material-design'] {
+  --background: oklch(0.15 0.01 317.69);
+  --foreground: oklch(0.95 0.01 321.5);
+  --card: oklch(0.22 0.02 322.13);
+  --card-foreground: oklch(0.95 0.01 321.5);
+  --popover: oklch(0.22 0.02 322.13);
+  --popover-foreground: oklch(0.95 0.01 321.5);
+  --primary: oklch(0.6 0.22 279.81);
+  --primary-foreground: oklch(0.98 0.01 321.51);
+  --secondary: oklch(0.45 0.03 294.79);
+  --secondary-foreground: oklch(0.95 0.01 321.5);
+  --muted: oklch(0.22 0.01 319.5);
+  --muted-foreground: oklch(0.7 0.01 320.7);
+  --accent: oklch(0.35 0.06 299.57);
+  --accent-foreground: oklch(0.95 0.01 321.5);
+  --destructive: oklch(0.57 0.23 29.21);
+  --border: oklch(0.4 0.04 309.35);
+  --input: oklch(0.4 0.04 309.35);
+  --ring: oklch(0.5 0.15 294.97);
+  --chart-1: oklch(0.5 0.25 274.99);
+  --chart-2: oklch(0.6 0.15 150.16);
+  --chart-3: oklch(0.65 0.2 309.96);
+  --chart-4: oklch(0.6 0.17 132.98);
+  --chart-5: oklch(0.6 0.2 255.25);
+  --sidebar: oklch(0.2 0.01 317.74);
+  --sidebar-foreground: oklch(0.95 0.01 321.5);
+  --sidebar-primary: oklch(0.59 0.11 225.82);
+  --sidebar-primary-foreground: oklch(0.95 0.01 321.5);
+  --sidebar-accent: oklch(0.3 0.01 319.52);
+  --sidebar-accent-foreground: oklch(0.95 0.01 321.5);
+  --sidebar-border: oklch(0.35 0.01 319.53 / 30%);
+  --sidebar-ring: oklch(0.59 0.11 225.82);
+}
+
 @layer base {
   * {
     @apply border-border;

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -155,5 +155,9 @@ export function getRepositoryTypeLabel(type: RepositoryType | string): string {
 // Type and constant for color themes. New themes can be added to the project
 // by extending these definitions, and adding the corresponding CSS definitions
 // and labeling them with the `data-theme` attribute.
-export type ColorTheme = 'default';
-export const colorThemes: ColorTheme[] = ['default'];
+export type ColorTheme = 'material-design' | 'shadcn' | 'default';
+export const colorThemes: ColorTheme[] = [
+  'material-design',
+  'shadcn',
+  'default',
+];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -151,3 +151,9 @@ export function getRepositoryTypeLabel(type: RepositoryType | string): string {
   }
   return type ? `"${type}"` : 'Unset';
 }
+
+// Type and constant for color themes. New themes can be added to the project
+// by extending these definitions, and adding the corresponding CSS definitions
+// and labeling them with the `data-theme` attribute.
+export type ColorTheme = 'default';
+export const colorThemes: ColorTheme[] = ['default'];

--- a/ui/src/routes/organizations/$orgId/-components/organization-issues-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-issues-statistics-card.tsx
@@ -24,7 +24,6 @@ import { Severity } from '@/api';
 import { getOrganizationRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
 import { StatisticsCard } from '@/components/statistics-card';
 import { getIssueSeverityBackgroundColor } from '@/helpers/get-status-class';
-import { cn } from '@/lib/utils';
 
 type OrganizationIssuesStatisticsCardProps = {
   organizationId: number;
@@ -58,7 +57,7 @@ export const OrganizationIssuesStatisticsCard = ({
             }))
           : []
       }
-      className={cn('hover:bg-muted/50 h-full', className)}
+      className={className}
     />
   );
 };

--- a/ui/src/routes/organizations/$orgId/-components/organization-packages-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-packages-statistics-card.tsx
@@ -23,7 +23,6 @@ import { Boxes } from 'lucide-react';
 import { getOrganizationRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
 import { StatisticsCard } from '@/components/statistics-card';
 import { getEcosystemBackgroundColor } from '@/helpers/get-status-class';
-import { cn } from '@/lib/utils';
 
 type OrganizationPackagesStatisticsCardProps = {
   organizationId: number;
@@ -53,7 +52,7 @@ export const OrganizationPackagesStatisticsCard = ({
         count: count,
         color: getEcosystemBackgroundColor(name),
       }))}
-      className={cn('hover:bg-muted/50 h-full', className)}
+      className={className}
     />
   );
 };

--- a/ui/src/routes/organizations/$orgId/-components/organization-violations-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-violations-statistics-card.tsx
@@ -24,7 +24,6 @@ import { Severity } from '@/api';
 import { getOrganizationRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
 import { StatisticsCard } from '@/components/statistics-card';
 import { getRuleViolationSeverityBackgroundColor } from '@/helpers/get-status-class';
-import { cn } from '@/lib/utils';
 
 type OrganizationViolationsStatisticsCardProps = {
   organizationId: number;
@@ -60,7 +59,7 @@ export const OrganizationViolationsStatisticsCard = ({
             }))
           : []
       }
-      className={cn('hover:bg-muted/50 h-full', className)}
+      className={className}
     />
   );
 };

--- a/ui/src/routes/organizations/$orgId/-components/organization-vulnerabilities-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-vulnerabilities-statistics-card.tsx
@@ -24,7 +24,6 @@ import { VulnerabilityRating } from '@/api';
 import { getOrganizationRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
 import { StatisticsCard } from '@/components/statistics-card';
 import { getVulnerabilityRatingBackgroundColor } from '@/helpers/get-status-class';
-import { cn } from '@/lib/utils';
 
 type OrganizationVulnerabilitiesStatisticsCardProps = {
   organizationId: number;
@@ -60,7 +59,7 @@ export const OrganizationVulnerabilitiesStatisticsCard = ({
             }))
           : []
       }
-      className={cn('hover:bg-muted/50 h-full', className)}
+      className={className}
     />
   );
 };

--- a/ui/src/routes/organizations/$orgId/index.tsx
+++ b/ui/src/routes/organizations/$orgId/index.tsx
@@ -124,6 +124,7 @@ const OrganizationComponent = () => {
             >
               <OrganizationVulnerabilitiesStatisticsCard
                 organizationId={organization.id}
+                className='hover:bg-muted/50'
               />
             </Suspense>
           </Link>
@@ -139,7 +140,6 @@ const OrganizationComponent = () => {
           >
             <OrganizationIssuesStatisticsCard
               organizationId={organization.id}
-              className='hover:bg-muted/0'
             />
           </Suspense>
           <Suspense
@@ -154,7 +154,6 @@ const OrganizationComponent = () => {
           >
             <OrganizationViolationsStatisticsCard
               organizationId={organization.id}
-              className='hover:bg-muted/0'
             />
           </Suspense>
           <Suspense
@@ -169,7 +168,6 @@ const OrganizationComponent = () => {
           >
             <OrganizationPackagesStatisticsCard
               organizationId={organization.id}
-              className='hover:bg-muted/0'
             />
           </Suspense>
         </div>

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-issues-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-issues-statistics-card.tsx
@@ -24,7 +24,6 @@ import { Severity } from '@/api';
 import { getProductRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
 import { StatisticsCard } from '@/components/statistics-card';
 import { getIssueSeverityBackgroundColor } from '@/helpers/get-status-class';
-import { cn } from '@/lib/utils';
 
 type ProductIssuesStatisticsCardProps = {
   productId: number;
@@ -58,7 +57,7 @@ export const ProductIssuesStatisticsCard = ({
             }))
           : []
       }
-      className={cn('hover:bg-muted/50 h-full', className)}
+      className={className}
     />
   );
 };

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-packages-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-packages-statistics-card.tsx
@@ -23,7 +23,6 @@ import { Boxes } from 'lucide-react';
 import { getProductRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
 import { StatisticsCard } from '@/components/statistics-card';
 import { getEcosystemBackgroundColor } from '@/helpers/get-status-class';
-import { cn } from '@/lib/utils';
 
 type ProductPackagesStatisticsCardProps = {
   productId: number;
@@ -53,7 +52,7 @@ export const ProductPackagesStatisticsCard = ({
         count: count,
         color: getEcosystemBackgroundColor(name),
       }))}
-      className={cn('hover:bg-muted/50 h-full', className)}
+      className={className}
     />
   );
 };

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-violations-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-violations-statistics-card.tsx
@@ -24,7 +24,6 @@ import { Severity } from '@/api';
 import { getProductRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
 import { StatisticsCard } from '@/components/statistics-card';
 import { getRuleViolationSeverityBackgroundColor } from '@/helpers/get-status-class';
-import { cn } from '@/lib/utils';
 
 type ProductViolationsStatisticsCardProps = {
   productId: number;
@@ -60,7 +59,7 @@ export const ProductViolationsStatisticsCard = ({
             }))
           : []
       }
-      className={cn('hover:bg-muted/50 h-full', className)}
+      className={className}
     />
   );
 };

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-vulnerabilities-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-vulnerabilities-statistics-card.tsx
@@ -24,7 +24,6 @@ import { VulnerabilityRating } from '@/api';
 import { getProductRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
 import { StatisticsCard } from '@/components/statistics-card';
 import { getVulnerabilityRatingBackgroundColor } from '@/helpers/get-status-class';
-import { cn } from '@/lib/utils';
 
 type ProductVulnerabilitiesStatisticsCardProps = {
   productId: number;
@@ -60,7 +59,7 @@ export const ProductVulnerabilitiesStatisticsCard = ({
             }))
           : []
       }
-      className={cn('hover:bg-muted/50 h-full', className)}
+      className={className}
     />
   );
 };

--- a/ui/src/routes/organizations/$orgId/products/$productId/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/index.tsx
@@ -117,7 +117,10 @@ const ProductComponent = () => {
               />
             }
           >
-            <ProductVulnerabilitiesStatisticsCard productId={product.id} />
+            <ProductVulnerabilitiesStatisticsCard
+              productId={product.id}
+              className='hover:bg-muted/50'
+            />
           </Suspense>
         </Link>
         <Suspense
@@ -130,10 +133,7 @@ const ProductComponent = () => {
             />
           }
         >
-          <ProductIssuesStatisticsCard
-            productId={product.id}
-            className='hover:bg-muted/0'
-          />
+          <ProductIssuesStatisticsCard productId={product.id} />
         </Suspense>
         <Suspense
           fallback={
@@ -145,10 +145,7 @@ const ProductComponent = () => {
             />
           }
         >
-          <ProductViolationsStatisticsCard
-            productId={product.id}
-            className='hover:bg-muted/0'
-          />
+          <ProductViolationsStatisticsCard productId={product.id} />
         </Suspense>
         <Suspense
           fallback={
@@ -160,10 +157,7 @@ const ProductComponent = () => {
             />
           }
         >
-          <ProductPackagesStatisticsCard
-            productId={product.id}
-            className='hover:bg-muted/0'
-          />
+          <ProductPackagesStatisticsCard productId={product.id} />
         </Suspense>
       </div>
       <Card>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/sbom/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/sbom/index.tsx
@@ -47,7 +47,7 @@ const SBOMComponent = () => {
   // theme automatically. Two different logos are provided instead in
   // https://cyclonedx.org/about/branding/ and the correct one is selected
   // based on the current theme.
-  const { activeTheme } = useTheme();
+  const { theme } = useTheme();
   const { user } = useUser();
 
   const { data: ortRun } = useSuspenseQuery({
@@ -134,9 +134,7 @@ const SBOMComponent = () => {
                 <TooltipTrigger>
                   <img
                     alt='CycloneDX'
-                    src={
-                      activeTheme === 'dark' ? CycloneDXLight : CycloneDXDark
-                    }
+                    src={theme === 'dark' ? CycloneDXLight : CycloneDXDark}
                     width={230}
                   />
                 </TooltipTrigger>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/sbom/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/sbom/index.tsx
@@ -46,8 +46,8 @@ const SBOMComponent = () => {
   // For CycloneDX, no SVG logo was found which would adapt to the color
   // theme automatically. Two different logos are provided instead in
   // https://cyclonedx.org/about/branding/ and the correct one is selected
-  // based on the current theme.
-  const { theme } = useTheme();
+  // based on the current mode.
+  const { mode } = useTheme();
   const { user } = useUser();
 
   const { data: ortRun } = useSuspenseQuery({
@@ -134,7 +134,7 @@ const SBOMComponent = () => {
                 <TooltipTrigger>
                   <img
                     alt='CycloneDX'
-                    src={theme === 'dark' ? CycloneDXLight : CycloneDXDark}
+                    src={mode === 'dark' ? CycloneDXLight : CycloneDXDark}
                     width={230}
                   />
                 </TooltipTrigger>


### PR DESCRIPTION
This PR lays the groundwork for theming in the UI. Existing themes can be easily changed and new themes can be added to `globals.css`.

The old theme is still the default, so the users shouldn't see any difference, if they don't deliberately change the theme in the selector in the header.

<img width="1411" height="715" alt="Screenshot from 2025-10-08 10-51-04" src="https://github.com/user-attachments/assets/eabe05da-b0c9-4be3-a6bd-f884f756dc1b" />

<img width="1411" height="715" alt="Screenshot from 2025-10-08 10-51-14" src="https://github.com/user-attachments/assets/8c000713-b376-4490-b52c-c86430353a53" />

<img width="1411" height="715" alt="Screenshot from 2025-10-08 10-51-23" src="https://github.com/user-attachments/assets/6ef67a2f-4a42-4c9e-9202-6d0f14319a44" />

New themes are added with the free tool [shadcn Theme Generator](https://www.shadcn.io/theme-generator), which is encouraged to try out by any interested parties.

Please see the commits for details.
