### PR TITLE
fix(dao): Distinguish issues by identifier when storing resolved issues

### DIFF
--- a/dao/src/main/kotlin/repositories/resolvedconfiguration/DaoResolvedConfigurationRepository.kt
+++ b/dao/src/main/kotlin/repositories/resolvedconfiguration/DaoResolvedConfigurationRepository.kt
@@ -60,6 +60,7 @@ import org.eclipse.apoapsis.ortserver.model.runs.RuleViolation
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.Vulnerability
 import org.eclipse.apoapsis.ortserver.model.runs.repository.PackageConfiguration
 
+import org.jetbrains.exposed.v1.core.Op
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.stringLiteral
@@ -284,10 +285,12 @@ class DaoResolvedConfigurationRepository(private val db: Database) : ResolvedCon
 
     /**
      * Find the OrtRunIssue ID for a given issue in the context of an ORT run.
-     * Matches by message, timestamp, source, severity, and affectedPath.
+     * Matches by message, timestamp, source, severity, affectedPath, and identifier if available.
      */
-    private fun findOrtRunIssueId(ortRunId: Long, issue: Issue): Long? =
-        OrtRunsIssuesTable
+    private fun findOrtRunIssueId(ortRunId: Long, issue: Issue): Long? {
+        val identifierId = issue.identifier?.let { findIdentifierId(it) ?: return null }
+
+        return OrtRunsIssuesTable
             .innerJoin(IssuesTable)
             .select(OrtRunsIssuesTable.id)
             .where {
@@ -295,9 +298,25 @@ class DaoResolvedConfigurationRepository(private val db: Database) : ResolvedCon
                     (IssuesTable.issueSource eq issue.source) and
                     (DigestFunction(IssuesTable.message) eq DigestFunction(stringLiteral(issue.message))) and
                     (IssuesTable.severity eq issue.severity) and
-                    (IssuesTable.affectedPath eq issue.affectedPath)
+                    (IssuesTable.affectedPath eq issue.affectedPath) and
+                        (identifierId?.let { OrtRunsIssuesTable.identifierId eq it } ?: Op.TRUE)
             }
             .firstOrNull()?.get(OrtRunsIssuesTable.id)?.value
+    }
+
+    /**
+     * Find the identifier ID for the given identifier details.
+     */
+    private fun findIdentifierId(identifier: Identifier): Long? =
+        IdentifiersTable
+            .select(IdentifiersTable.id)
+            .where {
+                (IdentifiersTable.type eq identifier.type) and
+                        (IdentifiersTable.namespace eq identifier.namespace) and
+                        (IdentifiersTable.name eq identifier.name) and
+                        (IdentifiersTable.version eq identifier.version)
+            }
+            .firstOrNull()?.get(IdentifiersTable.id)?.value
 
     /**
      * Find the RuleViolation ID for a given rule violation in the context of an ORT run.

--- a/dao/src/test/kotlin/repositories/resolvedconfiguration/DaoResolvedConfigurationRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/resolvedconfiguration/DaoResolvedConfigurationRepositoryTest.kt
@@ -24,6 +24,7 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldBeSingleton
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -39,6 +40,7 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesAnaly
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.evaluatorrun.ResolvedRuleViolationsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.OrtRunsIssuesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.ResolvedIssuesTable
 import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
 import org.eclipse.apoapsis.ortserver.dao.test.Fixtures
@@ -471,6 +473,58 @@ class DaoResolvedConfigurationRepositoryTest : WordSpec({
             // Verify the resolution was also stored in the resolved configuration
             val resolvedConfiguration = resolvedConfigurationRepository.getForOrtRun(ortRunId).shouldNotBeNull()
             resolvedConfiguration.resolutions.issues should containExactly(issueResolution1)
+        }
+
+        "store separate resolutions for issues sharing issue ID but having different identifiers" {
+            val issueWithIdentifier1 = Issue(
+                timestamp = Clock.System.now(),
+                source = "Analyzer",
+                message = "Issue with identifier context",
+                severity = Severity.WARNING,
+                identifier = identifier1
+            )
+            val issueWithIdentifier2 = issueWithIdentifier1.copy(identifier = identifier2)
+
+            fixtures.createAnalyzerRun(
+                analyzerJobId = fixtures.analyzerJob.id,
+                issues = listOf(issueWithIdentifier1, issueWithIdentifier2)
+            )
+
+            val ortRunIssueRows = dbExtension.db.dbQuery {
+                OrtRunsIssuesTable.select(
+                    OrtRunsIssuesTable.id,
+                    OrtRunsIssuesTable.issueId,
+                    OrtRunsIssuesTable.identifierId
+                ).where {
+                    OrtRunsIssuesTable.ortRunId eq ortRunId
+                }.toList()
+            }
+
+            ortRunIssueRows shouldHaveSize 2
+            ortRunIssueRows.mapTo(mutableSetOf()) { it[OrtRunsIssuesTable.issueId].value } shouldHaveSize 1
+            ortRunIssueRows.mapTo(mutableSetOf()) { it[OrtRunsIssuesTable.identifierId]?.value } shouldHaveSize 2
+
+            resolvedConfigurationRepository.addResolutions(
+                ortRunId = ortRunId,
+                resolvedItems = ResolvedItemsResult(
+                    issues = mapOf(
+                        issueWithIdentifier1 to listOf(issueResolution1),
+                        issueWithIdentifier2 to listOf(issueResolution2)
+                    ),
+                    ruleViolations = emptyMap(),
+                    vulnerabilities = emptyMap()
+                )
+            )
+
+            val storedResolvedIssues = dbExtension.db.dbQuery {
+                ResolvedIssuesTable.selectAll()
+                    .where { ResolvedIssuesTable.ortRunId eq ortRunId }
+                    .toList()
+            }
+
+            storedResolvedIssues shouldHaveSize 2
+            storedResolvedIssues.mapTo(mutableSetOf()) { it[ResolvedIssuesTable.ortRunIssueId].value } shouldBe
+                ortRunIssueRows.mapTo(mutableSetOf()) { it[OrtRunsIssuesTable.id].value }
         }
 
         "store resolved rule violations with their mappings" {


### PR DESCRIPTION
Ensure that issue resolutions are matched against `OrtRunsIssuesTable` entries using the identifier (if available) in addition to issue details.

Previously, issues sharing the same issue ID but having different identifiers were treated as the same entry, causing resolutions to be stored only for one of them. Now, resolutions are stored separately per identifier in the conjunction table.