### PR TITLE
chore: Remove unused Keycloak config options

### DIFF
--- a/clients/keycloak/src/main/kotlin/KeycloakClientConfiguration.kt
+++ b/clients/keycloak/src/main/kotlin/KeycloakClientConfiguration.kt
@@ -39,19 +39,6 @@ data class KeycloakClientConfiguration(
     val apiUser: String,
     val apiSecret: String,
 
-    /**
-     * The (external) ID of the client to be manipulated by the Keycloak client. The roles of this client will be
-     * updated.
-     */
-    val subjectClientId: String,
-
-    /**
-     * The size of the chunks in which data is fetched from Keycloak. This is used to avoid timeouts when fetching
-     * large lists of results (i.e. groups). In the future this param can be parameterized just by adding an entry
-     * to the [ConfigManager.createKeycloakClientConfiguration] method.
-     */
-    val dataGetChunkSize: Int = DEFAULT_DATA_GET_CHUNK_SIZE,
-
     /** A timeout to be applied to all requests against the Keycloak server. */
     val timeout: Duration = DEFAULT_TIMEOUT
 ) {

--- a/clients/keycloak/src/test/kotlin/DefaultKeycloakClientTest.kt
+++ b/clients/keycloak/src/test/kotlin/DefaultKeycloakClientTest.kt
@@ -123,7 +123,6 @@ class DefaultKeycloakClientTest : WordSpec() {
                         accessTokenUrl = "${server.baseUrl()}/realms/some-realm/protocol/openid-connect/token",
                         apiUser = "some-user",
                         apiSecret = "some-secret",
-                        subjectClientId = "some-subject-client",
                         timeout = 50.milliseconds
                     )
 

--- a/clients/keycloak/src/testFixtures/kotlin/Extensions.kt
+++ b/clients/keycloak/src/testFixtures/kotlin/Extensions.kt
@@ -72,8 +72,7 @@ fun User.toUserRepresentation(
 fun KeycloakContainer.createKeycloakClientConfigurationForTestRealm(
     secret: String = TEST_REALM_ADMIN_PASSWORD,
     user: String = TEST_REALM_ADMIN_USERNAME,
-    clientId: String = TEST_CLIENT,
-    dataGetChunkSize: Int = 9999
+    clientId: String = TEST_CLIENT
 ) =
     KeycloakClientConfiguration(
         baseUrl = authServerUrl,
@@ -82,9 +81,7 @@ fun KeycloakContainer.createKeycloakClientConfigurationForTestRealm(
         clientId = clientId,
         accessTokenUrl = "$authServerUrl/realms/$TEST_REALM/protocol/openid-connect/token",
         apiUser = user,
-        apiSecret = secret,
-        subjectClientId = TEST_SUBJECT_CLIENT,
-        dataGetChunkSize = dataGetChunkSize
+        apiSecret = secret
     )
 
 /**
@@ -100,8 +97,7 @@ fun KeycloakContainer.createKeycloakConfigMapForTestRealm() =
             "keycloak.clientId" to config.clientId,
             "keycloak.accessTokenUrl" to config.accessTokenUrl,
             "keycloak.apiUser" to config.apiUser,
-            "keycloak.apiSecret" to config.apiSecret,
-            "keycloak.subjectClientId" to config.subjectClientId
+            "keycloak.apiSecret" to config.apiSecret
         )
     }
 
@@ -114,7 +110,7 @@ fun KeycloakContainer.createJwtConfigMapForTestRealm() =
         "jwt.jwksUri" to "$authServerUrl/realms/$TEST_REALM/protocol/openid-connect/certs",
         "jwt.issuer" to "$authServerUrl/realms/$TEST_REALM",
         "jwt.realm" to TEST_REALM,
-        "jwt.audience" to TEST_SUBJECT_CLIENT,
+        "jwt.audience" to TEST_CLIENT,
         "jwt.roleCacheLifetimeSeconds" to "0"
     )
 
@@ -138,7 +134,7 @@ private fun audienceMapper(audience: String) = ProtocolMapperRepresentation().ap
  * the default scopes of the [TEST_CLIENT].
  */
 fun Keycloak.setUpClientScope(audience: String) {
-    val subjectClientScope = "$TEST_SUBJECT_CLIENT-scope"
+    val subjectClientScope = "$TEST_CLIENT-scope"
 
     realm(TEST_REALM).apply {
         clientScopes().create(
@@ -163,11 +159,11 @@ fun Keycloak.setUpUser(user: User, password: String) {
 }
 
 /**
- * Create the provided [roles] in the [TEST_SUBJECT_CLIENT] and assign them to the provided [username].
+ * Create the provided [roles] in the [TEST_CLIENT] and assign them to the provided [username].
  */
 fun Keycloak.setUpUserRoles(username: String, roles: List<String>) {
     realm(TEST_REALM).apply {
-        val client = clients().findByClientId(TEST_SUBJECT_CLIENT).single()
+        val client = clients().findByClientId(TEST_CLIENT).single()
 
         val roleRepresentations = roles.map { role ->
             clients().get(client.id).roles().run {

--- a/clients/keycloak/src/testFixtures/kotlin/TestRealm.kt
+++ b/clients/keycloak/src/testFixtures/kotlin/TestRealm.kt
@@ -58,9 +58,6 @@ const val TEST_CONFIDENTIAL_CLIENT = "test-confidential-client"
 /** A secret used by the confidential test client. */
 const val TEST_CLIENT_SECRET = "abcdefghijklmnopqrstuvwxyz"
 
-/** The name of a test client that is subject to role manipulations. */
-const val TEST_SUBJECT_CLIENT = "subjectClient"
-
 /**
  * A test [realm configuration][RealmRepresentation] that creates a [realm][TEST_REALM] with two clients that can be
  * used to access it:
@@ -69,9 +66,6 @@ const val TEST_SUBJECT_CLIENT = "subjectClient"
  *   [TEST_REALM_ADMIN_PASSWORD].
  * - [TEST_CONFIDENTIAL_CLIENT] is a confidential client that supports the client credentials flow with
  *   [TEST_CLIENT_SECRET] as secret. Note: To use it, it must be assigned corresponding client roles.
- *
- * There is one additional [client][TEST_SUBJECT_CLIENT] that is the subject of role manipulations. It is not used for
- * authentication, but role manipulations are done on this client.
  */
 val testRealm = RealmRepresentation().apply {
     realm = TEST_REALM
@@ -90,12 +84,6 @@ val testRealm = RealmRepresentation().apply {
             isPublicClient = false
             isServiceAccountsEnabled = true
             secret = TEST_CLIENT_SECRET
-        },
-        ClientRepresentation().apply {
-            id = TEST_SUBJECT_CLIENT
-            isEnabled = true
-            isPublicClient = true
-            isStandardFlowEnabled = true
         }
     )
 

--- a/core/src/main/kotlin/utils/Extensions.kt
+++ b/core/src/main/kotlin/utils/Extensions.kt
@@ -51,7 +51,6 @@ fun ConfigManager.createKeycloakClientConfiguration(): KeycloakClientConfigurati
         accessTokenUrl = tryGetString("keycloak.accessTokenUrl") ?: defaultAccessTokenUrl,
         apiUser = getString("keycloak.apiUser"),
         apiSecret = getSecret(Path("keycloak.apiSecret")),
-        subjectClientId = getString("keycloak.subjectClientId"),
         timeout = getInt("keycloak.timeoutSeconds").seconds
     )
 }

--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -70,8 +70,6 @@ keycloak {
   apiUser = ${?KEYCLOAK_API_USER}
   apiSecret = "admin"
   apiSecret = ${?KEYCLOAK_API_SECRET}
-  subjectClientId = "ort-server"
-  subjectClientId = ${?KEYCLOAK_SUBJECT_CLIENT_ID}
   groupPrefix = ""
   groupPrefix = ${?KEYCLOAK_GROUP_PREFIX}
   migrationGroupPrefix = ${?KEYCLOAK_MIGRATION_GROUP_PREFIX}

--- a/core/src/test/kotlin/api/AbstractIntegrationTest.kt
+++ b/core/src/test/kotlin/api/AbstractIntegrationTest.kt
@@ -32,7 +32,7 @@ import kotlinx.serialization.json.Json
 
 import org.eclipse.apoapsis.ortserver.clients.keycloak.DefaultKeycloakClient.Companion.configureAuthentication
 import org.eclipse.apoapsis.ortserver.clients.keycloak.test.KeycloakTestExtension
-import org.eclipse.apoapsis.ortserver.clients.keycloak.test.TEST_SUBJECT_CLIENT
+import org.eclipse.apoapsis.ortserver.clients.keycloak.test.TEST_CLIENT
 import org.eclipse.apoapsis.ortserver.clients.keycloak.test.createJwtConfigMapForTestRealm
 import org.eclipse.apoapsis.ortserver.clients.keycloak.test.createKeycloakClientConfigurationForTestRealm
 import org.eclipse.apoapsis.ortserver.clients.keycloak.test.createKeycloakConfigMapForTestRealm
@@ -70,7 +70,7 @@ abstract class AbstractIntegrationTest(
     val keycloak = install(KeycloakTestExtension(createRealmPerTest = createKeycloakRealmPerTest)) {
         setUpUser(SUPERUSER, SUPERUSER_PASSWORD)
         setUpUser(TEST_USER, TEST_USER_PASSWORD)
-        setUpClientScope(TEST_SUBJECT_CLIENT)
+        setUpClientScope(TEST_CLIENT)
     }
 
     private val keycloakConfig = keycloak.createKeycloakConfigMapForTestRealm()

--- a/core/src/test/kotlin/api/AuthenticationRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/AuthenticationRouteIntegrationTest.kt
@@ -28,7 +28,7 @@ import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 
 import org.eclipse.apoapsis.ortserver.api.v1.model.OidcConfig
-import org.eclipse.apoapsis.ortserver.clients.keycloak.test.TEST_SUBJECT_CLIENT
+import org.eclipse.apoapsis.ortserver.clients.keycloak.test.TEST_CLIENT
 import org.eclipse.apoapsis.ortserver.utils.test.Integration
 
 class AuthenticationRouteIntegrationTest : AbstractIntegrationTest({
@@ -44,7 +44,7 @@ class AuthenticationRouteIntegrationTest : AbstractIntegrationTest({
 
                 with(body) {
                     accessTokenUrl shouldEndWith "/protocol/openid-connect/token"
-                    clientId shouldBe TEST_SUBJECT_CLIENT
+                    clientId shouldBe TEST_CLIENT
                 }
             }
         }

--- a/core/src/test/kotlin/api/ErrorsIntegrationTest.kt
+++ b/core/src/test/kotlin/api/ErrorsIntegrationTest.kt
@@ -32,7 +32,7 @@ import kotlinx.serialization.json.Json
 
 import org.eclipse.apoapsis.ortserver.clients.keycloak.DefaultKeycloakClient.Companion.configureAuthentication
 import org.eclipse.apoapsis.ortserver.clients.keycloak.test.KeycloakTestExtension
-import org.eclipse.apoapsis.ortserver.clients.keycloak.test.TEST_SUBJECT_CLIENT
+import org.eclipse.apoapsis.ortserver.clients.keycloak.test.TEST_CLIENT
 import org.eclipse.apoapsis.ortserver.clients.keycloak.test.createJwtConfigMapForTestRealm
 import org.eclipse.apoapsis.ortserver.clients.keycloak.test.createKeycloakClientConfigurationForTestRealm
 import org.eclipse.apoapsis.ortserver.clients.keycloak.test.createKeycloakConfigMapForTestRealm
@@ -58,7 +58,7 @@ class ErrorsIntegrationTest : StringSpec() {
     private val keycloak = install(KeycloakTestExtension()) {
         setUpUser(SUPERUSER, SUPERUSER_PASSWORD)
         setUpUserRoles(SUPERUSER.username.value, listOf(Superuser.ROLE_NAME))
-        setUpClientScope(TEST_SUBJECT_CLIENT)
+        setUpClientScope(TEST_CLIENT)
     }
 
     private val keycloakConfig = keycloak.createKeycloakConfigMapForTestRealm()

--- a/core/src/test/kotlin/auth/AuthenticationIntegrationTest.kt
+++ b/core/src/test/kotlin/auth/AuthenticationIntegrationTest.kt
@@ -40,7 +40,6 @@ import kotlinx.serialization.json.Json
 import org.eclipse.apoapsis.ortserver.clients.keycloak.DefaultKeycloakClient.Companion.configureAuthentication
 import org.eclipse.apoapsis.ortserver.clients.keycloak.test.KeycloakTestExtension
 import org.eclipse.apoapsis.ortserver.clients.keycloak.test.TEST_CLIENT
-import org.eclipse.apoapsis.ortserver.clients.keycloak.test.TEST_SUBJECT_CLIENT
 import org.eclipse.apoapsis.ortserver.clients.keycloak.test.createJwtConfigMapForTestRealm
 import org.eclipse.apoapsis.ortserver.clients.keycloak.test.createKeycloakClientConfigurationForTestRealm
 import org.eclipse.apoapsis.ortserver.clients.keycloak.test.createKeycloakConfigMapForTestRealm
@@ -95,7 +94,7 @@ class AuthenticationIntegrationTest : StringSpec({
         }
 
     "A request with a valid token should be accepted" {
-        keycloak.keycloakAdminClient.setUpClientScope(TEST_SUBJECT_CLIENT)
+        keycloak.keycloakAdminClient.setUpClientScope(TEST_CLIENT)
 
         authTestApplication {
             val authenticatedClient = client.configureAuthentication(testUserClientConfig, json)
@@ -105,7 +104,7 @@ class AuthenticationIntegrationTest : StringSpec({
     }
 
     "A request without a token should be rejected" {
-        keycloak.keycloakAdminClient.setUpClientScope(TEST_SUBJECT_CLIENT)
+        keycloak.keycloakAdminClient.setUpClientScope(TEST_CLIENT)
 
         authTestApplication {
             client.get("/api/v1/test") shouldHaveStatus HttpStatusCode.Unauthorized
@@ -121,7 +120,7 @@ class AuthenticationIntegrationTest : StringSpec({
     }
 
     "A token with a wrong audience claim should be rejected" {
-        keycloak.keycloakAdminClient.setUpClientScope(TEST_CLIENT)
+        keycloak.keycloakAdminClient.setUpClientScope("wrong-client")
 
         authTestApplication {
             val authenticatedClient = client.configureAuthentication(testUserClientConfig, json)
@@ -131,7 +130,7 @@ class AuthenticationIntegrationTest : StringSpec({
     }
 
     "A principal with correct properties should be created" {
-        keycloak.keycloakAdminClient.setUpClientScope(TEST_SUBJECT_CLIENT)
+        keycloak.keycloakAdminClient.setUpClientScope(TEST_CLIENT)
 
         authTestApplication(onCall = {
             val principal = call.principal<OrtServerPrincipal>(AuthenticationProviders.TOKEN_PROVIDER)

--- a/core/src/test/kotlin/utils/ExtensionsTest.kt
+++ b/core/src/test/kotlin/utils/ExtensionsTest.kt
@@ -253,7 +253,6 @@ class ExtensionsTest : WordSpec({
                 "keycloak.baseUrl" to "http://localhost:8080",
                 "keycloak.realm" to "myrealm",
                 "keycloak.clientId" to "myclient",
-                "keycloak.subjectClientId" to "subjectclient",
                 "keycloak.apiUser" to "user",
                 "keycloak.apiSecret" to "secret",
                 "keycloak.timeoutSeconds" to 30
@@ -265,13 +264,11 @@ class ExtensionsTest : WordSpec({
             keycloakClientConfig.baseUrl shouldBe "http://localhost:8080"
             keycloakClientConfig.realm shouldBe "myrealm"
             keycloakClientConfig.clientId shouldBe "myclient"
-            keycloakClientConfig.subjectClientId shouldBe "subjectclient"
             keycloakClientConfig.apiSecret shouldBe "secret"
             keycloakClientConfig.apiUser shouldBe "user"
             keycloakClientConfig.apiUrl shouldBe "http://localhost:8080/admin/realms/myrealm"
             keycloakClientConfig.accessTokenUrl shouldBe
                     "http://localhost:8080/realms/myrealm/protocol/openid-connect/token"
-            keycloakClientConfig.dataGetChunkSize shouldBe 5000
             keycloakClientConfig.timeout shouldBe 30.seconds
         }
     }

--- a/shared/ktor-utils/src/testFixtures/kotlin/AbstractAuthorizationTest.kt
+++ b/shared/ktor-utils/src/testFixtures/kotlin/AbstractAuthorizationTest.kt
@@ -47,7 +47,7 @@ import org.eclipse.apoapsis.ortserver.clients.keycloak.User
 import org.eclipse.apoapsis.ortserver.clients.keycloak.UserId
 import org.eclipse.apoapsis.ortserver.clients.keycloak.UserName
 import org.eclipse.apoapsis.ortserver.clients.keycloak.test.KeycloakTestExtension
-import org.eclipse.apoapsis.ortserver.clients.keycloak.test.TEST_SUBJECT_CLIENT
+import org.eclipse.apoapsis.ortserver.clients.keycloak.test.TEST_CLIENT
 import org.eclipse.apoapsis.ortserver.clients.keycloak.test.createJwtConfigMapForTestRealm
 import org.eclipse.apoapsis.ortserver.clients.keycloak.test.createKeycloakClientConfigurationForTestRealm
 import org.eclipse.apoapsis.ortserver.clients.keycloak.test.createKeycloakConfigMapForTestRealm
@@ -92,7 +92,7 @@ abstract class AbstractAuthorizationTest(body: AbstractAuthorizationTest.() -> U
 
     val keycloak = keycloakExtension.mount {
         setUpUser(TEST_USER, TEST_USER_PASSWORD)
-        setUpClientScope(TEST_SUBJECT_CLIENT)
+        setUpClientScope(TEST_CLIENT)
     }
 
     val json = Json { ignoreUnknownKeys = true }
@@ -118,7 +118,7 @@ abstract class AbstractAuthorizationTest(body: AbstractAuthorizationTest.() -> U
         testApplication {
             val config = MapApplicationConfig()
             (keycloakConfig + jwtConfig).forEach { config.put(it.key, it.value) }
-            config.put("jwt.audience", TEST_SUBJECT_CLIENT)
+            config.put("jwt.audience", TEST_CLIENT)
 
             environment {
                 this.config = config


### PR DESCRIPTION
The `subjectClientId` and `dataGetChunkSize` config options are not used anymore since 343e2ac.