### PR TITLE
feat!: Use enums for the license source

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
@@ -44,6 +44,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.JobStatus as ApiJobStatus
 import org.eclipse.apoapsis.ortserver.api.v1.model.JobSummaries as ApiJobSummaries
 import org.eclipse.apoapsis.ortserver.api.v1.model.JobSummary as ApiJobSummary
 import org.eclipse.apoapsis.ortserver.api.v1.model.Jobs as ApiJobs
+import org.eclipse.apoapsis.ortserver.api.v1.model.LicenseSource as ApiLicenseSource
 import org.eclipse.apoapsis.ortserver.api.v1.model.LogLevel as ApiLogLevel
 import org.eclipse.apoapsis.ortserver.api.v1.model.LogSource as ApiLogSource
 import org.eclipse.apoapsis.ortserver.api.v1.model.NotifierJob as ApiNotifierJob
@@ -142,6 +143,7 @@ import org.eclipse.apoapsis.ortserver.model.VulnerabilityWithDetails
 import org.eclipse.apoapsis.ortserver.model.authentication.OidcConfig
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
+import org.eclipse.apoapsis.ortserver.model.runs.LicenseSource
 import org.eclipse.apoapsis.ortserver.model.runs.Package
 import org.eclipse.apoapsis.ortserver.model.runs.PackageFilters
 import org.eclipse.apoapsis.ortserver.model.runs.PackageManagerConfiguration
@@ -638,13 +640,19 @@ fun RuleViolation.mapToApi() = ApiRuleViolation(
     id = id?.mapToApi(),
     license = license,
     // TODO: Add support for multiple license sources, see issue #4185.
-    licenseSource = licenseSources.firstOrNull(),
+    licenseSource = licenseSources.firstOrNull()?.mapToApi(),
     severity = severity.mapToApi(),
     message = message,
     howToFix = howToFix,
     resolutions = resolutions.map { it.mapToApi() },
     purl = purl
 )
+
+fun LicenseSource.mapToApi() = when (this) {
+    LicenseSource.CONCLUDED -> ApiLicenseSource.CONCLUDED
+    LicenseSource.DECLARED -> ApiLicenseSource.DECLARED
+    LicenseSource.DETECTED -> ApiLicenseSource.DETECTED
+}
 
 fun Identifier.mapToApi() = ApiIdentifier(type = type, namespace = namespace, name = name, version = version)
 

--- a/api/v1/model/src/commonMain/kotlin/LicenseSource.kt
+++ b/api/v1/model/src/commonMain/kotlin/LicenseSource.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.api.v1.model
+
+/** The source where a license originates from. */
+enum class LicenseSource {
+    CONCLUDED,
+    DECLARED,
+    DETECTED
+}

