### PR TITLE
fix(ui): Reduce the number of requested runs to 100

### DIFF
--- a/ui/src/components/siblings.tsx
+++ b/ui/src/components/siblings.tsx
@@ -104,7 +104,7 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
   } = useQuery({
     ...getRepositoryRunsOptions({
       path: { repositoryId: Number(params.repoId) },
-      query: { limit: ALL_ITEMS, sort: '-index' },
+      query: { limit: 100, sort: '-index' },
     }),
     staleTime: staleTime,
     enabled: entity === 'run' || !!params.repoId,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/run-details-bar.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/run-details-bar.tsx
@@ -38,7 +38,6 @@ import {
 } from '@/components/ui/tooltip';
 import { config } from '@/config';
 import { getStatusBackgroundColor } from '@/helpers/get-status-class';
-import { ALL_ITEMS } from '@/lib/constants';
 import { cn } from '@/lib/utils';
 
 type RunDetailsBarProps = {
@@ -62,7 +61,8 @@ export const RunDetailsBar = ({ className }: RunDetailsBarProps) => {
         repositoryId: Number.parseInt(params.repoId),
       },
       query: {
-        limit: ALL_ITEMS,
+        limit: 100,
+        sort: '-index',
       },
     }),
     select: (data) => data.data.map((run) => run.index).sort((a, b) => a - b),


### PR DESCRIPTION
Requesting a large number of runs creates a lot of load on the backend, especially if a repository has thousands of runs. Therefore, change two requests to request the last 100 runs at most.

Note that both changed requests only require the run indexes but still request the whole summary for all runs.

For the run siblings dropdown this change means that only the last 100 runs can be selected, and the navigation to the last or next run now only works for the last 100 runs.

This is a temporary measure to reduce the load on the backend, the full functionality of the two affected features needs to be restored later in a way that does not overload the backend.