### PR TITLE
fix(compose): Add the missing `basic` client scope

### DIFF
--- a/scripts/docker/keycloak/master-realm.json
+++ b/scripts/docker/keycloak/master-realm.json
@@ -751,7 +751,7 @@
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : true,
     "nodeReRegistrationTimeout" : -1,
-    "defaultClientScopes" : [ "profile", "ort-server-api-access", "email" ],
+    "defaultClientScopes" : [ "profile", "ort-server-api-access", "basic", "email" ],
     "optionalClientScopes" : [ "offline_access" ]
   }, {
     "id" : "559d3c4a-ed70-4a36-b4b4-32d798ee6262",
@@ -805,7 +805,7 @@
     "authenticationFlowBindingOverrides" : { },
     "fullScopeAllowed" : true,
     "nodeReRegistrationTimeout" : -1,
-    "defaultClientScopes" : [ "profile", "ort-server-api-access", "email" ],
+    "defaultClientScopes" : [ "profile", "ort-server-api-access", "basic", "email" ],
     "optionalClientScopes" : [ ]
   }, {
     "id" : "115c6dcc-fcba-460c-95bb-f2ad93a2aba3",

--- a/website/docs/admin-guide/guides/keycloak-config.md
+++ b/website/docs/admin-guide/guides/keycloak-config.md
@@ -78,7 +78,7 @@ Currently, the UI only supports the "Standard flow" which corresponds to the "Au
 - _Client authentication:_ Disabled
 - _Authentication flow:_ Standard flow
 - _PKCE method:_ S256
-- _Client scopes:_ `email`, `profile`, `ort-server-api-access`
+- _Client scopes:_ `basic`, `email`, `profile`, `ort-server-api-access`
 - _Valid redirect URIs:_ The URL where the UI is hosted followed by `/*`, for example `http://localhost:8082/*`.
 - _Web origins:_ Use `+` to allow all valid redirect URIs.
 
@@ -99,7 +99,7 @@ Currently, the CLI only supports the "Direct access grants" flow which correspon
 - _Default client ID:_ `ort-server-cli`
 - _Client authentication:_ Disabled
 - _Authentication flow:_ Direct access grants
-- _Client scopes:_ `email`, `profile`, `ort-server-api-access`, `offline_access`
+- _Client scopes:_ `basic`, `email`, `profile`, `ort-server-api-access`, `offline_access`
 
 The remaining default scopes are not required and can be removed to minimize the token size.
 


### PR DESCRIPTION
Add the `basic` scope to the `ort-server-cli` and `ort-server-ui` clients to add the missing `sub` claim to the tokens.

This is a fixup for 5b9d754.