### PR TITLE
fix(workers): Always consider all secrets when resolving services

### DIFF
--- a/workers/common/src/main/kotlin/env/config/EnvironmentConfigLoader.kt
+++ b/workers/common/src/main/kotlin/env/config/EnvironmentConfigLoader.kt
@@ -210,11 +210,7 @@ class EnvironmentConfigLoader(
             allSecretsNames += service.passwordSecret
         }
 
-        val resolvedSecrets = if (allSecretsNames.isNotEmpty()) {
-            secretService.listForHierarchy(hierarchy).associateBy(Secret::name)
-        } else {
-            emptyMap()
-        }
+        val resolvedSecrets = secretService.listForHierarchy(hierarchy).associateBy(Secret::name)
 
         allSecretsNames -= resolvedSecrets.keys
 

--- a/workers/common/src/test/kotlin/env/EnvironmentServiceTest.kt
+++ b/workers/common/src/test/kotlin/env/EnvironmentServiceTest.kt
@@ -286,11 +286,14 @@ class EnvironmentServiceTest : WordSpec({
             """.trimIndent()
             )
 
-            val service = mockk<InfrastructureServiceService>()
-            val configLoader = EnvironmentConfigLoader(mockk(), mockk(), EnvironmentDefinitionFactory())
+            val infrastructureServiceService = mockk<InfrastructureServiceService>()
+            val secretService = mockk<SecretService> {
+                coEvery { listForHierarchy(repositoryHierarchy) } returns emptyList()
+            }
+            val configLoader = EnvironmentConfigLoader(secretService, mockk(), EnvironmentDefinitionFactory())
             val environmentService = EnvironmentService(
-                service,
-                mockk(),
+                infrastructureServiceService,
+                secretService,
                 emptyList(),
                 configLoader,
                 createMockAdminConfigService()

--- a/workers/common/src/test/kotlin/env/config/EnvironmentConfigLoaderTest.kt
+++ b/workers/common/src/test/kotlin/env/config/EnvironmentConfigLoaderTest.kt
@@ -269,6 +269,19 @@ class EnvironmentConfigLoaderTest : StringSpec({
         config.shouldContainDefinition<MavenDefinition>(orgService) { it.id == "repo3" }
     }
 
+    "Services can be resolved if no secrets are referenced in the repository configuration" {
+        val helper = TestHelper()
+        val userSecret = helper.createSecret("testUser", repository = repository)
+        val passSecret = helper.createSecret("testPassword1", repository = repository)
+
+        val repoService = createTestService(1, userSecret, passSecret)
+        helper.withRepositoryService(repoService)
+
+        val config = parseConfig(".ort.env.no-services.yml", helper).resolve(helper)
+
+        config.shouldContainDefinition<MavenDefinition>(repoService) { it.id == "repo1" }
+    }
+
     "Services with unknown secrets in the hierarchy cause exceptions in strict mode" {
         val helper = TestHelper()
         val unknownUserSecret = createSecret("unknownUser")


### PR DESCRIPTION
There was an optimization not to load the secrets of the hierarchy if the
environment configuration does not reference any secrets. This does not
work any more after infrastructure services reference their secrets by
name. Fix this by loading all secrets of the current hierarchy
unconditionally in `EnvironmentConfigLoader`.

This is a follow-up of c1101909.