### PR TITLE
ui: Also disable "delete ORT run" with insufficient permissions

### DIFF
--- a/components/authorization/backend/src/main/kotlin/rights/RepositoryPermission.kt
+++ b/components/authorization/backend/src/main/kotlin/rights/RepositoryPermission.kt
@@ -45,6 +45,6 @@ enum class RepositoryPermission {
     /** Permission to trigger an [OrtRun] for the [Repository]. */
     TRIGGER_ORT_RUN,
 
-    /** Permission to delete the [Repository]. */
+    /** Permission to delete the [Repository], or to delete an [OrtRun] from it. */
     DELETE
 }

--- a/ui/src/components/delete-dialog.tsx
+++ b/ui/src/components/delete-dialog.tsx
@@ -18,7 +18,13 @@
  */
 
 import { Loader2, OctagonAlert } from 'lucide-react';
-import { ReactNode, useEffect, useState } from 'react';
+import {
+  cloneElement,
+  isValidElement,
+  ReactNode,
+  useEffect,
+  useState,
+} from 'react';
 
 import {
   AlertDialog,
@@ -76,6 +82,12 @@ interface DeleteDialogProps {
    * The title of the delete dialog.
    */
   title?: string;
+
+  /**
+   * Whether the delete action is disabled (e.g. due to insufficient permissions).
+   * When true, the uiComponent is rendered as disabled and the dialog cannot be opened.
+   */
+  disabled?: boolean;
 }
 
 export const DeleteDialog = ({
@@ -86,11 +98,22 @@ export const DeleteDialog = ({
   onDelete,
   tooltip,
   title,
+  disabled,
 }: DeleteDialogProps) => {
   const [input, setInput] = useState('');
   const [open, setOpen] = useState(false);
   const [isPending, setIsPending] = useState(false);
   const isDeleteDisabled = thingId ? input !== thingId : false;
+
+  const triggerElement =
+    disabled && isValidElement(uiComponent)
+      ? cloneElement(
+          uiComponent as React.ReactElement<{ disabled?: boolean }>,
+          {
+            disabled: true,
+          }
+        )
+      : uiComponent;
 
   // Reset the input field whenever the dialog is opened/closed
   useEffect(() => {
@@ -103,9 +126,17 @@ export const DeleteDialog = ({
     <AlertDialog open={open} onOpenChange={setOpen}>
       <Tooltip delayDuration={300}>
         <TooltipTrigger asChild>
-          <AlertDialogTrigger asChild>{uiComponent}</AlertDialogTrigger>
+          {disabled ? (
+            <span className='inline-flex cursor-not-allowed'>
+              {triggerElement}
+            </span>
+          ) : (
+            <AlertDialogTrigger asChild>{uiComponent}</AlertDialogTrigger>
+          )}
         </TooltipTrigger>
-        <TooltipContent>{tooltip || 'Delete'}</TooltipContent>
+        <TooltipContent>
+          {disabled ? 'Insufficient permissions.' : tooltip || 'Delete'}
+        </TooltipContent>
       </Tooltip>
       {/* Adding the preventDefault will prevent focusing on the trigger after closing the modal (which would cause the tooltip to show) */}
       <AlertDialogContent onCloseAutoFocus={(e) => e.preventDefault()}>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/repository-runs-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/repository-runs-table.tsx
@@ -272,6 +272,11 @@ const columns = [
         'TRIGGER_ORT_RUN'
       );
 
+      const { isAllowed: canDeleteRun } = useRepositoryPermission(
+        row.original.repositoryId,
+        'DELETE'
+      );
+
       const { mutateAsync: deleteRun } = useMutation({
         ...deleteRepositoryRunMutation(),
         onSuccess() {
@@ -370,6 +375,7 @@ const columns = [
             }
             uiComponent={<DeleteIconButton />}
             onDelete={handleDelete}
+            disabled={canDeleteRun === false}
           />
         </div>
       );


### PR DESCRIPTION
This is a follow-up for #4610.

<img width="1045" height="182" alt="Screenshot from 2026-03-06 07-07-50" src="https://github.com/user-attachments/assets/8bf521e9-aed9-4d93-8f38-45060ea39780" />

Please see the commit for details.