### PR TITLE
Temporarily hide "License findings" from run overview menu

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/route.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/route.tsx
@@ -24,7 +24,6 @@ import {
   CalendarCheck,
   Eye,
   Files,
-  FileText,
   FolderKanban,
   ListCheck,
   Logs,
@@ -65,12 +64,14 @@ const Layout = () => {
           },
           icon: () => <Scale className='h-4 w-4' />,
         },
-        {
-          title: 'License Findings',
-          to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings',
-          params,
-          icon: () => <FileText className='h-4 w-4' />,
-        },
+        // This menu option is temporarily disabled until the license findings page is implemented.
+        // The code is still left here as a bookmark/reminder for future implementation.
+        //{
+        //  title: 'License Findings',
+        //  to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings',
+        //  params,
+        //  icon: () => <FileText className='h-4 w-4' />,
+        //},
         {
           title: 'Vulnerabilities',
           to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities',


### PR DESCRIPTION
Please see the commit for details.

<img width="252" height="711" alt="Screenshot from 2025-12-12 11-01-42" src="https://github.com/user-attachments/assets/f1c80165-57b1-4d5e-b05b-f9e971041b1e" />
