### PR TITLE
Optimize performance of organization and product vulnerabilities queries

### DIFF
--- a/services/ort-run/src/main/kotlin/OrtRunsVulnerabilityQueryBuilder.kt
+++ b/services/ort-run/src/main/kotlin/OrtRunsVulnerabilityQueryBuilder.kt
@@ -1,0 +1,463 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.services.ortrun
+
+import org.eclipse.apoapsis.ortserver.dao.repositories.advisorjob.AdvisorJobsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.AdvisorResultsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.AdvisorResultsVulnerabilitiesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.AdvisorRunsIdentifiersTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.AdvisorRunsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.VulnerabilitiesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.VulnerabilityReferencesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerjob.AnalyzerJobsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.AnalyzerRunsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesAnalyzerRunsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.ortrun.OrtRunsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.repository.RepositoriesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageCurationDataTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageCurationsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.resolvedconfiguration.ResolvedConfigurationsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.resolvedconfiguration.ResolvedPackageCurationProvidersTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.resolvedconfiguration.ResolvedPackageCurationsTable
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
+import org.eclipse.apoapsis.ortserver.dao.utils.applyILike
+import org.eclipse.apoapsis.ortserver.model.VulnerabilityForRunsFilters
+import org.eclipse.apoapsis.ortserver.model.util.ComparisonOperator
+
+import org.jetbrains.exposed.v1.core.Case
+import org.jetbrains.exposed.v1.core.CustomFunction
+import org.jetbrains.exposed.v1.core.Expression
+import org.jetbrains.exposed.v1.core.ExpressionWithColumnType
+import org.jetbrains.exposed.v1.core.ExpressionWithColumnTypeAlias
+import org.jetbrains.exposed.v1.core.IntegerColumnType
+import org.jetbrains.exposed.v1.core.JoinType
+import org.jetbrains.exposed.v1.core.Max
+import org.jetbrains.exposed.v1.core.Op
+import org.jetbrains.exposed.v1.core.QueryAlias
+import org.jetbrains.exposed.v1.core.TextColumnType
+import org.jetbrains.exposed.v1.core.alias
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.concat
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.core.innerJoin
+import org.jetbrains.exposed.v1.core.isNotNull
+import org.jetbrains.exposed.v1.core.min
+import org.jetbrains.exposed.v1.core.neq
+import org.jetbrains.exposed.v1.core.notInList
+import org.jetbrains.exposed.v1.core.plus
+import org.jetbrains.exposed.v1.core.stringLiteral
+import org.jetbrains.exposed.v1.core.times
+import org.jetbrains.exposed.v1.jdbc.select
+
+/**
+ * Build the [OrtRunsQueryContext] for querying vulnerabilities across multiple ORT runs.
+ *
+ * The query is decomposed into small, independently pre-aggregated relations that are joined
+ * back at the end, rather than building one wide join chain. This avoids row amplification
+ * (e.g., joining vulnerability_references directly would multiply rows by reference count)
+ * and keeps each subquery simple enough for PostgreSQL's query planner and JIT compiler to
+ * handle efficiently. The plan shape is fixed regardless of data volume, so JIT compilation
+ * cost stays constant as the number of vulnerabilities grows.
+ *
+ * Steps:
+ * 1. [buildBasePairs] — minimal (vulnerability, identifier, run) tuples from the advisor chain
+ * 2. [buildRatingsByVulnerability] — pre-aggregated ratings scoped to relevant vulnerabilities
+ * 3. [buildPurlByRunIdentifier] — PURL lookup via analyzer packages + curated packages
+ * 4. [buildFinalQuery] — join everything, apply filters, group and aggregate
+ */
+internal fun buildOrtRunsQueryContext(
+    ortRunIds: List<Long>,
+    filters: VulnerabilityForRunsFilters
+): OrtRunsQueryContext {
+    val runIdsAlias = runIdsAlias()
+    val repositoriesCountAlias = repositoriesCountAlias()
+    val ratingAlias = ratingAlias()
+
+    val bp = buildBasePairs(ortRunIds)
+    val ratings = buildRatingsByVulnerability(bp, ratingAlias)
+    val purls = buildPurlByRunIdentifier(bp)
+
+    return buildFinalQuery(bp, ratings, purls, ratingAlias, filters, runIdsAlias, repositoriesCountAlias)
+}
+
+// -- Column carriers ----------------------------------------------------------------------------------
+// Each helper returns a lightweight holder pairing a QueryAlias with the alias expressions used in its
+// SELECT, so downstream code can reference them via queryAlias[alias].
+
+private class BasePairsResult(
+    val alias: QueryAlias,
+    val vulnerabilityId: ExpressionWithColumnTypeAlias<EntityID<Long>>,
+    val identifierId: ExpressionWithColumnTypeAlias<EntityID<Long>>,
+    val ortRunId: ExpressionWithColumnTypeAlias<EntityID<Long>>,
+    val externalId: ExpressionWithColumnTypeAlias<String>,
+    val summary: ExpressionWithColumnTypeAlias<String?>,
+    val description: ExpressionWithColumnTypeAlias<String?>
+)
+
+private class CuratedPurlResult(
+    val alias: QueryAlias,
+    val ortRunId: ExpressionWithColumnTypeAlias<EntityID<Long>>,
+    val identifierId: ExpressionWithColumnTypeAlias<EntityID<Long>>,
+    val purl: ExpressionWithColumnTypeAlias<String?>
+)
+
+private class PurlResult(
+    val alias: QueryAlias,
+    val ortRunId: ExpressionWithColumnTypeAlias<EntityID<Long>>,
+    val identifierId: ExpressionWithColumnTypeAlias<EntityID<Long>>,
+    val purl: ExpressionWithColumnTypeAlias<String>
+)
+
+// -- Step 1: Base pairs -------------------------------------------------------------------------------
+
+/**
+ * Build distinct (vulnerability_id, identifier_id, ort_run_id) tuples from the advisor join chain,
+ * carrying vulnerability metadata columns needed downstream.
+ */
+private fun buildBasePairs(ortRunIds: List<Long>): BasePairsResult {
+    val vulnerabilityId = VulnerabilitiesTable.id.alias("vulnerability_id")
+    val identifierId = IdentifiersTable.id.alias("identifier_id")
+    val ortRunId = OrtRunsTable.id.alias("ort_run_id")
+    val externalId = VulnerabilitiesTable.externalId.alias("external_id")
+    val summary = VulnerabilitiesTable.summary.alias("summary")
+    val description = VulnerabilitiesTable.description.alias("description")
+
+    val query = VulnerabilitiesTable
+        .innerJoin(AdvisorResultsVulnerabilitiesTable)
+        .innerJoin(AdvisorResultsTable)
+        .innerJoin(AdvisorRunsIdentifiersTable)
+        .innerJoin(AdvisorRunsTable)
+        .innerJoin(AdvisorJobsTable)
+        .innerJoin(OrtRunsTable)
+        .innerJoin(IdentifiersTable)
+        .select(vulnerabilityId, identifierId, ortRunId, externalId, summary, description)
+        .where { OrtRunsTable.id inList ortRunIds }
+        .groupBy(VulnerabilitiesTable.id, IdentifiersTable.id, OrtRunsTable.id)
+        .alias("base_pairs")
+
+    return BasePairsResult(query, vulnerabilityId, identifierId, ortRunId, externalId, summary, description)
+}
+
+// -- Step 2: Ratings ----------------------------------------------------------------------------------
+
+/**
+ * Pre-aggregate vulnerability ratings scoped to only the vulnerabilities present in [bp].
+ */
+private fun buildRatingsByVulnerability(
+    bp: BasePairsResult,
+    ratingAlias: ExpressionWithColumnTypeAlias<Int?>
+): QueryAlias {
+    val distinctVulnId = bp.alias[bp.vulnerabilityId].alias("distinct_vuln_id")
+    val distinctVulns = bp.alias
+        .select(distinctVulnId)
+        .withDistinct()
+        .alias("distinct_vulns")
+
+    return VulnerabilityReferencesTable
+        .join(distinctVulns, JoinType.INNER) {
+            VulnerabilityReferencesTable.vulnerabilityId eq distinctVulns[distinctVulnId]
+        }
+        .select(VulnerabilityReferencesTable.vulnerabilityId, ratingAlias)
+        .groupBy(VulnerabilityReferencesTable.vulnerabilityId)
+        .alias("ratings_by_vulnerability")
+}
+
+// -- Step 3: PURL lookup ------------------------------------------------------------------------------
+
+/**
+ * Build a `purl_by_run_identifier` relation keyed by (ort_run_id, identifier_id).
+ * PURL = COALESCE(curated_purl, base_purl, '').
+ */
+private fun buildPurlByRunIdentifier(bp: BasePairsResult): PurlResult {
+    // Distinct (ort_run_id, identifier_id) pairs from base_pairs.
+    val riOrtRunId = bp.alias[bp.ortRunId].alias("ri_ort_run_id")
+    val riIdentifierId = bp.alias[bp.identifierId].alias("ri_identifier_id")
+    val runIdPairs = bp.alias
+        .select(riOrtRunId, riIdentifierId)
+        .withDistinct()
+        .alias("run_identifier_pairs")
+
+    val riOrtRunIdCol = runIdPairs[riOrtRunId]
+    val riIdentifierIdCol = runIdPairs[riIdentifierId]
+
+    // Base (uncurated) PURL from analyzer packages.
+    val bpOrtRunId = riOrtRunIdCol.alias("bp_ort_run_id")
+    val bpIdentifierId = riIdentifierIdCol.alias("bp_identifier_id")
+    val basePurlMin = PackagesTable.purl.min().alias("base_purl")
+
+    val basePurl = AnalyzerJobsTable
+        .innerJoin(AnalyzerRunsTable)
+        .innerJoin(PackagesAnalyzerRunsTable)
+        .innerJoin(PackagesTable)
+        .join(runIdPairs, JoinType.INNER) {
+            (AnalyzerJobsTable.ortRunId eq riOrtRunIdCol) and
+                (PackagesTable.identifierId eq riIdentifierIdCol)
+        }
+        .select(bpOrtRunId, bpIdentifierId, basePurlMin)
+        .groupBy(bpOrtRunId, bpIdentifierId)
+        .alias("base_purl_by_run_identifier")
+
+    // Curated PURL using composite rank (provider_rank * 10000 + curation_rank).
+    val curated = buildCuratedPurlByRunIdentifier(runIdPairs, riOrtRunIdCol, riIdentifierIdCol)
+
+    // Combine: COALESCE(curated, base, '').
+    val purl = CustomFunction(
+        "COALESCE",
+        TextColumnType(),
+        curated.alias[curated.purl],
+        basePurl[basePurlMin],
+        stringLiteral("")
+    ).alias("purl")
+    val outOrtRunId = riOrtRunIdCol.alias("purl_ort_run_id")
+    val outIdentifierId = riIdentifierIdCol.alias("purl_identifier_id")
+
+    val query = runIdPairs
+        .join(basePurl, JoinType.LEFT) {
+            (riOrtRunIdCol eq basePurl[bpOrtRunId]) and
+                (riIdentifierIdCol eq basePurl[bpIdentifierId])
+        }
+        .join(curated.alias, JoinType.LEFT) {
+            (riOrtRunIdCol eq curated.alias[curated.ortRunId]) and
+                (riIdentifierIdCol eq curated.alias[curated.identifierId])
+        }
+        .select(outOrtRunId, outIdentifierId, purl)
+        .alias("purl_by_run_identifier")
+
+    return PurlResult(query, outOrtRunId, outIdentifierId, purl)
+}
+
+/**
+ * Find the highest-priority curated PURL for each (ort_run_id, identifier_id) pair.
+ *
+ * Curations are prioritized by two independent rank dimensions: the *provider rank*
+ * (which curation provider supplied it) and the *curation rank* (ordering within that provider).
+ * The correct priority is lexicographic: lowest provider_rank wins first, then lowest
+ * curation_rank breaks ties within the same provider.
+ *
+ * Replace two separate min/filter passes (find min provider_rank, filter, then find
+ * min curation_rank within those, filter again) with collapsing both dimensions into a
+ * single composite key which preserves the lexicographic ordering (provider_rank is
+ * always the dominant term).
+ *
+ * With the composite rank, the resolution becomes 3 stages instead of 5:
+ * 1. Collect all candidates with their composite rank
+ * 2. Find the minimum composite rank per (ort_run_id, identifier_id)
+ * 3. Join back once to retrieve the PURL at that rank (with `min()` as a tiebreaker
+ *    for the theoretical case of duplicate composite ranks)
+ *
+ * As a side benefit, fewer subquery stages means fewer plan nodes for PostgreSQL's JIT
+ * compiler to process, modestly reducing compilation overhead.
+ */
+private fun buildCuratedPurlByRunIdentifier(
+    runIdPairs: QueryAlias,
+    riOrtRunIdCol: ExpressionWithColumnType<EntityID<Long>>,
+    riIdentifierIdCol: ExpressionWithColumnType<EntityID<Long>>
+): CuratedPurlResult {
+    // Stage 1: All curated PURL candidates with composite rank.
+    val ccOrtRunId = riOrtRunIdCol.alias("cc_ort_run_id")
+    val ccIdentifierId = riIdentifierIdCol.alias("cc_identifier_id")
+    val compositeRank =
+        (ResolvedPackageCurationProvidersTable.rank * 10000 + ResolvedPackageCurationsTable.rank)
+            .alias("composite_rank")
+    val ccPurl = PackageCurationDataTable.purl.alias("cc_purl")
+
+    val candidates = ResolvedConfigurationsTable
+        .innerJoin(ResolvedPackageCurationProvidersTable)
+        .innerJoin(ResolvedPackageCurationsTable)
+        .innerJoin(PackageCurationsTable)
+        .innerJoin(PackageCurationDataTable)
+        .join(runIdPairs, JoinType.INNER) {
+            (ResolvedConfigurationsTable.ortRunId eq riOrtRunIdCol) and
+                (PackageCurationsTable.identifierId eq riIdentifierIdCol)
+        }
+        .select(ccOrtRunId, ccIdentifierId, compositeRank, ccPurl)
+        .where { PackageCurationDataTable.purl.isNotNull() }
+        .alias("curated_candidates")
+
+    // Stage 2: Min composite rank per (ort_run_id, identifier_id).
+    val mrOrtRunId = candidates[ccOrtRunId].alias("mr_ort_run_id")
+    val mrIdentifierId = candidates[ccIdentifierId].alias("mr_identifier_id")
+    val minRank = candidates[compositeRank].min().alias("min_composite_rank")
+
+    val minRanks = candidates
+        .select(mrOrtRunId, mrIdentifierId, minRank)
+        .groupBy(mrOrtRunId, mrIdentifierId)
+        .alias("curated_min_rank")
+
+    // Stage 3: Join back to get PURL at min rank, with min() as tiebreaker.
+    val outOrtRunId = candidates[ccOrtRunId].alias("cp_ort_run_id")
+    val outIdentifierId = candidates[ccIdentifierId].alias("cp_identifier_id")
+    val curatedPurl = candidates[ccPurl].min().alias("curated_purl")
+
+    val query = candidates
+        .join(minRanks, JoinType.INNER) {
+            (candidates[ccOrtRunId] eq minRanks[mrOrtRunId]) and
+                (candidates[ccIdentifierId] eq minRanks[mrIdentifierId]) and
+                (candidates[compositeRank] eq minRanks[minRank])
+        }
+        .select(outOrtRunId, outIdentifierId, curatedPurl)
+        .groupBy(outOrtRunId, outIdentifierId)
+        .alias("curated_purl_by_run_identifier")
+
+    return CuratedPurlResult(query, outOrtRunId, outIdentifierId, curatedPurl)
+}
+
+// -- Steps 4-5: Final query ---------------------------------------------------------------------------
+
+/**
+ * Assemble the final query: join base_pairs with ratings and PURLs, apply filters,
+ * and group for aggregation.
+ */
+private fun buildFinalQuery(
+    bp: BasePairsResult,
+    ratingsByVulnerability: QueryAlias,
+    purls: PurlResult,
+    ratingAlias: ExpressionWithColumnTypeAlias<Int?>,
+    filters: VulnerabilityForRunsFilters,
+    runIdsAlias: ExpressionWithColumnTypeAlias<String>,
+    repositoriesCountAlias: ExpressionWithColumnTypeAlias<Long>
+): OrtRunsQueryContext {
+    val bpVulnId = bp.alias[bp.vulnerabilityId]
+    val bpIdentifierId = bp.alias[bp.identifierId]
+    val bpOrtRunId = bp.alias[bp.ortRunId]
+    val bpExternalId = bp.alias[bp.externalId]
+    val bpSummary = bp.alias[bp.summary]
+    val bpDescription = bp.alias[bp.description]
+
+    val ratingsVulnId = ratingsByVulnerability[VulnerabilityReferencesTable.vulnerabilityId]
+    val scopedRating = ratingsByVulnerability[ratingAlias].alias("scoped_rating")
+
+    val purlOrtRunId = purls.alias[purls.ortRunId]
+    val purlIdentifierId = purls.alias[purls.identifierId]
+
+    // Build a subquery joining base_pairs + ratings + purls.
+    val sqVulnId = bpVulnId.alias("sq_vulnerability_id")
+    val sqIdentifierId = bpIdentifierId.alias("sq_identifier_id")
+    val sqOrtRunId = bpOrtRunId.alias("sq_ort_run_id")
+    val sqExternalId = bpExternalId.alias("sq_external_id")
+    val sqSummary = bpSummary.alias("sq_summary")
+    val sqDescription = bpDescription.alias("sq_description")
+    val sqPurl = purls.alias[purls.purl].alias("sq_purl")
+
+    val subQuery = bp.alias
+        .join(ratingsByVulnerability, JoinType.LEFT) {
+            bpVulnId eq ratingsVulnId
+        }
+        .join(purls.alias, JoinType.INNER) {
+            (bpOrtRunId eq purlOrtRunId) and
+                (bpIdentifierId eq purlIdentifierId)
+        }
+        .select(sqVulnId, sqIdentifierId, sqOrtRunId, sqExternalId, sqSummary, sqDescription, sqPurl, scopedRating)
+        .alias("subquery")
+
+    // Final query columns.
+    val vulnerabilityIdColumn: Expression<EntityID<Long>> = subQuery[sqVulnId]
+    val identifierIdColumn = subQuery[sqIdentifierId]
+    val ortRunIdColumn = subQuery[sqOrtRunId]
+    val externalIdColumn: Expression<String> = subQuery[sqExternalId]
+    val summaryColumn: Expression<String?> = subQuery[sqSummary]
+    val descriptionColumn: Expression<String?> = subQuery[sqDescription]
+    val purlColumn: Expression<String> = subQuery[sqPurl]
+    val ratingColumn = subQuery[scopedRating]
+    val maxRatingAlias = Max(ratingColumn, IntegerColumnType()).alias("maxRating")
+
+    val query = subQuery
+        .innerJoin(IdentifiersTable, { identifierIdColumn }, { IdentifiersTable.id })
+        .innerJoin(OrtRunsTable, { ortRunIdColumn }, { OrtRunsTable.id })
+        .innerJoin(RepositoriesTable)
+        .select(
+            vulnerabilityIdColumn,
+            externalIdColumn,
+            summaryColumn,
+            descriptionColumn,
+            IdentifiersTable.type,
+            IdentifiersTable.namespace,
+            IdentifiersTable.name,
+            IdentifiersTable.version,
+            maxRatingAlias,
+            runIdsAlias,
+            repositoriesCountAlias,
+            purlColumn
+        )
+        .where {
+            var condition: Op<Boolean> = Op.TRUE
+
+            filters.rating?.let {
+                val ratingsAsInt = it.value.map { severity -> severity.ordinal }
+                condition = condition and when (it.operator) {
+                    ComparisonOperator.IN -> ratingColumn inList ratingsAsInt
+                    else -> ratingColumn notInList ratingsAsInt
+                }
+            }
+
+            filters.identifier?.let {
+                val namespaceWithSlash = Case()
+                    .When(
+                        IdentifiersTable.namespace neq stringLiteral(""),
+                        concat(IdentifiersTable.namespace, stringLiteral("/"))
+                    )
+                    .Else(stringLiteral(":"))
+
+                val concatenatedIdentifier = concat(
+                    IdentifiersTable.type,
+                    stringLiteral(":"),
+                    namespaceWithSlash,
+                    IdentifiersTable.name,
+                    stringLiteral("@"),
+                    IdentifiersTable.version
+                )
+
+                condition = condition and concatenatedIdentifier.applyILike(it.value)
+            }
+
+            filters.purl?.let {
+                condition = condition and purlColumn.applyILike(it.value)
+            }
+
+            filters.externalId?.let {
+                condition = condition and externalIdColumn.applyILike(it.value)
+            }
+
+            condition
+        }
+        .groupBy(
+            vulnerabilityIdColumn,
+            externalIdColumn,
+            summaryColumn,
+            descriptionColumn,
+            IdentifiersTable.id,
+            purlColumn
+        )
+
+    return OrtRunsQueryContext(
+        query = query,
+        purlColumn = purlColumn,
+        maxRatingAlias = maxRatingAlias,
+        runIdsAlias = runIdsAlias,
+        repositoriesCountAlias = repositoriesCountAlias,
+        vulnerabilityIdColumn = vulnerabilityIdColumn,
+        externalIdColumn = externalIdColumn,
+        summaryColumn = summaryColumn,
+        descriptionColumn = descriptionColumn
+    )
+}

