### PR TITLE
build: Remove the unused "json-schema-serialization" dependency

### DIFF
--- a/buildSrc/src/main/kotlin/ort-server-base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-base-conventions.gradle.kts
@@ -30,16 +30,6 @@ repositories {
 
     exclusiveContent {
         forRepository {
-            maven("https://jitpack.io")
-        }
-
-        filter {
-            includeModule("com.github.Ricky12Awesome", "json-schema-serialization")
-        }
-    }
-
-    exclusiveContent {
-        forRepository {
             maven("https://packages.atlassian.com/maven-external")
         }
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -122,7 +122,6 @@ dependencies {
     implementation(ktorLibs.server.requestValidation)
     implementation(ktorLibs.server.statusPages)
     implementation(libs.bundles.schemaKenerator)
-    implementation(libs.jsonSchemaSerialization)
     implementation(libs.koinKtor)
     implementation(libs.konform)
     implementation(libs.ktorOpenApi)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,7 +41,6 @@ commonsText = "1.14.0"
 exposed = "0.61.0"
 flyway = "11.17.0"
 hikari = "7.0.2"
-jsonSchemaSerialization = "0.6.6"
 jsonSchemaValidator = "2.0.0"
 kaml = "0.102.0"
 keycloakTestcontainerVersion = "3.9.0"
@@ -98,7 +97,6 @@ exposedKotlinDatetime = { module = "org.jetbrains.exposed:exposed-kotlin-datetim
 flywayCore = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
 flywayPostgresql = { module = "org.flywaydb:flyway-database-postgresql", version.ref = "flyway" }
 hikari = { module = "com.zaxxer:HikariCP", version.ref = "hikari" }
-jsonSchemaSerialization = { module = "com.github.Ricky12Awesome:json-schema-serialization", version.ref = "jsonSchemaSerialization" }
 jsonSchemaValidator = { module = "com.networknt:json-schema-validator", version.ref = "jsonSchemaValidator" }
 kaml = { module = "com.charleskorn.kaml:kaml", version.ref = "kaml" }
 koinCore = { module = "io.insert-koin:koin-core", version.ref = "koin" }


### PR DESCRIPTION
By now, the "schema-kenerator" project is used instead.