### PR TITLE
feat(cli): Support the system CA bundle under Linux

### DIFF
--- a/api/v1/client/build.gradle.kts
+++ b/api/v1/client/build.gradle.kts
@@ -43,6 +43,7 @@ kotlin {
                 implementation(ktorLibs.client.auth)
                 implementation(ktorLibs.client.contentNegotiation)
                 implementation(ktorLibs.serialization.kotlinx.json)
+                implementation(libs.okio)
             }
         }
 

--- a/api/v1/client/src/commonMain/kotlin/HttpClientUtils.kt
+++ b/api/v1/client/src/commonMain/kotlin/HttpClientUtils.kt
@@ -53,6 +53,13 @@ import org.eclipse.apoapsis.ortserver.utils.system.getEnv
 private val proxyEnvironmentVariables = sequenceOf("HTTP_PROXY", "http_proxy", "HTTPS_PROXY", "https_proxy")
 
 /**
+ * Platform-specific configuration for the HTTP client engine to handle SSL certificates correctly.
+ * This is particularly important for native platforms (Linux with Curl engine) where the system trust store
+ * is not automatically used.
+ */
+internal expect fun HttpClientConfig<*>.configurePlatformSpecificSsl()
+
+/**
  * Create a default HTTP client with the given [json] configuration and [engine]. If no engine is provided, it will
  * choose the engine automatically based on the platform. If [maxRetriesOnTimeout] is greater than zero, the client
  * will retry requests that failed due to a timeout or received a 504 Gateway Timeout response up to the given
@@ -70,6 +77,9 @@ fun createDefaultHttpClient(
                 proxy = ProxyBuilder.http(proxyUrl)
             }
         }
+
+        // Configure platform-specific SSL settings.
+        configurePlatformSpecificSsl()
     }
 
     return client.config {

--- a/api/v1/client/src/jvmMain/kotlin/HttpClientUtilsJvm.kt
+++ b/api/v1/client/src/jvmMain/kotlin/HttpClientUtilsJvm.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.client
+
+import io.ktor.client.HttpClientConfig
+
+/**
+ * JVM-specific implementation. The OkHttp engine on JVM automatically uses the system trust store,
+ * so no additional configuration is needed.
+ */
+internal actual fun HttpClientConfig<*>.configurePlatformSpecificSsl() {
+    // No additional configuration needed for JVM/OkHttp - it uses the system trust store automatically
+}

--- a/api/v1/client/src/linuxMain/kotlin/HttpClientUtilsLinux.kt
+++ b/api/v1/client/src/linuxMain/kotlin/HttpClientUtilsLinux.kt
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.client
+
+import io.ktor.client.HttpClientConfig
+import io.ktor.client.engine.curl.CurlClientEngineConfig
+
+import okio.FileSystem
+import okio.Path.Companion.toPath
+
+import org.eclipse.apoapsis.ortserver.utils.system.getEnv
+
+/**
+ * Environment variables that can be used to configure the SSL CA bundle path.
+ */
+private val caBundleEnvironmentVariables = sequenceOf("SSL_CERT_FILE", "CURL_CA_BUNDLE")
+
+/**
+ * Common paths where SSL CA certificates are typically located on Linux systems.
+ */
+private val commonCaBundlePaths = sequenceOf(
+    "/etc/ssl/certs/ca-certificates.crt", // Debian/Ubuntu/Gentoo etc.
+    "/etc/pki/tls/certs/ca-bundle.crt", // Fedora/RHEL/CentOS
+    "/etc/ssl/ca-bundle.pem", // OpenSUSE
+    "/etc/ssl/cert.pem", // Alpine Linux
+    "/etc/pki/tls/cert.pem" // Amazon Linux
+)
+
+/**
+ * Check if a file exists at the given [path].
+ */
+private fun fileExists(path: String): Boolean =
+    FileSystem.SYSTEM.exists(path.toPath())
+
+/**
+ * Find the CA bundle path from environment variables or common system locations.
+ */
+private fun findCaBundlePath(): String? {
+    // First, check environment variables
+    caBundleEnvironmentVariables.firstNotNullOfOrNull { getEnv(it) }?.let { path ->
+        if (fileExists(path)) return path
+    }
+
+    // Then check common system paths
+    return commonCaBundlePaths.firstOrNull { fileExists(it) }
+}
+
+/**
+ * Linux-specific implementation that configures the Curl engine to use the system CA bundle.
+ * The Curl engine does not automatically use the system trust store, so we need to explicitly
+ * configure the CA bundle path.
+ */
+@Suppress("UNCHECKED_CAST")
+internal actual fun HttpClientConfig<*>.configurePlatformSpecificSsl() {
+    val caBundlePath = findCaBundlePath()
+
+    if (caBundlePath != null) {
+        (this as? HttpClientConfig<CurlClientEngineConfig>)?.engine {
+            sslVerify = true
+            // Set the CA info path for the Curl engine to use the system CA bundle
+            caInfo = caBundlePath
+        }
+    }
+}

--- a/api/v1/client/src/macosMain/kotlin/HttpClientUtilsMacos.kt
+++ b/api/v1/client/src/macosMain/kotlin/HttpClientUtilsMacos.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.client
+
+import io.ktor.client.HttpClientConfig
+
+/**
+ * macOS-specific implementation. The Darwin engine on macOS automatically uses the system keychain,
+ * so no additional configuration is needed.
+ */
+internal actual fun HttpClientConfig<*>.configurePlatformSpecificSsl() {
+    // No additional configuration needed for macOS/Darwin - it uses the system keychain automatically
+}

--- a/api/v1/client/src/mingwMain/kotlin/HttpClientUtilsWindows.kt
+++ b/api/v1/client/src/mingwMain/kotlin/HttpClientUtilsWindows.kt
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.client
+
+import io.ktor.client.HttpClientConfig
+
+/**
+ * Windows-specific implementation. The WinHttp engine on Windows automatically uses the Windows certificate store,
+ * so no additional configuration is needed.
+ */
+internal actual fun HttpClientConfig<*>.configurePlatformSpecificSsl() {
+    // No additional configuration needed for Windows/WinHttp - it uses the Windows certificate store automatically
+}


### PR DESCRIPTION
In contrast to other platform-specific client engines, the curl engine used under Linux does not automatically use a system CA bundle, but needs to be explicitly configured for this purpose. Add an `expect` function to handle this configuration and provide a custom implementation for Linux. The other platforms can use empty dummy implementations.