### PR TITLE
Use Identifier instead of String for package search

### DIFF
--- a/components/search/api-model/src/commonMain/kotlin/RunWithPackage.kt
+++ b/components/search/api-model/src/commonMain/kotlin/RunWithPackage.kt
@@ -22,6 +22,8 @@ package org.eclipse.apoapsis.ortserver.components.search.apimodel
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
+import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
+
 @Serializable
 data class RunWithPackage(
     val organizationId: Long,
@@ -31,6 +33,6 @@ data class RunWithPackage(
     val ortRunIndex: Long,
     val revision: String?,
     val createdAt: Instant,
-    val packageId: String?,
+    val packageId: Identifier?,
     val purl: String?
 )

--- a/components/search/backend/src/routes/kotlin/routes/GetRunsWithPackage.kt
+++ b/components/search/backend/src/routes/kotlin/routes/GetRunsWithPackage.kt
@@ -25,6 +25,7 @@ import io.ktor.server.routing.Route
 
 import kotlinx.datetime.Clock
 
+import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
 import org.eclipse.apoapsis.ortserver.components.authorization.routes.OrtServerPrincipal.Companion.requirePrincipal
 import org.eclipse.apoapsis.ortserver.components.authorization.routes.get
 import org.eclipse.apoapsis.ortserver.components.search.apimodel.RunWithPackage
@@ -50,15 +51,15 @@ internal fun Route.getRunsWithPackage(searchService: SearchService) =
             }
             queryParameter<Long?>("organizationId") {
                 description = "Optional organization ID to filter the search. " +
-                    "Cannot be combined with productId or repositoryId."
+                    "Cannot be combined with 'productId' or 'repositoryId'."
             }
             queryParameter<Long?>("productId") {
                 description = "Optional product ID to filter the search. " +
-                    "Cannot be combined with organizationId or repositoryId."
+                    "Cannot be combined with 'organizationId' or 'repositoryId'."
             }
             queryParameter<Long?>("repositoryId") {
                 description = "Optional repository ID to filter the search. " +
-                    "Cannot be combined with organizationId or productId."
+                    "Cannot be combined with 'organizationId' or 'productId'."
             }
         }
 
@@ -76,7 +77,12 @@ internal fun Route.getRunsWithPackage(searchService: SearchService) =
                                 ortRunIndex = 42L,
                                 revision = "a1b2c3d4",
                                 createdAt = Clock.System.now(),
-                                packageId = "Maven:foo:bar:1.0.0",
+                                packageId = Identifier(
+                                    type = "Maven",
+                                    namespace = "foo",
+                                    name = "bar",
+                                    version = "1.0.0"
+                                ),
                                 purl = null
                             )
                         )

--- a/components/search/backend/src/test/kotlin/Utils.kt
+++ b/components/search/backend/src/test/kotlin/Utils.kt
@@ -28,7 +28,6 @@ import org.eclipse.apoapsis.ortserver.dao.test.Fixtures
 import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.PackageCurationProviderConfig
 import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.ResolvedPackageCurations
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
-import org.eclipse.apoapsis.ortserver.model.runs.Package
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.AdvisorResult
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.Vulnerability
 import org.eclipse.apoapsis.ortserver.model.runs.repository.PackageCuration
@@ -50,7 +49,7 @@ fun createRunWithPackage(
         ortRunIndex = ortRun.index,
         revision = ortRun.revision,
         createdAt = ortRun.createdAt,
-        packageId = pkgId.toCoordinates(),
+        packageId = pkgId.toApiIdentifier(),
         purl = null
     )
 }
@@ -123,8 +122,6 @@ fun Identifier.toCoordinates(): String = "$type:$namespace:$name:$version"
 fun Identifier.toPurl(): String = "pkg:$type/$namespace/$name@$version"
 
 fun Identifier.toApiIdentifier(): ApiIdentifier = ApiIdentifier(type, namespace, name, version)
