### PR TITLE
build(gradle): Avoid rebuilds due to version changes only

### DIFF
--- a/buildSrc/src/main/kotlin/ort-server-base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-base-conventions.gradle.kts
@@ -82,4 +82,12 @@ tasks.withType<Jar>().configureEach {
     }
 }
 
+normalization {
+    runtimeClasspath {
+        metaInf {
+            ignoreAttribute("Implementation-Version")
+        }
+    }
+}
+
 if (project != rootProject) version = rootProject.version


### PR DESCRIPTION
Ignore changes to the "Implementation-Version" attribute of a JAR's manifest when determining what to rebuild. See [1] for reference.

[1]: https://docs.gradle.org/current/userguide/incremental_build.html#sec:configure_input_normalization