### PR TITLE
fix(ui): Don't submit form when clicking copy button

### DIFF
--- a/ui/src/components/copy-to-clipboard.tsx
+++ b/ui/src/components/copy-to-clipboard.tsx
@@ -54,7 +54,12 @@ export const CopyToClipboard = ({ copyText }: CopyToClipboardProps) => {
     <TooltipProvider delayDuration={0}>
       <Tooltip>
         <TooltipTrigger asChild>
-          <Button variant='ghost' size='sm' onClick={handleCopyClick}>
+          <Button
+            variant='ghost'
+            size='sm'
+            type='button'
+            onClick={handleCopyClick}
+          >
             <span className='fg-slate-300'>
               {isCopied ? <Check color='gray' /> : <Copy color='gray' />}
             </span>


### PR DESCRIPTION
The default type for a button is `submit`, so when the `CopyToClipboard` component was used inside the create run form, the form got submitted when clicking the copy button. Fix by setting the button type to `button` in the `CopyToClipboard` component.