### PR TITLE
ci(renovate): Pin dependenies in PNPM projects

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,10 @@
   "labels": ["dependencies"],
   "packageRules": [
     {
+      "matchDatasources": ["npm"],
+      "rangeStrategy": "pin"
+    },
+    {
       "matchManagers": ["gradle"],
       "commitMessageTopic": "{{depName}}"
     },


### PR DESCRIPTION
Configure Renovate to convert version ranges in `package.json` files to exact versions [1]. This makes it visible in the `package.json` files which versions of direct dependencies are used and prevents unintentional version upgrades during development.

[1]: https://docs.renovatebot.com/configuration-options/#rangestrategy