### PR TITLE
docs(ui): Tweak the title for visible runs in the durations chart

### DIFF
--- a/ui/src/components/form/runs-filter-form.tsx
+++ b/ui/src/components/form/runs-filter-form.tsx
@@ -138,7 +138,7 @@ export function RunsFilterForm({
                       />
                     </FormControl>
                     <FormLabel htmlFor='visible-runs' className='-ml-2'>
-                      visible runs
+                      runs on page
                     </FormLabel>
                   </FormItem>
 


### PR DESCRIPTION
Make more clear what "visible" refers to, i.e. the runs for the current pagination.