### PR TITLE
chore(common): Log more obvious placeholders for secrets

### DIFF
--- a/workers/common/src/main/kotlin/common/env/GitCredentialsGenerator.kt
+++ b/workers/common/src/main/kotlin/common/env/GitCredentialsGenerator.kt
@@ -50,7 +50,7 @@ class GitCredentialsGenerator : EnvironmentConfigGenerator<EnvironmentServiceDef
             val serviceUrl = URI.create(url).toURL()
 
             GeneratorLogger.entryAdded(
-                "${serviceUrl.protocol}://username:****@${serviceUrl.authority}${serviceUrl.path}",
+                "${serviceUrl.protocol}://<username>:<password>@${serviceUrl.authority}${serviceUrl.path}",
                 GIT_CREDENTIALS_FILE_NAME,
                 this
             )


### PR DESCRIPTION
Avoid the impression that (due to some bug) "username" would be the literal username used for authentication.