### PR TITLE
fix(docker-compose): Remove the "data" directory from the volume mount

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,7 +32,7 @@ services:
     # Use port 5433 on the host to avoid a conflict with a running postgres instance on the host.
     - "5433:5432"
     volumes:
-    - db:/var/lib/postgresql/data
+    - db:/var/lib/postgresql
     logging:
       driver: ${LOG_DRIVER:-gelf}
       options:


### PR DESCRIPTION
See the comment at [1]. This fixes the startup error saying:

```
In 18+, these Docker images are configured to store database data in a
format which is compatible with "pg_ctlcluster" (specifically, using
major-version-specific directory names).  This better reflects how
PostgreSQL itself works, and how upgrades are to be performed.

See also https://github.com/docker-library/postgres/pull/1259

Counter to that, there appears to be PostgreSQL data in:
  /var/lib/postgresql/data (unused mount/volume)

This is usually the result of upgrading the Docker image without
upgrading the underlying database using "pg_upgrade" (which requires both
versions).

The suggested container configuration for 18+ is to place a single mount
at /var/lib/postgresql which will then place PostgreSQL data in a
subdirectory, allowing usage of "pg_upgrade --link" without mount point
boundary issues.
```

[1]: https://github.com/docker-library/postgres/pull/1259#issuecomment-3433788598