### PR TITLE
Refactor the `/issues` endpoint for performance

### DIFF
--- a/services/ort-run/src/main/kotlin/IssueService.kt
+++ b/services/ort-run/src/main/kotlin/IssueService.kt
@@ -20,91 +20,248 @@
 package org.eclipse.apoapsis.ortserver.services.ortrun
 
 import org.eclipse.apoapsis.ortserver.dao.QueryParametersException
+import org.eclipse.apoapsis.ortserver.dao.blockingQuery
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
-import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.AdvisorRunDao
-import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.AnalyzerRunDao
-import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunDao
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerjob.AnalyzerJobsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.AnalyzerRunsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesAnalyzerRunsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.IssueResolutionsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageCurationDataTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageCurationsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.resolvedconfiguration.ResolvedConfigurationsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.resolvedconfiguration.ResolvedPackageCurationProvidersTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.resolvedconfiguration.ResolvedPackageCurationsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
-import org.eclipse.apoapsis.ortserver.dao.tables.shared.IssueDao
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IssuesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.OrtRunsIssuesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.ResolvedIssuesTable
-import org.eclipse.apoapsis.ortserver.dao.utils.toDatabasePrecision
 import org.eclipse.apoapsis.ortserver.model.CountByCategory
 import org.eclipse.apoapsis.ortserver.model.Severity
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
 import org.eclipse.apoapsis.ortserver.model.runs.IssueFilter
+import org.eclipse.apoapsis.ortserver.model.runs.repository.IssueResolution
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
 import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
 import org.eclipse.apoapsis.ortserver.model.util.OrderField
 import org.eclipse.apoapsis.ortserver.services.ResourceNotFoundException
+import org.eclipse.apoapsis.ortserver.services.utils.toSortOrder
 
 import org.jetbrains.exposed.v1.core.Count
 import org.jetbrains.exposed.v1.core.JoinType
+import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.inSubQuery
 import org.jetbrains.exposed.v1.core.innerJoin
+import org.jetbrains.exposed.v1.core.isNotNull
 import org.jetbrains.exposed.v1.core.not
 import org.jetbrains.exposed.v1.jdbc.Database
-import org.jetbrains.exposed.v1.jdbc.Query
+import org.jetbrains.exposed.v1.jdbc.andWhere
 import org.jetbrains.exposed.v1.jdbc.select
