### PR TITLE
Align Analyzer Docker image with ORT

### DIFF
--- a/workers/analyzer/docker/Analyzer.Dockerfile
+++ b/workers/analyzer/docker/Analyzer.Dockerfile
@@ -361,7 +361,16 @@ RUN mkdir -p $SWIFT_HOME \
     SWIFT_PACKAGE="ubuntu2204/swift-$SWIFT_VERSION-RELEASE/swift-$SWIFT_VERSION-RELEASE-ubuntu22.04.tar.gz"; \
     fi \
     && curl -L https://download.swift.org/swift-$SWIFT_VERSION-release/$SWIFT_PACKAGE \
-    | tar -xz -C $SWIFT_HOME --strip-components=2
+    | tar -xz -C $SWIFT_HOME --strip-components=2 \
+    # Prune Swift installation: remove debugging tools, IDE support, static libraries,
+    # sanitizers, and other components not needed for 'swift package show-dependencies'.
+    && rm -rf \
+    $SWIFT_HOME/bin/{*-swift-linux-musl-clang*,clangd,docc,lldb*,plutil,repl_swift,sourcekit-lsp,wasm-ld,wasmkit} \
+    $SWIFT_HOME/bin/llvm-{cov,objcopy,objdump,profdata,symbolizer} \
+    $SWIFT_HOME/bin/swift-{api-checker.py,build-sdk-interfaces,demangle,format,help} \
+    $SWIFT_HOME/lib/{clang/*/lib,liblldb*,libLTO*,libsourcekitdInProc.so,lldb,sourcekitd.framework,swift_static} \
+    $SWIFT_HOME/lib/swift/{embedded,FrameworkABIBaseline,migrator} \
+    $SWIFT_HOME/{libexec,local,share}
 
 FROM scratch AS swift
 COPY --from=swiftbuild /opt/swift /opt/swift


### PR DESCRIPTION
This PR integrates the recent modifications of the ORT Docker image to Analyzer Docker image. The commit list used for mirroring the changes is this:
https://github.com/oss-review-toolkit/ort/commits/main/Dockerfile

The changes involve size reductions as well as adding support for Gleam.

NOTE 1: The author has tried to mirror only changes he deemed relevant, and there can be errors.
NOTE 2: Disappointingly, the dramatic size reductions from commits https://github.com/oss-review-toolkit/ort/commit/586dcee992e9b0d56e5d0b9065b74915be686829 and https://github.com/oss-review-toolkit/ort/commit/222c28c298f26a9c75145a5446cd2edf3736c72d are not seen quite as big in the Analyzer image. This might very well be due to an error made by the author, so changes should be reviewed carefully.
NOTE 3: Gleam support is also verified with some temporary additions to the UI and analyzing some trivial Gleam repositories. Full support for Gleam in the UI will be added as a follow-up PR, so this image is only a preview.

<img width="1346" height="699" alt="Screenshot from 2026-02-03 11-37-44" src="https://github.com/user-attachments/assets/74c41cc0-754c-4908-89e4-c7ce90d0e0ae" />
