### PR TITLE
feat(s3): Add an optional key prefix

### DIFF
--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -118,6 +118,7 @@ fileListStorage {
   s3Region = ${?FILE_LIST_STORAGE_REGION}
   s3BucketName = ${?FILE_LIST_STORAGE_BUCKET_NAME}
   s3EndpointUrl = ${?FILE_LIST_STORAGE_ENDPOINT_URL}
+  s3KeyPrefix = ${?FILE_LIST_STORAGE_KEY_PREFIX}
 }
 
 reportStorage {
@@ -135,6 +136,7 @@ reportStorage {
   s3Region = ${?REPORT_STORAGE_REGION}
   s3BucketName = ${?REPORT_STORAGE_BUCKET_NAME}
   s3EndpointUrl = ${?REPORT_STORAGE_ENDPOINT_URL}
+  s3KeyPrefix = ${?REPORT_STORAGE_KEY_PREFIX}
 }
 
 logFileService {

--- a/storage/s3/src/main/kotlin/S3StorageProvider.kt
+++ b/storage/s3/src/main/kotlin/S3StorageProvider.kt
@@ -52,7 +52,10 @@ class S3StorageProvider(
     private val s3Client: S3Client,
 
     /** The name of the S3 bucket. */
-    private val bucketName: String?
+    private val bucketName: String?,
+
+    /** An optional prefix for the storage keys. */
+    private val keyPrefix: String?
 ) : StorageProvider {
     /**
      * Retrieve the data associated with the given [key] from the S3 bucket.
@@ -60,10 +63,10 @@ class S3StorageProvider(
     override suspend fun read(key: Key): StorageEntry = s3Client.getObject(
         GetObjectRequest {
             bucket = bucketName
-            this.key = key.key
+            this.key = prefixKey(key)
         }
     ) { response ->
-        val data = checkNotNull(response.body) { "No data found for ${key.key}." }
+        val data = checkNotNull(response.body) { "No data found for ${prefixKey(key)}." }
         val contentType = response.contentType
         val tempFile = createTempFile()
 
@@ -89,7 +92,7 @@ class S3StorageProvider(
                     bucket = bucketName
                     body = ByteStream.fromFile(tempFile.toFile())
                     this.contentType = contentType
-                    this.key = key.key
+                    this.key = prefixKey(key)
                     checksumSha256 = calculateSha256Checksum(tempFile.toFile())
                 }
             )
@@ -105,7 +108,7 @@ class S3StorageProvider(
         s3Client.headObject(
             HeadObjectRequest {
                 this.bucket = bucketName
-                this.key = key.key
+                this.key = prefixKey(key)
             }
         )
     }.isSuccess
@@ -117,11 +120,16 @@ class S3StorageProvider(
         runCatching {
             s3Client.deleteObject {
                 this.bucket = bucketName
-                this.key = key.key
+                this.key = prefixKey(key)
             }
         }.isSuccess
     } else {
         false
+    }
+
+    private fun prefixKey(key: Key) = when {
+        keyPrefix != null -> "$keyPrefix|${key.key}"
+        else -> key.key
     }
 }
 

--- a/storage/s3/src/main/kotlin/S3StorageProviderFactory.kt
+++ b/storage/s3/src/main/kotlin/S3StorageProviderFactory.kt
@@ -63,6 +63,11 @@ class S3StorageProviderFactory : StorageProviderFactory {
          * The name of the configuration property for the endpoint URL of the S3 storage.
          */
         const val ENDPOINT_URL_PROPERTY = "s3EndpointUrl"
+
+        /**
+         * An optional prefix for the storage keys. This can be used when different storage types share the same bucket.
+         */
+        const val KEY_PREFIX_PROPERTY = "s3KeyPrefix"
     }
 
     override val name: String = NAME
@@ -82,6 +87,10 @@ class S3StorageProviderFactory : StorageProviderFactory {
             logMode = LogMode.LogRequest + LogMode.LogResponse
         }
 
-        return S3StorageProvider(client, config.getStringOrNull(BUCKET_NAME_PROPERTY))
+        return S3StorageProvider(
+            s3Client = client,
+            bucketName = config.getStringOrNull(BUCKET_NAME_PROPERTY),
+            keyPrefix = config.getStringOrNull(KEY_PREFIX_PROPERTY)
+        )
     }
 }

--- a/storage/s3/src/test/kotlin/S3StorageTest.kt
+++ b/storage/s3/src/test/kotlin/S3StorageTest.kt
@@ -126,6 +126,26 @@ class S3StorageTest : WordSpec({
                 response.contentType shouldBe contentType
             }
         }
