### PR TITLE
Reapply "fix(config): Clear HTTP basic auth cache to prevent credenti…

### DIFF
--- a/config/git/src/main/kotlin/GitConfigFileProvider.kt
+++ b/config/git/src/main/kotlin/GitConfigFileProvider.kt
@@ -23,6 +23,7 @@ import com.typesafe.config.Config
 
 import java.io.File
 import java.io.InputStream
+import java.util.HashMap
 
 import kotlin.time.measureTime
 
@@ -109,31 +110,66 @@ class GitConfigFileProvider internal constructor(
      */
     private fun updateWorkingTree(requestedRevision: String): String {
         synchronized(this) {
-            // TODO: There might be a better way to do check if the configDir already contains a Git repository.
-            val revision = if (!configDir.resolve(".git").isDirectory) {
-                val initRevision = requestedRevision.takeUnless { it.isEmpty() } ?: git.getDefaultBranchName(gitUrl)
-                val vcsInfo = VcsInfo(VcsType.GIT, gitUrl, initRevision)
+            try {
+                // TODO: There might be a better way to do check if the configDir already contains a Git repository.
+                val revision = if (!configDir.resolve(".git").isDirectory) {
+                    val initRevision = requestedRevision.takeUnless { it.isEmpty() } ?: git.getDefaultBranchName(gitUrl)
+                    val vcsInfo = VcsInfo(VcsType.GIT, gitUrl, initRevision)
 
-                measureTime { git.initWorkingTree(configDir, vcsInfo) }.also {
-                    logger.debug("Initialized Git working tree in $it.")
+                    measureTime { git.initWorkingTree(configDir, vcsInfo) }.also {
+                        logger.debug("Initialized Git working tree in $it.")
+                    }
+
+                    initRevision
+                } else {
+                    requestedRevision
                 }
 
-                initRevision
-            } else {
-                requestedRevision
+                val workingTree = git.getWorkingTree(configDir)
+
+                // Check if the requested revision was already checked out.
+                if (revision == workingTree.getRevision()) return revision
+
+                // Update the working tree to the requested revision.
+                measureTime { git.updateWorkingTree(workingTree, revision, recursive = true).getOrThrow() }.also {
+                    logger.debug("Updated Git working tree to revision '$revision' in $it.")
+                }
+
+                return workingTree.getRevision()
+            } finally {
+                clearHttpAuthCache()
             }
-
-            val workingTree = git.getWorkingTree(configDir)
-
-            // Check if the requested revision was already checked out.
-            if (revision == workingTree.getRevision()) return revision
-
-            // Update the working tree to the requested revision.
-            measureTime { git.updateWorkingTree(workingTree, revision, recursive = true).getOrThrow() }.also {
-                logger.debug("Updated Git working tree to revision '$revision' in $it.")
-            }
-
-            return workingTree.getRevision()
         }
+    }
+
+    /**
+     * Clear the HTTP basic authentication cache used by HttpURLConnection.
+     *
+     * JGit uses HttpURLConnection for HTTP(S) connections, which caches authentication credentials.
+     * If the Git repository requires authentication and the credentials change between requests,
+     * the cached credentials may lead to authentication failures.
+     *
+     * Clearing the HTTP authentication cache ensures that new credentials are used for subsequent requests.
+     *
+     * Requires JVM argument: --add-opens java.base/sun.net.www.protocol.http=ALL-UNNAMED
+     */
+    private fun clearHttpAuthCache() = runCatching {
+        logger.debug("Clearing JGit HTTP authentication cache.")
+
+        val authCacheImplClass = Class.forName("sun.net.www.protocol.http.AuthCacheImpl")
+        val getDefaultMethod = authCacheImplClass.getDeclaredMethod("getDefault")
+        val defaultCache = getDefaultMethod.invoke(null)
+
+        val setMapMethod = authCacheImplClass.getDeclaredMethod("setMap", HashMap::class.java)
+        // Replace the cache map with an empty one.
+        setMapMethod.invoke(defaultCache, HashMap<Any, Any>())
+
+        logger.debug("Successfully cleared JGit HTTP authentication cache.")
+    }.onFailure { e ->
+        logger.warn(
+            "Failed to clear JGit HTTP authentication cache. This may lead to Git authentication issues. Consider " +
+                    "setting '--add-opens java.base/sun.net.www.protocol.http=ALL-UNNAMED' javaOpts.",
+            e
+        )
     }
 }

--- a/workers/analyzer/build.gradle.kts
+++ b/workers/analyzer/build.gradle.kts
@@ -110,8 +110,10 @@ jib {
         mainClass = "org.eclipse.apoapsis.ortserver.workers.analyzer.EntrypointKt"
         creationTime = "USE_CURRENT_TIMESTAMP"
 
-        if (System.getProperty("idea.active").toBoolean()) {
-            jvmFlags = listOf("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5030")
+        jvmFlags = mutableListOf("--add-opens=java.base/sun.net.www.protocol.http=ALL-UNNAMED").apply {
+            if (System.getProperty("idea.active")?.toBoolean() == true) {
+                add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5030")
+            }
         }
     }
 }

--- a/workers/evaluator/build.gradle.kts
+++ b/workers/evaluator/build.gradle.kts
@@ -85,8 +85,10 @@ jib {
         mainClass = "org.eclipse.apoapsis.ortserver.workers.evaluator.EntrypointKt"
         creationTime = "USE_CURRENT_TIMESTAMP"
 
-        if (System.getProperty("idea.active").toBoolean()) {
-            jvmFlags = listOf("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5060")
+        jvmFlags = mutableListOf("--add-opens=java.base/sun.net.www.protocol.http=ALL-UNNAMED").apply {
+            if (System.getProperty("idea.active")?.toBoolean() == true) {
+                add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5030")
+            }
         }
     }
 }

--- a/workers/reporter/build.gradle.kts
+++ b/workers/reporter/build.gradle.kts
@@ -92,8 +92,10 @@ jib {
         mainClass = "org.eclipse.apoapsis.ortserver.workers.reporter.EntrypointKt"
         creationTime = "USE_CURRENT_TIMESTAMP"
 
-        if (System.getProperty("idea.active").toBoolean()) {
-            jvmFlags = listOf("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5070")
+        jvmFlags = mutableListOf("--add-opens=java.base/sun.net.www.protocol.http=ALL-UNNAMED").apply {
+            if (System.getProperty("idea.active")?.toBoolean() == true) {
+                add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5030")
+            }
         }
     }
 }

--- a/workers/scanner/build.gradle.kts
+++ b/workers/scanner/build.gradle.kts
@@ -101,8 +101,10 @@ jib {
         mainClass = "org.eclipse.apoapsis.ortserver.workers.scanner.EntrypointKt"
         creationTime = "USE_CURRENT_TIMESTAMP"
 
-        if (System.getProperty("idea.active").toBoolean()) {
-            jvmFlags = listOf("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5050")
+        jvmFlags = mutableListOf("--add-opens=java.base/sun.net.www.protocol.http=ALL-UNNAMED").apply {
+            if (System.getProperty("idea.active")?.toBoolean() == true) {
+                add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5030")
+            }
         }
     }
 }


### PR DESCRIPTION
…al conflicts"

Unfortunately, the change to Apache's HttpClient resulted in another authentication issue causing to only allow a single set of credentials for a Git host.
Reapply the fix that uses reflection to clear the authentication cache after updating the working tree.

This reverts commit 437518d6335364c74ec9009f3b36c6bd3bce2d5c.