### PR TITLE
Resolve plugin secrets in run requests from user secrets

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
@@ -710,7 +710,7 @@ fun ResolvablePluginConfig.mapToApi() = ApiPluginConfig(
 
 fun ApiPluginConfig.mapToModel() = ResolvablePluginConfig(
     options = options,
-    secrets = secrets.mapValues { ResolvableSecret(it.value, SecretSource.ADMIN) }
+    secrets = secrets.mapValues { ResolvableSecret(it.value, SecretSource.USER) }
 )
 
 fun ResolvableProviderPluginConfig.mapToApi() =
@@ -728,7 +728,7 @@ fun ApiProviderPluginConfiguration.mapToModel() =
         id = id,
         enabled = enabled,
         options = options,
-        secrets = secrets.mapValues { ResolvableSecret(it.value, SecretSource.ADMIN) }
+        secrets = secrets.mapValues { ResolvableSecret(it.value, SecretSource.USER) }
     )
 
 fun SourceCodeOrigin.mapToApi() =

--- a/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
@@ -750,7 +750,7 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
             }
         }
 
-        "resolve provided plugin secrets from the admin secrets" {
+        "resolve provided plugin secrets from the user secrets" {
             integrationTestApplication {
                 val createdRepository = createRepository()
 
@@ -795,7 +795,7 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                         get("VulnerableCode").shouldNotBeNull {
                             secrets["apiKey"].shouldNotBeNull {
                                 name shouldBe "VC_API_KEY"
-                                source shouldBe SecretSource.ADMIN
+                                source shouldBe SecretSource.USER
                             }
                         }
                     }
@@ -806,7 +806,7 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                         it.type shouldBe "DOS"
                         it.secrets["token"].shouldNotBeNull {
                             name shouldBe "DOS_TOKEN"
-                            source shouldBe SecretSource.ADMIN
+                            source shouldBe SecretSource.USER
                         }
                     }
                 }


### PR DESCRIPTION
When secret names in plugin configs are set by the user as part of a run request, resolve them from the user secrets instead of the admin secrets. This makes it possible for users to provide secrets for ORT plugins. It also ensures that users cannot configure plugins to use arbitrary admin secrets.

When configuring plugin secrets in the parameter validation script, server admins can still choose from which source secrets shall be resolved.