### PR TITLE
fix(compose): Enable Keycloak database migrations during realm import

### DIFF
--- a/scripts/docker/keycloak/init-keycloak.sh
+++ b/scripts/docker/keycloak/init-keycloak.sh
@@ -22,7 +22,7 @@ echo "Using Keycloak script: $KEYCLOAK_SCRIPT."
 # 4. Export the configuration:
 #    `KC_HTTP_PORT=8081 /opt/keycloak/bin/kc.sh export --dir /opt/keycloak_init --users realm_file
 $KEYCLOAK_SCRIPT build
-$KEYCLOAK_SCRIPT import --file /opt/keycloak_init/master-realm.json
+$KEYCLOAK_SCRIPT import --file /opt/keycloak_init/master-realm.json --spi-connections-jpa--quarkus--migration-strategy=update
 
 # Start KeyCloak
 $KEYCLOAK_SCRIPT "$@"


### PR DESCRIPTION
Since [1] Keycloak does not automatically migrate the database during realm import anymore. Explicitly enable it as suggested in [2] as otherwise starting the Docker Compose environment might fail after a Keycloak version upgrade.

[1]: https://github.com/keycloak/keycloak/issues/42321
[2]: https://github.com/keycloak/keycloak/issues/43793