### PR TITLE
ci(renovate): Ignore legacy Kubernetes Java Client updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -40,6 +40,10 @@
     {
       "matchPackageNames": ["node"],
       "schedule": ["after 9pm on sunday"]
+    },
+    {
+      "matchPackageNames": ["io.kubernetes:client-java-extended", "io.kubernetes:client-java"],
+      "allowedVersions": "!/.*-legacy$/"
     }
   ],
   "prHourlyLimit": 5


### PR DESCRIPTION
The Kubernetes Java Client now releases two versions: a standard version and a legacy version (Java 8, old API) [1].

Prevent Renovate from proposing `-legacy` suffixed versions for the Kubernetes Java Client, as has happened in #2793 and #4040. This should make Renovate propose the latest standard versions.

[1]: https://github.com/kubernetes-client/java?tab=readme-ov-file#release