### PR TITLE
fix(dao): Fix the values for the `source` command

### DIFF
--- a/dao/src/main/resources/db/migration/V133__fixResolutionsSource.sql
+++ b/dao/src/main/resources/db/migration/V133__fixResolutionsSource.sql
@@ -1,0 +1,20 @@
+UPDATE issue_resolutions
+SET source = 'REPOSITORY_FILE'
+WHERE source = 'REPOSITORY';
+
+ALTER TABLE issue_resolutions
+    ALTER COLUMN source SET DEFAULT 'REPOSITORY_FILE';
+
+UPDATE rule_violation_resolutions
+SET source = 'REPOSITORY_FILE'
+WHERE source = 'REPOSITORY';
+
+ALTER TABLE rule_violation_resolutions
+    ALTER COLUMN source SET DEFAULT 'REPOSITORY_FILE';
+
+UPDATE vulnerability_resolutions
+SET source = 'REPOSITORY_FILE'
+WHERE source = 'REPOSITORY';
+
+ALTER TABLE vulnerability_resolutions
+    ALTER COLUMN source SET DEFAULT 'REPOSITORY_FILE';


### PR DESCRIPTION
A previous migration set a wrong default value for the new `source` columns of the resolution tables. Fix the default value and all existing rows to use the correct enum constant `REPOSITORY_FILE` instead of `REPOSITORY`.

This is a fixup for dfef3fd.