### PR TITLE
chore(compose): Set a name for the admin user

### DIFF
--- a/scripts/docker/keycloak/master-realm.json
+++ b/scripts/docker/keycloak/master-realm.json
@@ -411,6 +411,7 @@
   "users" : [ {
     "id" : "b4192f3c-d52a-43a8-8e5d-4ea429f08ca4",
     "username" : "admin",
+    "firstName" : "admin",
     "emailVerified" : false,
     "enabled" : true,
     "createdTimestamp" : 1660816938576,


### PR DESCRIPTION
With the upcoming changes in [1] it will be required that the name is not empty. Before, the admin user did not have any name set which lead to the `name` claim missing from the JWT.

[1]: https://github.com/eclipse-apoapsis/ort-server/pull/3908