### PR TITLE
Make UI Docker image compatible with read-only root filesystems

### DIFF
--- a/ui/README.md
+++ b/ui/README.md
@@ -86,3 +86,16 @@ The Docker image can be configured by the following environment variables:
 | `UI_BASEPATH`  | `/`                                   | The base path of the UI.             |
 | `UI_AUTHORITY` | `http://localhost:8081/realms/master` | The URL of the Keycloak realm.       |
 | `UI_CLIENT_ID` | `ort-server-ui`                       | The client ID of the UI in Keycloak. |
+
+### Read-only Root Filesystem
+
+The image supports running with a read-only root filesystem (e.g. in OpenShift).
+The following directories must be writable and should be mounted as `emptyDir` volumes:
+
+| Path                    | Purpose                                 |
+| ----------------------- | --------------------------------------- |
+| `/etc/nginx/conf.d`     | Generated nginx config.                 |
+| `/var/cache/nginx`      | nginx cache.                            |
+| `/var/log/nginx`        | nginx logs.                             |
+| `/usr/share/nginx/html` | Serving directory populated at startup. |
+| `/var/run`              | nginx PID file.                         |

--- a/ui/docker/UI.Dockerfile
+++ b/ui/docker/UI.Dockerfile
@@ -40,19 +40,26 @@ RUN pnpm run build
 # Stage 2: Serve the app with nginx.
 FROM nginx:1.29-alpine@sha256:f46cb72c7df02710e693e863a983ac42f6a9579058a59a35f1ae36c9958e4ce0
 
-# Copy the build output to the nginx html directory.
-COPY --from=build /app/dist /usr/share/nginx/html
+# Copy the build output to a template directory. The entrypoint script will copy the files to /usr/share/nginx/html at
+# startup, allowing the serving directory to be a writable volume mount.
+COPY --from=build /app/dist /usr/share/nginx/html-template
 
-# Copy custom nginx configuration.
-COPY docker/nginx.conf.template /etc/nginx/conf.d/default.conf.template
+# Copy custom nginx configuration to /etc/nginx/. The entrypoint script will copy the file to
+# /etc/nginx/conf.d/default.conf at startup, allowing /etc/nginx/conf.d to be a writable volume mount.
+COPY docker/nginx.conf.template /etc/nginx/default.conf.template
 
 # Copy entrypoint script.
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 # Make sure the user executing the container has access rights to the directories required by nginx.
-RUN chgrp -R 0 /var/cache/nginx /var/run /var/log/nginx /usr/share/nginx/html /etc/nginx/conf.d \
-    && chmod -R g+rwX /var/cache/nginx /var/run /var/log/nginx /usr/share/nginx/html /etc/nginx/conf.d
+# The template directory only needs to be readable by the group.
+RUN chgrp -R 0 /usr/share/nginx/html-template \
+    && chmod -R g+rX /usr/share/nginx/html-template
+
+# nginx needs to write to these directories at runtime.
+RUN chgrp -R 0 /var/cache/nginx /var/run /var/log/nginx \
+    && chmod -R g+rwX /var/cache/nginx /var/run /var/log/nginx
 
 # Expose port 8080.
 EXPOSE 8080

--- a/ui/docker/entrypoint.sh
+++ b/ui/docker/entrypoint.sh
@@ -24,6 +24,9 @@
 : "${UI_CLIENT_ID:=ort-server-ui}"
 : "${UI_URL:=http://localhost:8082/}"
 
+# Copy template files to the serving directory. This allows the serving directory to be a writable volume mount.
+cp -r /usr/share/nginx/html-template/. /usr/share/nginx/html/
+
 # Replace placeholders with actual environment variables in JavaScript files.
 find /usr/share/nginx/html/assets -name '*.js' -exec sed -i "s#UI_API_URL_PLACEHOLDER#$UI_API_URL#g" {} +
 find /usr/share/nginx/html/assets -name '*.js' -exec sed -i "s#UI_AUTHORITY_PLACEHOLDER#$UI_AUTHORITY#g" {} +
@@ -33,8 +36,7 @@ find /usr/share/nginx/html/assets -name '*.js' -exec sed -i "s#UI_URL_PLACEHOLDE
 
 # Replace placeholders with actual environment variables in the nginx configuration.
 export UI_BASEPATH
-envsubst '${UI_BASEPATH}' < /etc/nginx/conf.d/default.conf.template > /etc/nginx/conf.d/default.conf
-rm /etc/nginx/conf.d/default.conf.template
+envsubst '${UI_BASEPATH}' < /etc/nginx/default.conf.template > /etc/nginx/conf.d/default.conf
 
 # Add base path to assets references in index.html.
 sed -i "s|/assets/|${UI_BASEPATH}assets/|g" /usr/share/nginx/html/index.html


### PR DESCRIPTION
See the commit messages for details. This was tested in Docker Compose by adding the following config to the UI service:

```yaml
    read_only: true
    tmpfs:
      - /etc/nginx/conf.d
      - /var/cache/nginx
      - /var/log/nginx
      - /usr/share/nginx/html
      - /var/run
```