### PR TITLE
ui: Show labels and source code origins

### DIFF
--- a/ui/src/components/package-curation.tsx
+++ b/ui/src/components/package-curation.tsx
@@ -121,12 +121,12 @@ export const PackageCuration = ({ curation }: PackageCurationProps) => {
                       showIfEmpty={false}
                     />
                     <RenderProperty
-                      label='Hash value'
+                      label='Hash Value'
                       value={curation.binaryArtifact.hashValue}
                       showIfEmpty={false}
                     />
                     <RenderProperty
-                      label='Hash algorithm'
+                      label='Hash Algorithm'
                       value={curation.binaryArtifact.hashAlgorithm}
                       showIfEmpty={false}
                     />
@@ -144,12 +144,12 @@ export const PackageCuration = ({ curation }: PackageCurationProps) => {
                       showIfEmpty={false}
                     />
                     <RenderProperty
-                      label='Hash value'
+                      label='Hash Value'
                       value={curation.sourceArtifact.hashValue}
                       showIfEmpty={false}
                     />
                     <RenderProperty
-                      label='Hash algorithm'
+                      label='Hash Algorithm'
                       value={curation.sourceArtifact.hashAlgorithm}
                       showIfEmpty={false}
                     />
@@ -158,19 +158,19 @@ export const PackageCuration = ({ curation }: PackageCurationProps) => {
               )}
               {Object.keys(curation.declaredLicenseMapping).length > 0 && (
                 <RenderProperty
-                  label='Declared license mapping'
+                  label='Declared License Mapping'
                   value={curation.declaredLicenseMapping}
                   type='keyvalue'
                   showIfEmpty={false}
                 />
               )}
               <RenderProperty
-                label='Concluded license'
+                label='Concluded License'
                 value={curation.concludedLicense}
                 showIfEmpty={false}
               />
               <RenderProperty
-                label='Metadata only'
+                label='Metadata Only'
                 value={curation.isMetadataOnly}
                 showIfEmpty={false}
               />

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
@@ -244,11 +244,11 @@ const renderSubComponent = ({
               type='url'
             />
             <RenderProperty
-              label='Hash value'
+              label='Hash Value'
               value={pkg.binaryArtifact.hashValue}
             />
             <RenderProperty
-              label='Hash algorithm'
+              label='Hash Algorithm'
               value={pkg.binaryArtifact.hashAlgorithm}
             />
           </div>
@@ -268,11 +268,11 @@ const renderSubComponent = ({
               type='url'
             />
             <RenderProperty
-              label='Hash value'
+              label='Hash Value'
               value={pkg.sourceArtifact.hashValue}
             />
             <RenderProperty
-              label='Hash algorithm'
+              label='Hash Algorithm'
               value={pkg.sourceArtifact.hashAlgorithm}
             />
           </div>
@@ -282,7 +282,7 @@ const renderSubComponent = ({
       )}
       {pkg.shortestDependencyPaths.length > 0 && (
         <div>
-          <div className='font-semibold'>Shortest dependency paths</div>
+          <div className='font-semibold'>Shortest Dependency Paths</div>
           <DependencyPaths
             pkg={pkg}
             pkgIdType={packageIdType}


### PR DESCRIPTION

<img width="1190" height="354" alt="Screenshot from 2025-10-13 10-04-35" src="https://github.com/user-attachments/assets/b7580a22-95a3-4d66-8272-01b11ff1f8ca" />

(@sschuberth The badge color in this first picture is still the old green one, don't pay attention to that.)

<img width="1190" height="292" alt="Screenshot from 2025-10-13 10-13-47" src="https://github.com/user-attachments/assets/91fccb5f-172c-4efc-b125-a708a9472401" />

(This has the correct badge color.)

Please see the commits for details.