### PR TITLE
build(gradle): Simplify accessing the version catalog from `buildSrc`

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -30,7 +30,6 @@ repositories {
 }
 
 dependencies {
-    implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
     implementation(libs.kotlinxSerializationJson)
     implementation(libs.plugin.detekt)
     implementation(libs.plugin.kotlin)

--- a/buildSrc/settings.gradle.kts
+++ b/buildSrc/settings.gradle.kts
@@ -19,10 +19,7 @@
 
 rootProject.name = "buildSrc"
 
-dependencyResolutionManagement {
-    versionCatalogs {
-        create("libs") {
-            from(files("../gradle/libs.versions.toml"))
-        }
-    }
+plugins {
+    // Gradle cannot access the version catalog from here, so hard-code the dependency.
+    id("dev.panuszewski.typesafe-conventions").version("0.10.0")
 }

--- a/buildSrc/src/main/kotlin/ort-server-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-kotlin-conventions.gradle.kts
@@ -23,9 +23,6 @@ import org.gradle.accessors.dm.LibrariesForLibs
 
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-private val Project.libs: LibrariesForLibs
-    get() = extensions.getByType()
-
 private val catalogs = extensions.getByType<VersionCatalogsExtension>()
 private val detektRulesVersion = catalogs.named("ortLibs").findLibrary("detektRules").get().get().version
 

--- a/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-conventions.gradle.kts
@@ -24,9 +24,6 @@ import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 val javaLanguageVersion: String by project
 
-private val Project.libs: LibrariesForLibs
-    get() = extensions.getByType()
-
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-conventions")


### PR DESCRIPTION
Make use of [1].

[1]: https://github.com/radoslaw-panuszewski/typesafe-conventions-gradle-plugin