### PR TITLE
Resolve default package managers in config worker

### DIFF
--- a/components/plugin-manager/backend/src/main/kotlin/PluginTemplateService.kt
+++ b/components/plugin-manager/backend/src/main/kotlin/PluginTemplateService.kt
@@ -263,7 +263,7 @@ class PluginTemplateService(
      *  [organizationId]. This is either a template that is assigned to the organization, a global template if no
      *  template is assigned to the organization, or `null` if no template exists for the organization.
      */
-    internal fun getTemplateForOrganization(
+    fun getTemplateForOrganization(
         pluginType: PluginType,
         pluginId: String,
         organizationId: OrganizationId
@@ -571,7 +571,7 @@ class PluginTemplateService(
     }
 }
 
-internal sealed interface TemplateError {
+sealed interface TemplateError {
     val message: String
 
     data class InvalidPlugin(override val message: String) : TemplateError

--- a/workers/analyzer/build.gradle.kts
+++ b/workers/analyzer/build.gradle.kts
@@ -50,7 +50,6 @@ repositories {
 dependencies {
     implementation(projects.api.v1.apiV1Model)
     implementation(projects.components.authorization.authorizationBackend)
-    implementation(projects.components.pluginManager.pluginManagerBackend)
     implementation(projects.dao)
     implementation(projects.model)
     implementation(projects.services.adminConfigService)

--- a/workers/analyzer/src/main/kotlin/AnalyzerComponent.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerComponent.kt
@@ -21,7 +21,6 @@ package org.eclipse.apoapsis.ortserver.workers.analyzer
 
 import org.eclipse.apoapsis.ortserver.components.authorization.service.AuthorizationService
 import org.eclipse.apoapsis.ortserver.components.authorization.service.DbAuthorizationService
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginService
 import org.eclipse.apoapsis.ortserver.components.resolutions.issues.IssueResolutionEventStore
 import org.eclipse.apoapsis.ortserver.components.resolutions.issues.IssueResolutionService
 import org.eclipse.apoapsis.ortserver.dao.databaseModule
@@ -100,7 +99,6 @@ class AnalyzerComponent : EndpointComponent<AnalyzerRequest>(AnalyzerEndpoint) {
         singleOf(::AnalyzerDownloader)
         singleOf(::AnalyzerRunner)
         singleOf(::AnalyzerWorker)
-        singleOf(::PluginService)
         single<AuthorizationService> { DbAuthorizationService(get()) }
         singleOf(::RepositoryService)
         singleOf(::IssueResolutionEventStore)

--- a/workers/analyzer/src/main/kotlin/AnalyzerWorker.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerWorker.kt
@@ -19,7 +19,6 @@
 
 package org.eclipse.apoapsis.ortserver.workers.analyzer
 
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginService
 import org.eclipse.apoapsis.ortserver.components.resolutions.issues.IssueResolutionService
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
@@ -54,7 +53,6 @@ internal class AnalyzerWorker(
     private val ortRunService: OrtRunService,
     private val contextFactory: WorkerContextFactory,
     private val environmentService: EnvironmentService,
-    private val pluginService: PluginService,
     private val adminConfigService: AdminConfigService,
     private val issueResolutionService: IssueResolutionService
 ) {
@@ -104,18 +102,13 @@ internal class AnalyzerWorker(
 
             ortRunService.updateResolvedRevision(ortRun.id, downloadResult.resolvedRevision)
 
-            // Set the default package managers if none are configured, because the runner might be executed in a
-            // separate process which cannot access the database.
-            val jobConfiguration = job.configuration.takeUnless { it.enabledPackageManagers.isNullOrEmpty() }
-                ?: job.configuration.copy(enabledPackageManagers = getDefaultPackageManagers(pluginService))
-
             val resolvedEnvConfig = environmentService.setUpEnvironment(
                 context,
                 downloadResult.directory,
                 envConfigFromJob,
                 repositoryServices
             )
-            val ortResult = runner.run(context, downloadResult.directory, jobConfiguration, resolvedEnvConfig)
+            val ortResult = runner.run(context, downloadResult.directory, job.configuration, resolvedEnvConfig)
 
             ortRunService.storeRepositoryInformation(ortRun.id, ortResult.repository)
             ortRunService.storeResolvedPackageCurations(job.ortRunId, ortResult.resolvedConfiguration.packageCurations)

--- a/workers/analyzer/src/main/kotlin/Utils.kt
+++ b/workers/analyzer/src/main/kotlin/Utils.kt
@@ -19,15 +19,11 @@
 
 package org.eclipse.apoapsis.ortserver.workers.analyzer
 
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginAvailability
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginService
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.ShortestDependencyPath
 import org.eclipse.apoapsis.ortserver.services.ortrun.mapToModel
 
 import org.ossreviewtoolkit.model.Identifier as OrtIdentifier
-import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 
 /**
  * Helper function to find the shortest dependency path across scopes for each package identifier.
@@ -50,20 +46,4 @@ fun getIdentifierToShortestPathsMap(
     }
 
     return map
-}
-
-/**
- * Returns the IDs of the package managers that are enabled by default. This includes package managers which are enabled
- * by default in ORT and which are enabled in the [pluginService].
- */
-fun getDefaultPackageManagers(pluginService: PluginService): List<String> {
-    val ortDefaultPackageManagers = AnalyzerConfiguration().enabledPackageManagers
-    return pluginService.getPlugins()
-        .filter {
-            it.type == PluginType.PACKAGE_MANAGER &&
-                    // TODO: Validate if restricted plugins are available in the current organization.
-                    it.availability != PluginAvailability.DISABLED &&
-                    it.id in ortDefaultPackageManagers
-        }
-        .map { it.id }
 }

--- a/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
@@ -47,10 +47,6 @@ import kotlin.time.Clock
 import kotlin.time.Instant
 import kotlin.time.toJavaInstant
 
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginAvailability
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginDescriptor
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginService
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
 import org.eclipse.apoapsis.ortserver.components.resolutions.issues.IssueResolutionService
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.dao.test.mockkTransaction
@@ -76,7 +72,6 @@ import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContextFactor
 import org.eclipse.apoapsis.ortserver.workers.common.env.EnvironmentService
 import org.eclipse.apoapsis.ortserver.workers.common.env.config.ResolvedEnvironmentConfig
 
-import org.ossreviewtoolkit.analyzer.PackageManagerFactory
 import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.ResolvedPackageCurations
@@ -187,7 +182,6 @@ class AnalyzerWorkerTest : StringSpec({
             ortRunService,
             contextFactory,
             envService,
-            mockPluginService(),
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
@@ -252,7 +246,6 @@ class AnalyzerWorkerTest : StringSpec({
             ortRunService,
             contextFactory,
             envService,
-            mockPluginService(),
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
@@ -321,7 +314,6 @@ class AnalyzerWorkerTest : StringSpec({
             ortRunService,
             contextFactory,
             envService,
-            mockPluginService(),
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
@@ -343,10 +335,9 @@ class AnalyzerWorkerTest : StringSpec({
 
     "AnalyzerRunner should be invoked correctly with an environment config from the job configuration" {
         val envConfig = mockk<EnvironmentConfig>()
-        val pluginService = mockPluginService()
         val jobConfig = AnalyzerJobConfiguration(
             environmentConfig = envConfig,
-            enabledPackageManagers = getDefaultPackageManagers(pluginService)
+            enabledPackageManagers = listOf("Maven")
         )
         val job = analyzerJob.copy(configuration = jobConfig)
 
@@ -393,7 +384,6 @@ class AnalyzerWorkerTest : StringSpec({
             ortRunService,
             contextFactory,
             envService,
-            pluginService,
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
@@ -438,16 +428,13 @@ class AnalyzerWorkerTest : StringSpec({
             coEvery { setUpEnvironment(context, projectDir, null, emptyList()) } returns resolvedEnvConfig
         }
 
-        val pluginService = mockPluginService()
-        val analyzerConfig =
-            analyzerJob.configuration.copy(enabledPackageManagers = getDefaultPackageManagers(pluginService))
         val testException = IllegalStateException("AnalyzerRunner test exception")
         val runner = mockk<AnalyzerRunner> {
             coEvery {
                 run(
                     context,
                     any(),
-                    analyzerConfig,
+                    analyzerJob.configuration,
                     resolvedEnvConfig
                 )
             } throws testException
@@ -460,7 +447,6 @@ class AnalyzerWorkerTest : StringSpec({
             ortRunService,
             contextFactory,
             envService,
-            pluginService,
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
@@ -486,7 +472,6 @@ class AnalyzerWorkerTest : StringSpec({
             ortRunService,
             mockk(),
             mockk(),
-            mockPluginService(),
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
@@ -512,7 +497,6 @@ class AnalyzerWorkerTest : StringSpec({
             ortRunService,
             mockk(),
             mockk(),
-            mockPluginService(),
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
@@ -613,7 +597,6 @@ class AnalyzerWorkerTest : StringSpec({
             ortRunService,
             contextFactory,
             envService,
-            mockPluginService(),
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
@@ -704,7 +687,6 @@ class AnalyzerWorkerTest : StringSpec({
             ortRunService,
             contextFactory,
             envService,
-            mockPluginService(),
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
@@ -762,7 +744,6 @@ class AnalyzerWorkerTest : StringSpec({
             ortRunService,
             contextFactory,
             envService,
-            mockPluginService(),
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
@@ -834,7 +815,6 @@ class AnalyzerWorkerTest : StringSpec({
             ortRunService,
             contextFactory,
             envService,
-            mockPluginService(),
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
@@ -903,7 +883,6 @@ class AnalyzerWorkerTest : StringSpec({
             ortRunService,
             contextFactory,
             envService,
-            mockPluginService(),
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
@@ -984,7 +963,6 @@ class AnalyzerWorkerTest : StringSpec({
             ortRunService,
             contextFactory,
             envService,
-            mockPluginService(),
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
@@ -1043,7 +1021,6 @@ class AnalyzerWorkerTest : StringSpec({
             ortRunService,
             contextFactory,
             envService,
-            mockPluginService(),
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
@@ -1065,20 +1042,6 @@ private fun mockContextFactory(context: WorkerContext = mockk()): WorkerContextF
         coEvery { withContext(analyzerJob.ortRunId, capture(slot)) } coAnswers {
             slot.captured(context)
         }
-    }
-}
-
-private fun mockPluginService() = mockk<PluginService> {
-    every { getPlugins() } returns PackageManagerFactory.ALL.values.map { packageManagerFactory ->
-        val ortDescriptor = packageManagerFactory.descriptor
-        PluginDescriptor(
-            id = ortDescriptor.id,
-            type = PluginType.PACKAGE_MANAGER,
-            displayName = ortDescriptor.displayName,
-            description = ortDescriptor.description,
-            options = emptyList(),
-            availability = PluginAvailability.ENABLED
-        )
     }
 }
 

--- a/workers/analyzer/src/test/kotlin/UtilsTest.kt
+++ b/workers/analyzer/src/test/kotlin/UtilsTest.kt
@@ -20,20 +20,11 @@
 package org.eclipse.apoapsis.ortserver.workers.analyzer
 
 import io.kotest.core.spec.style.WordSpec
-import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.maps.shouldHaveSize
 import io.kotest.matchers.nulls.shouldNotBeNull
-import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
-import io.mockk.every
-import io.mockk.mockk
-
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginAvailability
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginDescriptor
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginService
-import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 
 import org.ossreviewtoolkit.model.Identifier as OrtIdentifier
@@ -83,40 +74,6 @@ class UtilsTest : WordSpec({
                 scope shouldBe "dependencies"
                 path shouldHaveSize 3
             }
-        }
-    }
-
-    "getDefaultPackageManagers()" should {
-        "return all enabled and restricted package managers" {
-            val pluginService = mockk<PluginService> {
-                every { getPlugins() } returns listOf(
-                    PluginDescriptor(
-                        "Maven",
-                        PluginType.PACKAGE_MANAGER,
-                        "Maven",
-                        "description",
-                        availability = PluginAvailability.DISABLED
-                    ),
-                    PluginDescriptor(
-                        "NPM",
-                        PluginType.PACKAGE_MANAGER,
-                        "NPM",
-                        "description",
-                        availability = PluginAvailability.RESTRICTED
-                    ),
-                    PluginDescriptor(
-                        "PNPM",
-                        PluginType.PACKAGE_MANAGER,
-                        "PNPM",
-                        "description",
-                        availability = PluginAvailability.ENABLED
-                    )
-                )
-            }
-
-            val defaultPackageManagers = getDefaultPackageManagers(pluginService)
-
-            defaultPackageManagers should containExactlyInAnyOrder("NPM", "PNPM")
         }
     }
 })

--- a/workers/config/build.gradle.kts
+++ b/workers/config/build.gradle.kts
@@ -32,7 +32,20 @@ plugins {
 
 group = "org.eclipse.apoapsis.ortserver.workers"
 
+repositories {
+    exclusiveContent {
+        forRepository {
+            maven("https://repo.gradle.org/gradle/libs-releases/")
+        }
+
+        filter {
+            includeGroup("org.gradle")
+        }
+    }
+}
+
 dependencies {
+    implementation(projects.components.pluginManager.pluginManagerBackend)
     implementation(projects.config.configSpi)
     implementation(projects.dao)
     implementation(projects.model)
@@ -52,7 +65,9 @@ dependencies {
 
     runtimeOnly(libs.log4jToSlf4j)
     runtimeOnly(libs.logback)
+    runtimeOnly(platform(ortLibs.ortPlugins.packageManagers))
 
+    testImplementation(projects.components.pluginManager.pluginManagerBackend)
     testImplementation(testFixtures(projects.config.configSpi))
     testImplementation(testFixtures(projects.dao))
     testImplementation(testFixtures(projects.secrets.secretsSpi))

--- a/workers/config/src/main/kotlin/ConfigComponent.kt
+++ b/workers/config/src/main/kotlin/ConfigComponent.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.apoapsis.ortserver.workers.config
 
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginService
 import org.eclipse.apoapsis.ortserver.dao.databaseModule
 import org.eclipse.apoapsis.ortserver.model.orchestrator.ConfigRequest
 import org.eclipse.apoapsis.ortserver.model.orchestrator.ConfigWorkerError
@@ -75,5 +76,6 @@ class ConfigComponent : EndpointComponent<ConfigRequest>(ConfigEndpoint) {
 
     private fun configModule(): Module = module {
         singleOf(::ConfigWorker)
+        singleOf(::PluginService)
     }
 }

--- a/workers/config/src/main/kotlin/ConfigComponent.kt
+++ b/workers/config/src/main/kotlin/ConfigComponent.kt
@@ -20,10 +20,16 @@
 package org.eclipse.apoapsis.ortserver.workers.config
 
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginService
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplateEventStore
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplateService
 import org.eclipse.apoapsis.ortserver.dao.databaseModule
+import org.eclipse.apoapsis.ortserver.dao.repositories.organization.DaoOrganizationRepository
+import org.eclipse.apoapsis.ortserver.dao.repositories.repository.DaoRepositoryRepository
 import org.eclipse.apoapsis.ortserver.model.orchestrator.ConfigRequest
 import org.eclipse.apoapsis.ortserver.model.orchestrator.ConfigWorkerError
 import org.eclipse.apoapsis.ortserver.model.orchestrator.ConfigWorkerResult
+import org.eclipse.apoapsis.ortserver.model.repositories.OrganizationRepository
+import org.eclipse.apoapsis.ortserver.model.repositories.RepositoryRepository
 import org.eclipse.apoapsis.ortserver.transport.ConfigEndpoint
 import org.eclipse.apoapsis.ortserver.transport.EndpointComponent
 import org.eclipse.apoapsis.ortserver.transport.EndpointHandler
@@ -37,6 +43,7 @@ import org.eclipse.apoapsis.ortserver.workers.common.context.workerContextModule
 import org.koin.core.component.inject
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 /**
@@ -77,5 +84,10 @@ class ConfigComponent : EndpointComponent<ConfigRequest>(ConfigEndpoint) {
     private fun configModule(): Module = module {
         singleOf(::ConfigWorker)
         singleOf(::PluginService)
+
+        singleOf(::DaoOrganizationRepository).bind<OrganizationRepository>()
+        singleOf(::DaoRepositoryRepository).bind<RepositoryRepository>()
+        singleOf(::PluginTemplateEventStore)
+        singleOf(::PluginTemplateService)
     }
 }

--- a/workers/config/src/main/kotlin/ConfigWorker.kt
+++ b/workers/config/src/main/kotlin/ConfigWorker.kt
@@ -20,10 +20,12 @@
 package org.eclipse.apoapsis.ortserver.workers.config
 
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginService
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplateService
 import org.eclipse.apoapsis.ortserver.config.Context
 import org.eclipse.apoapsis.ortserver.config.Path
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
 import org.eclipse.apoapsis.ortserver.model.JobConfigurations
+import org.eclipse.apoapsis.ortserver.model.OrganizationId
 import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
 import org.eclipse.apoapsis.ortserver.model.util.OptionalValue
@@ -54,7 +56,10 @@ class ConfigWorker(
     private val adminConfigService: AdminConfigService,
 
     /** The service for accessing plugin information. */
-    private val pluginService: PluginService
+    private val pluginService: PluginService,
+
+    /** The service for accessing plugin templates. */
+    private val pluginTemplateService: PluginTemplateService
 ) {
     companion object {
         /** Constant for the path to the script that validates and transforms parameters. */
@@ -88,7 +93,7 @@ class ConfigWorker(
 
             // Resolve the default package managers before the validation script runs so the script can see and
             // potentially override them.
-            val baseConfigs = resolveDefaultPackageManagers(context.ortRun.jobConfigs)
+            val baseConfigs = context.resolveDefaultPackageManagers(context.ortRun.jobConfigs)
 
             // TODO: Currently the path to the validation script is hard-coded. It may make sense to have it
             //       configurable.
@@ -182,10 +187,14 @@ class ConfigWorker(
      * configuration if [AnalyzerJobConfiguration.enabledPackageManagers][org.eclipse.apoapsis.ortserver.model
      * .AnalyzerJobConfiguration.enabledPackageManagers] is null or empty.
      */
-    private fun resolveDefaultPackageManagers(jobConfigs: JobConfigurations): JobConfigurations {
+    private fun WorkerContext.resolveDefaultPackageManagers(jobConfigs: JobConfigurations): JobConfigurations {
         if (!jobConfigs.analyzer.enabledPackageManagers.isNullOrEmpty()) return jobConfigs
 
-        val defaults = getDefaultPackageManagers(pluginService)
+        val defaults = getDefaultPackageManagers(
+            pluginService,
+            pluginTemplateService,
+            OrganizationId(ortRun.organizationId)
+        )
 
         logger.info("Determined default package managers: $defaults")
 

--- a/workers/config/src/main/kotlin/ConfigWorker.kt
+++ b/workers/config/src/main/kotlin/ConfigWorker.kt
@@ -19,9 +19,11 @@
 
 package org.eclipse.apoapsis.ortserver.workers.config
 
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginService
 import org.eclipse.apoapsis.ortserver.config.Context
 import org.eclipse.apoapsis.ortserver.config.Path
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
+import org.eclipse.apoapsis.ortserver.model.JobConfigurations
 import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
 import org.eclipse.apoapsis.ortserver.model.util.OptionalValue
@@ -49,7 +51,10 @@ class ConfigWorker(
     private val contextFactory: WorkerContextFactory,
 
     /** The service to access the admin configuration. */
-    private val adminConfigService: AdminConfigService
+    private val adminConfigService: AdminConfigService,
+
+    /** The service for accessing plugin information. */
+    private val pluginService: PluginService
 ) {
     companion object {
         /** Constant for the path to the script that validates and transforms parameters. */
@@ -81,6 +86,10 @@ class ConfigWorker(
                 resolvedJobConfigContext.name
             )
 
+            // Resolve the default package managers before the validation script runs so the script can see and
+            // potentially override them.
+            val baseConfigs = resolveDefaultPackageManagers(context.ortRun.jobConfigs)
+
             // TODO: Currently the path to the validation script is hard-coded. It may make sense to have it
             //       configurable.
             val validationScriptExists = context.configManager.containsFile(
@@ -96,7 +105,7 @@ class ConfigWorker(
                     VALIDATION_SCRIPT_PATH
                 )
                 val validator = ConfigValidator.create(
-                    createValidationWorkerContext(context, resolvedJobConfigContext),
+                    createValidationWorkerContext(context, resolvedJobConfigContext, baseConfigs),
                     adminConfigService
                 )
                 val validationResult = validator.validate(validationScript)
@@ -122,7 +131,7 @@ class ConfigWorker(
                 logger.info("Skipping validation as no script exists.")
 
                 RunResult.Success to Triple(
-                    context.ortRun.jobConfigs.asPresent(),
+                    baseConfigs.asPresent(),
                     OptionalValue.Absent,
                     OptionalValue.Absent
                 )
@@ -146,19 +155,42 @@ class ConfigWorker(
 
     /**
      * Create a [WorkerContext] that delegates to the given [context], but returns the provided
-     * [resolvedJobConfigContext]. This is needed because the [WorkerContext.ortRun] object contained in the original
-     * [WorkerContext] does not have the resolved configuration context yet; it is updated at the end of the worker
-     * execution. However, the config validation script needs the right configuration context.
+     * [resolvedJobConfigContext] and [baseConfigs]. This is needed because the [WorkerContext.ortRun] object contained
+     * in the original [WorkerContext] does not have the resolved configuration context yet; it is updated at the end
+     * of the worker execution. However, the config validation script needs the right configuration context. The
+     * [baseConfigs] override ensures the script sees the pre-resolved job configurations, including the default
+     * package managers.
      */
     private fun createValidationWorkerContext(
         context: WorkerContext,
-        resolvedJobConfigContext: Context
+        resolvedJobConfigContext: Context,
+        baseConfigs: JobConfigurations
     ): WorkerContext {
-        val runWithConfigContext = context.ortRun.copy(resolvedJobConfigContext = resolvedJobConfigContext.name)
+        val runWithConfigContext = context.ortRun.copy(
+            resolvedJobConfigContext = resolvedJobConfigContext.name,
+            jobConfigs = baseConfigs
+        )
 
         return object : WorkerContext by context {
             override val ortRun: OrtRun
                 get() = runWithConfigContext
         }
+    }
+
+    /**
+     * Return a copy of the given [jobConfigs] with the default package managers filled in for the analyzer
+     * configuration if [AnalyzerJobConfiguration.enabledPackageManagers][org.eclipse.apoapsis.ortserver.model
+     * .AnalyzerJobConfiguration.enabledPackageManagers] is null or empty.
+     */
+    private fun resolveDefaultPackageManagers(jobConfigs: JobConfigurations): JobConfigurations {
+        if (!jobConfigs.analyzer.enabledPackageManagers.isNullOrEmpty()) return jobConfigs
+
+        val defaults = getDefaultPackageManagers(pluginService)
+
+        logger.info("Determined default package managers: $defaults")
+
+        return jobConfigs.copy(
+            analyzer = jobConfigs.analyzer.copy(enabledPackageManagers = defaults)
+        )
     }
 }

--- a/workers/config/src/main/kotlin/Utils.kt
+++ b/workers/config/src/main/kotlin/Utils.kt
@@ -19,9 +19,13 @@
 
 package org.eclipse.apoapsis.ortserver.workers.config
 
+import com.github.michaelbull.result.getOrElse
+
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginAvailability
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginService
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplateService
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
+import org.eclipse.apoapsis.ortserver.model.OrganizationId
 
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
 
@@ -29,15 +33,30 @@ import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
  * Returns the IDs of the package managers that are enabled by default. This includes package managers which are enabled
  * by default in ORT and which are enabled in the [pluginService].
  */
-fun getDefaultPackageManagers(pluginService: PluginService): List<String> {
+fun getDefaultPackageManagers(
+    pluginService: PluginService,
+    pluginTemplateService: PluginTemplateService,
+    organizationId: OrganizationId
+): List<String> {
     val ortDefaultPackageManagers = AnalyzerConfiguration().enabledPackageManagers
 
     return pluginService.getPlugins()
         .filter {
-            it.type == PluginType.PACKAGE_MANAGER &&
-                    // TODO: Validate if restricted plugins are available in the current organization.
-                    it.availability in listOf(PluginAvailability.ENABLED, PluginAvailability.RESTRICTED) &&
-                    it.id in ortDefaultPackageManagers
+            val isPluginEnabled by lazy {
+                when (it.availability) {
+                    PluginAvailability.ENABLED -> true
+
+                    PluginAvailability.DISABLED -> false
+
+                    PluginAvailability.RESTRICTED -> {
+                        // Add restricted package managers only if a template exists for the organization.
+                        pluginTemplateService.getTemplateForOrganization(it.type, it.id, organizationId)
+                            .getOrElse { null } != null
+                    }
+                }
+            }
+
+            it.type == PluginType.PACKAGE_MANAGER && it.id in ortDefaultPackageManagers && isPluginEnabled
         }
         .map { it.id }
 }

--- a/workers/config/src/main/kotlin/Utils.kt
+++ b/workers/config/src/main/kotlin/Utils.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.config
+
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginAvailability
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginService
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
+
+import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
+
+/**
+ * Returns the IDs of the package managers that are enabled by default. This includes package managers which are enabled
+ * by default in ORT and which are enabled in the [pluginService].
+ */
+fun getDefaultPackageManagers(pluginService: PluginService): List<String> {
+    val ortDefaultPackageManagers = AnalyzerConfiguration().enabledPackageManagers
+
+    return pluginService.getPlugins()
+        .filter {
+            it.type == PluginType.PACKAGE_MANAGER &&
+                    // TODO: Validate if restricted plugins are available in the current organization.
+                    it.availability in listOf(PluginAvailability.ENABLED, PluginAvailability.RESTRICTED) &&
+                    it.id in ortDefaultPackageManagers
+        }
+        .map { it.id }
+}

--- a/workers/config/src/test/kotlin/ConfigWorkerTest.kt
+++ b/workers/config/src/test/kotlin/ConfigWorkerTest.kt
@@ -35,10 +35,15 @@ import io.mockk.verify
 
 import kotlin.time.Clock
 
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginAvailability
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginDescriptor
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginService
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
 import org.eclipse.apoapsis.ortserver.config.ConfigException
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.config.Context
 import org.eclipse.apoapsis.ortserver.dao.test.mockkTransaction
+import org.eclipse.apoapsis.ortserver.model.AnalyzerJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.Hierarchy
 import org.eclipse.apoapsis.ortserver.model.JobConfigurations
 import org.eclipse.apoapsis.ortserver.model.OrtRun
@@ -75,7 +80,7 @@ class ConfigWorkerTest : StringSpec({
         }
 
         mockkTransaction {
-            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk())
+            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk(), mockPluginService())
             worker.testRun() shouldBe RunResult.Success
 
             verify {
@@ -105,7 +110,7 @@ class ConfigWorkerTest : StringSpec({
         }
 
         mockkTransaction {
-            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk())
+            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk(), mockPluginService())
             worker.testRun() shouldBe RunResult.Success
 
             verify {
@@ -134,7 +139,7 @@ class ConfigWorkerTest : StringSpec({
         }
 
         mockkTransaction {
-            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk())
+            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk(), mockPluginService())
             when (val result = worker.testRun()) {
                 is RunResult.Failed -> result.error should beInstanceOf<IllegalArgumentException>()
                 else -> AssertionErrorBuilder.fail("Unexpected result: $result")
@@ -159,7 +164,7 @@ class ConfigWorkerTest : StringSpec({
         val configManager = mockConfigManager()
         every { configManager.getFileAsString(any(), any()) } throws configException
 
-        val worker = ConfigWorker(mockk(), mockk(), contextFactory, mockk())
+        val worker = ConfigWorker(mockk(), mockk(), contextFactory, mockk(), mockPluginService())
         when (val result = worker.testRun()) {
             is RunResult.Failed -> result.error shouldBe configException
             else -> AssertionErrorBuilder.fail("Unexpected result: $result")
@@ -179,7 +184,7 @@ class ConfigWorkerTest : StringSpec({
         }
 
         mockkTransaction {
-            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk())
+            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk(), mockPluginService())
             worker.testRun() shouldBe RunResult.Success
 
             val slotContext = mutableListOf<WorkerContext>()
@@ -199,10 +204,7 @@ class ConfigWorkerTest : StringSpec({
     }
 
     "A missing validation script should be ignored" {
-        val (contextFactory, context, configManager) = mockContext(validationScriptExists = false)
-
-        val resolvedConfig = mockk<JobConfigurations>()
-        mockValidator(ConfigValidationResultSuccess(resolvedConfig, validationIssues, validationLabels))
+        val (contextFactory, _, configManager) = mockContext(validationScriptExists = false)
 
         val ortRunRepository = mockk<OrtRunRepository> {
             every {
@@ -211,10 +213,12 @@ class ConfigWorkerTest : StringSpec({
         }
 
         mockkTransaction {
-            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk())
+            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk(), mockPluginService())
             worker.testRun() shouldBe RunResult.Success
 
-            val expectedJobConfigs = context.ortRun.jobConfigs
+            val expectedJobConfigs = JobConfigurations(
+                analyzer = AnalyzerJobConfiguration(enabledPackageManagers = DEFAULT_PACKAGE_MANAGERS)
+            )
 
             verify {
                 configManager.resolveContext(Context(ORIGINAL_CONTEXT))
@@ -225,6 +229,60 @@ class ConfigWorkerTest : StringSpec({
                     resolvedJobConfigContext = RESOLVED_CONTEXT.asPresent()
                 )
             }
+        }
+    }
+
+    "Default package managers should be injected into the context passed to the validation script" {
+        val (contextFactory, _, _) = mockContext()
+
+        val resolvedConfig = mockk<JobConfigurations>()
+        mockValidator(ConfigValidationResultSuccess(resolvedConfig, validationIssues))
+
+        val ortRunRepository = mockk<OrtRunRepository> {
+            every {
+                update(RUN_ID, any(), any(), any(), any(), any(), any(), any())
+            } returns mockk()
+        }
+
+        mockkTransaction {
+            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk(), mockPluginService())
+            worker.testRun() shouldBe RunResult.Success
+
+            val slotContext = mutableListOf<WorkerContext>()
+            verify {
+                ConfigValidator.create(capture(slotContext), any())
+            }
+
+            val capturedContext = slotContext.last()
+            capturedContext.ortRun.jobConfigs.analyzer.enabledPackageManagers shouldBe DEFAULT_PACKAGE_MANAGERS
+        }
+    }
+
+    "Existing package managers should not be overwritten by defaults" {
+        val existingManagers = listOf("Maven")
+        val jobConfig = AnalyzerJobConfiguration(enabledPackageManagers = existingManagers)
+        val (contextFactory, _, _) = mockContext(jobConfigs = JobConfigurations(analyzer = jobConfig))
+
+        val resolvedConfig = mockk<JobConfigurations>()
+        mockValidator(ConfigValidationResultSuccess(resolvedConfig, validationIssues))
+
+        val ortRunRepository = mockk<OrtRunRepository> {
+            every {
+                update(RUN_ID, any(), any(), any(), any(), any(), any(), any())
+            } returns mockk()
+        }
+
+        mockkTransaction {
+            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk(), mockPluginService())
+            worker.testRun() shouldBe RunResult.Success
+
+            val slotContext = mutableListOf<WorkerContext>()
+            verify {
+                ConfigValidator.create(capture(slotContext), any())
+            }
+
+            val capturedContext = slotContext.last()
+            capturedContext.ortRun.jobConfigs.analyzer.enabledPackageManagers shouldBe existingManagers
         }
     }
 })
@@ -241,6 +299,9 @@ private const val RESOLVED_CONTEXT = "theResolvedConfigurationContext"
 /** Simulated script to perform parameter validation and transformation. */
 private const val PARAMETERS_SCRIPT = "Script to validate parameters"
 
+/** The package managers returned by the mock plugin service. */
+private val DEFAULT_PACKAGE_MANAGERS = listOf("NPM", "Maven")
+
 /** A list with validation issues to be returned by the mock validator. */
 private val validationIssues = listOf(
     Issue(Clock.System.now(), "ConfigWorkerTest", "Test message", Severity.ERROR)
@@ -251,11 +312,13 @@ private val validationLabels = mapOf("validated" to "yes", "test" to "true")
 
 /**
  * Create a mock context factory together with a mock context that is returned by the factory. Prepare the mocks to
- * return typical answers. Use the given [orgConfigContext] for the [OrtRun.jobConfigContext] property.
+ * return typical answers. Use the given [orgConfigContext] for the [OrtRun.jobConfigContext] property and the given
+ * [jobConfigs] as the job configurations.
  */
 private fun mockContext(
     orgConfigContext: String? = ORIGINAL_CONTEXT,
     validationScriptExists: Boolean = true,
+    jobConfigs: JobConfigurations = JobConfigurations(),
     configureConfigManager: ConfigManager.() -> Unit = {}
 ): Triple<WorkerContextFactory, WorkerContext, ConfigManager> {
     val run = OrtRun(
@@ -267,7 +330,7 @@ private fun mockContext(
         revision = "main",
         path = null,
         createdAt = Clock.System.now(),
-        jobConfigs = JobConfigurations(),
+        jobConfigs = jobConfigs,
         resolvedJobConfigs = null,
         status = OrtRunStatus.ACTIVE,
         finishedAt = null,
@@ -326,6 +389,15 @@ private fun mockConfigManager(validationScriptExists: Boolean = true): ConfigMan
     } returns PARAMETERS_SCRIPT
 
     every { resolveContext(any()) } returns Context(RESOLVED_CONTEXT)
+}
+
+/**
+ * Create a mock [PluginService] that returns [DEFAULT_PACKAGE_MANAGERS] as the enabled package managers.
+ */
+private fun mockPluginService(): PluginService = mockk {
+    every { getPlugins() } returns DEFAULT_PACKAGE_MANAGERS.map { id ->
+        PluginDescriptor(id, PluginType.PACKAGE_MANAGER, id, "", availability = PluginAvailability.ENABLED)
+    }
 }
 
 /**

--- a/workers/config/src/test/kotlin/ConfigWorkerTest.kt
+++ b/workers/config/src/test/kotlin/ConfigWorkerTest.kt
@@ -80,7 +80,7 @@ class ConfigWorkerTest : StringSpec({
         }
 
         mockkTransaction {
-            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk(), mockPluginService())
+            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk(), mockPluginService(), mockk())
             worker.testRun() shouldBe RunResult.Success
 
             verify {
@@ -110,7 +110,7 @@ class ConfigWorkerTest : StringSpec({
         }
 
         mockkTransaction {
-            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk(), mockPluginService())
+            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk(), mockPluginService(), mockk())
             worker.testRun() shouldBe RunResult.Success
 
             verify {
@@ -139,7 +139,7 @@ class ConfigWorkerTest : StringSpec({
         }
 
         mockkTransaction {
-            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk(), mockPluginService())
+            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk(), mockPluginService(), mockk())
             when (val result = worker.testRun()) {
                 is RunResult.Failed -> result.error should beInstanceOf<IllegalArgumentException>()
                 else -> AssertionErrorBuilder.fail("Unexpected result: $result")
@@ -164,7 +164,7 @@ class ConfigWorkerTest : StringSpec({
         val configManager = mockConfigManager()
         every { configManager.getFileAsString(any(), any()) } throws configException
 
-        val worker = ConfigWorker(mockk(), mockk(), contextFactory, mockk(), mockPluginService())
+        val worker = ConfigWorker(mockk(), mockk(), contextFactory, mockk(), mockPluginService(), mockk())
         when (val result = worker.testRun()) {
             is RunResult.Failed -> result.error shouldBe configException
             else -> AssertionErrorBuilder.fail("Unexpected result: $result")
@@ -184,7 +184,7 @@ class ConfigWorkerTest : StringSpec({
         }
 
         mockkTransaction {
-            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk(), mockPluginService())
+            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk(), mockPluginService(), mockk())
             worker.testRun() shouldBe RunResult.Success
 
             val slotContext = mutableListOf<WorkerContext>()
@@ -213,7 +213,7 @@ class ConfigWorkerTest : StringSpec({
         }
 
         mockkTransaction {
-            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk(), mockPluginService())
+            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk(), mockPluginService(), mockk())
             worker.testRun() shouldBe RunResult.Success
 
             val expectedJobConfigs = JobConfigurations(
@@ -245,7 +245,7 @@ class ConfigWorkerTest : StringSpec({
         }
 
         mockkTransaction {
-            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk(), mockPluginService())
+            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk(), mockPluginService(), mockk())
             worker.testRun() shouldBe RunResult.Success
 
             val slotContext = mutableListOf<WorkerContext>()
@@ -273,7 +273,7 @@ class ConfigWorkerTest : StringSpec({
         }
 
         mockkTransaction {
-            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk(), mockPluginService())
+            val worker = ConfigWorker(mockk(), ortRunRepository, contextFactory, mockk(), mockPluginService(), mockk())
             worker.testRun() shouldBe RunResult.Success
 
             val slotContext = mutableListOf<WorkerContext>()

--- a/workers/config/src/test/kotlin/UtilsTest.kt
+++ b/workers/config/src/test/kotlin/UtilsTest.kt
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.config
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.should
+
+import io.mockk.every
+import io.mockk.mockk
+
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginAvailability
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginDescriptor
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginService
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
+
+class UtilsTest : WordSpec({
+    "getDefaultPackageManagers()" should {
+        "return all enabled and restricted package managers that are ORT defaults" {
+            val pluginService = mockk<PluginService> {
+                every { getPlugins() } returns listOf(
+                    PluginDescriptor(
+                        "Maven",
+                        PluginType.PACKAGE_MANAGER,
+                        "Maven",
+                        "description",
+                        availability = PluginAvailability.DISABLED
+                    ),
+                    PluginDescriptor(
+                        "NPM",
+                        PluginType.PACKAGE_MANAGER,
+                        "NPM",
+                        "description",
+                        availability = PluginAvailability.RESTRICTED
+                    ),
+                    PluginDescriptor(
+                        "PNPM",
+                        PluginType.PACKAGE_MANAGER,
+                        "PNPM",
+                        "description",
+                        availability = PluginAvailability.ENABLED
+                    ),
+                    PluginDescriptor(
+                        "OSV",
+                        PluginType.ADVISOR,
+                        "OSV",
+                        "description",
+                        availability = PluginAvailability.ENABLED
+                    )
+                )
+            }
+
+            val defaultPackageManagers = getDefaultPackageManagers(pluginService)
+
+            defaultPackageManagers should containExactlyInAnyOrder("NPM", "PNPM")
+        }
+    }
+})

--- a/workers/config/src/test/kotlin/UtilsTest.kt
+++ b/workers/config/src/test/kotlin/UtilsTest.kt
@@ -19,6 +19,8 @@
 
 package org.eclipse.apoapsis.ortserver.workers.config
 
+import com.github.michaelbull.result.Ok
+
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.should
@@ -29,11 +31,14 @@ import io.mockk.mockk
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginAvailability
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginDescriptor
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginService
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplate
+import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplateService
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
+import org.eclipse.apoapsis.ortserver.model.OrganizationId
 
 class UtilsTest : WordSpec({
     "getDefaultPackageManagers()" should {
-        "return all enabled and restricted package managers that are ORT defaults" {
+        "return all enabled and restricted package managers available for an organization that are ORT defaults" {
             val pluginService = mockk<PluginService> {
                 every { getPlugins() } returns listOf(
                     PluginDescriptor(
@@ -58,6 +63,13 @@ class UtilsTest : WordSpec({
                         availability = PluginAvailability.ENABLED
                     ),
                     PluginDescriptor(
+                        "Yarn2",
+                        PluginType.PACKAGE_MANAGER,
+                        "Yarn2",
+                        "description",
+                        availability = PluginAvailability.RESTRICTED
+                    ),
+                    PluginDescriptor(
                         "OSV",
                         PluginType.ADVISOR,
                         "OSV",
@@ -67,7 +79,29 @@ class UtilsTest : WordSpec({
                 )
             }
 
-            val defaultPackageManagers = getDefaultPackageManagers(pluginService)
+            val pluginTemplateService = mockk<PluginTemplateService> {
+                every { getTemplateForOrganization(any(), any(), any()) } answers {
+                    // Return a template for NPM but not for Yarn2 to validate that only restricted plugins with a
+                    // template are added to the defaults.
+                    if (secondArg<String>() == "NPM") {
+                        Ok(
+                            PluginTemplate(
+                                name = "PNPM",
+                                pluginType = PluginType.PACKAGE_MANAGER,
+                                pluginId = "template content",
+                                options = emptyList(),
+                                isGlobal = false,
+                                organizationIds = listOf(1)
+                            )
+                        )
+                    } else {
+                        Ok(null)
+                    }
+                }
+            }
+
+            val defaultPackageManagers =
+                getDefaultPackageManagers(pluginService, pluginTemplateService, OrganizationId(1))
 
             defaultPackageManagers should containExactlyInAnyOrder("NPM", "PNPM")
         }


### PR DESCRIPTION
Move the `getDefaultPackageManagers` logic from the analyzer worker to
the config worker so that the default package managers are resolved
before the validation script runs. This makes the resolution transparent
to the script, which can now see and potentially override the defaults.

The resolved defaults are stored in `resolvedJobConfigs`, keeping all
job config resolution in one place. The analyzer worker no longer needs
to inject default package managers at runtime.

This is also a preparation for applying plugin templates in the config
worker which requires that the actually used package managers are
already known.