### PR TITLE
build(gradle): Revert using the "build-health" settings plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,10 +29,6 @@ plugins {
     alias(libs.plugins.jib) apply false
 }
 
-dependencyAnalysis {
-    useTypesafeProjectAccessors(true)
-}
-
 semver {
     // Do not create an empty release commit when running the "releaseVersion" task.
     createReleaseCommit = false

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -32,6 +32,7 @@ repositories {
 dependencies {
     implementation(files(libs.javaClass.superclass.protectionDomain.codeSource.location))
     implementation(libs.kotlinxSerializationJson)
+    implementation(libs.plugin.dependencyAnalysis)
     implementation(libs.plugin.detekt)
     implementation(libs.plugin.kotlin)
     implementation(libs.plugin.mavenPublish)

--- a/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-conventions.gradle.kts
@@ -32,6 +32,7 @@ plugins {
     id("ort-server-kotlin-conventions")
 
     // Apply third-party plugins.
+    id("com.autonomousapps.dependency-analysis")
     id("org.jetbrains.kotlin.jvm")
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@
 [versions]
 # Gradle plugins
 buildConfigPlugin = "6.0.6"
+dependencyAnalysisPlugin = "3.5.1"
 detektPlugin = "1.23.8"
 gitSemverPlugin = "0.17.1"
 jibPlugin = "3.5.1"
@@ -75,6 +76,7 @@ ksp = { id = "com.google.devtools.ksp", version.ref = "kspPlugin" }
 
 [libraries]
 # These are Maven coordinates for Gradle plugins, which is necessary to use them in precompiled plugin scripts.
+plugin-dependencyAnalysis = { module = "com.autonomousapps:dependency-analysis-gradle-plugin", version.ref = "dependencyAnalysisPlugin" }
 plugin-detekt = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detektPlugin" }
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinPlugin" }
 plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublishPlugin" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -117,11 +117,7 @@ project(":workers:config").name = "config-worker"
 
 plugins {
     // Gradle cannot access the version catalog from here, so hard-code the dependency.
-    id("com.autonomousapps.build-health").version("3.5.1")
     id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
-
-    // Required for the build-health plugin. Keep the version in sync with the one from the version catalog.
-    id("org.jetbrains.kotlin.jvm").version("2.2.21").apply(false)
 }
 
 dependencyResolutionManagement {


### PR DESCRIPTION
This reverts commits 7491d9c9402d89afe8677666b0d313adf9848d97 and 2218c74aac11c8b6a7487af9fe4ad48ccf08fadb. The changes were causing strange build errors for some developers locally and in the release workflow. The root cause still has to be investigated.