--- a/services/ort-run/src/main/kotlin/VulnerabilityService.kt
+++ b/services/ort-run/src/main/kotlin/VulnerabilityService.kt
@@ -30,20 +30,10 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.AdvisorRunsTab
 import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.ResolvedVulnerabilitiesTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.VulnerabilitiesTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.VulnerabilityReferencesTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerjob.AnalyzerJobsTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.AnalyzerRunsTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesAnalyzerRunsTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.ortrun.OrtRunsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.repository.RepositoriesTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageCurationDataTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageCurationsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.VulnerabilityResolutionsTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.resolvedconfiguration.ResolvedConfigurationsTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.resolvedconfiguration.ResolvedPackageCurationProvidersTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.resolvedconfiguration.ResolvedPackageCurationsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
-import org.eclipse.apoapsis.ortserver.dao.utils.applyILike
 import org.eclipse.apoapsis.ortserver.model.CountByCategory
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityFilters
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityForRunsFilters
@@ -55,7 +45,6 @@ import org.eclipse.apoapsis.ortserver.model.runs.advisor.AdvisorDetails
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.Vulnerability
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.VulnerabilityReference
 import org.eclipse.apoapsis.ortserver.model.runs.repository.VulnerabilityResolution
-import org.eclipse.apoapsis.ortserver.model.util.ComparisonOperator
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
 import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
