### PR TITLE
ci(release): Increase timeout for validating Maven Central deployment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,7 @@ jobs:
         ORG_GRADLE_PROJECT_signingInMemoryKeyId: ${{ secrets.ORG_GPG_SUBKEY_ID }}
         ORG_GRADLE_PROJECT_signingInMemoryKeyPassword: ${{ secrets.ORG_GPG_PASSPHRASE }}
         SONATYPE_CONNECT_TIMEOUT_SECONDS: 300
+        SONATYPE_CLOSE_TIMEOUT_SECONDS: 1800
       run: ./gradlew --stacktrace publishAndReleaseToMavenCentral
 
   build-cli:


### PR DESCRIPTION
Sometimes it can take longer than the default 15 minutes [1] to validate the deployment, so double the timeout to 30 minutes.

[1]: https://vanniktech.github.io/gradle-maven-publish-plugin/central/#deployment-validation