### PR TITLE
chore(buildSrc): Consistently call `add` on `freeCompilerArgs`

### DIFF
--- a/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-conventions.gradle.kts
@@ -66,7 +66,7 @@ tasks.named<KotlinCompile>("compileKotlin") {
 
     compilerOptions {
         allWarningsAsErrors = true
-        freeCompilerArgs = listOf("-Xconsistent-data-class-copy-visibility", "-Xnon-local-break-continue")
+        freeCompilerArgs.addAll("-Xconsistent-data-class-copy-visibility", "-Xnon-local-break-continue")
         jvmTarget = maxKotlinJvmTarget
         optIn = optInRequirements
     }


### PR DESCRIPTION
Avoid accidental overwriting of values added before, e.g. by Gradle plugins. Note that `freeCompilerArgs` is a provider that does not support operator overloading yet.