### PR TITLE
fix(workers): Also show ORT stacktraces for forked processes

### DIFF
--- a/workers/common/src/main/kotlin/env/EnvironmentForkHelper.kt
+++ b/workers/common/src/main/kotlin/env/EnvironmentForkHelper.kt
@@ -35,6 +35,7 @@ import org.eclipse.apoapsis.ortserver.workers.common.auth.OrtServerAuthenticator
 import org.eclipse.apoapsis.ortserver.workers.common.auth.credentialResolver
 import org.eclipse.apoapsis.ortserver.workers.common.auth.infraSecretResolverFromConfig
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerOrtConfig
+import org.eclipse.apoapsis.ortserver.workers.common.enableOrtStackTraces
 
 import org.slf4j.LoggerFactory
 import org.slf4j.MDC
@@ -101,6 +102,9 @@ object EnvironmentForkHelper {
 
         val netrcManager = NetRcManager.create(credentialResolver(authInfo))
         authenticator.updateAuthenticationListener(netrcManager)
+
+        logger.info("Enabling ORT stack traces for the AnalyzerRunner forked process.")
+        enableOrtStackTraces()
     }
 
     /**


### PR DESCRIPTION
ORT Server always enable the stacktraces from ORT. However, when a worker process is forked (e.g. when the Analyzer work has environment variables to set) the new JVM does not have this property set. Therefore, this commit also enabled the stacktraces for the forked process.

Please note that, since ORT does a call to `printStackTrace()` which outputs to STDERR, the stacktrace is not visible in the logs downloadable from the UI.

[1]: https://github.com/docker-library/postgres/pull/1259