### PR TITLE
build(gradle): Make `generateOpenApiSpec` visible in task help

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -188,4 +188,5 @@ tasks.register<Test>("generateOpenApiSpec") {
     classpath = files(test.map { it.sources.runtimeClasspath })
     include("org/eclipse/apoapsis/ortserver/core/utils/GenerateOpenApiSpec.class")
     systemProperties("generateOpenApiSpec" to "true")
+    outputs.file(rootDir.resolve("ui/build/openapi.json"))
 }


### PR DESCRIPTION
Add a `group` and move the code comment to the `description` to make the task visible in `./gardlew tasks` output when run without `--all`.