### PR TITLE
docs(dao): Avoid duplicate "provenance" in an error message

### DIFF
--- a/dao/src/main/kotlin/repositories/scannerrun/DaoScannerRunRepository.kt
+++ b/dao/src/main/kotlin/repositories/scannerrun/DaoScannerRunRepository.kt
@@ -143,7 +143,7 @@ class DaoScannerRunRepository(private val db: Database) : ScannerRunRepository {
                         nestedProvenanceResolutionIssue = Issue(
                             timestamp = Clock.System.now(),
                             source = "Scanner",
-                            message = "Could not resolve nested provenance for provenance '$packageProvenance'.",
+                            message = "Could not resolve nested provenance for '$packageProvenance'.",
                             severity = Severity.ERROR
                         )
                     )


### PR DESCRIPTION
Instead of "for provenance 'RepositoryProvenance(..." shorten to just "for 'RepositoryProvenance(...".