### PR TITLE
Show unresolved/total counts in all statistics cards

### DIFF
--- a/ui/src/routes/organizations/$orgId/-components/organization-issues-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-issues-statistics-card.tsx
@@ -40,14 +40,16 @@ export const OrganizationIssuesStatisticsCard = ({
     }),
   });
 
-  const total = data.data.issuesCount;
+  const unresolved = data.data.issuesCount;
+  const total = data.data.issuesCountTotal;
   const counts = data.data.issuesCountBySeverity;
 
   return (
     <StatisticsCard
       title='Issues'
       icon={() => <Bug className='h-4 w-4 text-green-500' />}
-      value={total || '-'}
+      value={unresolved || '-'}
+      total={total || undefined}
       counts={
         counts
           ? Object.entries(counts).map(([severity, count]) => ({

--- a/ui/src/routes/organizations/$orgId/-components/organization-violations-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-violations-statistics-card.tsx
@@ -40,14 +40,16 @@ export const OrganizationViolationsStatisticsCard = ({
     }),
   });
 
-  const total = data.data.ruleViolationsCount;
+  const unresolved = data.data.ruleViolationsCount;
+  const total = data.data.ruleViolationsCountTotal;
   const counts = data.data.ruleViolationsCountBySeverity;
 
   return (
     <StatisticsCard
       title='Rule Violations'
       icon={() => <Scale className='h-4 w-4 text-green-500' />}
-      value={total || '-'}
+      value={unresolved || '-'}
+      total={total || undefined}
       counts={
         counts
           ? Object.entries(counts).map(([severity, count]) => ({

--- a/ui/src/routes/organizations/$orgId/-components/organization-vulnerabilities-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-vulnerabilities-statistics-card.tsx
@@ -40,14 +40,16 @@ export const OrganizationVulnerabilitiesStatisticsCard = ({
     }),
   });
 
-  const total = data.data.vulnerabilitiesCount;
+  const unresolved = data.data.vulnerabilitiesCount;
+  const total = data.data.vulnerabilitiesCountTotal;
   const counts = data.data.vulnerabilitiesCountByRating;
 
   return (
     <StatisticsCard
       title='Vulnerabilities'
       icon={() => <ShieldQuestion className='h-4 w-4 text-green-500' />}
-      value={total || '-'}
+      value={unresolved || '-'}
+      total={total || undefined}
       counts={
         counts
           ? Object.entries(counts).map(([rating, count]) => ({

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-issues-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-issues-statistics-card.tsx
@@ -40,14 +40,16 @@ export const ProductIssuesStatisticsCard = ({
     }),
   });
 
-  const total = data.data.issuesCount;
+  const unresolved = data.data.issuesCount;
+  const total = data.data.issuesCountTotal;
   const counts = data.data.issuesCountBySeverity;
 
   return (
     <StatisticsCard
       title='Issues'
       icon={() => <Bug className='h-4 w-4 text-green-500' />}
-      value={total || '-'}
+      value={unresolved || '-'}
+      total={total || undefined}
       counts={
         counts
           ? Object.entries(counts).map(([severity, count]) => ({

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-violations-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-violations-statistics-card.tsx
@@ -40,14 +40,16 @@ export const ProductViolationsStatisticsCard = ({
     }),
   });
 
-  const total = data.data.ruleViolationsCount;
+  const unresolved = data.data.ruleViolationsCount;
+  const total = data.data.ruleViolationsCountTotal;
   const counts = data.data.ruleViolationsCountBySeverity;
 
   return (
     <StatisticsCard
       title='Rule Violations'
       icon={() => <Scale className='h-4 w-4 text-green-500' />}
-      value={total || '-'}
+      value={unresolved || '-'}
+      total={total || undefined}
       counts={
         counts
           ? Object.entries(counts).map(([severity, count]) => ({

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-vulnerabilities-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-vulnerabilities-statistics-card.tsx
@@ -40,14 +40,16 @@ export const ProductVulnerabilitiesStatisticsCard = ({
     }),
   });
 
-  const total = data.data.vulnerabilitiesCount;
+  const unresolved = data.data.vulnerabilitiesCount;
+  const total = data.data.vulnerabilitiesCountTotal;
   const counts = data.data.vulnerabilitiesCountByRating;
 
   return (
     <StatisticsCard
       title='Vulnerabilities'
       icon={() => <ShieldQuestion className='h-4 w-4 text-green-500' />}
-      value={total || '-'}
+      value={unresolved || '-'}
+      total={total || undefined}
       counts={
         counts
           ? Object.entries(counts).map(([rating, count]) => ({


### PR DESCRIPTION
Align the UX of statistics cards throughout the UI by showing unresolved and total counts for vulnerabilities, rule violations and issues also on organization and product level.

<img width="1325" height="332" alt="Screenshot from 2026-01-26 10-32-02" src="https://github.com/user-attachments/assets/dfe0fe7e-ca19-42fc-acce-72f8db64ff24" />

Please see the commit for details.