### PR TITLE
deps(reporter): Force JRuby 9.x for the Reporter worker

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ commonsText = "1.14.0"
 exposed = "0.61.0"
 flyway = "11.18.0"
 hikari = "7.0.2"
+jrubyAscciiDoc = "9.4.14.0"
 jsonSchemaValidator = "2.0.0"
 kaml = "0.104.0"
 keycloakTestcontainerVersion = "4.0.0"
@@ -96,6 +97,7 @@ exposedKotlinDatetime = { module = "org.jetbrains.exposed:exposed-kotlin-datetim
 flywayCore = { module = "org.flywaydb:flyway-core", version.ref = "flyway" }
 flywayPostgresql = { module = "org.flywaydb:flyway-database-postgresql", version.ref = "flyway" }
 hikari = { module = "com.zaxxer:HikariCP", version.ref = "hikari" }
+jrubyAsciiDoc = { module = "org.jruby:jruby", version.ref = "jrubyAscciiDoc" }
 jsonSchemaValidator = { module = "com.networknt:json-schema-validator", version.ref = "jsonSchemaValidator" }
 kaml = { module = "com.charleskorn.kaml:kaml", version.ref = "kaml" }
 koinCore = { module = "io.insert-koin:koin-core", version.ref = "koin" }

--- a/workers/reporter/build.gradle.kts
+++ b/workers/reporter/build.gradle.kts
@@ -66,6 +66,7 @@ dependencies {
     runtimeOnly(platform(projects.storage))
     runtimeOnly(platform(projects.transport))
 
+    runtimeOnly(libs.jrubyAsciiDoc)
     runtimeOnly(libs.log4jToSlf4j)
     runtimeOnly(libs.logback)
     runtimeOnly(platform(ortLibs.ortPlugins.reporters))
@@ -96,6 +97,19 @@ jib {
             if (System.getProperty("idea.active")?.toBoolean() == true) {
                 add("-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=*:5030")
             }
+        }
+    }
+}
+
+// ORT uses the JRuby version 10.x for both the Analyzer and the Reporter. Experiments have shown that switching
+// from JRuby 9.x to 10.x causes a measurable decrease in performance for the PDF report generation. Therefore,
+// as a temporary workaround, force the use of JRuby 9.x for the Reporter worker.
+configurations.all {
+    resolutionStrategy.eachDependency {
+        if (requested.group == "org.jruby" && requested.name == "jruby"
+            && requested.version?.startsWith("10") == true
+        ) {
+            useTarget(libs.jrubyAsciiDoc)
         }
     }
 }


### PR DESCRIPTION
It has been observed that there is a slight performance decrease when generating PDF reports with JRuby 10.x. Also, AsciidoctorJ officially still depends on JRuby 9.x. Therefore, override the JRuby 10.x dependency from ORT to use JRuby 9.x in the Reporter image.