### PR TITLE
docs(ui): Improve vulnerability overview descriptions

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
@@ -458,15 +458,14 @@ const ProductVulnerabilitiesComponent = () => {
           {filtersInUse && matching})
         </CardTitle>
         <CardDescription>
-          These are the vulnerabilities found currently from this product.
-          Please note that the vulnerability status may change over time, as
-          your dependencies change. Therefore, your product repositories should
-          be scanned for vulnerabilities regularly.
+          This is an overview of the vulnerabilities found within this product.
+          It only takes into account the latest runs per repository that have
+          successful advisor results.
         </CardDescription>
         <CardDescription>
-          By clicking on "References" you can see more information about the
-          vulnerability. The overall severity rating is calculated based on the
-          highest severity rating found in the references.
+          Please note that new vulnerabilities may get discovered over time.
+          Therefore, your product's repositories should be scanned for
+          vulnerabilities regularly, even if no code changes occurred.
         </CardDescription>
       </CardHeader>
       <CardContent>

--- a/ui/src/routes/organizations/$orgId/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/vulnerabilities/index.tsx
@@ -463,15 +463,14 @@ const OrganizationVulnerabilitiesComponent = () => {
           {filtersInUse && matching})
         </CardTitle>
         <CardDescription>
-          These are the vulnerabilities found currently from this organization.
-          Please note that the vulnerability status may change over time, as
-          your dependencies change. Therefore, your organization's repositories
-          should be scanned for vulnerabilities regularly.
+          This is an overview of the vulnerabilities found within this
+          organization. It only takes into account the latest runs per
+          repository that have successful advisor results.
         </CardDescription>
         <CardDescription>
-          By clicking on "References" you can see more information about the
-          vulnerability. The overall severity rating is calculated based on the
-          highest severity rating found in the references.
+          Please note that new vulnerabilities may get discovered over time.
+          Therefore, your organization's repositories should be scanned for
+          vulnerabilities regularly, even if no code changes occurred.
         </CardDescription>
       </CardHeader>
       <CardContent>


### PR DESCRIPTION
Clarify that only latest runs are taken into account. Also, omit the outdated note about clicking "References" in favor of making the note about regular scans stand out more as a separate description.