### PR TITLE
Refactor vulnerability resolutions API to comply with naming conventions

### DIFF
--- a/components/resolutions/api-model/src/commonMain/kotlin/PatchVulnerabilityResolution.kt
+++ b/components/resolutions/api-model/src/commonMain/kotlin/PatchVulnerabilityResolution.kt
@@ -24,7 +24,7 @@ import kotlinx.serialization.Serializable
 import org.eclipse.apoapsis.ortserver.shared.apimodel.VulnerabilityResolutionReason
 
 @Serializable
-data class CreateVulnerabilityResolution(
-    val reason: VulnerabilityResolutionReason,
-    val comment: String
+data class PatchVulnerabilityResolution(
+    val reason: VulnerabilityResolutionReason? = null,
+    val comment: String? = null
 )

--- a/components/resolutions/api-model/src/commonMain/kotlin/PostVulnerabilityResolution.kt
+++ b/components/resolutions/api-model/src/commonMain/kotlin/PostVulnerabilityResolution.kt
@@ -24,7 +24,7 @@ import kotlinx.serialization.Serializable
 import org.eclipse.apoapsis.ortserver.shared.apimodel.VulnerabilityResolutionReason
 
 @Serializable
-data class UpdateVulnerabilityResolution(
-    val reason: VulnerabilityResolutionReason? = null,
-    val comment: String? = null
+data class PostVulnerabilityResolution(
+    val reason: VulnerabilityResolutionReason,
+    val comment: String
 )

--- a/components/resolutions/backend/src/routes/kotlin/routes/Routing.kt
+++ b/components/resolutions/backend/src/routes/kotlin/routes/Routing.kt
@@ -21,13 +21,13 @@ package org.eclipse.apoapsis.ortserver.components.resolutions.routes
 
 import io.ktor.server.routing.Route
 
-import org.eclipse.apoapsis.ortserver.components.resolutions.routes.vulnerabilities.createVulnerabilityResolution
 import org.eclipse.apoapsis.ortserver.components.resolutions.routes.vulnerabilities.deleteVulnerabilityResolution
-import org.eclipse.apoapsis.ortserver.components.resolutions.routes.vulnerabilities.updateVulnerabilityResolution
+import org.eclipse.apoapsis.ortserver.components.resolutions.routes.vulnerabilities.patchVulnerabilityResolution
+import org.eclipse.apoapsis.ortserver.components.resolutions.routes.vulnerabilities.postVulnerabilityResolution
 import org.eclipse.apoapsis.ortserver.components.resolutions.vulnerabilities.VulnerabilityResolutionService
 
 fun Route.resolutionRoutes(vulnerabilityResolutionService: VulnerabilityResolutionService) {
-    createVulnerabilityResolution(vulnerabilityResolutionService)
     deleteVulnerabilityResolution(vulnerabilityResolutionService)
-    updateVulnerabilityResolution(vulnerabilityResolutionService)
+    patchVulnerabilityResolution(vulnerabilityResolutionService)
+    postVulnerabilityResolution(vulnerabilityResolutionService)
 }

--- a/components/resolutions/backend/src/routes/kotlin/routes/vulnerabilities/PatchVulnerabilityResolution.kt
+++ b/components/resolutions/backend/src/routes/kotlin/routes/vulnerabilities/PatchVulnerabilityResolution.kt
@@ -29,9 +29,9 @@ import io.ktor.server.routing.Route
 
 import org.eclipse.apoapsis.ortserver.components.authorization.rights.RepositoryPermission
 import org.eclipse.apoapsis.ortserver.components.authorization.routes.OrtServerPrincipal.Companion.requirePrincipal
-import org.eclipse.apoapsis.ortserver.components.authorization.routes.post
+import org.eclipse.apoapsis.ortserver.components.authorization.routes.patch
 import org.eclipse.apoapsis.ortserver.components.authorization.routes.requirePermission
-import org.eclipse.apoapsis.ortserver.components.resolutions.CreateVulnerabilityResolution
+import org.eclipse.apoapsis.ortserver.components.resolutions.PatchVulnerabilityResolution
 import org.eclipse.apoapsis.ortserver.components.resolutions.vulnerabilities.VulnerabilityResolutionError
 import org.eclipse.apoapsis.ortserver.components.resolutions.vulnerabilities.VulnerabilityResolutionService
 import org.eclipse.apoapsis.ortserver.model.RepositoryId
@@ -41,14 +41,14 @@ import org.eclipse.apoapsis.ortserver.shared.ktorutils.jsonBody
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireIdParameter
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireParameter
 
-internal fun Route.createVulnerabilityResolution(
+internal fun Route.patchVulnerabilityResolution(
     vulnerabilityResolutionService: VulnerabilityResolutionService
-) = post(
+) = patch(
     "repositories/{repositoryId}/resolutions/vulnerabilities/{externalId}",
     {
-        operationId = "CreateVulnerabilityResolution"
-        summary = "Create a vulnerability resolution for a vulnerability in a repository."
-        description = "Create a vulnerability resolution for a vulnerability in a repository."
+        operationId = "PatchVulnerabilityResolution"
+        summary = "Update a vulnerability resolution for a vulnerability in a repository."
+        description = "Update a vulnerability resolution for a vulnerability in a repository."
         tags = listOf("Resolutions")
 
         request {
@@ -62,12 +62,12 @@ internal fun Route.createVulnerabilityResolution(
                 required = true
             }
 
-            jsonBody<CreateVulnerabilityResolution> {
-                description = "The details of the vulnerability resolution to create."
+            jsonBody<PatchVulnerabilityResolution> {
+                description = "The details of the vulnerability resolution to update."
                 required = true
 
                 example("Example") {
-                    value = CreateVulnerabilityResolution(
+                    value = PatchVulnerabilityResolution(
                         reason = VulnerabilityResolutionReason.INEFFECTIVE_VULNERABILITY,
                         comment = "This vulnerability is not relevant because it affects code that is not used."
                     )
@@ -76,8 +76,8 @@ internal fun Route.createVulnerabilityResolution(
         }
 
         response {
-            HttpStatusCode.Created to {
-                description = "The vulnerability resolution was successfully created."
+            HttpStatusCode.OK to {
+                description = "The vulnerability resolution was updated successfully."
             }
 
             HttpStatusCode.BadRequest to {
@@ -85,7 +85,7 @@ internal fun Route.createVulnerabilityResolution(
             }
 
             HttpStatusCode.NotFound to {
-                description = "The repository or vulnerability was not found."
+                description = "The repository or vulnerability resolution was not found."
             }
         }
     },
@@ -95,16 +95,16 @@ internal fun Route.createVulnerabilityResolution(
     val repositoryId = call.requireIdParameter("repositoryId")
     val externalId = call.requireParameter("externalId")
 
-    val createVulnerabilityResolution = call.receive<CreateVulnerabilityResolution>()
+    val patchVulnerabilityResolution = call.receive<PatchVulnerabilityResolution>()
 
-    vulnerabilityResolutionService.createResolution(
+    vulnerabilityResolutionService.updateResolution(
         repositoryId = RepositoryId(repositoryId),
         externalId = externalId,
         userId = userId,
-        reason = createVulnerabilityResolution.reason.mapToModel(),
-        comment = createVulnerabilityResolution.comment
+        reason = patchVulnerabilityResolution.reason?.mapToModel(),
+        comment = patchVulnerabilityResolution.comment
     ).onOk {
-        call.respond(HttpStatusCode.Created)
+        call.respond(HttpStatusCode.OK)
     }.onErr {
         when (it) {
             is VulnerabilityResolutionError.InvalidState -> call.respond(HttpStatusCode.BadRequest, it.message)

--- a/components/resolutions/backend/src/routes/kotlin/routes/vulnerabilities/PostVulnerabilityResolution.kt
+++ b/components/resolutions/backend/src/routes/kotlin/routes/vulnerabilities/PostVulnerabilityResolution.kt
@@ -29,9 +29,9 @@ import io.ktor.server.routing.Route
 
 import org.eclipse.apoapsis.ortserver.components.authorization.rights.RepositoryPermission
 import org.eclipse.apoapsis.ortserver.components.authorization.routes.OrtServerPrincipal.Companion.requirePrincipal
-import org.eclipse.apoapsis.ortserver.components.authorization.routes.patch
+import org.eclipse.apoapsis.ortserver.components.authorization.routes.post
 import org.eclipse.apoapsis.ortserver.components.authorization.routes.requirePermission
-import org.eclipse.apoapsis.ortserver.components.resolutions.UpdateVulnerabilityResolution
+import org.eclipse.apoapsis.ortserver.components.resolutions.PostVulnerabilityResolution
 import org.eclipse.apoapsis.ortserver.components.resolutions.vulnerabilities.VulnerabilityResolutionError
 import org.eclipse.apoapsis.ortserver.components.resolutions.vulnerabilities.VulnerabilityResolutionService
 import org.eclipse.apoapsis.ortserver.model.RepositoryId
@@ -41,14 +41,14 @@ import org.eclipse.apoapsis.ortserver.shared.ktorutils.jsonBody
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireIdParameter
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireParameter
 
-internal fun Route.updateVulnerabilityResolution(
+internal fun Route.postVulnerabilityResolution(
     vulnerabilityResolutionService: VulnerabilityResolutionService
-) = patch(
+) = post(
     "repositories/{repositoryId}/resolutions/vulnerabilities/{externalId}",
     {
-        operationId = "UpdateVulnerabilityResolution"
-        summary = "Update a vulnerability resolution for a vulnerability in a repository."
-        description = "Update a vulnerability resolution for a vulnerability in a repository."
+        operationId = "PostVulnerabilityResolution"
+        summary = "Create a vulnerability resolution for a vulnerability in a repository."
+        description = "Create a vulnerability resolution for a vulnerability in a repository."
         tags = listOf("Resolutions")
 
         request {
@@ -62,12 +62,12 @@ internal fun Route.updateVulnerabilityResolution(
                 required = true
             }
 
-            jsonBody<UpdateVulnerabilityResolution> {
-                description = "The details of the vulnerability resolution to update."
+            jsonBody<PostVulnerabilityResolution> {
+                description = "The details of the vulnerability resolution to create."
                 required = true
 
                 example("Example") {
-                    value = UpdateVulnerabilityResolution(
+                    value = PostVulnerabilityResolution(
                         reason = VulnerabilityResolutionReason.INEFFECTIVE_VULNERABILITY,
                         comment = "This vulnerability is not relevant because it affects code that is not used."
                     )
@@ -76,8 +76,8 @@ internal fun Route.updateVulnerabilityResolution(
         }
 
         response {
-            HttpStatusCode.OK to {
-                description = "The vulnerability resolution was updated successfully."
+            HttpStatusCode.Created to {
+                description = "The vulnerability resolution was successfully created."
             }
 
             HttpStatusCode.BadRequest to {
@@ -85,7 +85,7 @@ internal fun Route.updateVulnerabilityResolution(
             }
 
             HttpStatusCode.NotFound to {
-                description = "The repository or vulnerability resolution was not found."
+                description = "The repository or vulnerability was not found."
             }
         }
     },
@@ -95,16 +95,16 @@ internal fun Route.updateVulnerabilityResolution(
     val repositoryId = call.requireIdParameter("repositoryId")
     val externalId = call.requireParameter("externalId")
 
-    val updateVulnerabilityResolution = call.receive<UpdateVulnerabilityResolution>()
+    val postVulnerabilityResolution = call.receive<PostVulnerabilityResolution>()
 
-    vulnerabilityResolutionService.updateResolution(
+    vulnerabilityResolutionService.createResolution(
         repositoryId = RepositoryId(repositoryId),
         externalId = externalId,
         userId = userId,
-        reason = updateVulnerabilityResolution.reason?.mapToModel(),
-        comment = updateVulnerabilityResolution.comment
+        reason = postVulnerabilityResolution.reason.mapToModel(),
+        comment = postVulnerabilityResolution.comment
     ).onOk {
-        call.respond(HttpStatusCode.OK)
+        call.respond(HttpStatusCode.Created)
     }.onErr {
         when (it) {
             is VulnerabilityResolutionError.InvalidState -> call.respond(HttpStatusCode.BadRequest, it.message)

--- a/components/resolutions/backend/src/test/kotlin/routes/ResolutionsAuthorizationTest.kt
+++ b/components/resolutions/backend/src/test/kotlin/routes/ResolutionsAuthorizationTest.kt
@@ -28,8 +28,8 @@ import io.ktor.http.HttpStatusCode
 import io.mockk.mockk
 
 import org.eclipse.apoapsis.ortserver.components.authorization.rights.RepositoryRole
-import org.eclipse.apoapsis.ortserver.components.resolutions.CreateVulnerabilityResolution
-import org.eclipse.apoapsis.ortserver.components.resolutions.UpdateVulnerabilityResolution
+import org.eclipse.apoapsis.ortserver.components.resolutions.PatchVulnerabilityResolution
+import org.eclipse.apoapsis.ortserver.components.resolutions.PostVulnerabilityResolution
 import org.eclipse.apoapsis.ortserver.components.resolutions.vulnerabilities.VulnerabilityResolutionEventStore
 import org.eclipse.apoapsis.ortserver.components.resolutions.vulnerabilities.VulnerabilityResolutionService
 import org.eclipse.apoapsis.ortserver.model.CompoundHierarchyId
@@ -72,7 +72,7 @@ class ResolutionsAuthorizationTest : AbstractAuthorizationTest({
         )
     }
 
-    "CreateVulnerabilityResolution" should {
+    "PostVulnerabilityResolution" should {
         "require RepositoryPermission.MANAGE_RESOLUTIONS" {
             requestShouldRequireRole(
                 routes = { resolutionRoutes(vulnerabilityResolutionService) },
@@ -82,7 +82,7 @@ class ResolutionsAuthorizationTest : AbstractAuthorizationTest({
             ) {
                 post("/repositories/${repositoryId.value}/resolutions/vulnerabilities/CVE-2021-1234") {
                     setBody(
-                        CreateVulnerabilityResolution(
+                        PostVulnerabilityResolution(
                             comment = "This is not a vulnerability.",
                             reason = VulnerabilityResolutionReason.NOT_A_VULNERABILITY
                         )
@@ -105,7 +105,7 @@ class ResolutionsAuthorizationTest : AbstractAuthorizationTest({
         }
     }
 
-    "UpdateVulnerabilityResolution" should {
+    "PatchVulnerabilityResolution" should {
         "require RepositoryPermission.MANAGE_RESOLUTIONS" {
             requestShouldRequireRole(
                 routes = { resolutionRoutes(vulnerabilityResolutionService) },
@@ -115,7 +115,7 @@ class ResolutionsAuthorizationTest : AbstractAuthorizationTest({
             ) {
                 patch("/repositories/${repositoryId.value}/resolutions/vulnerabilities/CVE-2021-1234") {
                     setBody(
-                        UpdateVulnerabilityResolution(
+                        PatchVulnerabilityResolution(
                             comment = "This is not a vulnerability.",
                             reason = VulnerabilityResolutionReason.NOT_A_VULNERABILITY
                         )

--- a/components/resolutions/backend/src/test/kotlin/routes/vulnerabilities/PatchVulnerabilityResolutionIntegrationTest.kt
+++ b/components/resolutions/backend/src/test/kotlin/routes/vulnerabilities/PatchVulnerabilityResolutionIntegrationTest.kt
@@ -23,11 +23,12 @@ import io.kotest.assertions.ktor.client.shouldHaveStatus
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.should
 
-import io.ktor.client.request.post
+import io.ktor.client.request.patch
 import io.ktor.client.request.setBody
 import io.ktor.http.HttpStatusCode
 
-import org.eclipse.apoapsis.ortserver.components.resolutions.CreateVulnerabilityResolution
+import org.eclipse.apoapsis.ortserver.components.resolutions.PatchVulnerabilityResolution
+import org.eclipse.apoapsis.ortserver.components.resolutions.PostVulnerabilityResolution
 import org.eclipse.apoapsis.ortserver.components.resolutions.beOk
 import org.eclipse.apoapsis.ortserver.components.resolutions.routes.ResolutionsIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.resolutions.shouldBeOk
@@ -37,58 +38,15 @@ import org.eclipse.apoapsis.ortserver.model.runs.repository.VulnerabilityResolut
 import org.eclipse.apoapsis.ortserver.model.runs.repository.VulnerabilityResolutionReason
 import org.eclipse.apoapsis.ortserver.shared.apimodel.VulnerabilityResolutionReason as ApiVulnerabilityResolutionReason
 
-class CreateVulnerabilityResolutionIntegrationTest : ResolutionsIntegrationTest({
+class PatchVulnerabilityResolutionIntegrationTest : ResolutionsIntegrationTest({
     var repositoryId = RepositoryId(-1)
 
     beforeEach {
         repositoryId = RepositoryId(dbExtension.fixtures.repository.id)
     }
 
-    "CreateVulnerabilityResolution" should {
-        "create a vulnerability resolution for a repository" {
-            resolutionsTestApplication { client ->
-                val response = client.post(
-                    "/repositories/${repositoryId.value}/resolutions/vulnerabilities/CVE-2021-1234"
-                ) {
-                    setBody(
-                        CreateVulnerabilityResolution(
-                            comment = "This is not a vulnerability.",
-                            reason = ApiVulnerabilityResolutionReason.NOT_A_VULNERABILITY
-                        )
-                    )
-                }
-
-                response shouldHaveStatus HttpStatusCode.Created
-
-                vulnerabilityResolutionService.getResolutionsForRepository(repositoryId).shouldBeOk {
-                    it should containExactly(
-                        VulnerabilityResolution(
-                            externalId = "CVE-2021-1234",
-                            comment = "This is not a vulnerability.",
-                            reason = VulnerabilityResolutionReason.NOT_A_VULNERABILITY,
-                            source = ResolutionSource.SERVER
-                        )
-                    )
-                }
-            }
-        }
-
-        "fail if the repository does not exist" {
-            resolutionsTestApplication { client ->
-                val response = client.post("/repositories/9999/resolutions/vulnerabilities/CVE-2021-1234") {
-                    setBody(
-                        CreateVulnerabilityResolution(
-                            comment = "This is not a vulnerability.",
-                            reason = ApiVulnerabilityResolutionReason.NOT_A_VULNERABILITY
-                        )
-                    )
-                }
-
-                response shouldHaveStatus HttpStatusCode.NotFound
-            }
-        }
-
-        "fail if there is already a resolution for the vulnerability" {
+    "PatchVulnerabilityResolution" should {
+        "update a vulnerability resolution for a repository" {
             resolutionsTestApplication { client ->
                 vulnerabilityResolutionService.createResolution(
                     repositoryId = repositoryId,
@@ -98,18 +56,61 @@ class CreateVulnerabilityResolutionIntegrationTest : ResolutionsIntegrationTest(
                     userId = "test-user"
                 ) should beOk()
 
-                val response = client.post(
+                val response = client.patch(
                     "/repositories/${repositoryId.value}/resolutions/vulnerabilities/CVE-2021-1234"
                 ) {
                     setBody(
-                        CreateVulnerabilityResolution(
-                            comment = "This is not a vulnerability.",
-                            reason = ApiVulnerabilityResolutionReason.NOT_A_VULNERABILITY
+                        PatchVulnerabilityResolution(
+                            comment = "This vulnerability does not apply to our project.",
+                            reason = ApiVulnerabilityResolutionReason.INEFFECTIVE_VULNERABILITY
                         )
                     )
                 }
 
-                response shouldHaveStatus HttpStatusCode.BadRequest
+                response shouldHaveStatus HttpStatusCode.OK
+
+                vulnerabilityResolutionService.getResolutionsForRepository(repositoryId).shouldBeOk {
+                    it should containExactly(
+                        VulnerabilityResolution(
+                            externalId = "CVE-2021-1234",
+                            comment = "This vulnerability does not apply to our project.",
+                            reason = VulnerabilityResolutionReason.INEFFECTIVE_VULNERABILITY,
+                            source = ResolutionSource.SERVER
+                        )
+                    )
+                }
+            }
+        }
+
+        "fail if the repository does not exist" {
+            resolutionsTestApplication { client ->
+                val response = client.patch("/repositories/9999/resolutions/vulnerabilities/CVE-2021-1234") {
+                    setBody(
+                        PostVulnerabilityResolution(
+                            comment = "This vulnerability does not apply to our project.",
+                            reason = ApiVulnerabilityResolutionReason.INEFFECTIVE_VULNERABILITY
+                        )
+                    )
+                }
+
+                response shouldHaveStatus HttpStatusCode.NotFound
+            }
+        }
+
+        "fail if the vulnerability resolution does not exist" {
+            resolutionsTestApplication { client ->
+                val response = client.patch(
+                    "/repositories/${repositoryId.value}/resolutions/vulnerabilities/CVE-2021-9999"
+                ) {
+                    setBody(
+                        PostVulnerabilityResolution(
+                            comment = "This vulnerability does not apply to our project.",
+                            reason = ApiVulnerabilityResolutionReason.INEFFECTIVE_VULNERABILITY
+                        )
+                    )
+                }
+
+                response shouldHaveStatus HttpStatusCode.NotFound
             }
         }
     }

--- a/components/resolutions/backend/src/test/kotlin/routes/vulnerabilities/PostVulnerabilityResolutionIntegrationTest.kt
+++ b/components/resolutions/backend/src/test/kotlin/routes/vulnerabilities/PostVulnerabilityResolutionIntegrationTest.kt
@@ -23,12 +23,11 @@ import io.kotest.assertions.ktor.client.shouldHaveStatus
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.should
 
-import io.ktor.client.request.patch
+import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.HttpStatusCode
 
-import org.eclipse.apoapsis.ortserver.components.resolutions.CreateVulnerabilityResolution
-import org.eclipse.apoapsis.ortserver.components.resolutions.UpdateVulnerabilityResolution
+import org.eclipse.apoapsis.ortserver.components.resolutions.PostVulnerabilityResolution
 import org.eclipse.apoapsis.ortserver.components.resolutions.beOk
 import org.eclipse.apoapsis.ortserver.components.resolutions.routes.ResolutionsIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.resolutions.shouldBeOk
@@ -38,43 +37,35 @@ import org.eclipse.apoapsis.ortserver.model.runs.repository.VulnerabilityResolut
 import org.eclipse.apoapsis.ortserver.model.runs.repository.VulnerabilityResolutionReason
 import org.eclipse.apoapsis.ortserver.shared.apimodel.VulnerabilityResolutionReason as ApiVulnerabilityResolutionReason
 
-class UpdateVulnerabilityResolutionIntegrationTest : ResolutionsIntegrationTest({
+class PostVulnerabilityResolutionIntegrationTest : ResolutionsIntegrationTest({
     var repositoryId = RepositoryId(-1)
 
     beforeEach {
         repositoryId = RepositoryId(dbExtension.fixtures.repository.id)
     }
 
-    "UpdateVulnerabilityResolution" should {
-        "update a vulnerability resolution for a repository" {
+    "PostVulnerabilityResolution" should {
+        "create a vulnerability resolution for a repository" {
             resolutionsTestApplication { client ->
-                vulnerabilityResolutionService.createResolution(
-                    repositoryId = repositoryId,
-                    externalId = "CVE-2021-1234",
-                    reason = VulnerabilityResolutionReason.NOT_A_VULNERABILITY,
-                    comment = "This is not a vulnerability.",
-                    userId = "test-user"
-                ) should beOk()
-
-                val response = client.patch(
+                val response = client.post(
                     "/repositories/${repositoryId.value}/resolutions/vulnerabilities/CVE-2021-1234"
                 ) {
                     setBody(
-                        UpdateVulnerabilityResolution(
-                            comment = "This vulnerability does not apply to our project.",
-                            reason = ApiVulnerabilityResolutionReason.INEFFECTIVE_VULNERABILITY
+                        PostVulnerabilityResolution(
+                            comment = "This is not a vulnerability.",
+                            reason = ApiVulnerabilityResolutionReason.NOT_A_VULNERABILITY
                         )
                     )
                 }
 
-                response shouldHaveStatus HttpStatusCode.OK
+                response shouldHaveStatus HttpStatusCode.Created
 
                 vulnerabilityResolutionService.getResolutionsForRepository(repositoryId).shouldBeOk {
                     it should containExactly(
                         VulnerabilityResolution(
                             externalId = "CVE-2021-1234",
-                            comment = "This vulnerability does not apply to our project.",
-                            reason = VulnerabilityResolutionReason.INEFFECTIVE_VULNERABILITY,
+                            comment = "This is not a vulnerability.",
+                            reason = VulnerabilityResolutionReason.NOT_A_VULNERABILITY,
                             source = ResolutionSource.SERVER
                         )
                     )
@@ -84,11 +75,11 @@ class UpdateVulnerabilityResolutionIntegrationTest : ResolutionsIntegrationTest(
 
         "fail if the repository does not exist" {
             resolutionsTestApplication { client ->
-                val response = client.patch("/repositories/9999/resolutions/vulnerabilities/CVE-2021-1234") {
+                val response = client.post("/repositories/9999/resolutions/vulnerabilities/CVE-2021-1234") {
                     setBody(
-                        CreateVulnerabilityResolution(
-                            comment = "This vulnerability does not apply to our project.",
-                            reason = ApiVulnerabilityResolutionReason.INEFFECTIVE_VULNERABILITY
+                        PostVulnerabilityResolution(
+                            comment = "This is not a vulnerability.",
+                            reason = ApiVulnerabilityResolutionReason.NOT_A_VULNERABILITY
                         )
                     )
                 }
@@ -97,20 +88,28 @@ class UpdateVulnerabilityResolutionIntegrationTest : ResolutionsIntegrationTest(
             }
         }
 
-        "fail if the vulnerability resolution does not exist" {
+        "fail if there is already a resolution for the vulnerability" {
             resolutionsTestApplication { client ->
-                val response = client.patch(
-                    "/repositories/${repositoryId.value}/resolutions/vulnerabilities/CVE-2021-9999"
+                vulnerabilityResolutionService.createResolution(
+                    repositoryId = repositoryId,
+                    externalId = "CVE-2021-1234",
+                    reason = VulnerabilityResolutionReason.NOT_A_VULNERABILITY,
+                    comment = "This is not a vulnerability.",
+                    userId = "test-user"
+                ) should beOk()
+
+                val response = client.post(
+                    "/repositories/${repositoryId.value}/resolutions/vulnerabilities/CVE-2021-1234"
                 ) {
                     setBody(
-                        CreateVulnerabilityResolution(
-                            comment = "This vulnerability does not apply to our project.",
-                            reason = ApiVulnerabilityResolutionReason.INEFFECTIVE_VULNERABILITY
+                        PostVulnerabilityResolution(
+                            comment = "This is not a vulnerability.",
+                            reason = ApiVulnerabilityResolutionReason.NOT_A_VULNERABILITY
                         )
                     )
                 }
 
-                response shouldHaveStatus HttpStatusCode.NotFound
+                response shouldHaveStatus HttpStatusCode.BadRequest
             }
         }
     }

--- a/ui/src/components/resolutions.tsx
+++ b/ui/src/components/resolutions.tsx
@@ -25,17 +25,17 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import {
-  createVulnerabilityResolutionMutation,
   deleteVulnerabilityResolutionMutation,
   getRunVulnerabilitiesQueryKey,
-  updateVulnerabilityResolutionMutation,
+  patchVulnerabilityResolutionMutation,
+  postVulnerabilityResolutionMutation,
 } from '@/api/@tanstack/react-query.gen';
 import {
   AppliedVulnerabilityResolution,
   VulnerabilityResolution,
 } from '@/api/types.gen';
 import {
-  zCreateVulnerabilityResolution,
+  zPostVulnerabilityResolution,
   zVulnerabilityResolutionReason,
 } from '@/api/zod.gen';
 import { DeleteDialog } from '@/components/delete-dialog';
@@ -75,7 +75,7 @@ import {
 import { ApiError } from '@/lib/api-error';
 import { toast, toastError } from '@/lib/toast';
 
-type ResolutionFormValues = z.infer<typeof zCreateVulnerabilityResolution>;
+type ResolutionFormValues = z.infer<typeof zPostVulnerabilityResolution>;
 type ResolutionItem =
   | NonNullable<ItemWithResolutions['resolutions']>[number]
   | VulnerabilityResolution;
@@ -152,14 +152,14 @@ function ResolutionForm({
   const queryClient = useQueryClient();
 
   const form = useForm<ResolutionFormValues>({
-    resolver: zodResolver(zCreateVulnerabilityResolution),
+    resolver: zodResolver(zPostVulnerabilityResolution),
     defaultValues,
   });
 
   const { mutateAsync, isPending } = useMutation({
     ...(mode === 'create'
-      ? createVulnerabilityResolutionMutation()
-      : updateVulnerabilityResolutionMutation()),
+      ? postVulnerabilityResolutionMutation()
+      : patchVulnerabilityResolutionMutation()),
     onSuccess() {
       queryClient.invalidateQueries({
         queryKey: getRunVulnerabilitiesQueryKey({


### PR DESCRIPTION
#3678 and #3712 aligned the naming conventions for the OpenAPI specifications, which acts as the back-end <-> front-end contract, to assist UI development by reliably finding proper query functions with consistent names. #4573 introduced a slight regression to this for the vulnerability resolutions, which is fixed in this PR.

Apart from the usual checks and tests, sanity checks in the UI have been run for creation, editing and deletion of vulnerability resolutions.