### PR TITLE
fix(ui): Add missing Tycho package manager to UI

### DIFF
--- a/ui/src/helpers/get-status-class.ts
+++ b/ui/src/helpers/get-status-class.ts
@@ -218,6 +218,8 @@ export function getEcosystemBackgroundColor(
       return 'bg-slate-400';
     case 'SwiftPM':
       return 'bg-rose-500';
+    case 'Tycho':
+      return 'bg-indigo-700';
     case 'Yarn':
       return 'bg-teal-600';
     case 'Yarn2':

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -197,6 +197,10 @@ export const packageManagers = [
     label: 'SwiftPM (Swift)',
   },
   {
+    id: 'Tycho',
+    label: 'Tycho (Java)',
+  },
+  {
     id: 'Yarn',
     label: 'Yarn 1 (JavaScript / Node.js)',
   },

--- a/ui/src/routes/admin/colors/index.tsx
+++ b/ui/src/routes/admin/colors/index.tsx
@@ -191,7 +191,7 @@ const ColorsComponent = () => {
               <TableRow>
                 <TableCell>Java/Kotlin</TableCell>
                 <TableCell className='flex gap-2'>
-                  {['Gradle', 'GradleInspector', 'Maven'].map((p) => (
+                  {['Gradle', 'GradleInspector', 'Maven', 'Tycho'].map((p) => (
                     <Badge
                       className={`border ${getEcosystemBackgroundColor(p)}`}
                     >

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
@@ -101,6 +101,7 @@ export const createRunFormSchema = z.object({
           SpdxDocumentFile: packageManagerOptionsSchema,
           Stack: packageManagerOptionsSchema,
           SwiftPM: packageManagerOptionsSchema,
+          Tycho: packageManagerOptionsSchema,
           Yarn: packageManagerOptionsSchema,
           Yarn2: packageManagerOptionsSchema,
         })
@@ -321,6 +322,7 @@ export function defaultValues(
           SpdxDocumentFile: defaultPackageManagerOptions('SpdxDocumentFile'),
           Stack: defaultPackageManagerOptions('Stack'),
           SwiftPM: defaultPackageManagerOptions('SwiftPM'),
+          Tycho: defaultPackageManagerOptions('Tycho'),
           Yarn: defaultPackageManagerOptions('Yarn'),
           Yarn2: defaultPackageManagerOptions('Yarn2'),
         },


### PR DESCRIPTION
Tycho was not part of the list of package managers shown in the UI.

This PR has been created without deeper understanding of the underlying mechanisms of the UI - by just doing things analogously to other package managers. I may well have missed essential parts. So, please review carefully.