### PR TITLE
feat(logs): Add custom header for UI and CLI clients

### DIFF
--- a/cli/src/commonMain/kotlin/utils/OrtServerClientUtils.kt
+++ b/cli/src/commonMain/kotlin/utils/OrtServerClientUtils.kt
@@ -24,6 +24,7 @@ import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.client.plugins.auth.providers.bearer
 import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.header
 
 import org.eclipse.apoapsis.ortserver.cli.COMMAND_NAME
 import org.eclipse.apoapsis.ortserver.cli.model.AuthenticationStorage
@@ -35,6 +36,7 @@ import org.eclipse.apoapsis.ortserver.client.auth.AuthService
 import org.eclipse.apoapsis.ortserver.client.auth.AuthenticationException
 import org.eclipse.apoapsis.ortserver.client.createDefaultHttpClient
 import org.eclipse.apoapsis.ortserver.client.createOrtHttpClient
+import org.eclipse.apoapsis.ortserver.utils.system.CustomHttpHeaders
 
 /**
  * Create an authenticated ORT Server client using the stored authentication. Returns null if the user is not
@@ -53,6 +55,7 @@ fun createUnauthenticatedOrtServerClient(baseUrl: String) = OrtServerClient(crea
 private fun createHttpClient(url: String) = createOrtHttpClient(JSON) {
     defaultRequest {
         url(url)
+        header(CustomHttpHeaders.ClientType, "ort-server-cli")
     }
 }
 

--- a/core/src/main/kotlin/plugins/HTTP.kt
+++ b/core/src/main/kotlin/plugins/HTTP.kt
@@ -27,6 +27,8 @@ import io.ktor.server.config.ApplicationConfig
 import io.ktor.server.plugins.cors.routing.CORS
 import io.ktor.server.plugins.defaultheaders.DefaultHeaders
 
+import org.eclipse.apoapsis.ortserver.utils.system.CustomHttpHeaders
+
 import org.koin.ktor.ext.inject
 
 fun Application.configureHTTP() {
@@ -39,6 +41,7 @@ fun Application.configureHTTP() {
     install(CORS) {
         allowedHosts.split(',').forEach(::allowHost)
         allowCredentials = true
+        allowHeader(CustomHttpHeaders.ClientType)
         allowHeader(HttpHeaders.Authorization)
         allowHeader(HttpHeaders.ContentType)
         allowMethod(HttpMethod.Delete)

--- a/core/src/main/kotlin/plugins/Monitoring.kt
+++ b/core/src/main/kotlin/plugins/Monitoring.kt
@@ -19,12 +19,16 @@
 
 package org.eclipse.apoapsis.ortserver.core.plugins
 
+import io.ktor.http.HttpHeaders
 import io.ktor.server.application.Application
 import io.ktor.server.application.install
 import io.ktor.server.plugins.calllogging.CallLogging
+import io.ktor.server.request.httpMethod
 import io.ktor.server.request.path
 
 import java.util.UUID
+
+import org.eclipse.apoapsis.ortserver.utils.system.CustomHttpHeaders
 
 import org.slf4j.event.Level
 
@@ -42,5 +46,17 @@ fun Application.configureMonitoring() {
         mdc("organizationId") { it.parameters["organizationId"] }
         mdc("productId") { it.parameters["productId"] }
         mdc("repositoryId") { it.parameters["repositoryId"] }
+
+        format { call ->
+            val clientType = call.request.headers[CustomHttpHeaders.ClientType]
+                ?: call.request.headers[HttpHeaders.UserAgent]
+                ?: "unknown"
+
+            val status = call.response.status()?.value ?: "unknown"
+            val method = call.request.httpMethod.value
+            val path = call.request.path()
+
+            "clientType=$clientType $method $path: $status"
+        }
     }
 }

--- a/ui/src/app.tsx
+++ b/ui/src/app.tsx
@@ -40,6 +40,9 @@ import { routeTree } from '@/routeTree.gen';
 client.setConfig({
   baseURL: config.API_URL,
   auth: () => authRef.current?.user?.access_token,
+  headers: {
+    'X-Client-Type': 'ort-server-ui',
+  },
 });
 
 export interface RouterContext {

--- a/utils/system/src/commonMain/kotlin/Constants.kt
+++ b/utils/system/src/commonMain/kotlin/Constants.kt
@@ -23,3 +23,10 @@ package org.eclipse.apoapsis.ortserver.utils.system
  * The version of the ORT Server as a string.
  */
 const val ORT_SERVER_VERSION = BuildConfig.ORT_SERVER_VERSION
+
+object CustomHttpHeaders {
+    /**
+     * HTTP header name used to identify the client type making API requests.
+     */
+    const val ClientType = "X-Client-Type"
+}


### PR DESCRIPTION
Add the value of the `X-Client-Type` header for tracking UI and CLI clients to the MDC logs. This can be used to distinguish all API requests originating from the known clients from unknown ones.