-
-import org.ossreviewtoolkit.model.Identifier as OrtIdentifier
-import org.ossreviewtoolkit.model.Issue as OrtIssue
-import org.ossreviewtoolkit.model.OrtResult
 
 /**
  * A service to manage and get information about issues.
  */
 class IssueService(private val db: Database, private val ortRunService: OrtRunService) {
-    suspend fun listForOrtRunId(
+    fun listForOrtRunId(
         ortRunId: Long,
         parameters: ListQueryParameters = ListQueryParameters.DEFAULT,
         issuesFilter: IssueFilter = IssueFilter()
     ): ListQueryResult<Issue> {
-        val ortRun = ortRunService.getOrtRun(ortRunId) ?: throw ResourceNotFoundException(
+        ortRunService.getOrtRun(ortRunId) ?: throw ResourceNotFoundException(
             "ORT run with ID $ortRunId not found."
         )
 
-        val ortResult = ortRunService.generateOrtResult(ortRun, failIfRepoInfoMissing = false, loadFileLists = false)
+        return db.blockingQuery {
+            val baseJoin = OrtRunsIssuesTable
+                .innerJoin(IssuesTable, { issueId }, { id })
+                .join(IdentifiersTable, JoinType.LEFT, OrtRunsIssuesTable.identifierId, IdentifiersTable.id)
 
-        val issues = collectIssues(ortRunId, ortResult)
+            // Step 1: Build the ID query with filtering.
+            val query = baseJoin
+                .select(OrtRunsIssuesTable.id)
+                .where { OrtRunsIssuesTable.ortRunId eq ortRunId }
 
-        val issuesWithResolutions = issues.map { issue ->
-            val matchingResolutions = ortResult.getResolutions().issues.filter { resolution ->
-                val resolutionPattern = resolution.message.toRegex()
-                resolutionPattern.containsMatchIn(issue.message)
+            // Step 2: Apply resolved/unresolved filter.
+            val resolvedIssueIdsSubquery = ResolvedIssuesTable
+                .select(ResolvedIssuesTable.ortRunIssueId)
+                .where { ResolvedIssuesTable.ortRunId eq ortRunId }
+
+            when (issuesFilter.resolved) {
+                true -> query.andWhere { OrtRunsIssuesTable.id inSubQuery resolvedIssueIdsSubquery }
+                false -> query.andWhere { not(OrtRunsIssuesTable.id inSubQuery resolvedIssueIdsSubquery) }
+                null -> {} // no filter
             }
 
-            issue.copy(
-                resolutions = matchingResolutions.map { it.mapToModel() },
-                purl = issue.identifier?.mapToOrt()?.let {
-                    ortResult.getPackage(it)?.metadata?.purl
+            // Step 3: Count total before pagination.
+            val totalCount = query.count()
+
+            // Step 4: Sorting.
+            val sortFields = parameters.sortFields.ifEmpty {
+                listOf(OrderField("timestamp", OrderDirection.DESCENDING))
+            }
+
+            sortFields.forEach { orderField ->
+                val sortOrder = orderField.direction.toSortOrder()
+                when (orderField.name) {
+                    "timestamp" -> query.orderBy(OrtRunsIssuesTable.timestamp to sortOrder)
+
+                    "source" -> query.orderBy(IssuesTable.issueSource to sortOrder)
+
+                    "message" -> query.orderBy(IssuesTable.message to sortOrder)
+
+                    "severity" -> query.orderBy(IssuesTable.severity to sortOrder)
+
+                    "affectedPath" -> query.orderBy(IssuesTable.affectedPath to sortOrder)
+
+                    "identifier" -> {
+                        query.orderBy(IdentifiersTable.type to sortOrder)
+                        query.orderBy(IdentifiersTable.namespace to sortOrder)
+                        query.orderBy(IdentifiersTable.name to sortOrder)
+                        query.orderBy(IdentifiersTable.version to sortOrder)
+                    }
+
+                    "worker" -> query.orderBy(OrtRunsIssuesTable.worker to sortOrder)
+
+                    else -> throw QueryParametersException("Unknown sort field '${orderField.name}'.")
                 }
-            )
+            }
+            query.orderBy(OrtRunsIssuesTable.id to SortOrder.ASC)
+
+            // Step 5: Pagination.
+            val limit = parameters.limit ?: ListQueryParameters.DEFAULT_LIMIT
+            val offset = parameters.offset ?: 0L
+            query.limit(limit).offset(offset)
+
+            // Step 6: Fetch paginated IDs, then batch-load full rows.
+            val ortRunIssueIds = query.map { it[OrtRunsIssuesTable.id].value }
+            if (ortRunIssueIds.isEmpty()) {
+                return@blockingQuery ListQueryResult(emptyList(), parameters, totalCount)
+            }
+
+            // Single batch query to fetch all columns needed to construct Issue models.
+            val issueRowsById = baseJoin
+                .select(
+                    OrtRunsIssuesTable.id,
+                    OrtRunsIssuesTable.timestamp,
+                    OrtRunsIssuesTable.worker,
+                    OrtRunsIssuesTable.identifierId,
+                    IssuesTable.issueSource,
+                    IssuesTable.message,
+                    IssuesTable.severity,
+                    IssuesTable.affectedPath,
+                    IdentifiersTable.type,
+                    IdentifiersTable.namespace,
+                    IdentifiersTable.name,
+                    IdentifiersTable.version
+                )
+                .where { OrtRunsIssuesTable.id inList ortRunIssueIds }
+                .associateBy { it[OrtRunsIssuesTable.id].value }
+
+            // Step 7: Batch-fetch resolutions.
+            val resolutionsByOrtRunIssueId = ResolvedIssuesTable
+                .innerJoin(IssueResolutionsTable, { issueResolutionId }, { id })
+                .select(
+                    ResolvedIssuesTable.ortRunIssueId,
+                    IssueResolutionsTable.message,
+                    IssueResolutionsTable.reason,
+                    IssueResolutionsTable.comment
+                )
+                .where { ResolvedIssuesTable.ortRunIssueId inList ortRunIssueIds }
+                .groupBy(
+                    { it[ResolvedIssuesTable.ortRunIssueId].value },
+                    {
+                        IssueResolution(
+                            message = it[IssueResolutionsTable.message],
+                            reason = it[IssueResolutionsTable.reason],
+                            comment = it[IssueResolutionsTable.comment]
+                        )
+                    }
+                )
+
+            // Step 8: Batch-fetch purls with curation support.
+            val identifierIds = ortRunIssueIds
+                .mapNotNull { issueRowsById[it]?.getOrNull(OrtRunsIssuesTable.identifierId)?.value }
+                .distinct()
+
+            val purlByIdentifierId = if (identifierIds.isNotEmpty()) {
+                val basePurls = PackagesTable
+                    .innerJoin(PackagesAnalyzerRunsTable)
+                    .innerJoin(AnalyzerRunsTable)
+                    .innerJoin(AnalyzerJobsTable)
+                    .select(PackagesTable.identifierId, PackagesTable.purl)
+                    .where {
+                        (AnalyzerJobsTable.ortRunId eq ortRunId) and
+                            (PackagesTable.identifierId inList identifierIds)
+                    }
+                    .associate { it[PackagesTable.identifierId].value to it[PackagesTable.purl] }
+
+                // Curated purls override base purls. ORDER BY rank ensures the highest-priority
+                // curation (lowest rank) comes first; groupBy preserves this order so first() picks it.
+                val curatedPurls = PackageCurationDataTable
+                    .innerJoin(PackageCurationsTable)
+                    .innerJoin(ResolvedPackageCurationsTable)
+                    .innerJoin(ResolvedPackageCurationProvidersTable)
+                    .innerJoin(ResolvedConfigurationsTable)
+                    .select(PackageCurationsTable.identifierId, PackageCurationDataTable.purl)
+                    .where {
+                        (ResolvedConfigurationsTable.ortRunId eq ortRunId) and
+                            (PackageCurationsTable.identifierId inList identifierIds) and
+                            (PackageCurationDataTable.purl.isNotNull())
+                    }
+                    .orderBy(ResolvedPackageCurationProvidersTable.rank)
+                    .orderBy(ResolvedPackageCurationsTable.rank)
+                    .groupBy { it[PackageCurationsTable.identifierId].value }
+                    .mapValues { (_, rows) ->
+                        requireNotNull(rows.first()[PackageCurationDataTable.purl]) {
+                            "Curated purl was unexpectedly null after filtering."
+                        }
+                    }
+
+                basePurls + curatedPurls
+            } else {
+                emptyMap()
+            }
+
+            // Step 9: Assemble Issue models directly from ResultRows.
+            val finalIssues = ortRunIssueIds.map { ortRunIssueId ->
+                val row = issueRowsById.getValue(ortRunIssueId)
+
+                val type = row.getOrNull(IdentifiersTable.type)
+                val namespace = row.getOrNull(IdentifiersTable.namespace)
+                val name = row.getOrNull(IdentifiersTable.name)
+                val version = row.getOrNull(IdentifiersTable.version)
+                val identifier = type?.let { safeType ->
+                    namespace?.let { safeNamespace ->
+                        name?.let { safeName ->
+                            version?.let { safeVersion ->
+                                Identifier(safeType, safeNamespace, safeName, safeVersion)
+                            }
+                        }
+                    }
+                }
+
+                val identifierId = row.getOrNull(OrtRunsIssuesTable.identifierId)?.value
+
+                Issue(
+                    timestamp = row[OrtRunsIssuesTable.timestamp],
+                    source = row[IssuesTable.issueSource],
+                    message = row[IssuesTable.message],
+                    severity = row[IssuesTable.severity],
+                    affectedPath = row.getOrNull(IssuesTable.affectedPath),
+                    identifier = identifier,
+                    worker = row.getOrNull(OrtRunsIssuesTable.worker),
+                    resolutions = resolutionsByOrtRunIssueId[ortRunIssueId].orEmpty(),
+                    purl = identifierId?.let { purlByIdentifierId[it] }
+                )
+            }
+
+            ListQueryResult(data = finalIssues, params = parameters, totalCount = totalCount)
         }
-
-        val filteredResult = issuesWithResolutions.applyResultFilter(issuesFilter)
-
-        val sortFields = parameters.sortFields.ifEmpty {
-            listOf(OrderField("timestamp", OrderDirection.DESCENDING))
-        }
-
-        return ListQueryResult(
-            filteredResult.sort(sortFields).paginate(parameters),
-            parameters,
-            filteredResult.size.toLong()
-        )
-    }
-
-    private fun List<Issue>.applyResultFilter(issuesFilter: IssueFilter) = when (issuesFilter.resolved) {
-        true -> filter { it.resolutions.isNotEmpty() }
-        false -> filter { it.resolutions.isEmpty() }
-        null -> this
     }
 
     /** Count issues found in provided ORT runs. */
@@ -174,93 +331,4 @@ class IssueService(private val db: Database, private val ortRunService: OrtRunSe
 
         CountByCategory(severityToCountMap)
     }
-
-    /**
-     * Collect issues from the ORT result and the database for the given [ortRunId].
-     */
-    private suspend fun collectIssues(ortRunId: Long, ortResult: OrtResult): Set<Issue> {
-        val ortWorkerIssues = listOf(
-            ortResult.getAnalyzerIssues() to AnalyzerRunDao.ISSUE_WORKER_TYPE,
-            ortResult.getAdvisorIssues() to AdvisorRunDao.ISSUE_WORKER_TYPE,
-            ortResult.getScannerIssues() to ScannerRunDao.ISSUE_WORKER_TYPE
-        ).flatMap { (issuesByIdentifier, workerType) ->
-            // While the database contains almost all issues, some issues like dependency graph issues are only
-            // available in the ORT result. To ensure that no issues are lost, also collect them from the ORT result.
-            collectIssuesFromWorker(issuesByIdentifier, workerType)
-        }.map { issue ->
-            // Normalize timestamp to database precision to help with duplicate detection
-            issue.copy(timestamp = issue.timestamp.toDatabasePrecision())
-        }
-
-        val dbIssues = db.dbQuery { IssueDao.createFromQuery(createOrtRunIssuesQuery(ortRunId)) }
-
-        return (ortWorkerIssues + dbIssues).toSet()
-    }
-
-    private fun collectIssuesFromWorker(
-        issueMap: Map<OrtIdentifier, Set<OrtIssue>>,
-        workerType: String
-    ) = issueMap.flatMap { (identifier, ortIssues) ->
-        ortIssues.map { ortIssue ->
-            ortIssue.mapToModel(identifier = identifier.mapToModel(), worker = workerType)
-        }
-    }
-
-    private fun createOrtRunIssuesQuery(ortRunId: Long): Query {
-        val issuesIdentifiersJoin = OrtRunsIssuesTable
-            .innerJoin(IssuesTable, { issueId }, { id })
-            .join(IdentifiersTable, JoinType.LEFT, OrtRunsIssuesTable.identifierId, IdentifiersTable.id)
-        return issuesIdentifiersJoin.select(
-            OrtRunsIssuesTable.timestamp,
-            IssuesTable.issueSource,
-            IssuesTable.message,
-            IssuesTable.severity,
-            IssuesTable.affectedPath,
-            IdentifiersTable.type,
-            IdentifiersTable.name,
-            IdentifiersTable.namespace,
-            IdentifiersTable.version,
-            OrtRunsIssuesTable.worker
-        ).where { OrtRunsIssuesTable.ortRunId eq ortRunId }
-    }
-}
-
-internal fun Identifier.toConcatenatedString() = "$type $namespace $name $version"
-
-/**
- * Sort the list of issues by the given [sortFields], also using the hash code of the issue as a second sort criterion
- * to get a stable sort order. Although the API supports having more than one sort order field, this implementation
- * only supports a single sort field.
- */
-internal fun Collection<Issue>.sort(sortFields: List<OrderField>): List<Issue> {
-    require(sortFields.isNotEmpty()) {
-        "At least one sort field must be defined."
-    }
-
-    // Explicitly only support a single sort field
-    val sortField = sortFields.first()
-
-    val comparator: Comparator<Issue> = when (sortField.name) {
-        "timestamp" -> compareBy { it.timestamp }
-        "source" -> compareBy { it.source }
-        "message" -> compareBy { it.message }
-        "severity" -> compareBy { it.severity }
-        "affectedPath" -> compareBy { it.affectedPath }
-        "identifier" -> compareBy { it.identifier?.toConcatenatedString() }
-        "worker" -> compareBy { it.worker }
-        else -> throw QueryParametersException("Unknown sort field '${sortField.name}'.")
-    }
-
-    return sortedWith(comparator.thenBy { issue -> issue.hashCode() })
-        .let { if (sortField.direction == OrderDirection.DESCENDING) it.reversed() else it }
-}
-
-/**
- * Paginate the list of issues by the given [parameters].
- */
-internal fun List<Issue>.paginate(parameters: ListQueryParameters): List<Issue> {
-    val offset = parameters.offset ?: 0L
-    val limit = parameters.limit ?: ListQueryParameters.DEFAULT_LIMIT
-
-    return drop(offset.toInt()).take(limit)
 }


### PR DESCRIPTION
Similar to PR #4558, eliminate totally the usage of `OrtResult` and expensive in-memory calculations based on it, and replace it with direct SQL queries, to improve the performance of all issues queries.

No numerical data available, but manual verification using local development environment shows the issues query executes almost lightning-fast now (earlier, it took ~1 sec for 50 issues). The real benefit can probably better be assessed on production environment.

Please see the commit for details.

Note to @oheger-bosch: I exercised special care to alleviate N+1 query issues this time.

One could also argue that the conventional commit could be `perf(service)` - but I retained `feat(service)` because no-one had anything to complain about it in #4558.