### PR TITLE
fix(services): Fix filtering packages by identifier

### DIFF
--- a/services/ort-run/src/main/kotlin/PackageService.kt
+++ b/services/ort-run/src/main/kotlin/PackageService.kt
@@ -126,18 +126,7 @@ class PackageService(private val db: Database, private val ortRunService: OrtRun
             }
 
             filteredResult = filteredResult.filter { pkg ->
-                val identifierString = buildString {
-                    append(pkg.pkg.identifier.type)
-                    append(":")
-                    if (pkg.pkg.identifier.namespace.isNotEmpty()) {
-                        append(pkg.pkg.identifier.namespace)
-                        append("/")
-                    }
-                    append(pkg.pkg.identifier.name)
-                    append("@")
-                    append(pkg.pkg.identifier.version)
-                }
-                identifierString.contains(Regex(filter.value, RegexOption.IGNORE_CASE))
+                pkg.pkg.identifier.mapToOrt().toCoordinates().contains(Regex(filter.value, RegexOption.IGNORE_CASE))
             }
         }
 

--- a/services/ort-run/src/test/kotlin/PackageServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/PackageServiceTest.kt
@@ -351,7 +351,7 @@ class PackageServiceTest : WordSpec() {
                     PackageFilters(
                         identifier = FilterOperatorAndValue(
                             ComparisonOperator.ILIKE,
-                            "com.example/example2"
+                            "com.example:example2"
                         )
                     )
                 )
@@ -376,7 +376,7 @@ class PackageServiceTest : WordSpec() {
                     filters = PackageFilters(
                         identifier = FilterOperatorAndValue(
                             ComparisonOperator.ILIKE,
-                            "NPM:example@1.0"
+                            "NPM::example:1.0"
                         )
                     )
                 )
@@ -400,7 +400,7 @@ class PackageServiceTest : WordSpec() {
                     filters = PackageFilters(
                         identifier = FilterOperatorAndValue(
                             ComparisonOperator.ILIKE,
-                            "maven:com.example/Example2"
+                            "maven:com.example:Example2"
                         )
                     )
                 )


### PR DESCRIPTION
Displaying the identifier was fixed to match ORT's `toCoordinates()` in https://github.com/eclipse-apoapsis/ort-server/commit/b400c09a035b2d64f977bc2f605a60e6398de408 but the backend still constructed the compared string for filtering by identifier the way the identifier was initially displayed. Fix the filtering by using `toCoordinates()` to construct the compared string.