### PR TITLE
deps(docker): Upgrade to ScanCode 32.5.0

### DIFF
--- a/workers/reporter/docker/Reporter.Dockerfile
+++ b/workers/reporter/docker/Reporter.Dockerfile
@@ -26,7 +26,7 @@ ARG BASE_IMAGE_TAG="latest"
 FROM --platform=linux/amd64 python:3.13-slim AS scancode-license-data-build
 
 # Keep in sync with Scanner.Dockerfile
-ARG SCANCODE_VERSION=32.4.1
+ARG SCANCODE_VERSION=32.5.0
 
 RUN apt-get update && apt-get install -y curl libgomp1 && rm -rf /var/lib/apt/lists/*
 

--- a/workers/scanner/docker/Scanner.Dockerfile
+++ b/workers/scanner/docker/Scanner.Dockerfile
@@ -59,7 +59,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 ARG ASKALONO_VERSION=0.5.0
 ARG LICENSEE_VERSION=9.18.0
 ARG RUBY_VERSION=3.4.4
-ARG SCANCODE_VERSION=32.4.1
+ARG SCANCODE_VERSION=32.5.0
 
 # Install Askalono
 RUN curl -LOs https://github.com/amzn/askalono/releases/download/$ASKALONO_VERSION/askalono-Linux.zip && \


### PR DESCRIPTION
See [1].

[1]: https://github.com/aboutcode-org/scancode-toolkit/releases/tag/v32.5.0