@@ -65,7 +54,6 @@ import org.eclipse.apoapsis.ortserver.services.utils.toSortOrder
 
 import org.jetbrains.exposed.v1.core.Case
 import org.jetbrains.exposed.v1.core.Count
-import org.jetbrains.exposed.v1.core.CustomFunction
 import org.jetbrains.exposed.v1.core.Expression
 import org.jetbrains.exposed.v1.core.ExpressionWithColumnTypeAlias
 import org.jetbrains.exposed.v1.core.GroupConcat
@@ -73,7 +61,6 @@ import org.jetbrains.exposed.v1.core.IntegerColumnType
 import org.jetbrains.exposed.v1.core.JoinType
 import org.jetbrains.exposed.v1.core.LiteralOp
 import org.jetbrains.exposed.v1.core.Max
-import org.jetbrains.exposed.v1.core.Op
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.TextColumnType
@@ -81,18 +68,14 @@ import org.jetbrains.exposed.v1.core.UpperCase
 import org.jetbrains.exposed.v1.core.alias
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.castTo
-import org.jetbrains.exposed.v1.core.concat
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.innerJoin
-import org.jetbrains.exposed.v1.core.isNotNull
-import org.jetbrains.exposed.v1.core.neq
 import org.jetbrains.exposed.v1.core.not
 import org.jetbrains.exposed.v1.core.notExists
