### PR TITLE
Fix the horizontal overflow of repository runs table

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/repository-runs-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/repository-runs-table.tsx
@@ -97,6 +97,7 @@ const columns = [
   }),
   columnHelper.accessor('createdAt', {
     header: 'Created',
+    size: 100,
     cell: ({ row }) => (
       <div>
         <TimestampWithUTC timestamp={row.original.createdAt} />
@@ -134,6 +135,7 @@ const columns = [
   columnHelper.display({
     id: 'jobStatuses',
     header: () => <div>Jobs</div>,
+    size: 70,
     cell: ({ row }) => (
       <OrtRunJobStatus
         jobs={row.original.jobs}
@@ -149,6 +151,7 @@ const columns = [
   columnHelper.display({
     id: 'duration',
     header: 'Duration',
+    size: 70,
     cell: ({ row }) => (
       <RunDuration
         createdAt={row.original.createdAt}


### PR DESCRIPTION
<img width="1133" height="324" alt="Screenshot from 2025-11-21 09-10-01" src="https://github.com/user-attachments/assets/a3e23614-5af5-4bde-96de-c72c51e59008" />

Please see the commit for details.