### PR TITLE
ci(docker): Use latest tag only for release builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -17,6 +17,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IS_PR: ${{ github.event_name == 'pull_request' || github.event_name == 'merge_group' }}
+  IS_RELEASE: ${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref, '-RC') }}
 
 jobs:
   build:
@@ -128,7 +129,7 @@ jobs:
           type=raw,value=${{ env.ORT_SERVER_VERSION }}
           type=ref,event=branch
           type=sha
-          type=raw,value=latest,enable={{ is_default_branch }}
+          type=raw,value=latest,enable=${{ env.IS_RELEASE }}
 
     - name: Set cache-to
       run: |
@@ -175,7 +176,7 @@ jobs:
           type=raw,value=${{ env.ORT_SERVER_VERSION }}
           type=ref,event=branch
           type=sha
-          type=raw,value=latest,enable={{ is_default_branch }}
+          type=raw,value=latest,enable=${{ env.IS_RELEASE }}
 
     - name: Prepare Jib Cache Directories
       if: ${{ matrix.docker.task != '' }}
@@ -252,7 +253,7 @@ jobs:
           type=raw,value=${{ env.ORT_SERVER_VERSION }}
           type=ref,event=branch
           type=sha
-          type=raw,value=latest,enable={{ is_default_branch }}
+          type=raw,value=latest,enable=${{ env.IS_RELEASE }}
 
     - name: Build and push base image to registry
       uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2


### PR DESCRIPTION
Add the latest tag only for release builds, but not for builds for the main branch and pre-releases.

Fixes #3601.

I have manually verified in a fork that this sets the correct labels for main-branch, pre-release and release builds.