### PR TITLE
ui: Use optionally an arrow between key-value pairs

### DIFF
--- a/ui/src/components/formatted-value.tsx
+++ b/ui/src/components/formatted-value.tsx
@@ -17,16 +17,20 @@
  * License-Filename: LICENSE
  */
 
+import { MoveRight } from 'lucide-react';
+
 import { valueOrNa } from '@/helpers/value-or-na'; // Adjust import path as needed
 
 type FormattedValueProps<T> = {
   value: T | T[] | Record<string, unknown> | null | undefined;
   type?: 'string' | 'array' | 'url' | 'keyvalue';
+  useArrows?: boolean;
 };
 
 export const FormattedValue = <T,>({
   value,
   type = 'string',
+  useArrows = false,
 }: FormattedValueProps<T>) => {
   const arrayFormat =
     type === 'array' || type === 'keyvalue' ? 'array' : 'string';
@@ -64,8 +68,12 @@ export const FormattedValue = <T,>({
             {entries
               .sort(([a], [b]) => a.localeCompare(b))
               .map(([key, val], idx) => (
-                <div className='text-muted-foreground ml-2' key={idx}>
-                  {`${key}: ${String(val)}`}
+                <div
+                  className='text-muted-foreground ml-2 flex items-center gap-1'
+                  key={idx}
+                >
+                  {key} {useArrows ? <MoveRight size={16} /> : ':'}{' '}
+                  {String(val)}
                 </div>
               ))}
           </div>

--- a/ui/src/components/package-curation.tsx
+++ b/ui/src/components/package-curation.tsx
@@ -182,6 +182,7 @@ export const PackageCuration = ({ curation }: PackageCurationProps) => {
                     label='Declared License Mapping'
                     value={curation.data.declaredLicenseMapping}
                     type='keyvalue'
+                    useArrowsInKeyValue
                     showIfEmpty={false}
                   />
                 )}

--- a/ui/src/components/render-property.tsx
+++ b/ui/src/components/render-property.tsx
@@ -24,6 +24,7 @@ type RenderPropertyProps<T> = {
   value: T | T[] | Record<string, unknown> | null | undefined;
   type?: 'string' | 'textblock' | 'array' | 'url' | 'keyvalue';
   showIfEmpty?: boolean;
+  useArrowsInKeyValue?: boolean;
 };
 
 export const RenderProperty = <T,>({
@@ -31,6 +32,7 @@ export const RenderProperty = <T,>({
   value,
   type = 'string',
   showIfEmpty = true,
+  useArrowsInKeyValue = false,
 }: RenderPropertyProps<T>) => {
   if (value || showIfEmpty) {
     switch (type) {
@@ -43,7 +45,11 @@ export const RenderProperty = <T,>({
               {label}
               {isEmpty && ':'}
             </div>
-            <FormattedValue value={value} type={type} />
+            <FormattedValue
+              value={value}
+              type={type}
+              useArrows={useArrowsInKeyValue}
+            />
           </div>
         );
       }


### PR DESCRIPTION
<img width="1079" height="394" alt="Screenshot from 2026-02-13 12-21-31" src="https://github.com/user-attachments/assets/8ca8c795-d44e-4921-a609-b26398290ceb" />

Please see the commit for details.