### PR TITLE
fix(compose): Use `UI_HOSTS` instead of `UI_HOST` to configure CORS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,7 +164,7 @@ services:
       - "5000:5000"
     environment:
       PORT: 8080
-      UI_HOST: "localhost:5173"
+      UI_HOSTS: "localhost:5173,localhost:8082"
       DB_HOST: postgres
       DB_PORT: 5432
       DB_NAME: ort_server


### PR DESCRIPTION
The variable has been renamed in d02e851. While at it, also add `localhost:8082` as this is were the UI is running in compose.