### PR TITLE
build(gradle): Enforce the Kotlin version for JVM builds

### DIFF
--- a/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-conventions.gradle.kts
@@ -32,6 +32,8 @@ plugins {
 }
 
 dependencies {
+    implementation(enforcedPlatform(libs.kotlinBom))
+
     testImplementation(project(":utils:logging"))
     testImplementation(project(":utils:test"))
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -107,6 +107,7 @@ kotestExtensions = { module = "io.kotest:kotest-extensions", version.ref = "kote
 kotestExtensionsTestcontainers = { module = "io.kotest:kotest-extensions-testcontainers", version.ref = "kotest" }
 kotestFrameworkEngine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
 kotestRunnerJunit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
+kotlinBom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlinPlugin" }
 kotlinResult = { module = "com.michael-bull.kotlin-result:kotlin-result", version.ref = "kotlinResult" }
 kotlinxCoroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinxCoroutinesSlf4j = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-slf4j", version.ref = "kotlinxCoroutines" }


### PR DESCRIPTION
Use the Kotlin BOM to force all transitive dependencies on Kotlin libraries to the same version as used by the project. This avoids potential issue when different version of Kotlin are on the classpath. This is especially important when using Jib because it may copy the wrong version of a library to `/app/libs` if multiple versions of it are on the runtime classpath.

Fixes #4419.