### PR TITLE
feat(analyzer): Set the `ANDROID_SDK_ROOT` environment variable

### DIFF
--- a/workers/analyzer/docker/Analyzer.Dockerfile
+++ b/workers/analyzer/docker/Analyzer.Dockerfile
@@ -450,6 +450,7 @@ COPY --from=ruby --chown=$USER:$USER $RBENV_ROOT $RBENV_ROOT
 
 # Repo and Android
 ENV ANDROID_HOME=/opt/android-sdk
+ENV ANDROID_SDK_ROOT=$ANDROID_HOME
 ENV ANDROID_USER_HOME=$HOME/.android
 ENV PATH=$PATH:$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/cmdline-tools/bin
 ENV PATH=$PATH:$ANDROID_HOME/platform-tools


### PR DESCRIPTION
The variable is required by old Android projects which use a version of the Gradle Android plugin that does not yet support `ANDROID_HOME`.