### PR TITLE
ci(github): Stop using the `macos-13` image

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -43,7 +43,7 @@ jobs:
             buildPath: 'cli/build/bin/macosArm64/releaseExecutable/osc.kexe'
             binName: 'osc'
           - name: 'macOS x64'
-            os: macos-13
+            os: macos-15-intel
             task: 'linkReleaseExecutableMacosX64'
             artifact: 'osc-cli-macos-x64'
             buildPath: 'cli/build/bin/macosX64/releaseExecutable/osc.kexe'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
           binName: osc
           archiveExt: tar.gz
         - name: "macOS x64"
-          os: macos-13
+          os: macos-15-intel
           task: :cli:linkReleaseExecutableMacosX64
           artifact: osc-cli-macos-x64
           buildPath: cli/build/bin/macosX64/releaseExecutable/osc.kexe


### PR DESCRIPTION
GitHub is running a burnout for users of this image as it is going to be removed, see [1]. Use `macos-15-intel` instead "as the last supported image based on Intel CPU".

[1]: https://github.com/actions/runner-images/issues/13046