### PR TITLE
build(logging): Turn an `implementation` dependency to an `api` one.

### DIFF
--- a/utils/logging/build.gradle.kts
+++ b/utils/logging/build.gradle.kts
@@ -31,9 +31,9 @@ group = "org.eclipse.apoapsis.ortserver.utils"
 
 dependencies {
     api(libs.kotlinxCoroutines)
+    api(libs.kotlinxSerializationJson)
 
     implementation(libs.kotlinxCoroutinesSlf4j)
-    implementation(libs.kotlinxSerializationJson)
     implementation(libs.logback)
     implementation(libs.slf4j)
 


### PR DESCRIPTION
This is a fixup for eb337552 which used the wrong dependency declaration for kotlinx serialization.