### PR TITLE
Align the default NPM auth mode with the backend

### DIFF
--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -94,7 +94,7 @@ export const npmEnvironmentDefinitions: EnvironmentDefinitions = {
       service: '',
       scope: '',
       email: '',
-      authMode: NpmAuthMode.USERNAME_PASSWORD_AUTH,
+      authMode: NpmAuthMode.PASSWORD,
     },
   ],
 };


### PR DESCRIPTION
This is a small fixup for #3849.

Please see the commit for details.