### PR TITLE
fix(docker): Align ScanCode versions to 32.4.1

### DIFF
--- a/workers/reporter/docker/Reporter.Dockerfile
+++ b/workers/reporter/docker/Reporter.Dockerfile
@@ -23,7 +23,7 @@
 FROM --platform=linux/amd64 python:3.13-slim AS scancode-license-data-build
 
 # Keep in sync with Scanner.Dockerfile
-ARG SCANCODE_VERSION=32.4.0
+ARG SCANCODE_VERSION=32.4.1
 
 RUN apt-get update && apt-get install -y curl libgomp1 && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Use the same version as in `Scanner.Dockerfile`.