### PR TITLE
fix(vault): Fix a failing request after token renewal

### DIFF
--- a/secrets/vault/src/main/kotlin/VaultSecretsProvider.kt
+++ b/secrets/vault/src/main/kotlin/VaultSecretsProvider.kt
@@ -23,6 +23,7 @@ import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.HttpSend
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
@@ -138,6 +139,10 @@ class VaultSecretsProvider(
                         ignoreUnknownKeys = true
                     }
                 )
+            }
+
+            install(HttpRequestRetry) {
+                maxRetries = 3
             }
 
             expectSuccess = true

--- a/secrets/vault/src/test/kotlin/VaultTestContainer.kt
+++ b/secrets/vault/src/test/kotlin/VaultTestContainer.kt
@@ -51,6 +51,9 @@ class VaultTestContainer {
         /** The root path under which secrets are stored in the vault. */
         const val PATH = "ort/server/secrets/"
 
+        /** The live time of tokens in seconds. This is used to test token renewal. */
+        const val TOKEN_TTL_SECONDS = 3
+
         /** The root token used by the vault service. */
         private const val VAULT_TOKEN = "onetobindthemall"
 
@@ -108,7 +111,7 @@ class VaultTestContainer {
                     """
                         {
                             "token_policies": "$ROLE_NAME",
-                            "token_ttl": "2h"
+                            "token_ttl": "${TOKEN_TTL_SECONDS}s"
                         }
                     """.trimIndent()
                 )


### PR DESCRIPTION
When the API token expired and was renewed, the retried request fails for unknown reasons. Adding a retry configuration to the HTTP client fixes the problem. Retrying failed requests for a number of times is beneficial anyway.