### PR TITLE
build(gradle): Update Eclipse Maven Repository URL

### DIFF
--- a/buildSrc/src/main/kotlin/ort-server-base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-base-conventions.gradle.kts
@@ -40,7 +40,7 @@ repositories {
 
     exclusiveContent {
         forRepository {
-            maven("https://repo.eclipse.org/content/groups/releases")
+            maven("https://repo.eclipse.org/content/repositories/releases")
         }
 
         filter {


### PR DESCRIPTION
This is due to the Nexus 2 to 3 migration, see [1].

[1]: https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/7168