### PR TITLE
fix(ui): Abbreviate long usernames and emails

### DIFF
--- a/ui/src/routes/admin/users/index.tsx
+++ b/ui/src/routes/admin/users/index.tsx
@@ -68,7 +68,11 @@ const columnHelper = createColumnHelper<UserWithSuperuserStatus>();
 const columns = [
   columnHelper.accessor('user.username', {
     header: 'Username',
-    cell: ({ row }) => <>{row.original.user.username}</>,
+    cell: ({ row }) => (
+      <div className='overflow-hidden text-ellipsis'>
+        {row.original.user.username}
+      </div>
+    ),
   }),
   columnHelper.accessor('user.firstName', {
     header: 'First name',
@@ -80,7 +84,11 @@ const columns = [
   }),
   columnHelper.accessor('user.email', {
     header: 'Email address',
-    cell: ({ row }) => <>{row.original.user.email}</>,
+    cell: ({ row }) => (
+      <div className='overflow-hidden text-ellipsis'>
+        {row.original.user.email}
+      </div>
+    ),
   }),
   columnHelper.accessor('isSuperuser', {
     header: 'Superuser',


### PR DESCRIPTION
Too long usernames and email addresses break the admin/users table, so use ellipsis to hide them.

<img width="1418" height="475" alt="Screenshot from 2026-01-19 12-39-57" src="https://github.com/user-attachments/assets/740eaf39-6902-481e-8d72-7ecf7d72864e" />

@sschuberth sadly, there is no TailwindCSS class to put the ellipsis in the middle of the e-mail address, and I'd rather not start solving this programmatically (with a function to cut in the middle and replace by ellipsis), since this solution is so quick and simple.