### PR TITLE
fix: Persist Analyzer/Advisor issues before resolution mapping

### DIFF
--- a/workers/advisor/src/main/kotlin/AdvisorWorker.kt
+++ b/workers/advisor/src/main/kotlin/AdvisorWorker.kt
@@ -95,8 +95,8 @@ internal class AdvisorWorker(
 
             db.dbQuery {
                 getValidAdvisorJob(jobId)
-                ortRunService.storeResolvedItems(job.ortRunId, resolvedItems)
                 ortRunService.storeAdvisorRun(advisorRun.mapToModel(jobId))
+                ortRunService.storeResolvedItems(job.ortRunId, resolvedItems)
             }
 
             // Calculate unresolved issues for logging.

--- a/workers/analyzer/src/main/kotlin/AnalyzerWorker.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerWorker.kt
@@ -158,8 +158,8 @@ internal class AnalyzerWorker(
 
             db.dbQuery {
                 getValidAnalyzerJob(jobId)
-                ortRunService.storeResolvedItems(job.ortRunId, resolvedItems)
                 ortRunService.storeAnalyzerRun(analyzerRun.mapToModel(jobId), shortestPathsByIdentifier)
+                ortRunService.storeResolvedItems(job.ortRunId, resolvedItems)
             }
 
             val packageIds = ortResult.getPackages().map { it.metadata.id }.toSet()


### PR DESCRIPTION
A recent PR #4475 for applying resolutions after each job has a bug, where the Analyzer and Advisor are storing resolution mappings before storing the runs. This causes the resolved-item links for these workers to be missing in `resolved_issues`, which might skew resolved/unresolved reporting.

Fix by correcting the order so resolution mappings are created against existing issue rows.

NOTE: The author hasn't found any test cases for this from local dev environment, but the fix is probably still best to be done, to be on the safe side and align the order of storing and resolving items in Analyzer and Advisor to the order used in Scanner and Evaluator.