### PR TITLE
ui: Manage vulnerability resolutions in the UI

### DIFF
--- a/ui/src/components/resolutions.tsx
+++ b/ui/src/components/resolutions.tsx
@@ -17,52 +17,511 @@
  * License-Filename: LICENSE
  */
 
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Pencil } from 'lucide-react';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import {
+  createVulnerabilityResolutionMutation,
+  deleteVulnerabilityResolutionMutation,
+  getRunVulnerabilitiesQueryKey,
+  updateVulnerabilityResolutionMutation,
+} from '@/api/@tanstack/react-query.gen';
+import {
+  AppliedVulnerabilityResolution,
+  VulnerabilityResolution,
+} from '@/api/types.gen';
+import {
+  zCreateVulnerabilityResolution,
+  zVulnerabilityResolutionReason,
+} from '@/api/zod.gen';
+import { DeleteDialog } from '@/components/delete-dialog';
+import { DeleteIconButton } from '@/components/delete-icon-button';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { getIssueSeverityBackgroundColor } from '@/helpers/get-status-class';
-import { ItemWithResolutions } from '@/helpers/resolutions';
+import {
+  getAppliedVulnerabilityResolutions,
+  getUnappliedVulnerabilityResolutions,
+  hasVulnerabilityResolutionActivity,
+  isVulnerabilityItem,
+  ItemWithResolutions,
+} from '@/helpers/resolutions';
+import { ApiError } from '@/lib/api-error';
+import { toast, toastError } from '@/lib/toast';
+
+type ResolutionFormValues = z.infer<typeof zCreateVulnerabilityResolution>;
+type ResolutionItem =
+  | NonNullable<ItemWithResolutions['resolutions']>[number]
+  | VulnerabilityResolution;
+
+type ResolutionFormFieldsProps = {
+  form: ReturnType<typeof useForm<ResolutionFormValues>>;
+};
+
+function ResolutionFormFields({ form }: ResolutionFormFieldsProps) {
+  return (
+    <>
+      <FormField
+        control={form.control}
+        name='reason'
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Reason</FormLabel>
+            <Select onValueChange={field.onChange} value={field.value}>
+              <FormControl>
+                <SelectTrigger>
+                  <SelectValue placeholder='Select a reason' />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                {zVulnerabilityResolutionReason.options.map((reason) => (
+                  <SelectItem key={reason} value={reason}>
+                    {reason}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={form.control}
+        name='comment'
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Comment</FormLabel>
+            <FormControl>
+              <Input {...field} placeholder='Add a comment...' />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </>
+  );
+}
+
+type ManagedResolutionContext = {
+  repositoryId: string;
+  externalId: string;
+  runId: number;
+};
+
+type ResolutionFormProps = {
+  context: ManagedResolutionContext;
+  mode: 'create' | 'edit';
+  defaultValues: ResolutionFormValues;
+  onCancel?: () => void;
+  onSuccess?: () => void;
+};
+
+function ResolutionForm({
+  context,
+  mode,
+  defaultValues,
+  onCancel,
+  onSuccess,
+}: ResolutionFormProps) {
+  const queryClient = useQueryClient();
+
+  const form = useForm<ResolutionFormValues>({
+    resolver: zodResolver(zCreateVulnerabilityResolution),
+    defaultValues,
+  });
+
+  const { mutateAsync, isPending } = useMutation({
+    ...(mode === 'create'
+      ? createVulnerabilityResolutionMutation()
+      : updateVulnerabilityResolutionMutation()),
+    onSuccess() {
+      queryClient.invalidateQueries({
+        queryKey: getRunVulnerabilitiesQueryKey({
+          path: { runId: context.runId },
+        }),
+      });
+      toast.info(
+        mode === 'create' ? 'Resolution created' : 'Resolution updated',
+        {
+          description:
+            mode === 'create'
+              ? 'Vulnerability resolution created successfully.'
+              : 'Vulnerability resolution updated successfully.',
+        }
+      );
+    },
+    onError(error: ApiError) {
+      toastError(error.message, error);
+    },
+  });
+
+  const onSubmit = async (values: ResolutionFormValues) => {
+    await mutateAsync({
+      path: {
+        repositoryId: context.repositoryId,
+        externalId: context.externalId,
+      },
+      body: values,
+    });
+
+    if (mode === 'edit') {
+      onSuccess?.();
+    }
+  };
+
+  const formButtons =
+    mode === 'create' ? (
+      <Button type='submit' disabled={isPending} className='w-fit'>
+        {isPending ? 'Creating...' : 'Create resolution'}
+      </Button>
+    ) : (
+      <div className='flex gap-2'>
+        <Button type='submit' disabled={isPending}>
+          {isPending ? 'Saving...' : 'Save'}
+        </Button>
+        <Button type='button' variant='outline' onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    );
+
+  const formContent = (
+    <Form {...form}>
+      <form
+        onSubmit={form.handleSubmit(onSubmit)}
+        className='flex flex-col gap-4'
+      >
+        <ResolutionFormFields form={form} />
+        {formButtons}
+      </form>
+    </Form>
+  );
+
+  if (mode === 'create') {
+    return (
+      <Card>
+        <CardContent>{formContent}</CardContent>
+      </Card>
+    );
+  }
+
+  return <CardContent>{formContent}</CardContent>;
+}
+
+type ResolutionDisplayItem = {
+  key: string;
+  resolution: ResolutionItem;
+  state: 'applied' | 'pending-create' | 'pending-update' | 'pending-delete';
+  showActions: boolean;
+};
+
+function getResolutionKey(
+  resolution:
+    | Pick<AppliedVulnerabilityResolution, 'source'>
+    | Pick<VulnerabilityResolution, 'source'>
+) {
+  return resolution.source;
+}
+
+function getVulnerabilityDisplayItems(
+  item: Extract<ItemWithResolutions, { vulnerability: unknown }>,
+  canManage: boolean
+): ResolutionDisplayItem[] {
+  const appliedResolutions = getAppliedVulnerabilityResolutions(item);
+  const unappliedResolutions = getUnappliedVulnerabilityResolutions(item);
+  const unappliedBySource = new Map(
+    unappliedResolutions.map((resolution) => [
+      getResolutionKey(resolution),
+      resolution,
+    ])
+  );
+
+  const displayItems: ResolutionDisplayItem[] = [];
+
+  for (const resolution of appliedResolutions) {
+    const source = getResolutionKey(resolution);
+    const unappliedResolution = unappliedBySource.get(source);
+
+    displayItems.push({
+      key: `${source}:applied`,
+      resolution,
+      state:
+        resolution.isDeleted && !unappliedResolution
+          ? 'pending-delete'
+          : 'applied',
+      showActions: !resolution.isDeleted && !unappliedResolution && canManage,
+    });
+
+    if (unappliedResolution) {
+      displayItems.push({
+        key: `${source}:pending-update`,
+        resolution: unappliedResolution,
+        state: 'pending-update',
+        showActions: canManage,
+      });
+    }
+  }
+
+  for (const resolution of unappliedResolutions) {
+    if (
+      !appliedResolutions.some(
+        (applied) => getResolutionKey(applied) === getResolutionKey(resolution)
+      )
+    ) {
+      displayItems.push({
+        key: `${getResolutionKey(resolution)}:pending-create`,
+        resolution,
+        state: 'pending-create',
+        showActions: canManage,
+      });
+    }
+  }
+
+  return displayItems;
+}
+
+function getDisplayItems(
+  item: ItemWithResolutions,
+  canManage: boolean
+): ResolutionDisplayItem[] {
+  if (isVulnerabilityItem(item)) {
+    return getVulnerabilityDisplayItems(item, canManage);
+  }
+
+  return (item.resolutions ?? []).map((resolution) => ({
+    key: resolution.source,
+    resolution,
+    state: 'applied',
+    showActions: false,
+  }));
+}
 
 type ResolutionsProps = {
   item: ItemWithResolutions;
+  repositoryId?: string;
+  runId?: number;
 };
 
-export function Resolutions({ item }: ResolutionsProps) {
+type ResolutionCardProps = {
+  displayItem: ResolutionDisplayItem;
+  editingKey: string | null;
+  setEditingKey: (key: string | null) => void;
+  context?: ManagedResolutionContext;
+  onDelete?: () => void;
+};
+
+function ResolutionCard({
+  displayItem,
+  editingKey,
+  setEditingKey,
+  context,
+  onDelete,
+}: ResolutionCardProps) {
+  const { key, resolution, state, showActions } = displayItem;
+  const isEditing = editingKey === key;
+  const pendingLabel =
+    state === 'pending-create'
+      ? 'Created: pending rerun'
+      : state === 'pending-update'
+        ? 'Updated: pending rerun'
+        : state === 'pending-delete'
+          ? 'Deleted: pending rerun'
+          : null;
+
   return (
-    <>
-      {item.resolutions && item.resolutions.length > 0 ? (
-        item.resolutions.map((resolution) => (
-          <Card>
-            <CardHeader>
-              <CardTitle className='flex justify-between'>
-                <div>{resolution.reason}</div>
-                <Badge
-                  variant='small'
-                  className={getIssueSeverityBackgroundColor('HINT')}
-                >
-                  {resolution.source}
-                </Badge>
-              </CardTitle>
-            </CardHeader>
-            <CardContent className='flex flex-col gap-2'>
-              <div className='italic'>{resolution.comment}</div>
-              <div className='flex gap-2'>
-                <div className='text-muted-foreground font-semibold'>
-                  {'externalId' in resolution
-                    ? 'ID Matcher:'
-                    : 'Message Matcher:'}
-                </div>
-                <div className='text-muted-foreground'>
-                  {'externalId' in resolution
-                    ? resolution.externalId
-                    : resolution.message}
-                </div>
-              </div>
-            </CardContent>
-          </Card>
-        ))
+    <Card key={key}>
+      <CardHeader>
+        <CardTitle className='flex justify-between'>
+          <div className='flex items-center gap-2'>
+            {resolution.reason}
+            {pendingLabel && (
+              <Tooltip>
+                <TooltipTrigger>
+                  <Badge variant='small' className='bg-yellow-200 text-black'>
+                    {pendingLabel}
+                  </Badge>
+                </TooltipTrigger>
+                <TooltipContent>
+                  The operation will be applied on the next run.
+                </TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+          <Badge
+            variant='small'
+            className={getIssueSeverityBackgroundColor('HINT')}
+          >
+            {resolution.source}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      {isEditing && context ? (
+        <ResolutionForm
+          context={context}
+          mode='edit'
+          defaultValues={{
+            comment: resolution.comment,
+            reason: resolution.reason as ResolutionFormValues['reason'],
+          }}
+          onCancel={() => setEditingKey(null)}
+          onSuccess={() => setEditingKey(null)}
+        />
       ) : (
-        <div className='text-muted-foreground italic'>No resolutions.</div>
+        <CardContent className='flex items-start justify-between gap-2'>
+          <div className='flex flex-col gap-2'>
+            <div className='italic'>{resolution.comment}</div>
+            <div className='flex gap-2'>
+              <div className='text-muted-foreground font-semibold'>
+                {'externalId' in resolution
+                  ? 'ID Matcher:'
+                  : 'Message Matcher:'}
+              </div>
+              <div className='text-muted-foreground'>
+                {'externalId' in resolution
+                  ? resolution.externalId
+                  : resolution.message}
+              </div>
+            </div>
+          </div>
+          {showActions && context && onDelete && (
+            <div className='flex flex-col gap-1'>
+              <Button
+                variant='outline'
+                size='sm'
+                onClick={() => setEditingKey(key)}
+              >
+                <Pencil className='h-4 w-4' />
+              </Button>
+              <DeleteDialog
+                thingName='resolution'
+                uiComponent={<DeleteIconButton />}
+                onDelete={onDelete}
+              />
+            </div>
+          )}
+        </CardContent>
       )}
-    </>
+    </Card>
+  );
+}
+
+function VulnerabilityResolutions({
+  item,
+  repositoryId,
+  runId,
+}: {
+  item: Extract<ItemWithResolutions, { vulnerability: unknown }>;
+  repositoryId: string;
+  runId: number;
+}) {
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const context: ManagedResolutionContext = {
+    repositoryId,
+    externalId: item.vulnerability.externalId,
+    runId,
+  };
+  const displayItems = getDisplayItems(item, true);
+  const hasAnyResolution = hasVulnerabilityResolutionActivity(item);
+
+  const { mutateAsync: deleteResolution } = useMutation({
+    ...deleteVulnerabilityResolutionMutation(),
+    onSuccess() {
+      queryClient.invalidateQueries({
+        queryKey: getRunVulnerabilitiesQueryKey({ path: { runId } }),
+      });
+      toast.info('Resolution deleted', {
+        description: 'Vulnerability resolution deleted successfully.',
+      });
+    },
+    onError(error: ApiError) {
+      toastError(error.message, error);
+    },
+  });
+
+  return (
+    <div className='flex flex-col gap-2'>
+      {displayItems.map((displayItem) => (
+        <ResolutionCard
+          key={displayItem.key}
+          displayItem={displayItem}
+          editingKey={editingKey}
+          setEditingKey={setEditingKey}
+          context={context}
+          onDelete={() =>
+            deleteResolution({
+              path: {
+                repositoryId: context.repositoryId,
+                externalId: context.externalId,
+              },
+            })
+          }
+        />
+      ))}
+      {!hasAnyResolution && (
+        <ResolutionForm
+          context={context}
+          mode='create'
+          defaultValues={{
+            comment: '',
+            reason: 'CANT_FIX_VULNERABILITY',
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+export function Resolutions({ item, repositoryId, runId }: ResolutionsProps) {
+  const [editingKey, setEditingKey] = useState<string | null>(null);
+  const displayItems = getDisplayItems(item, false);
+
+  if ('vulnerability' in item && repositoryId && runId !== undefined) {
+    return (
+      <VulnerabilityResolutions
+        item={item}
+        repositoryId={repositoryId}
+        runId={runId}
+      />
+    );
+  }
+
+  return (
+    <div className='flex flex-col gap-2'>
+      {displayItems.map((displayItem) => (
+        <ResolutionCard
+          key={displayItem.key}
+          displayItem={displayItem}
+          editingKey={editingKey}
+          setEditingKey={setEditingKey}
+        />
+      ))}
+    </div>
   );
 }

--- a/ui/src/helpers/resolutions.ts
+++ b/ui/src/helpers/resolutions.ts
@@ -24,7 +24,44 @@ export type ItemWithResolutions =
   | RuleViolation
   | VulnerabilityWithDetails;
 
+export function isVulnerabilityItem(
+  item: ItemWithResolutions
+): item is VulnerabilityWithDetails {
+  return 'vulnerability' in item;
+}
+
+export function getAppliedVulnerabilityResolutions(
+  item: VulnerabilityWithDetails
+) {
+  return item.resolutions.filter(
+    (resolution) => resolution.externalId === item.vulnerability.externalId
+  );
+}
+
+export function getUnappliedVulnerabilityResolutions(
+  item: VulnerabilityWithDetails
+) {
+  return item.unappliedResolutions.filter(
+    (resolution) => resolution.externalId === item.vulnerability.externalId
+  );
+}
+
+export function hasVulnerabilityResolutionActivity(
+  item: VulnerabilityWithDetails
+) {
+  return (
+    getAppliedVulnerabilityResolutions(item).length > 0 ||
+    getUnappliedVulnerabilityResolutions(item).length > 0
+  );
+}
+
 export function getResolvedStatus(item: ItemWithResolutions) {
+  if (isVulnerabilityItem(item)) {
+    return getAppliedVulnerabilityResolutions(item).length > 0
+      ? 'Resolved'
+      : 'Unresolved';
+  }
+
   return item.resolutions && item.resolutions.length > 0
     ? 'Resolved'
     : 'Unresolved';

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
@@ -31,7 +31,7 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 import { ChevronDown, ChevronUp } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import z from 'zod';
 
 import { VulnerabilityRating, VulnerabilityWithDetails } from '@/api';
@@ -82,7 +82,10 @@ import {
 } from '@/helpers/get-status-class';
 import { updateColumnSorting } from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-conversion';
-import { getResolvedStatus } from '@/helpers/resolutions';
+import {
+  getResolvedStatus,
+  hasVulnerabilityResolutionActivity,
+} from '@/helpers/resolutions';
 import { compareVulnerabilityRating } from '@/helpers/sorting-functions';
 import { ACTION_COLUMN_SIZE, ALL_ITEMS } from '@/lib/constants';
 import { toastError } from '@/lib/toast';
@@ -175,81 +178,6 @@ const VulnerabilityCard = ({
         </Badge>
       </div>
     </div>
-  );
-};
-
-const renderSubComponent = ({
-  row,
-}: {
-  row: Row<VulnerabilityWithDetails>;
-}) => {
-  const vulnerability = row.original.vulnerability;
-  const hasResolutions = getResolvedStatus(row.original) === 'Resolved';
-
-  return (
-    <Accordion
-      type='multiple'
-      className='w-full'
-      defaultValue={hasResolutions ? ['resolutions'] : ['details']}
-    >
-      <AccordionItem value='resolutions'>
-        <AccordionTrigger className='font-semibold'>
-          Resolutions
-        </AccordionTrigger>
-        <AccordionContent>
-          <Resolutions item={row.original} />
-        </AccordionContent>
-      </AccordionItem>
-      <AccordionItem value='details'>
-        <AccordionTrigger className='font-semibold'>Details</AccordionTrigger>
-        <AccordionContent>
-          <div className='flex flex-col gap-4'>
-            <VulnerabilityMetrics vulnerability={vulnerability} />
-            <div className='font-semibold'>Description</div>
-            <MarkdownRenderer
-              markdown={vulnerability.description || 'No description available'}
-            />
-            <div className='mt-2 text-lg font-semibold'>
-              Links to vulnerability references
-            </div>
-            <Table>
-              <TableHeader>
-                <TableRow>
-                  <TableHead>Severity</TableHead>
-                  <TableHead>Scoring system</TableHead>
-                  <TableHead>Score</TableHead>
-                  <TableHead>Vector</TableHead>
-                  <TableHead>Link</TableHead>
-                </TableRow>
-              </TableHeader>
-              <TableBody>
-                {vulnerability.references
-                  .sort((refA, refB) => (refB.score ?? 0) - (refA.score ?? 0))
-                  .map((reference, index) => (
-                    <TableRow key={index}>
-                      <TableCell>{reference.severity || '-'}</TableCell>
-                      <TableCell>{reference.scoringSystem || '-'}</TableCell>
-                      <TableCell>{reference.score || '-'}</TableCell>
-                      <TableCell>{reference.vector || '-'}</TableCell>
-                      <TableCell>
-                        {
-                          <Link
-                            className='font-semibold break-all text-blue-400 hover:underline'
-                            to={reference.url}
-                            target='_blank'
-                          >
-                            {reference.url}
-                          </Link>
-                        }
-                      </TableCell>
-                    </TableRow>
-                  ))}
-              </TableBody>
-            </Table>
-          </div>
-        </AccordionContent>
-      </AccordionItem>
-    </Accordion>
   );
 };
 
@@ -496,6 +424,92 @@ const VulnerabilitiesComponent = () => {
       query: { limit: ALL_ITEMS },
     }),
   });
+
+  const renderSubComponent = useCallback(
+    ({ row }: { row: Row<VulnerabilityWithDetails> }) => {
+      const vulnerability = row.original.vulnerability;
+      const hasAnyResolution = hasVulnerabilityResolutionActivity(row.original);
+
+      return (
+        <Accordion
+          type='multiple'
+          className='w-full'
+          defaultValue={
+            hasAnyResolution ? ['resolutions'] : ['resolutions', 'details']
+          }
+        >
+          <AccordionItem value='resolutions'>
+            <AccordionTrigger className='font-semibold'>
+              {hasAnyResolution ? 'Resolutions' : 'Create a resolution'}
+            </AccordionTrigger>
+            <AccordionContent>
+              <Resolutions
+                item={row.original}
+                repositoryId={params.repoId}
+                runId={ortRun.id}
+              />
+            </AccordionContent>
+          </AccordionItem>
+          <AccordionItem value='details'>
+            <AccordionTrigger className='font-semibold'>
+              Details
+            </AccordionTrigger>
+            <AccordionContent>
+              <div className='flex flex-col gap-4'>
+                <VulnerabilityMetrics vulnerability={vulnerability} />
+                <div className='font-semibold'>Description</div>
+                <MarkdownRenderer
+                  markdown={
+                    vulnerability.description || 'No description available'
+                  }
+                />
+                <div className='mt-2 text-lg font-semibold'>
+                  Links to vulnerability references
+                </div>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Severity</TableHead>
+                      <TableHead>Scoring system</TableHead>
+                      <TableHead>Score</TableHead>
+                      <TableHead>Vector</TableHead>
+                      <TableHead>Link</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {vulnerability.references
+                      .sort(
+                        (refA, refB) => (refB.score ?? 0) - (refA.score ?? 0)
+                      )
+                      .map((reference, index) => (
+                        <TableRow key={index}>
+                          <TableCell>{reference.severity || '-'}</TableCell>
+                          <TableCell>
+                            {reference.scoringSystem || '-'}
+                          </TableCell>
+                          <TableCell>{reference.score || '-'}</TableCell>
+                          <TableCell>{reference.vector || '-'}</TableCell>
+                          <TableCell>
+                            <Link
+                              className='font-semibold break-all text-blue-400 hover:underline'
+                              to={reference.url}
+                              target='_blank'
+                            >
+                              {reference.url}
+                            </Link>
+                          </TableCell>
+                        </TableRow>
+                      ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </AccordionContent>
+          </AccordionItem>
+        </Accordion>
+      );
+    },
+    [params.repoId, ortRun.id]
+  );
 
   const [expanded, setExpanded] = useState<ExpandedState>(
     search.marked ? { [search.marked]: true } : {}


### PR DESCRIPTION
### Create resolution and notify that applying needs a rerun

<img width="1007" height="405" alt="Screenshot from 2026-03-13 12-24-00" src="https://github.com/user-attachments/assets/6fcf404c-1b00-4e34-82f8-7a09d8fdda52" />
<img width="1007" height="405" alt="Screenshot from 2026-03-13 12-24-28" src="https://github.com/user-attachments/assets/72610c49-6698-40c5-aa3b-e8e34e938115" />

### After rerun, the resolution is persisted with source `SERVER`

<img width="1007" height="405" alt="Screenshot from 2026-03-13 12-25-28" src="https://github.com/user-attachments/assets/3d6dcde2-4ebf-4116-b572-2b3f3a6b3995" />

### User has edited the resolution and the edit is pending a rerun
The original (currently applied) resolution is seen in the list as the source-of-truth.

<img width="1007" height="486" alt="Screenshot from 2026-03-13 12-26-01" src="https://github.com/user-attachments/assets/af924d88-f216-4372-818d-825678886b2a" />

### Resolution is deleted, again pending on rerun

<img width="1007" height="334" alt="Screenshot from 2026-03-13 12-26-57" src="https://github.com/user-attachments/assets/351ede23-8ddf-45b4-9482-a110dda9c783" />

The UI has been demoed live to @mnonnenmacher and he's given his approval. There are probably still some things to improve, but feature-wise, that will need to be left for follow-up PRs.

Please see the commits for details.