+
+        "add the key prefix if configured" {
+            val key = Key("object-key")
+            val data = "This is a test object for the S3 storage."
+            val contentType = "application/octet-stream"
+
+            val storage = localStackContainer.createStorage(keyPrefix = "prefix")
+
+            storage.write(key, data, contentType)
+
+            s3Client.getObject(
+                GetObjectRequest {
+                    bucket = TEST_BUCKET_NAME
+                    this.key = "prefix|${key.key}"
+                }
+            ) { response ->
+                response.body.shouldNotBeNull().decodeToString() shouldBe data
+                response.contentType shouldBe contentType
+            }
+        }
     }
 
     "read" should {
@@ -156,6 +176,26 @@ class S3StorageTest : WordSpec({
                 storage.read(Key("object-not-existing"))
             }
         }
+
+        "add the key prefix if configured" {
+            val key = Key("existingEntry")
+            val data = "The data from the storage."
+            val contentType = "application/octet-stream"
+
+            s3Client.putObject {
+                body = ByteStream.fromString(data)
+                bucket = TEST_BUCKET_NAME
+                this.contentType = contentType
+                this.key = "prefix|${key.key}"
+            }
+
+            val storage = localStackContainer.createStorage(keyPrefix = "prefix")
+
+            storage.read(key).use {
+                it.contentType shouldBe contentType
+                it.dataString shouldBe data
+            }
+        }
     }
 
     "contains" should {
@@ -171,6 +211,23 @@ class S3StorageTest : WordSpec({
             val storage = localStackContainer.createStorage()
 
             storage.write(key, "test-data")
+
+            storage.containsKey(key) shouldBe true
+        }
+
+        "add the key prefix if configured" {
+            val key = Key("existingEntry")
+            val data = "The data from the storage."
+            val contentType = "application/octet-stream"
+
+            s3Client.putObject {
+                body = ByteStream.fromString(data)
+                bucket = TEST_BUCKET_NAME
+                this.contentType = contentType
+                this.key = "prefix|${key.key}"
+            }
+
+            val storage = localStackContainer.createStorage(keyPrefix = "prefix")
 
             storage.containsKey(key) shouldBe true
         }
@@ -193,6 +250,24 @@ class S3StorageTest : WordSpec({
 
             storage.delete(Key("object-not-existing")) shouldBe false
         }
+
+        "add the key prefix if configured" {
+            val key = Key("existingEntry")
+            val data = "The data from the storage."
+            val contentType = "application/octet-stream"
+
+            s3Client.putObject {
+                body = ByteStream.fromString(data)
+                bucket = TEST_BUCKET_NAME
+                this.contentType = contentType
+                this.key = "prefix|${key.key}"
+            }
+
+            val storage = localStackContainer.createStorage(keyPrefix = "prefix")
+
+            storage.delete(key) shouldBe true
+            storage.containsKey(key) shouldBe false
+        }
     }
 })
 
@@ -203,7 +278,11 @@ internal const val TEST_BUCKET_NAME = "test-bucket"
 /**
  * Create a [Storage] that is configured to use the [S3StorageProvider] implementation.
  */
-private fun LocalStackContainer.createStorage(region: String = S3_REGION, bucket: String = TEST_BUCKET_NAME): Storage {
+private fun LocalStackContainer.createStorage(
+    region: String = S3_REGION,
+    bucket: String = TEST_BUCKET_NAME,
+    keyPrefix: String? = null
+): Storage {
     val config = ConfigFactory.parseMap(
         mapOf(
             bucket to mapOf(
@@ -213,7 +292,12 @@ private fun LocalStackContainer.createStorage(region: String = S3_REGION, bucket
                 S3StorageProviderFactory.SECRET_KEY_PROPERTY to secretKey,
                 S3StorageProviderFactory.REGION_PROPERTY to region,
                 S3StorageProviderFactory.BUCKET_NAME_PROPERTY to bucket
-            )
+            ).let {
+                when {
+                    keyPrefix != null -> it + (S3StorageProviderFactory.KEY_PREFIX_PROPERTY to keyPrefix)
+                    else -> it
+                }
+            }
         )
     )
 

--- a/tasks/src/main/resources/application.conf
+++ b/tasks/src/main/resources/application.conf
@@ -40,6 +40,7 @@ fileListStorage {
   s3Region = ${?FILE_LIST_STORAGE_REGION}
   s3BucketName = ${?FILE_LIST_STORAGE_BUCKET_NAME}
   s3EndpointUrl = ${?FILE_LIST_STORAGE_ENDPOINT_URL}
+  s3KeyPrefix = ${?FILE_LIST_STORAGE_KEY_PREFIX}
 }
 
 reportStorage {
@@ -57,6 +58,7 @@ reportStorage {
   s3Region = ${?REPORT_STORAGE_REGION}
   s3BucketName = ${?REPORT_STORAGE_BUCKET_NAME}
   s3EndpointUrl = ${?REPORT_STORAGE_ENDPOINT_URL}
+  s3KeyPrefix = ${?REPORT_STORAGE_KEY_PREFIX}
 }
 
 dataRetention {

--- a/workers/common/src/main/resources/application.conf
+++ b/workers/common/src/main/resources/application.conf
@@ -50,6 +50,7 @@ fileArchiveStorage {
   s3Region = ${?FILE_ARCHIVE_STORAGE_REGION}
   s3BucketName = ${?FILE_ARCHIVE_STORAGE_BUCKET_NAME}
   s3EndpointUrl = ${?FILE_ARCHIVE_STORAGE_ENDPOINT_URL}
+  s3KeyPrefix = ${?FILE_ARCHIVE_STORAGE_KEY_PREFIX}
 }
 
 fileListStorage {
@@ -67,6 +68,7 @@ fileListStorage {
   s3Region = ${?FILE_LIST_STORAGE_REGION}
   s3BucketName = ${?FILE_LIST_STORAGE_BUCKET_NAME}
   s3EndpointUrl = ${?FILE_LIST_STORAGE_ENDPOINT_URL}
+  s3KeyPrefix = ${?FILE_LIST_STORAGE_KEY_PREFIX}
 }
 
 reportStorage {
@@ -84,4 +86,5 @@ reportStorage {
   s3Region = ${?REPORT_STORAGE_REGION}
   s3BucketName = ${?REPORT_STORAGE_BUCKET_NAME}
   s3EndpointUrl = ${?REPORT_STORAGE_ENDPOINT_URL}
+  s3KeyPrefix = ${?REPORT_STORAGE_KEY_PREFIX}
 }


### PR DESCRIPTION
The prefix can be used to ensure unique keys when different storage types share the same bucket.