### PR TITLE
fix(compose): Add missing mount for `secrets.properties`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -315,6 +315,9 @@ services:
     - type: bind
       source: ./scripts/compose/config
       target: /mnt/config
+    - type: bind
+      source: ./scripts/compose/secrets.properties
+      target: /mnt/secrets.properties
     - secrets:/mnt/secrets-provider
     logging:
       driver: ${LOG_DRIVER:-gelf}


### PR DESCRIPTION
Add the missing mount for `secrets.properties` to the advisor worker.

Fixes #4242.