-
-fun Package.toPurl(): String = purl
 
 /**
  * Create an ORT run with a vulnerability associated with the given package identifier.

--- a/components/search/backend/src/test/kotlin/routes/GetRunsWithPackageIntegrationTest.kt
+++ b/components/search/backend/src/test/kotlin/routes/GetRunsWithPackageIntegrationTest.kt
@@ -46,6 +46,7 @@ import ort.eclipse.apoapsis.ortserver.components.search.SearchIntegrationTest
 import ort.eclipse.apoapsis.ortserver.components.search.createRunWithCuratedPurl
 import ort.eclipse.apoapsis.ortserver.components.search.createRunWithPackage
 import ort.eclipse.apoapsis.ortserver.components.search.createRunWithPackageForPurlSearch
+import ort.eclipse.apoapsis.ortserver.components.search.toApiIdentifier
 import ort.eclipse.apoapsis.ortserver.components.search.toCoordinates
 import ort.eclipse.apoapsis.ortserver.components.search.toPurl
 
@@ -63,11 +64,16 @@ class GetRunsWithPackageIntegrationTest : SearchIntegrationTest({
 
         "return BadRequest if multiple scope parameters are provided" {
             val fixtures = dbExtension.fixtures
-            val run = createRunWithPackage(fixtures = fixtures, repoId = fixtures.repository.id)
+            val packageIdentifier = identifierFor("bad-request")
+            val run = createRunWithPackage(
+                fixtures = fixtures,
+                repoId = fixtures.repository.id,
+                pkgId = packageIdentifier
+            )
 
             searchTestApplication { client ->
                 val withTwoScopes = client.get(SEARCH_ROUTE) {
-                    parameter("identifier", run.packageId)
+                    parameter("identifier", packageIdentifier.toCoordinates())
                     parameter("organizationId", run.organizationId.toString())
                     parameter("productId", run.productId.toString())
                 }
@@ -75,7 +81,7 @@ class GetRunsWithPackageIntegrationTest : SearchIntegrationTest({
                 withTwoScopes shouldHaveStatus HttpStatusCode.BadRequest
 
                 val withAllScopes = client.get(SEARCH_ROUTE) {
-                    parameter("identifier", run.packageId)
+                    parameter("identifier", packageIdentifier.toCoordinates())
                     parameter("organizationId", run.organizationId.toString())
                     parameter("productId", run.productId.toString())
                     parameter("repositoryId", run.repositoryId.toString())
@@ -96,7 +102,7 @@ class GetRunsWithPackageIntegrationTest : SearchIntegrationTest({
 
             searchTestApplication { client ->
                 val response = client.get(SEARCH_ROUTE) {
-                    parameter("identifier", run.packageId)
+                    parameter("identifier", packageIdentifier.toCoordinates())
                 }
 
                 response shouldHaveStatus HttpStatusCode.OK
@@ -141,7 +147,7 @@ class GetRunsWithPackageIntegrationTest : SearchIntegrationTest({
 
             searchTestApplication { client ->
                 val response = client.get(SEARCH_ROUTE) {
-                    parameter("identifier", run.packageId)
+                    parameter("identifier", packageIdentifier.toCoordinates())
                     parameter("organizationId", run.organizationId.toString())
                 }
 
@@ -189,7 +195,7 @@ class GetRunsWithPackageIntegrationTest : SearchIntegrationTest({
 
             searchTestApplication { client ->
                 val response = client.get(SEARCH_ROUTE) {
-                    parameter("identifier", run.packageId)
+                    parameter("identifier", packageIdentifier.toCoordinates())
                     parameter("productId", run.productId.toString())
                 }
 
@@ -237,7 +243,7 @@ class GetRunsWithPackageIntegrationTest : SearchIntegrationTest({
 
             searchTestApplication { client ->
                 val response = client.get(SEARCH_ROUTE) {
-                    parameter("identifier", run.packageId)
+                    parameter("identifier", packageIdentifier.toCoordinates())
                     parameter("repositoryId", run.repositoryId.toString())
                 }
 
@@ -283,7 +289,7 @@ class GetRunsWithPackageIntegrationTest : SearchIntegrationTest({
 
             searchTestApplication { client ->
                 val response = client.get(SEARCH_ROUTE) {
-                    parameter("identifier", allowed.packageId)
+                    parameter("identifier", packageIdentifier.toCoordinates())
                 }
 
                 response shouldHaveStatus HttpStatusCode.OK
@@ -322,7 +328,7 @@ class GetRunsWithPackageIntegrationTest : SearchIntegrationTest({
 
             searchTestApplication { client ->
                 val response = client.get(SEARCH_ROUTE) {
-                    parameter("identifier", run1.packageId)
+                    parameter("identifier", packageIdentifier.toCoordinates())
                 }
 
                 response shouldHaveStatus HttpStatusCode.OK
@@ -461,7 +467,7 @@ class GetRunsWithPackageIntegrationTest : SearchIntegrationTest({
                 val body = response.body<List<RunWithPackage>>()
                 body.shouldBeSingleton {
                     it.purl.shouldBeNull()
-                    it.packageId shouldBe packageIdentifier.toCoordinates()
+                    it.packageId shouldBe packageIdentifier.toApiIdentifier()
                 }
             }
         }

--- a/ui/src/routes/organizations/$orgId/products/$productId/search-package/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/search-package/index.tsx
@@ -48,6 +48,7 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import { updateColumnSorting } from '@/helpers/handle-multisort';
+import { identifierToString } from '@/helpers/identifier-conversion';
 import { toast } from '@/lib/toast';
 import {
   paginationSearchParameterSchema,
@@ -138,9 +139,14 @@ function SearchPackageComponent() {
               repoId: row.original.repositoryId.toString(),
               runIndex: row.original.ortRunIndex.toString(),
             }}
-            search={{ pkgId: row.original.packageId ?? undefined, marked: '0' }}
+            search={{
+              pkgId: identifierToString(row.original.packageId) ?? undefined,
+              marked: '0',
+            }}
           >
-            <BreakableString text={row.original.packageId ?? ''} />
+            <BreakableString
+              text={identifierToString(row.original.packageId) ?? ''}
+            />
           </Link>
         );
       },


### PR DESCRIPTION
PR #4176 implements an endpoint for vulnerability search.  Align the package search endpoint with the former by returning `Identifier` instead of `String` for the found packages for consistency.

Review of #4176 also took up some good minor points, so this PR aligns with those also for the package search related implementation.

NOTE: This is technically a breaking change, however, the author doesn't believe there will be any other consumers for the endpoint yet (other than the UI).