--- a/api/v1/model/src/commonMain/kotlin/RuleViolation.kt
+++ b/api/v1/model/src/commonMain/kotlin/RuleViolation.kt
@@ -26,7 +26,7 @@ data class RuleViolation(
     val rule: String,
     val id: Identifier? = null,
     val license: String?,
-    val licenseSource: String?,
+    val licenseSource: LicenseSource?,
     val severity: Severity,
     val message: String,
     val howToFix: String,

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -33,6 +33,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.FilterOperatorAndValue
 import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
 import org.eclipse.apoapsis.ortserver.api.v1.model.Issue
 import org.eclipse.apoapsis.ortserver.api.v1.model.JobSummaries
+import org.eclipse.apoapsis.ortserver.api.v1.model.LicenseSource
 import org.eclipse.apoapsis.ortserver.api.v1.model.Licenses
 import org.eclipse.apoapsis.ortserver.api.v1.model.LogLevel
 import org.eclipse.apoapsis.ortserver.api.v1.model.LogSource
@@ -367,7 +368,7 @@ val getRunRuleViolations: RouteConfig.() -> Unit = {
                                     "2.42"
                                 ),
                                 "GPL-1.0-or-later",
-                                "DETECTED",
+                                LicenseSource.DETECTED,
                                 Severity.ERROR,
                                 "The declared license 'LPGL-2.1' could not be mapped to a valid SPDX expression.",
                                 """

--- a/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
@@ -118,6 +118,7 @@ import org.eclipse.apoapsis.ortserver.model.runs.AnalyzerConfiguration
 import org.eclipse.apoapsis.ortserver.model.runs.Environment
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
+import org.eclipse.apoapsis.ortserver.model.runs.LicenseSource
 import org.eclipse.apoapsis.ortserver.model.runs.Package
 import org.eclipse.apoapsis.ortserver.model.runs.ProcessedDeclaredLicense
 import org.eclipse.apoapsis.ortserver.model.runs.Project
@@ -1746,7 +1747,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                             "2.14.0"
                         ),
                         "License-1",
-                        setOf("CONCLUDED"),
+                        setOf(LicenseSource.CONCLUDED),
                         Severity.WARNING,
                         "Message-1",
                         "How_to_fix-1"
@@ -1761,7 +1762,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                             "2.9.6"
                         ),
                         "License-2",
-                        setOf("DETECTED"),
+                        setOf(LicenseSource.DETECTED),
                         Severity.ERROR,
                         "Message-2",
                         "How_to_fix-2"
@@ -1776,7 +1777,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                             "2.20.0"
                         ),
                         "License-3",
-                        setOf("CONCLUDED"),
+                        setOf(LicenseSource.CONCLUDED),
                         Severity.WARNING,
                         "Message-3",
                         "How_to_fix-3"
@@ -1786,7 +1787,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                         "a-Rule-4",
                         null,
                         "License-4",
-                        setOf("CONCLUDED"),
+                        setOf(LicenseSource.CONCLUDED),
                         Severity.WARNING,
                         "Message-4",
                         "How_to_fix-4"
@@ -1830,7 +1831,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                             "2.14.0"
                         ),
                         "License-1-obsolete",
-                        setOf("CONCLUDED"),
+                        setOf(LicenseSource.CONCLUDED),
                         Severity.WARNING,
                         "Message-1-obsolete",
                         "How_to_fix-1-obsolete"
@@ -1839,7 +1840,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                         "Rule-2-obsolete",
                         null,
                         "License-2-obsolete",
-                        setOf("DETECTED"),
+                        setOf(LicenseSource.DETECTED),
                         Severity.ERROR,
                         "Message-2-obsolete",
                         "How_to_fix-2-obsolete"
@@ -1938,7 +1939,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     "z-Rule-1",
                     Identifier("Maven", "com.example", "example", "1.0"),
                     "License-1",
-                    setOf("CONCLUDED"),
+                    setOf(LicenseSource.CONCLUDED),
                     Severity.WARNING,
                     "Message-1",
                     "How_to_fix-1"
@@ -1948,7 +1949,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     "b-Rule-2",
                     Identifier("Maven", "com.example", "example", "1.0"),
                     "License-2",
-                    setOf("DETECTED"),
+                    setOf(LicenseSource.DETECTED),
                     Severity.ERROR,
                     "Message-2",
                     "How_to_fix-2"
@@ -1958,7 +1959,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     "1-Rule-3",
                     Identifier("NPM", "com.example", "example2", "1.0"),
                     "License-3",
-                    setOf("CONCLUDED"),
+                    setOf(LicenseSource.CONCLUDED),
                     Severity.WARNING,
                     "Message-3",
                     "How_to_fix-3"
@@ -1968,7 +1969,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     "a-Rule-4",
                     null,
                     "License-4",
-                    setOf("CONCLUDED"),
+                    setOf(LicenseSource.CONCLUDED),
                     Severity.WARNING,
                     "Message-4",
                     "How_to_fix-4"

--- a/dao/src/main/kotlin/repositories/evaluatorrun/RuleViolationsTable.kt
+++ b/dao/src/main/kotlin/repositories/evaluatorrun/RuleViolationsTable.kt
@@ -24,6 +24,7 @@ import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
 import org.eclipse.apoapsis.ortserver.dao.utils.SortableEntityClass
 import org.eclipse.apoapsis.ortserver.dao.utils.SortableTable
 import org.eclipse.apoapsis.ortserver.model.Severity
+import org.eclipse.apoapsis.ortserver.model.runs.LicenseSource
 import org.eclipse.apoapsis.ortserver.model.runs.RuleViolation
 
 import org.jetbrains.exposed.dao.LongEntity
@@ -50,7 +51,7 @@ class RuleViolationDao(id: EntityID<Long>) : LongEntity(id) {
                 rule = ruleViolation.rule
                 identifierId = getIdentifierDaoOrNull(ruleViolation)
                 license = ruleViolation.license
-                licenseSources = ruleViolation.licenseSources.takeIf { it.isNotEmpty() }?.joinToString(",")
+                licenseSources = ruleViolation.licenseSources
                 severity = ruleViolation.severity
                 message = ruleViolation.message
                 howToFix = ruleViolation.howToFix
@@ -63,10 +64,7 @@ class RuleViolationDao(id: EntityID<Long>) : LongEntity(id) {
                 RuleViolationsTable.rule eq ruleViolation.rule and
                         (RuleViolationsTable.identifierId eq identifierDao?.id) and
                         (RuleViolationsTable.license eq ruleViolation.license) and
-                        (
-                            RuleViolationsTable.licenseSources eq
-                                ruleViolation.licenseSources.takeIf { it.isNotEmpty() }?.joinToString(",")
-                        ) and
+                        (RuleViolationsTable.licenseSources eq ruleViolation.licenseSources.mapToString()) and
                         (RuleViolationsTable.severity eq ruleViolation.severity)
             }.find { it.message == ruleViolation.message && it.howToFix == ruleViolation.howToFix }
         }
@@ -84,6 +82,7 @@ class RuleViolationDao(id: EntityID<Long>) : LongEntity(id) {
     var identifierId by IdentifierDao optionalReferencedOn RuleViolationsTable.identifierId
     var license by RuleViolationsTable.license
     var licenseSources by RuleViolationsTable.licenseSources
+        .transform({ it.mapToString() }, { it.mapToLicenseSources() })
     var severity by RuleViolationsTable.severity
     var message by RuleViolationsTable.message
     var howToFix by RuleViolationsTable.howToFix
@@ -94,9 +93,20 @@ class RuleViolationDao(id: EntityID<Long>) : LongEntity(id) {
         license = license,
         // Empty string need to be ignored because they could temporarily be written to the database, see:
         // https://github.com/eclipse-apoapsis/ort-server/issues/4229
-        licenseSources = licenseSources?.split(',')?.filterTo(mutableSetOf()) { it.isNotEmpty() }.orEmpty(),
+        licenseSources = licenseSources,
         severity = severity,
         message = message,
         howToFix = howToFix
     )
 }
+
+/**
+ * Map a set of [LicenseSource] to a comma-separated [String], or `null` if the set is empty.
+ */
+private fun Set<LicenseSource>.mapToString() = takeIf { it.isNotEmpty() }?.joinToString(",") { it.name }
+
+/**
+ * Map a comma-separated [String] to a set of [LicenseSource], or an empty set if the string is `null`.
+ */
+private fun String?.mapToLicenseSources(): Set<LicenseSource> =
+    this?.split(',')?.mapTo(mutableSetOf()) { enumValueOf<LicenseSource>(it) }.orEmpty()

--- a/dao/src/testFixtures/kotlin/Fixtures.kt
+++ b/dao/src/testFixtures/kotlin/Fixtures.kt
@@ -59,6 +59,7 @@ import org.eclipse.apoapsis.ortserver.model.runs.DependencyGraph
 import org.eclipse.apoapsis.ortserver.model.runs.Environment
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
+import org.eclipse.apoapsis.ortserver.model.runs.LicenseSource
 import org.eclipse.apoapsis.ortserver.model.runs.Package
 import org.eclipse.apoapsis.ortserver.model.runs.ProcessedDeclaredLicense
 import org.eclipse.apoapsis.ortserver.model.runs.Project
@@ -239,7 +240,7 @@ class Fixtures(private val db: Database) {
         rule = "rule",
         id = identifier,
         license = "license",
-        licenseSources = setOf("DETECTED", "DECLARED"),
+        licenseSources = setOf(LicenseSource.DETECTED, LicenseSource.DECLARED),
         message = "message",
         severity = Severity.ERROR,
         howToFix = "how to fix"

--- a/model/src/commonMain/kotlin/runs/LicenseSource.kt
+++ b/model/src/commonMain/kotlin/runs/LicenseSource.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.model.runs
+
+/** The source where a license originates from. */
+enum class LicenseSource {
+    CONCLUDED,
+    DECLARED,
+    DETECTED
+}

--- a/model/src/commonMain/kotlin/runs/RuleViolation.kt
+++ b/model/src/commonMain/kotlin/runs/RuleViolation.kt
@@ -29,7 +29,7 @@ data class RuleViolation(
     val rule: String,
     val id: Identifier?,
     val license: String?,
-    val licenseSources: Set<String>,
+    val licenseSources: Set<LicenseSource>,
     val severity: Severity,
     val message: String,
     val howToFix: String,

--- a/services/ort-run/src/main/kotlin/OrtMappings.kt
+++ b/services/ort-run/src/main/kotlin/OrtMappings.kt
@@ -41,6 +41,7 @@ import org.eclipse.apoapsis.ortserver.model.runs.Environment
 import org.eclipse.apoapsis.ortserver.model.runs.EvaluatorRun
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
+import org.eclipse.apoapsis.ortserver.model.runs.LicenseSource
 import org.eclipse.apoapsis.ortserver.model.runs.Package
 import org.eclipse.apoapsis.ortserver.model.runs.PackageManagerConfiguration
 import org.eclipse.apoapsis.ortserver.model.runs.ProcessedDeclaredLicense
@@ -116,6 +117,7 @@ import org.ossreviewtoolkit.model.EvaluatorRun as OrtEvaluatorRun
 import org.ossreviewtoolkit.model.Identifier as OrtIdentifier
 import org.ossreviewtoolkit.model.Issue as OrtIssue
 import org.ossreviewtoolkit.model.LicenseFinding as OrtLicenseFinding
+import org.ossreviewtoolkit.model.LicenseSource as OrtLicenseSource
 import org.ossreviewtoolkit.model.Package as OrtPackage
 import org.ossreviewtoolkit.model.PackageCuration as OrtPackageCuration
 import org.ossreviewtoolkit.model.PackageCurationData as OrtPackageCurationData
@@ -339,6 +341,12 @@ fun OrtLicenseFindingCuration.mapToModel() = LicenseFindingCuration(
     comment = comment
 )
 
+fun OrtLicenseSource.mapToModel() = when (this) {
+    OrtLicenseSource.CONCLUDED -> LicenseSource.CONCLUDED
+    OrtLicenseSource.DECLARED -> LicenseSource.DECLARED
+    OrtLicenseSource.DETECTED -> LicenseSource.DETECTED
+}
+
 fun OrtIssue.mapToModel(identifier: Identifier? = null, worker: String? = null) =
     Issue(
         timestamp = timestamp.toKotlinInstant(),
@@ -520,7 +528,7 @@ fun OrtRuleViolation.mapToModel() = RuleViolation(
     message = message,
     howToFix = howToFix,
     license = license?.toString(),
-    licenseSources = licenseSources.mapTo(mutableSetOf()) { it.name }
+    licenseSources = licenseSources.mapTo(mutableSetOf()) { it.mapToModel() }
 )
 
 fun OrtRuleViolationResolution.mapToModel() = RuleViolationResolution(

--- a/services/ort-run/src/main/kotlin/OrtServerMappings.kt
+++ b/services/ort-run/src/main/kotlin/OrtServerMappings.kt
@@ -45,6 +45,7 @@ import org.eclipse.apoapsis.ortserver.model.runs.Environment
 import org.eclipse.apoapsis.ortserver.model.runs.EvaluatorRun
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
+import org.eclipse.apoapsis.ortserver.model.runs.LicenseSource
 import org.eclipse.apoapsis.ortserver.model.runs.Package
 import org.eclipse.apoapsis.ortserver.model.runs.PackageManagerConfiguration
 import org.eclipse.apoapsis.ortserver.model.runs.ProcessedDeclaredLicense
@@ -381,6 +382,12 @@ fun LicenseFindingCuration.mapToOrt() = OrtLicenseFindingCuration(
     comment = comment
 )
 
+fun LicenseSource.mapToOrt() = when (this) {
+    LicenseSource.CONCLUDED -> OrtLicenseSource.CONCLUDED
+    LicenseSource.DECLARED -> OrtLicenseSource.DECLARED
+    LicenseSource.DETECTED -> OrtLicenseSource.DETECTED
+}
+
 fun NestedProvenance.mapToOrt() =
     OrtNestedProvenance(
         root = root.mapToOrt(),
@@ -610,7 +617,7 @@ fun RuleViolation.mapToOrt() =
         rule = rule,
         pkg = id?.mapToOrt(),
         license = license?.let { SpdxSingleLicenseExpression.parse(it) },
-        licenseSources = licenseSources.mapTo(enumSetOf()) { OrtLicenseSource.valueOf(it) },
+        licenseSources = licenseSources.mapTo(enumSetOf()) { it.mapToOrt() },
         severity = severity.mapToOrt(),
         message = message,
         howToFix = howToFix

--- a/services/ort-run/src/test/kotlin/OrtRunServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/OrtRunServiceTest.kt
@@ -74,6 +74,7 @@ import org.eclipse.apoapsis.ortserver.model.runs.Environment
 import org.eclipse.apoapsis.ortserver.model.runs.EvaluatorRun
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
+import org.eclipse.apoapsis.ortserver.model.runs.LicenseSource
 import org.eclipse.apoapsis.ortserver.model.runs.RemoteArtifact
 import org.eclipse.apoapsis.ortserver.model.runs.RuleViolation
 import org.eclipse.apoapsis.ortserver.model.runs.VcsInfo
@@ -1035,7 +1036,7 @@ class OrtRunServiceTest : WordSpec({
                         rule = "rule",
                         fixtures.identifier,
                         license = "license",
-                        licenseSources = setOf("CONCLUDED", "DECLARED"),
+                        licenseSources = setOf(LicenseSource.CONCLUDED, LicenseSource.DECLARED),
                         severity = Severity.ERROR,
                         message = "the rule is violated",
                         howToFix = "how to fix info"
@@ -1060,7 +1061,7 @@ class OrtRunServiceTest : WordSpec({
                         rule = "rule",
                         fixtures.identifier,
                         license = "license",
-                        licenseSources = setOf("CONCLUDED"),
+                        licenseSources = setOf(LicenseSource.CONCLUDED),
                         severity = Severity.ERROR,
                         message = "the rule is violated",
                         howToFix = howToFix

--- a/services/ort-run/src/test/kotlin/RuleViolationServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/RuleViolationServiceTest.kt
@@ -40,6 +40,7 @@ import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.PackageCuratio
 import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.ResolvedItemsResult
 import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.ResolvedPackageCurations
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
+import org.eclipse.apoapsis.ortserver.model.runs.LicenseSource
 import org.eclipse.apoapsis.ortserver.model.runs.RuleViolation
 import org.eclipse.apoapsis.ortserver.model.runs.RuleViolationFilters
 import org.eclipse.apoapsis.ortserver.model.runs.repository.PackageCuration
@@ -98,7 +99,7 @@ class RuleViolationServiceTest : WordSpec() {
 
                     rule shouldBe "Rule-1"
                     license shouldBe "License-1"
-                    licenseSources shouldBe setOf("CONCLUDED")
+                    licenseSources shouldBe setOf(LicenseSource.CONCLUDED)
                     severity shouldBe Severity.WARNING
                     message shouldBe "Message-1"
                     howToFix shouldBe "How_to_fix-1"
@@ -114,7 +115,7 @@ class RuleViolationServiceTest : WordSpec() {
                 with(results[1]) {
                     rule shouldBe "Rule-2"
                     license shouldBe "License-2"
-                    licenseSources shouldBe setOf("DETECTED")
+                    licenseSources shouldBe setOf(LicenseSource.DETECTED)
                     severity shouldBe Severity.ERROR
                     message shouldBe "Message-2"
                     howToFix shouldBe "How_to_fix-2"
@@ -130,7 +131,7 @@ class RuleViolationServiceTest : WordSpec() {
                 with(results[2]) {
                     rule shouldBe "Rule-3-no-id"
                     license shouldBe "License-3"
-                    licenseSources shouldBe setOf("CONCLUDED", "DECLARED")
+                    licenseSources shouldBe setOf(LicenseSource.CONCLUDED, LicenseSource.DECLARED)
                     severity shouldBe Severity.HINT
                     message shouldBe "Message-3"
                     howToFix shouldBe "How_to_fix-3"
@@ -215,7 +216,7 @@ class RuleViolationServiceTest : WordSpec() {
                         "Rule-4-project-id",
                         proj.identifier,
                         "License-4",
-                        setOf("DECLARED"),
+                        setOf(LicenseSource.DECLARED),
                         Severity.WARNING,
                         "Message-4",
                         "How_to_fix-4"
@@ -275,7 +276,7 @@ class RuleViolationServiceTest : WordSpec() {
                                 "2.14.0"
                             ),
                             "License-1",
-                            setOf("CONCLUDED"),
+                            setOf(LicenseSource.CONCLUDED),
                             Severity.WARNING,
                             "Message-1",
                             "How_to_fix-1"
@@ -303,7 +304,7 @@ class RuleViolationServiceTest : WordSpec() {
                                 "2.14.0"
                             ),
                             "License-1",
-                            setOf("CONCLUDED"),
+                            setOf(LicenseSource.CONCLUDED),
                             Severity.HINT,
                             "Message-1",
                             "How_to_fix-1"
@@ -322,7 +323,7 @@ class RuleViolationServiceTest : WordSpec() {
                                 "2.14.0"
                             ),
                             "License-1",
-                            setOf("CONCLUDED"),
+                            setOf(LicenseSource.CONCLUDED),
                             Severity.WARNING,
                             "Message-1",
                             "How_to_fix-1"
@@ -355,7 +356,7 @@ class RuleViolationServiceTest : WordSpec() {
                                 "2.14.0"
                             ),
                             "License-1",
-                            setOf("CONCLUDED"),
+                            setOf(LicenseSource.CONCLUDED),
                             Severity.WARNING,
                             "Message-1",
                             "How_to_fix-1"
@@ -457,7 +458,7 @@ class RuleViolationServiceTest : WordSpec() {
                         "Rule-4",
                         Identifier("Maven", "org.example", "lib", "1.0"),
                         "License-4",
-                        setOf("CONCLUDED"),
+                        setOf(LicenseSource.CONCLUDED),
                         Severity.ERROR,
                         "Message-4",
                         "How_to_fix-4"
@@ -552,7 +553,7 @@ class RuleViolationServiceTest : WordSpec() {
                     "2.14.0"
                 ),
                 "License-1",
-                setOf("CONCLUDED"),
+                setOf(LicenseSource.CONCLUDED),
                 Severity.WARNING,
                 "Message-1",
                 "How_to_fix-1"
@@ -566,7 +567,7 @@ class RuleViolationServiceTest : WordSpec() {
                     "2.9.6"
                 ),
                 "License-2",
-                setOf("DETECTED"),
+                setOf(LicenseSource.DETECTED),
                 Severity.ERROR,
                 "Message-2",
                 "How_to_fix-2"
@@ -575,7 +576,7 @@ class RuleViolationServiceTest : WordSpec() {
                 "Rule-3-no-id",
                 null,
                 "License-3",
-                setOf("CONCLUDED", "DECLARED"),
+                setOf(LicenseSource.CONCLUDED, LicenseSource.DECLARED),
                 Severity.HINT,
                 "Message-3",
                 "How_to_fix-3"


### PR DESCRIPTION
Introduce enums for the license source in the backend and API models to align with the ORT model.

Mappings between the enum types are done explicitly instead of using `enumValueOf()` to allow managing breaking changes and to ensure that changes in the upstream ORT enum are not missed as they require adapting the server enums and potentially a database migration.