-import org.jetbrains.exposed.v1.core.notInList
 import org.jetbrains.exposed.v1.core.or
 import org.jetbrains.exposed.v1.core.stringLiteral
-import org.jetbrains.exposed.v1.core.wrapAsExpression
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.Query
 import org.jetbrains.exposed.v1.jdbc.andWhere
@@ -381,149 +364,7 @@ class VulnerabilityService(private val db: Database, private val ortRunService: 
     private fun buildListForOrtRunsQuery(
         ortRunIds: List<Long>,
         filters: VulnerabilityForRunsFilters
-    ): OrtRunsQueryContext {
-        val runIdsAlias = runIdsAlias()
-        val repositoriesCountAlias = repositoriesCountAlias()
-
-        val curatedPurlSubquery = PackageCurationDataTable
-            .innerJoin(PackageCurationsTable)
-            .innerJoin(ResolvedPackageCurationsTable)
-            .innerJoin(ResolvedPackageCurationProvidersTable)
-            .innerJoin(ResolvedConfigurationsTable)
-            .select(PackageCurationDataTable.purl)
-            .where {
-                (ResolvedConfigurationsTable.ortRunId eq OrtRunsTable.id) and (
-                    PackageCurationsTable.identifierId eq
-                    IdentifiersTable.id
-                ) and (PackageCurationDataTable.purl.isNotNull())
-            }
-            .orderBy(ResolvedPackageCurationProvidersTable.rank)
-            .orderBy(ResolvedPackageCurationsTable.rank)
-            .limit(1)
-
-        val curatedPurlExpression: Expression<String?> = wrapAsExpression(curatedPurlSubquery)
-
-        val purlAlias = CustomFunction(
-            "COALESCE",
-            PackagesTable.purl.columnType,
-            curatedPurlExpression,
-            PackagesTable.purl
-        ).alias("purl")
-
-        // Pre-compute rating per vulnerability in a single pass over VulnerabilityReferencesTable,
-        // instead of joining it into the main query which multiplies rows by reference count.
-        val ratingAlias = ratingAlias()
-        val precomputedRatings = VulnerabilityReferencesTable
-            .select(VulnerabilityReferencesTable.vulnerabilityId, ratingAlias)
-            .groupBy(VulnerabilityReferencesTable.vulnerabilityId)
-            .alias("vuln_ratings")
-
-        val vulnerabilityIdAlias = VulnerabilitiesTable.id.alias("vulnerability_id")
-        val identifierIdAlias = IdentifiersTable.id.alias("identifier_id")
-        val ortRunIdAlias = OrtRunsTable.id.alias("ort_run_id")
-        val precomputedRatingAlias = Max(
-            precomputedRatings[ratingAlias], IntegerColumnType()
-        ).alias("precomputed_rating")
-
-        val subQuery = VulnerabilitiesTable
-            .innerJoin(AdvisorResultsVulnerabilitiesTable)
-            .innerJoin(AdvisorResultsTable)
-            .innerJoin(AdvisorRunsIdentifiersTable)
-            .innerJoin(AdvisorRunsTable)
-            .innerJoin(AdvisorJobsTable)
-            .innerJoin(OrtRunsTable)
-            .innerJoin(IdentifiersTable)
-            .innerJoin(AnalyzerJobsTable)
-            .innerJoin(AnalyzerRunsTable)
-            .innerJoin(PackagesAnalyzerRunsTable)
-            .innerJoin(PackagesTable)
-            .join(
-                precomputedRatings,
-                JoinType.LEFT,
-                VulnerabilitiesTable.id,
-                precomputedRatings[VulnerabilityReferencesTable.vulnerabilityId]
-            )
-            .select(
-                vulnerabilityIdAlias, identifierIdAlias, ortRunIdAlias, purlAlias, precomputedRatingAlias
-            )
-            .where { OrtRunsTable.id inList ortRunIds }
-            .groupBy(VulnerabilitiesTable.id, IdentifiersTable.id, purlAlias, OrtRunsTable.id)
-            .alias("subquery")
-
-        val purlColumn = subQuery[purlAlias]
-        val ratingColumn = subQuery[precomputedRatingAlias]
-        val maxRatingAlias = Max(ratingColumn, IntegerColumnType()).alias("maxRating")
-
-        val query = subQuery
-            .innerJoin(VulnerabilitiesTable, { subQuery[vulnerabilityIdAlias] }, { VulnerabilitiesTable.id })
-            .innerJoin(IdentifiersTable, { subQuery[identifierIdAlias] }, { IdentifiersTable.id })
-            .innerJoin(OrtRunsTable, { subQuery[ortRunIdAlias] }, { OrtRunsTable.id })
-            .innerJoin(RepositoriesTable)
-            .select(
-                VulnerabilitiesTable.id,
-                VulnerabilitiesTable.externalId,
-                VulnerabilitiesTable.summary,
-                VulnerabilitiesTable.description,
-                IdentifiersTable.type,
-                IdentifiersTable.namespace,
-                IdentifiersTable.name,
-                IdentifiersTable.version,
-                maxRatingAlias,
-                runIdsAlias,
-                repositoriesCountAlias,
-                purlColumn
-            )
-            .where {
-                var condition: Op<Boolean> = Op.TRUE
-
-                filters.rating?.let {
-                    val ratingsAsInt = it.value.map { severity -> severity.ordinal }
-                    condition = condition and when (it.operator) {
-                        ComparisonOperator.IN -> ratingColumn inList ratingsAsInt
-                        else -> ratingColumn notInList ratingsAsInt
-                    }
-                }
-
-                filters.identifier?.let {
-                    val namespaceWithSlash = Case()
-                        .When(
-                            IdentifiersTable.namespace neq stringLiteral(""),
-                            concat(IdentifiersTable.namespace, stringLiteral("/"))
-                        )
-                        .Else(stringLiteral(":"))
-
-                    val concatenatedIdentifier = concat(
-                        IdentifiersTable.type,
-                        stringLiteral(":"),
-                        namespaceWithSlash,
-                        IdentifiersTable.name,
-                        stringLiteral("@"),
-                        IdentifiersTable.version
-                    )
-
-                    condition = condition and concatenatedIdentifier.applyILike(it.value)
-                }
-
-                filters.purl?.let {
-                    condition = condition and purlColumn.applyILike(it.value)
-                }
-
-                filters.externalId?.let {
-                    condition = condition and VulnerabilitiesTable.externalId.applyILike(it.value)
-                }
-
-                condition
-            }
-            .groupBy(VulnerabilitiesTable.id, IdentifiersTable.id, purlColumn)
-
-        return OrtRunsQueryContext(
-            query = query,
-            purlColumn = purlColumn,
-            maxRatingAlias = maxRatingAlias,
-            runIdsAlias = runIdsAlias,
-            repositoriesCountAlias = repositoriesCountAlias
-        )
-    }
+    ): OrtRunsQueryContext = buildOrtRunsQueryContext(ortRunIds, filters)
 
     private fun fetchPagedAccumulatedVulnerabilities(
         context: OrtRunsQueryContext,
@@ -538,7 +379,7 @@ class VulnerabilityService(private val db: Database, private val ortRunService: 
 
                 "repositoriesCount" -> orders += context.repositoriesCountAlias to sortOrder
 
-                "externalId" -> orders += VulnerabilitiesTable.externalId to sortOrder
+                "externalId" -> orders += context.externalIdColumn to sortOrder
 
                 "identifier" -> {
                     orders += IdentifiersTable.type to sortOrder
@@ -563,17 +404,17 @@ class VulnerabilityService(private val db: Database, private val ortRunService: 
 
         if (pagedRows.isEmpty()) return emptyList()
 
-        val vulnerabilityIds = pagedRows.map { it[VulnerabilitiesTable.id].value }.distinct()
+        val vulnerabilityIds = pagedRows.map { it[context.vulnerabilityIdColumn].value }.distinct()
         val referencesById = fetchVulnerabilityReferencesById(vulnerabilityIds)
 
         return pagedRows.map { row ->
-            val vulnerabilityId = row[VulnerabilitiesTable.id].value
+            val vulnerabilityId = row[context.vulnerabilityIdColumn].value
 
             VulnerabilityWithAccumulatedData(
                 vulnerability = Vulnerability(
-                    externalId = row[VulnerabilitiesTable.externalId],
-                    summary = row[VulnerabilitiesTable.summary],
-                    description = row[VulnerabilitiesTable.description],
+                    externalId = row[context.externalIdColumn],
+                    summary = row[context.summaryColumn],
+                    description = row[context.descriptionColumn],
                     references = referencesById[vulnerabilityId].orEmpty()
                 ),
                 identifier = Identifier(
@@ -708,12 +549,16 @@ class VulnerabilityService(private val db: Database, private val ortRunService: 
         }
 }
 
-private data class OrtRunsQueryContext(
+internal data class OrtRunsQueryContext(
     val query: Query,
     val purlColumn: Expression<String>,
     val maxRatingAlias: ExpressionWithColumnTypeAlias<Int?>,
     val runIdsAlias: ExpressionWithColumnTypeAlias<String>,
-    val repositoriesCountAlias: ExpressionWithColumnTypeAlias<Long>
+    val repositoriesCountAlias: ExpressionWithColumnTypeAlias<Long>,
+    val vulnerabilityIdColumn: Expression<EntityID<Long>>,
+    val externalIdColumn: Expression<String>,
+    val summaryColumn: Expression<String?>,
+    val descriptionColumn: Expression<String?>
 )
 
 private data class PagedVulnerabilityRow(
@@ -724,7 +569,7 @@ private data class PagedVulnerabilityRow(
 )
 
 /** Alias for determining an advisory overall rating of a vulnerability based on its individual references. */
-private fun ratingAlias(): ExpressionWithColumnTypeAlias<Int?> {
+internal fun ratingAlias(): ExpressionWithColumnTypeAlias<Int?> {
     val severityCase = Case()
         .When(UpperCase(VulnerabilityReferencesTable.severity) eq "CRITICAL", LiteralOp(IntegerColumnType(), 4))
         .When(UpperCase(VulnerabilityReferencesTable.severity) eq "HIGH", LiteralOp(IntegerColumnType(), 3))
@@ -736,14 +581,14 @@ private fun ratingAlias(): ExpressionWithColumnTypeAlias<Int?> {
 }
 
 /** Alias for gathering the IDs of the runs where the vulnerability was found in. */
-private fun runIdsAlias() = GroupConcat(
+internal fun runIdsAlias() = GroupConcat(
     OrtRunsTable.id.castTo(TextColumnType()),
     ",",
     true
 ).alias("runIds")
 
 /** Alias to return the count for the repositories that the vulnerability was found in. */
-private fun repositoriesCountAlias() = Count(
+internal fun repositoriesCountAlias() = Count(
     RepositoriesTable.id,
     true
 ).alias("repositoriesCount")


### PR DESCRIPTION
Even with the recent refactoring of vulnerabilities queries in #4577, organization vulnerabilities query took several seconds for ~400 vulnerabilities. By measuring via pgAdmin's EXPLAIN ANALYZE, it was found that most of the query time was spent on expensive PostgreSQL JIT (Just In Time) compilation of the query.

The real root reason for these queries still involving wide join chains can very well be a flawed/sub-optimal database schema, resulting in a complex query plan, which explodes JIT compilation times.

This PR mitigates the problem by decomposing the query into independently pre-aggregated relations that are joined back at the end. This keeps each sub-query simple enough for the PostgreSQL planner and JIT compiler to handle efficiently. The plan shape is fixed regardless of data volume, so JIT cost stays constant as vulnerability counts grow.

The result of this refactor is measured manually, by replicating an organization with ~400 vulnerabilities, where the organization vulnerabilities query now executes in sub-second time.

One might very well argue that accepting this PR is controversial, because it trades performance wins (which are important to the user experience) to increased "Kotlin complexity" of the query and such, harder to maintain codebase.  I believe this should be a team discussion. 

However, the author regards it as "the best I can do with the current database schema", and the biggest refactor (`OrtRunsVulnerabilityQueryBuilder.kt`) is split out into sub-functions and documented.