### PR TITLE
Add optional repository name

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
@@ -515,6 +515,7 @@ fun Repository.mapToApi() = ApiRepository(
     productId = productId,
     type = type.mapToApi(),
     url = url,
+    name = name,
     description = description
 )
 

--- a/api/v1/model/src/commonMain/kotlin/Repository.kt
+++ b/api/v1/model/src/commonMain/kotlin/Repository.kt
@@ -20,6 +20,7 @@
 package org.eclipse.apoapsis.ortserver.api.v1.model
 
 import io.konform.validation.Validation
+import io.konform.validation.constraints.pattern
 
 import io.ktor.http.parseUrl
 
@@ -48,12 +49,17 @@ data class Repository(
     /** The url to the repository. */
     val url: String,
 
+    /** The name of the repository. */
+    val name: String? = null,
+
     /** The description of the repository. */
     val description: String? = null
 ) {
     companion object {
         const val INVALID_URL_MESSAGE = "The repository URL is malformed."
         const val USER_INFO_MESSAGE = "The repository URL must not contain userinfo."
+        val NAME_PATTERN_REGEX = Product.NAME_PATTERN_REGEX
+        const val NAME_PATTERN_MESSAGE = Product.NAME_PATTERN_MESSAGE
 
         fun isValidUrl(url: String): Boolean = parseUrl(url)?.host?.isValidHost() ?: false
 
@@ -73,6 +79,7 @@ private fun String.isValidHost() = all { it.isLetterOrDigit() || it == '.' || it
 data class PostRepository(
     val type: RepositoryType,
     val url: String,
+    val name: String? = null,
     val description: String? = null
 ) {
     companion object {
@@ -87,6 +94,10 @@ data class PostRepository(
                         !Repository.hasUserInfo(it)
                     } hint Repository.USER_INFO_MESSAGE
                 }
+
+                PostRepository::name ifPresent {
+                    pattern(Repository.NAME_PATTERN_REGEX) hint Repository.NAME_PATTERN_MESSAGE
+                }
             }.invoke(obj)
         }
     }
@@ -99,6 +110,7 @@ data class PostRepository(
 data class PatchRepository(
     val type: OptionalValue<RepositoryType> = OptionalValue.Absent,
     val url: OptionalValue<String> = OptionalValue.Absent,
+    val name: OptionalValue<String?> = OptionalValue.Absent,
     val description: OptionalValue<String?> = OptionalValue.Absent,
 
     /**
@@ -124,6 +136,15 @@ data class PatchRepository(
                             is OptionalValue.Absent -> true
                         }
                     } hint Repository.USER_INFO_MESSAGE
+                }
+
+                PatchRepository::name {
+                    constrain("must match the expected pattern '${Repository.NAME_PATTERN_REGEX.pattern}'") {
+                        when (it) {
+                            is OptionalValue.Present -> it.value?.matches(Repository.NAME_PATTERN_REGEX) ?: true
+                            is OptionalValue.Absent -> true
+                        }
+                    } hint Repository.NAME_PATTERN_MESSAGE
                 }
             }.invoke(obj)
         }

--- a/core/src/main/kotlin/api/ProductsRoute.kt
+++ b/core/src/main/kotlin/api/ProductsRoute.kt
@@ -158,6 +158,7 @@ fun Route.products() = route("products/{productId}") {
                 createRepository.type.mapToModel(),
                 createRepository.url,
                 id,
+                createRepository.name,
                 createRepository.description
             ).mapToApi()
 

--- a/core/src/main/kotlin/api/RepositoriesRoute.kt
+++ b/core/src/main/kotlin/api/RepositoriesRoute.kt
@@ -126,11 +126,12 @@ fun Route.repositories() = route("repositories/{repositoryId}") {
         }
 
         val updatedRepository = repositoryService.updateRepository(
-            id,
-            updateRepository.type.mapToModel { it.mapToModel() },
-            updateRepository.url.mapToModel(),
-            updateRepository.description.mapToModel(),
-            updateRepository.productId.mapToModel()
+            repositoryId = id,
+            type = updateRepository.type.mapToModel { it.mapToModel() },
+            url = updateRepository.url.mapToModel(),
+            description = updateRepository.description.mapToModel(),
+            productId = updateRepository.productId.mapToModel(),
+            name = updateRepository.name.mapToModel()
         )
 
         call.respond(HttpStatusCode.OK, updatedRepository.mapToApi())

--- a/core/src/main/kotlin/apiDocs/ProductsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/ProductsDocs.kt
@@ -163,14 +163,16 @@ val getProductRepositories: RouteConfig.() -> Unit = {
                                 organizationId = 2,
                                 productId = 3,
                                 type = RepositoryType.GIT,
-                                url = "https://example.com/first/repo.git"
+                                url = "https://example.com/first/repo.git",
+                                name = "first-repo"
                             ),
                             Repository(
                                 id = 2,
                                 organizationId = 3,
                                 productId = 4,
                                 type = RepositoryType.SUBVERSION,
-                                url = "https://example.com/second/repo"
+                                url = "https://example.com/second/repo",
+                                name = "second-repo"
                             )
                         ),
                         PagingData(
@@ -199,7 +201,8 @@ val postRepository: RouteConfig.() -> Unit = {
             example("Create repository") {
                 value = PostRepository(
                     type = RepositoryType.GIT,
-                    url = "https://example.com/namspace/repo.git"
+                    url = "https://example.com/namspace/repo.git",
+                    name = "repo"
                 )
             }
         }
@@ -215,7 +218,8 @@ val postRepository: RouteConfig.() -> Unit = {
                         organizationId = 2,
                         productId = 3,
                         type = RepositoryType.GIT,
-                        url = "https://example.com/namspace/repo.git"
+                        url = "https://example.com/namspace/repo.git",
+                        name = "repo"
                     )
                 }
             }

--- a/core/src/main/kotlin/apiDocs/ProductsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/ProductsDocs.kt
@@ -147,7 +147,7 @@ val getProductRepositories: RouteConfig.() -> Unit = {
         standardListQueryParameters()
 
         queryParameter<String>("filter") {
-            description = "A regular expression to filter repositories by URL."
+            description = "A regular expression to filter repositories by name or URL."
         }
     }
 

--- a/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
@@ -236,7 +236,8 @@ val getRepository: RouteConfig.() -> Unit = {
                         organizationId = 2,
                         productId = 3,
                         type = RepositoryType.GIT,
-                        url = "https://example.com/org/repo.git"
+                        url = "https://example.com/org/repo.git",
+                        name = "repo"
                     )
                 }
             }
@@ -260,6 +261,7 @@ val patchRepository: RouteConfig.() -> Unit = {
                 value = PatchRepository(
                     type = RepositoryType.GIT_REPO.asPresent(),
                     url = "https://example.com/org/updated-repo.git".asPresent(),
+                    name = "updated-repo".asPresent(),
                     description = "Updated repository description.".asPresent(),
                     productId = 42L.asPresent()
                 )
@@ -278,6 +280,7 @@ val patchRepository: RouteConfig.() -> Unit = {
                         productId = 3,
                         type = RepositoryType.GIT_REPO,
                         url = "https://example.com/org/updated-repo.git",
+                        name = "updated-repo",
                         description = "Updated repository description."
                     )
                 }

--- a/core/src/test/kotlin/api/DownloadsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/DownloadsRouteIntegrationTest.kt
@@ -73,6 +73,7 @@ class DownloadsRouteIntegrationTest : AbstractIntegrationTest({
             type = RepositoryType.GIT,
             url = "https://example.org/repo.git",
             productId = productId,
+            name = "repo",
             description = "description"
         ).id
     }

--- a/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
@@ -637,6 +637,7 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                     RepositoryType.GIT,
                     "https://example.com/repo.git",
                     createdProduct2.id,
+                    null,
                     null
                 )
                 val productInOtherOrg = organizationService.createProduct(

--- a/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
@@ -279,18 +279,22 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 val type = RepositoryType.GIT
                 val url1 = "https://example.com/repo1.git"
                 val url2 = "https://example.com/repo2.git"
+                val name1 = "repo1"
+                val name2 = "repo2"
                 val description = "description"
 
                 val createdRepository1 = productService.createRepository(
                     type = type,
                     url = url1,
                     productId = createdProduct.id,
+                    name = name1,
                     description = description
                 )
                 val createdRepository2 = productService.createRepository(
                     type = type,
                     url = url2,
                     productId = createdProduct.id,
+                    name = name2,
                     description = description
                 )
 
@@ -299,8 +303,24 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 response shouldHaveStatus HttpStatusCode.OK
                 response shouldHaveBody PagedResponse(
                     listOf(
-                        Repository(createdRepository1.id, orgId, createdProduct.id, type.mapToApi(), url1, description),
-                        Repository(createdRepository2.id, orgId, createdProduct.id, type.mapToApi(), url2, description)
+                        Repository(
+                            id = createdRepository1.id,
+                            organizationId = orgId,
+                            productId = createdProduct.id,
+                            type = type.mapToApi(),
+                            url = url1,
+                            name = name1,
+                            description = description
+                        ),
+                        Repository(
+                            id = createdRepository2.id,
+                            organizationId = orgId,
+                            productId = createdProduct.id,
+                            type = type.mapToApi(),
+                            url = url2,
+                            name = name2,
+                            description = description
+                        )
                     ),
                     PagingData(
                         limit = DEFAULT_LIMIT,
@@ -319,24 +339,29 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 val type = RepositoryType.GIT
                 val url1 = "https://example.com/repo1.git"
                 val url2 = "https://example.com/repo2.git"
+                val name1 = "repo1"
+                val name2 = "repo2"
                 val description = "description"
 
                 val createdRepository1 = productService.createRepository(
                     type = type,
                     url = url1,
                     productId = createdProduct.id,
+                    name = name1,
                     description = description
                 )
                 val createdRepository2 = productService.createRepository(
                     type = type,
                     url = url2,
                     productId = createdProduct.id,
+                    name = name2,
                     description = description
                 )
                 productService.createRepository(
                     type = type,
                     url = "https://example.com/hidden-repo.git",
                     productId = createdProduct.id,
+                    name = "hidden-repo",
                     description = "You cannot see me"
                 )
 
@@ -364,8 +389,24 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 response shouldHaveStatus HttpStatusCode.OK
                 response shouldHaveBody PagedResponse(
                     listOf(
-                        Repository(createdRepository1.id, orgId, createdProduct.id, type.mapToApi(), url1, description),
-                        Repository(createdRepository2.id, orgId, createdProduct.id, type.mapToApi(), url2, description)
+                        Repository(
+                            id = createdRepository1.id,
+                            organizationId = orgId,
+                            productId = createdProduct.id,
+                            type = type.mapToApi(),
+                            url = url1,
+                            name = name1,
+                            description = description
+                        ),
+                        Repository(
+                            id = createdRepository2.id,
+                            organizationId = orgId,
+                            productId = createdProduct.id,
+                            type = type.mapToApi(),
+                            url = url2,
+                            name = name2,
+                            description = description
+                        )
                     ),
                     PagingData(
                         limit = DEFAULT_LIMIT,
@@ -384,18 +425,22 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 val type = RepositoryType.GIT
                 val url1 = "https://example.com/repo1.git"
                 val url2 = "https://example.com/repo2.git"
+                val name1 = "repo1"
+                val name2 = "repo2"
                 val description = "description"
 
                 productService.createRepository(
                     type = type,
                     url = url1,
                     productId = createdProduct.id,
+                    name = name1,
                     description = description
                 )
                 val createdRepository2 = productService.createRepository(
                     type = type,
                     url = url2,
                     productId = createdProduct.id,
+                    name = name2,
                     description = description
                 )
 
@@ -406,12 +451,13 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 response shouldHaveBody PagedResponse(
                     listOf(
                         Repository(
-                            createdRepository2.id,
-                            orgId,
-                            createdProduct.id,
-                            type.mapToApi(),
-                            url2,
-                            description
+                            id = createdRepository2.id,
+                            organizationId = orgId,
+                            productId = createdProduct.id,
+                            type = type.mapToApi(),
+                            url = url2,
+                            name = name2,
+                            description = description
                         )
                     ),
                     PagingData(
@@ -437,14 +483,79 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication {
                 val createdProduct = createProduct()
 
-                val repository = PostRepository(ApiRepositoryType.GIT, "https://example.com/repo.git", "description")
+                val repository = PostRepository(
+                    type = ApiRepositoryType.GIT,
+                    url = "https://example.com/repo.git",
+                    name = "repository-name",
+                    description = "description"
+                )
                 val response = superuserClient.post("/api/v1/products/${createdProduct.id}/repositories") {
                     setBody(repository)
                 }
 
                 response shouldHaveStatus HttpStatusCode.Created
-                response shouldHaveBody
-                    Repository(1, orgId, createdProduct.id, repository.type, repository.url, repository.description)
+                response shouldHaveBody Repository(
+                    id = 1,
+                    organizationId = orgId,
+                    productId = createdProduct.id,
+                    type = repository.type,
+                    url = repository.url,
+                    name = repository.name,
+                    description = repository.description
+                )
+            }
+        }
+
+        "create repositories with the same url if their names differ" {
+            integrationTestApplication {
+                val createdProduct = createProduct()
+
+                val repository1 = PostRepository(
+                    type = ApiRepositoryType.GIT,
+                    url = "https://example.com/repo.git",
+                    name = "repository-name-1",
+                    description = "description"
+                )
+                val repository2 = PostRepository(
+                    type = ApiRepositoryType.GIT,
+                    url = "https://example.com/repo.git",
+                    name = "repository-name-2",
+                    description = "description"
+                )
+
+                superuserClient.post("/api/v1/products/${createdProduct.id}/repositories") {
+                    setBody(repository1)
+                } shouldHaveStatus HttpStatusCode.Created
+
+                val response = superuserClient.post("/api/v1/products/${createdProduct.id}/repositories") {
+                    setBody(repository2)
+                }
+
+                response shouldHaveStatus HttpStatusCode.Created
+                response.body<Repository>().name shouldBe repository2.name
+            }
+        }
+
+        "respond with 'Conflict' if the repository's url and name already exist" {
+            integrationTestApplication {
+                val createdProduct = createProduct()
+
+                val repository = PostRepository(
+                    type = ApiRepositoryType.GIT,
+                    url = "https://example.com/repo.git",
+                    name = "repository-name",
+                    description = "description"
+                )
+
+                superuserClient.post("/api/v1/products/${createdProduct.id}/repositories") {
+                    setBody(repository)
+                } shouldHaveStatus HttpStatusCode.Created
+
+                val response = superuserClient.post("/api/v1/products/${createdProduct.id}/repositories") {
+                    setBody(repository)
+                }
+
+                response shouldHaveStatus HttpStatusCode.Conflict
             }
         }
 
@@ -452,7 +563,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication {
                 val createdProduct = createProduct()
 
-                val repository = PostRepository(ApiRepositoryType.GIT, "https://git hub.com/org/repo.git")
+                val repository = PostRepository(type = ApiRepositoryType.GIT, url = "https://git hub.com/org/repo.git")
                 val response = superuserClient.post("/api/v1/products/${createdProduct.id}/repositories") {
                     setBody(repository)
                 }
@@ -469,7 +580,28 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
             integrationTestApplication {
                 val createdProduct = createProduct()
 
-                val repository = PostRepository(ApiRepositoryType.GIT, "https://user:password@github.com")
+                val repository = PostRepository(type = ApiRepositoryType.GIT, url = "https://user:password@github.com")
+                val response = superuserClient.post("/api/v1/products/${createdProduct.id}/repositories") {
+                    setBody(repository)
+                }
+
+                response shouldHaveStatus HttpStatusCode.BadRequest
+
+                val body = response.body<ErrorResponse>()
+                body.message shouldBe "Request validation has failed."
+                body.cause shouldContain "Validation failed for PostRepository"
+            }
+        }
+
+        "respond with 'Bad Request' if the repository's name contains invalid characters" {
+            integrationTestApplication {
+                val createdProduct = createProduct()
+
+                val repository = PostRepository(
+                    type = ApiRepositoryType.GIT,
+                    url = "https://github.com/org/repo.git",
+                    name = "invalid<name"
+                )
                 val response = superuserClient.post("/api/v1/products/${createdProduct.id}/repositories") {
                     setBody(repository)
                 }
@@ -489,7 +621,10 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                 createdProduct.hierarchyId(),
                 HttpStatusCode.Created
             ) {
-                val repository = PostRepository(ApiRepositoryType.GIT, "https://example.com/repo.git")
+                val repository = PostRepository(
+                    type = ApiRepositoryType.GIT,
+                    url = "https://example.com/repo.git"
+                )
                 post("/api/v1/products/${createdProduct.id}/repositories") { setBody(repository) }
             }
         }
@@ -694,17 +829,21 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
         "return vulnerabilities across repositories in the product found in latest successful advisor jobs" {
             integrationTestApplication {
                 val productId = createProduct().id
+                val repositoryName1 = "repo"
+                val repositoryName2 = "repo2"
                 val description = "description"
                 val repository1Id = productService.createRepository(
                     type = RepositoryType.GIT,
                     url = "https://example.org/repo.git",
                     productId = productId,
+                    name = repositoryName1,
                     description = description
                 ).id
                 val repository2Id = productService.createRepository(
                     type = RepositoryType.GIT,
                     url = "https://example.org/repo2.git",
                     productId = productId,
+                    name = repositoryName2,
                     description = description
                 ).id
 
@@ -1671,17 +1810,21 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
         "trigger ORT runs for repositories in the product" {
             integrationTestApplication {
                 val productId = createProduct().id
+                val repositoryName1 = "repo1"
+                val repositoryName2 = "repo2"
                 val description = "description"
                 val repository1Id = productService.createRepository(
                     type = RepositoryType.GIT,
                     url = "https://example.com/repo1.git",
                     productId = productId,
+                    name = repositoryName1,
                     description = description
                 ).id
                 val repository2Id = productService.createRepository(
                     type = RepositoryType.GIT,
                     url = "https://example.com/repo2.git",
                     productId = productId,
+                    name = repositoryName2,
                     description = description
                 ).id
 
@@ -1953,23 +2096,29 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
         "create ORT runs when 'repositoryFailedIds' is set and the last runs of all repositories failed" {
             integrationTestApplication {
                 val productId = createProduct().id
+                val repositoryName1 = "repo1"
+                val repositoryName2 = "repo2"
+                val repositoryName3 = "repo3"
                 val description = "description"
                 val repository1Id = productService.createRepository(
                     type = RepositoryType.GIT,
                     url = "https://example.com/repo1.git",
                     productId = productId,
+                    name = repositoryName1,
                     description = description
                 ).id
                 val repository2Id = productService.createRepository(
                     type = RepositoryType.GIT,
                     url = "https://example.com/repo2.git",
                     productId = productId,
+                    name = repositoryName2,
                     description = description
                 ).id
                 val repository3Id = productService.createRepository(
                     type = RepositoryType.GIT,
                     url = "https://example.com/repo3.git",
                     productId = productId,
+                    name = repositoryName3,
                     description = description
                 ).id
 
@@ -2017,23 +2166,29 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
         "return 'Conflict' when 'repositoryFailedIds' is used and the latest run for a repository did not fail" {
             integrationTestApplication {
                 val productId = createProduct().id
+                val repositoryName1 = "repo1"
+                val repositoryName2 = "repo2"
+                val repositoryName3 = "repo3"
                 val description = "description"
                 val repository1Id = productService.createRepository(
                     type = RepositoryType.GIT,
                     url = "https://example.com/repo1.git",
                     productId = productId,
+                    name = repositoryName1,
                     description = description
                 ).id
                 val repository2Id = productService.createRepository(
                     type = RepositoryType.GIT,
                     url = "https://example.com/repo2.git",
                     productId = productId,
+                    name = repositoryName2,
                     description = description
                 ).id
                 val repository3Id = productService.createRepository(
                     type = RepositoryType.GIT,
                     url = "https://example.com/repo3.git",
                     productId = productId,
+                    name = repositoryName3,
                     description = description
                 ).id
 

--- a/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
@@ -167,14 +167,16 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
 
     val repositoryType = RepositoryType.GIT
     val repositoryUrl = "https://example.org/repo.git"
+    val repositoryName = "repo-name"
     val repositoryDescription = "description"
 
     suspend fun createRepository(
         type: RepositoryType = repositoryType,
         url: String = repositoryUrl,
         prodId: Long = productId,
+        name: String? = repositoryName,
         description: String? = repositoryDescription
-    ) = productService.createRepository(type, url, prodId, description)
+    ) = productService.createRepository(type, url, prodId, name, description)
 
     fun createJobSummaries(ortRunId: Long) = dbExtension.fixtures.createJobs(ortRunId).mapToApiSummary()
 
@@ -193,15 +195,15 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                 val response = superuserClient.get("/api/v1/repositories/${createdRepository.id}")
 
                 response shouldHaveStatus HttpStatusCode.OK
-                response shouldHaveBody
-                    Repository(
-                        createdRepository.id,
-                        orgId,
-                        productId,
-                        repositoryType.mapToApi(),
-                        repositoryUrl,
-                        repositoryDescription
-                    )
+                response shouldHaveBody Repository(
+                    id = createdRepository.id,
+                    organizationId = orgId,
+                    productId = productId,
+                    type = repositoryType.mapToApi(),
+                    url = repositoryUrl,
+                    name = repositoryName,
+                    description = repositoryDescription
+                )
             }
         }
 
@@ -219,9 +221,10 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                 val createdRepository = createRepository()
 
                 val updateRepository = PatchRepository(
-                    ApiRepositoryType.SUBVERSION.asPresent(),
-                    "https://svn.example.com/repos/org/repo/trunk".asPresent(),
-                    "updateDescription".asPresent()
+                    type = ApiRepositoryType.SUBVERSION.asPresent(),
+                    url = "https://svn.example.com/repos/org/repo/trunk".asPresent(),
+                    name = "updated-repository-name".asPresent(),
+                    description = "updateDescription".asPresent()
                 )
 
                 val response = superuserClient.patch("/api/v1/repositories/${createdRepository.id}") {
@@ -230,12 +233,13 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
 
                 response shouldHaveStatus HttpStatusCode.OK
                 response shouldHaveBody Repository(
-                    createdRepository.id,
-                    orgId,
-                    productId,
-                    updateRepository.type.valueOrThrow,
-                    updateRepository.url.valueOrThrow,
-                    updateRepository.description.valueOrThrow
+                    id = createdRepository.id,
+                    organizationId = orgId,
+                    productId = productId,
+                    type = updateRepository.type.valueOrThrow,
+                    url = updateRepository.url.valueOrThrow,
+                    name = updateRepository.name.valueOrThrow,
+                    description = updateRepository.description.valueOrThrow
                 )
             }
         }
@@ -245,8 +249,8 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                 val createRepository = createRepository()
 
                 val repository = PatchRepository(
-                    ApiRepositoryType.SUBVERSION.asPresent(),
-                    "ht tps://github.com/org/repo.git".asPresent()
+                    type = ApiRepositoryType.SUBVERSION.asPresent(),
+                    url = "ht tps://github.com/org/repo.git".asPresent()
                 )
 
                 val response = superuserClient.patch("/api/v1/repositories/${createRepository.id}") {
@@ -266,8 +270,28 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                 val createRepository = createRepository()
 
                 val repository = PatchRepository(
-                    ApiRepositoryType.SUBVERSION.asPresent(),
-                    "https://user:password@github.com".asPresent()
+                    type = ApiRepositoryType.SUBVERSION.asPresent(),
+                    url = "https://user:password@github.com".asPresent()
+                )
+
+                val response = superuserClient.patch("/api/v1/repositories/${createRepository.id}") {
+                    setBody(repository)
+                }
+
+                response shouldHaveStatus HttpStatusCode.BadRequest
+
+                val body = response.body<ErrorResponse>()
+                body.message shouldBe "Request validation has failed."
+                body.cause shouldContain "Validation failed for PatchRepository"
+            }
+        }
+
+        "respond with 'Bad Request' if the repository's name contains invalid characters" {
+            integrationTestApplication {
+                val createRepository = createRepository()
+
+                val repository = PatchRepository(
+                    name = "invalid%name".asPresent()
                 )
 
                 val response = superuserClient.patch("/api/v1/repositories/${createRepository.id}") {
@@ -286,8 +310,8 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
             val createdRepository = createRepository()
             requestShouldRequireRole(RepositoryRole.WRITER, createdRepository.hierarchyId()) {
                 val updateRepository = PatchRepository(
-                    ApiRepositoryType.SUBVERSION.asPresent(),
-                    "https://svn.example.com/repos/org/repo/trunk".asPresent()
+                    type = ApiRepositoryType.SUBVERSION.asPresent(),
+                    url = "https://svn.example.com/repos/org/repo/trunk".asPresent()
                 )
                 patch("/api/v1/repositories/${createdRepository.id}") { setBody(updateRepository) }
             }
@@ -314,12 +338,13 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
 
                 response shouldHaveStatus HttpStatusCode.OK
                 response shouldHaveBody Repository(
-                    createdRepository.id,
-                    orgId,
-                    newProduct.id,
-                    createdRepository.type.mapToApi(),
-                    createdRepository.url,
-                    createdRepository.description
+                    id = createdRepository.id,
+                    organizationId = orgId,
+                    productId = newProduct.id,
+                    type = createdRepository.type.mapToApi(),
+                    url = createdRepository.url,
+                    name = createdRepository.name,
+                    description = createdRepository.description
                 )
 
                 // Test that role assignments on the old compound hierarchy ID have been removed.

--- a/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
@@ -191,6 +191,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
             type = RepositoryType.GIT,
             url = "https://example.org/repo.git",
             productId = productId,
+            name = "repo",
             description = "description"
         ).id
         hierarchyId = CompoundHierarchyId.forRepository(
@@ -1536,6 +1537,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     type = RepositoryType.GIT,
                     url = "https://example2.org/repo.git",
                     productId = productId2,
+                    name = "repo2",
                     description = "description"
                 ).id
 

--- a/dao/src/main/kotlin/repositories/repository/DaoRepositoryRepository.kt
+++ b/dao/src/main/kotlin/repositories/repository/DaoRepositoryRepository.kt
@@ -37,10 +37,14 @@ import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.OptionalValue
 
 import org.jetbrains.exposed.v1.core.Op
+import org.jetbrains.exposed.v1.core.TextColumnType
 import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.castTo
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.inSubQuery
+import org.jetbrains.exposed.v1.core.isNotNull
+import org.jetbrains.exposed.v1.core.or
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.select
@@ -72,13 +76,17 @@ class DaoRepositoryRepository(private val db: Database) : RepositoryRepository {
         Hierarchy(repository.mapToModel(), product.mapToModel(), organization.mapToModel())
     }
 
-    override fun list(parameters: ListQueryParameters, urlFilter: FilterParameter?, hierarchyFilter: HierarchyFilter) =
+    override fun list(parameters: ListQueryParameters, filter: FilterParameter?, hierarchyFilter: HierarchyFilter) =
         db.blockingQuery {
-            val urlCondition = urlFilter?.let {
-                RepositoriesTable.url.applyIRegex(it.value)
+            val filterCondition = filter?.let {
+                RepositoriesTable.url.applyIRegex(it.value) or
+                    (
+                        RepositoriesTable.name.isNotNull() and
+                            RepositoriesTable.name.castTo(TextColumnType()).applyIRegex(it.value)
+                    )
             } ?: Op.TRUE
 
-            val builder = hierarchyFilter.apply(urlCondition) { level, ids, _ ->
+            val builder = hierarchyFilter.apply(filterCondition) { level, ids, _ ->
                 generateHierarchyCondition(level, ids)
             }
 
@@ -87,14 +95,21 @@ class DaoRepositoryRepository(private val db: Database) : RepositoryRepository {
 
     override fun listForProduct(productId: Long, parameters: ListQueryParameters, filter: FilterParameter?) =
         db.blockingQuery {
-        RepositoryDao.listQuery(parameters, RepositoryDao::mapToModel) {
-            if (filter !== null) {
-                RepositoriesTable.productId eq productId and RepositoriesTable.url.applyIRegex(filter.value)
-            } else {
-                RepositoriesTable.productId eq productId
+            RepositoryDao.listQuery(parameters, RepositoryDao::mapToModel) {
+                if (filter != null) {
+                    RepositoriesTable.productId eq productId and
+                        (
+                            RepositoriesTable.url.applyIRegex(filter.value) or
+                                (
+                                    RepositoriesTable.name.isNotNull() and
+                                        RepositoriesTable.name.castTo(TextColumnType()).applyIRegex(filter.value)
+                                )
+                        )
+                } else {
+                    RepositoriesTable.productId eq productId
+                }
             }
         }
-    }
 
     override fun update(
         id: Long,

--- a/dao/src/main/kotlin/repositories/repository/DaoRepositoryRepository.kt
+++ b/dao/src/main/kotlin/repositories/repository/DaoRepositoryRepository.kt
@@ -46,11 +46,18 @@ import org.jetbrains.exposed.v1.jdbc.deleteWhere
 import org.jetbrains.exposed.v1.jdbc.select
 
 class DaoRepositoryRepository(private val db: Database) : RepositoryRepository {
-    override fun create(type: RepositoryType, url: String, productId: Long, description: String?) = db.blockingQuery {
+    override fun create(
+        type: RepositoryType,
+        url: String,
+        productId: Long,
+        name: String?,
+        description: String?
+    ) = db.blockingQuery {
         RepositoryDao.new {
             this.type = type.name
             this.url = url
             this.productId = productId
+            this.name = name
             this.description = description
         }.mapToModel()
     }
@@ -93,6 +100,7 @@ class DaoRepositoryRepository(private val db: Database) : RepositoryRepository {
         id: Long,
         type: OptionalValue<RepositoryType>,
         url: OptionalValue<String>,
+        name: OptionalValue<String?>,
         description: OptionalValue<String?>,
         productId: OptionalValue<Long>
     ) = db.blockingQuery {
@@ -100,6 +108,7 @@ class DaoRepositoryRepository(private val db: Database) : RepositoryRepository {
 
         type.ifPresent { repository.type = it.name }
         url.ifPresent { repository.url = it }
+        name.ifPresent { repository.name = it }
         description.ifPresent { repository.description = it }
         productId.ifPresent { repository.productId = it }
 

--- a/dao/src/main/kotlin/repositories/repository/RepositoriesTable.kt
+++ b/dao/src/main/kotlin/repositories/repository/RepositoriesTable.kt
@@ -38,6 +38,7 @@ object RepositoriesTable : SortableTable("repositories") {
 
     val type = text("type").sortable()
     val url = text("url").sortable()
+    val name = text("name").nullable()
     val description = text("description").nullable()
 }
 
@@ -49,6 +50,7 @@ class RepositoryDao(id: EntityID<Long>) : LongEntity(id) {
 
     var type by RepositoriesTable.type
     var url by RepositoriesTable.url
+    var name by RepositoriesTable.name
     var description by RepositoriesTable.description
 
     fun mapToModel() = Repository(
@@ -57,6 +59,7 @@ class RepositoryDao(id: EntityID<Long>) : LongEntity(id) {
         productId = product.id.value,
         type = RepositoryType.forName(type),
         url = url,
+        name = name,
         description = description
     )
 }

--- a/dao/src/main/resources/db/migration/V142__addRepositoryName.sql
+++ b/dao/src/main/resources/db/migration/V142__addRepositoryName.sql
@@ -1,0 +1,6 @@
+-- Add a name column to the repositories table.
+
+ALTER TABLE repositories ADD COLUMN IF NOT EXISTS name TEXT;
+ALTER TABLE repositories DROP CONSTRAINT repositories_url_product_id_key;
+ALTER TABLE repositories
+    ADD CONSTRAINT repositories_url_name_product_id_key UNIQUE NULLS NOT DISTINCT (url, name, product_id);

--- a/dao/src/test/kotlin/repositories/repository/DaoRepositoryRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/repository/DaoRepositoryRepositoryTest.kt
@@ -41,7 +41,6 @@ import org.eclipse.apoapsis.ortserver.model.util.FilterParameter
 import org.eclipse.apoapsis.ortserver.model.util.HierarchyFilter
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
-import org.eclipse.apoapsis.ortserver.model.util.OptionalValue
 import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
 import org.eclipse.apoapsis.ortserver.model.util.OrderField
 import org.eclipse.apoapsis.ortserver.model.util.asPresent
@@ -68,25 +67,75 @@ class DaoRepositoryRepositoryTest : StringSpec({
     "create should create an entry in the database" {
         val type = RepositoryType.GIT
         val url = "https://example.com/repo.git"
+        val name = "repo"
         val description = "description"
 
-        val createdRepository = repositoryRepository.create(type, url, productId, description)
+        val createdRepository =
+            repositoryRepository.create(type, url, productId, name = name, description = description)
 
         val dbEntry = repositoryRepository.get(createdRepository.id)
 
-        dbEntry shouldBe Repository(createdRepository.id, orgId, productId, type, url, description)
+        dbEntry shouldBe Repository(
+            id = createdRepository.id,
+            organizationId = orgId,
+            productId = productId,
+            type = type,
+            url = url,
+            name = name,
+            description = description
+        )
     }
 
-    "create should throw an exception if a repository with the same url exists" {
+    "create should allow repositories with the same url if their names differ" {
         val type = RepositoryType.GIT
         val url = "https://example.com/repo.git"
         val description = "description"
 
-        repositoryRepository.create(type, url, productId, description)
+        val repository1 = repositoryRepository.create(type, url, productId, name = "repo1", description = description)
+        val repository2 = repositoryRepository.create(type, url, productId, name = "repo2", description = description)
+
+        repository1.url shouldBe repository2.url
+        repository1.name shouldBe "repo1"
+        repository2.name shouldBe "repo2"
+    }
+
+    "create should throw an exception if a repository with the same url and name exists" {
+        val type = RepositoryType.GIT
+        val url = "https://example.com/repo.git"
+        val name = "repo"
+        val description = "description"
+
+        repositoryRepository.create(type, url, productId, name = name, description = description)
 
         shouldThrow<UniqueConstraintException> {
-            repositoryRepository.create(type, url, productId, description)
+            repositoryRepository.create(type, url, productId, name = name, description = description)
         }
+    }
+
+    "create should persist a non-null name" {
+        val repository = repositoryRepository.create(
+            type = RepositoryType.GIT,
+            url = "https://example.com/named-repo.git",
+            productId = productId,
+            name = "Named repository",
+            description = "description"
+        )
+
+        repository.name shouldBe "Named repository"
+        repositoryRepository.get(repository.id)?.name shouldBe "Named repository"
+    }
+
+    "create should persist a null name" {
+        val repository = repositoryRepository.create(
+            type = RepositoryType.GIT,
+            url = "https://example.com/unnamed-repo.git",
+            productId = productId,
+            name = null,
+            description = "description"
+        )
+
+        repository.name.shouldBeNull()
+        repositoryRepository.get(repository.id)?.name.shouldBeNull()
     }
 
     "list should retrieve all entities from the database" {
@@ -129,8 +178,22 @@ class DaoRepositoryRepositoryTest : StringSpec({
 
         repositoryRepository.list(urlFilter = FilterParameter("repository.git$")) shouldBe ListQueryResult(
             data = listOf(
-                Repository(repo1.id, orgId, repo1.productId, repo1.type, repo1.url, repo1.description),
-                Repository(repo2.id, orgId, repo2.productId, repo2.type, repo2.url, repo2.description)
+                Repository(
+                    id = repo1.id,
+                    organizationId = orgId,
+                    productId = repo1.productId,
+                    type = repo1.type,
+                    url = repo1.url,
+                    description = repo1.description
+                ),
+                Repository(
+                    id = repo2.id,
+                    organizationId = orgId,
+                    productId = repo2.productId,
+                    type = repo2.type,
+                    url = repo2.url,
+                    description = repo2.description
+                )
             ),
             params = ListQueryParameters.DEFAULT,
             totalCount = 2
@@ -152,9 +215,30 @@ class DaoRepositoryRepositoryTest : StringSpec({
 
         result shouldBe ListQueryResult(
             data = listOf(
-                Repository(repo1.id, orgId, repo1.productId, repo1.type, repo1.url, repo1.description),
-                Repository(repo2.id, orgId, repo2.productId, repo2.type, repo2.url, repo2.description),
-                Repository(repo4.id, orgId, repo4.productId, repo4.type, repo4.url, repo4.description)
+                Repository(
+                    id = repo1.id,
+                    organizationId = orgId,
+                    productId = repo1.productId,
+                    type = repo1.type,
+                    url = repo1.url,
+                    description = repo1.description
+                ),
+                Repository(
+                    id = repo2.id,
+                    organizationId = orgId,
+                    productId = repo2.productId,
+                    type = repo2.type,
+                    url = repo2.url,
+                    description = repo2.description
+                ),
+                Repository(
+                    id = repo4.id,
+                    organizationId = orgId,
+                    productId = repo4.productId,
+                    type = repo4.type,
+                    url = repo4.url,
+                    description = repo4.description
+                )
             ),
             params = ListQueryParameters.DEFAULT,
             totalCount = 3
@@ -184,8 +268,22 @@ class DaoRepositoryRepositoryTest : StringSpec({
 
         result shouldBe ListQueryResult(
             data = listOf(
-                Repository(repo1.id, orgId, repo1.productId, repo1.type, repo1.url, repo1.description),
-                Repository(repo2.id, orgId, repo2.productId, repo2.type, repo2.url, repo2.description)
+                Repository(
+                    id = repo1.id,
+                    organizationId = orgId,
+                    productId = repo1.productId,
+                    type = repo1.type,
+                    url = repo1.url,
+                    description = repo1.description
+                ),
+                Repository(
+                    id = repo2.id,
+                    organizationId = orgId,
+                    productId = repo2.productId,
+                    type = repo2.type,
+                    url = repo2.url,
+                    description = repo2.description
+                )
             ),
             params = ListQueryParameters.DEFAULT,
             totalCount = 2
@@ -215,8 +313,22 @@ class DaoRepositoryRepositoryTest : StringSpec({
 
         result shouldBe ListQueryResult(
             data = listOf(
-                Repository(repo1.id, orgId, repo1.productId, repo1.type, repo1.url, repo1.description),
-                Repository(repo2.id, orgId, repo2.productId, repo2.type, repo2.url, repo2.description)
+                Repository(
+                    id = repo1.id,
+                    organizationId = orgId,
+                    productId = repo1.productId,
+                    type = repo1.type,
+                    url = repo1.url,
+                    description = repo1.description
+                ),
+                Repository(
+                    id = repo2.id,
+                    organizationId = orgId,
+                    productId = repo2.productId,
+                    type = repo2.type,
+                    url = repo2.url,
+                    description = repo2.description
+                )
             ),
             params = ListQueryParameters.DEFAULT,
             totalCount = 2
@@ -249,8 +361,22 @@ class DaoRepositoryRepositoryTest : StringSpec({
 
         result shouldBe ListQueryResult(
             data = listOf(
-                Repository(repo1.id, organization1.id, repo1.productId, repo1.type, repo1.url, repo1.description),
-                Repository(repo2.id, organization2.id, repo2.productId, repo2.type, repo2.url, repo2.description)
+                Repository(
+                    id = repo1.id,
+                    organizationId = organization1.id,
+                    productId = repo1.productId,
+                    type = repo1.type,
+                    url = repo1.url,
+                    description = repo1.description
+                ),
+                Repository(
+                    id = repo2.id,
+                    organizationId = organization2.id,
+                    productId = repo2.productId,
+                    type = repo2.type,
+                    url = repo2.url,
+                    description = repo2.description
+                )
             ),
             params = ListQueryParameters.DEFAULT,
             totalCount = 2
@@ -262,16 +388,36 @@ class DaoRepositoryRepositoryTest : StringSpec({
 
         val url1 = "https://example.com/repo1.git"
         val url2 = "https://example.com/repo2.git"
+        val name1 = "repo1"
+        val name2 = "repo2"
         val description = "description"
 
-        val createdRepository1 = repositoryRepository.create(type, url1, productId, description)
-        val createdRepository2 = repositoryRepository.create(type, url2, productId, description)
+        val createdRepository1 =
+            repositoryRepository.create(type, url1, productId, name = name1, description = description)
+        val createdRepository2 =
+            repositoryRepository.create(type, url2, productId, name = name2, description = description)
 
         repositoryRepository.listForProduct(productId) shouldBe
                 ListQueryResult(
                     data = listOf(
-                        Repository(createdRepository1.id, orgId, productId, type, url1, description),
-                        Repository(createdRepository2.id, orgId, productId, type, url2, description)
+                        Repository(
+                            id = createdRepository1.id,
+                            organizationId = orgId,
+                            productId = productId,
+                            type = type,
+                            url = url1,
+                            name = name1,
+                            description = description
+                        ),
+                        Repository(
+                            id = createdRepository2.id,
+                            organizationId = orgId,
+                            productId = productId,
+                            type = type,
+                            url = url2,
+                            name = name2,
+                            description = description
+                        )
                     ),
                     params = ListQueryParameters.DEFAULT,
                     totalCount = 2
@@ -283,6 +429,8 @@ class DaoRepositoryRepositoryTest : StringSpec({
 
         val url1 = "https://example.com/repo1.git"
         val url2 = "https://example.com/repo2.git"
+        val name1 = "repo1"
+        val name2 = "repo2"
         val description = "description"
 
         val parameters = ListQueryParameters(
@@ -290,12 +438,23 @@ class DaoRepositoryRepositoryTest : StringSpec({
             limit = 1
         )
 
-        repositoryRepository.create(type, url1, productId, description)
-        val createdRepository2 = repositoryRepository.create(type, url2, productId, description)
+        repositoryRepository.create(type, url1, productId, name = name1, description = description)
+        val createdRepository2 =
+            repositoryRepository.create(type, url2, productId, name = name2, description = description)
 
         repositoryRepository.listForProduct(productId, parameters) shouldBe
                 ListQueryResult(
-                    data = listOf(Repository(createdRepository2.id, orgId, productId, type, url2, description)),
+                    data = listOf(
+                        Repository(
+                            id = createdRepository2.id,
+                            organizationId = orgId,
+                            productId = productId,
+                            type = type,
+                            url = url2,
+                            name = name2,
+                            description = description
+                        )
+                    ),
                     params = parameters,
                     totalCount = 2
                 )
@@ -326,8 +485,13 @@ class DaoRepositoryRepositoryTest : StringSpec({
     }
 
     "update should update an entry in the database" {
-        val createdRepository =
-            repositoryRepository.create(RepositoryType.GIT, "https://example.com/repo.git", productId, null)
+        val createdRepository = repositoryRepository.create(
+            RepositoryType.GIT,
+            "https://example.com/repo.git",
+            productId,
+            name = null,
+            description = null
+        )
 
         val updateType = RepositoryType.SUBVERSION.asPresent()
         val updateUrl = "https://svn.example.com/repos/org/repo/trunk".asPresent()
@@ -352,8 +516,13 @@ class DaoRepositoryRepositoryTest : StringSpec({
     }
 
     "update should move a repository to another product" {
-        val createdRepository =
-            repositoryRepository.create(RepositoryType.GIT, "https://example.com/repo.git", productId, null)
+        val createdRepository = repositoryRepository.create(
+            RepositoryType.GIT,
+            "https://example.com/repo.git",
+            productId,
+            name = null,
+            description = null
+        )
         val newProduct = fixtures.createProduct(name = "newProduct")
 
         val updateRepositoryResult = repositoryRepository.update(
@@ -378,31 +547,84 @@ class DaoRepositoryRepositoryTest : StringSpec({
         )
     }
 
-    "update should throw an exception if a repository with the same url exists" {
+    "update should set a repository name" {
+        val repository = fixtures.createRepository(url = "https://example.com/name-update.git", name = null)
+
+        val updatedRepository = repositoryRepository.update(
+            id = repository.id,
+            name = "Updated name".asPresent()
+        )
+
+        updatedRepository.name shouldBe "Updated name"
+        repositoryRepository.get(repository.id)?.name shouldBe "Updated name"
+    }
+
+    "update should clear a repository name" {
+        val repository = fixtures.createRepository(url = "https://example.com/name-clear.git", name = "Initial name")
+
+        val updatedRepository = repositoryRepository.update(
+            id = repository.id,
+            name = null.asPresent()
+        )
+
+        updatedRepository.name.shouldBeNull()
+        repositoryRepository.get(repository.id)?.name.shouldBeNull()
+    }
+
+    "update should allow changing a repository url to one used by another repository if their names differ" {
         val type = RepositoryType.GIT
 
         val url1 = "https://example.com/repo1.git"
         val url2 = "https://example.com/repo2.git"
+        val name1 = "repo1"
+        val name2 = "repo2"
         val description = "description"
 
-        repositoryRepository.create(type, url1, productId, description)
-        val createdRepository2 = repositoryRepository.create(type, url2, productId, description)
+        repositoryRepository.create(type, url1, productId, name = name1, description = description)
+        val createdRepository2 =
+            repositoryRepository.create(type, url2, productId, name = name2, description = description)
 
-        val updateType = OptionalValue.Absent
-        val updateUrl = url1.asPresent()
+        repositoryRepository.update(createdRepository2.id, url = url1.asPresent()).url shouldBe url1
+    }
+
+    "update should throw an exception if a repository with the same url and name exists" {
+        val type = RepositoryType.GIT
+
+        val url1 = "https://example.com/repo1.git"
+        val url2 = "https://example.com/repo2.git"
+        val name = "repo"
+        val description = "description"
+
+        repositoryRepository.create(type, url1, productId, name = name, description = description)
+        val createdRepository2 =
+            repositoryRepository.create(type, url2, productId, name = name, description = description)
 
         shouldThrow<UniqueConstraintException> {
-            repositoryRepository.update(createdRepository2.id, updateType, updateUrl)
+            repositoryRepository.update(createdRepository2.id, url = url1.asPresent())
         }
     }
 
-    "update should throw an exception when moving a repository and there is a conflict with the url" {
+    "update should allow moving a repository if the target product has the same url with a different name" {
         val url = "https://example.com/repo.git"
         val createdRepository =
-            repositoryRepository.create(RepositoryType.GIT, url, productId, null)
+            repositoryRepository.create(RepositoryType.GIT, url, productId, name = "repo1", description = null)
 
         val newProduct = fixtures.createProduct(name = "newProduct")
-        repositoryRepository.create(RepositoryType.GIT, url, newProduct.id, null)
+        repositoryRepository.create(RepositoryType.GIT, url, newProduct.id, name = "repo2", description = null)
+
+        repositoryRepository.update(
+            createdRepository.id,
+            productId = newProduct.id.asPresent()
+        ).productId shouldBe newProduct.id
+    }
+
+    "update should throw an exception when moving a repository and there is a conflict with the url and name" {
+        val url = "https://example.com/repo.git"
+        val createdRepository =
+            repositoryRepository.create(RepositoryType.GIT, url, productId, name = "repo", description = null)
+
+        val newProduct = fixtures.createProduct(name = "newProduct")
+        repositoryRepository.create(RepositoryType.GIT, url, newProduct.id, name = "repo", description = null)
 
         shouldThrow<UniqueConstraintException> {
             repositoryRepository.update(
@@ -414,7 +636,13 @@ class DaoRepositoryRepositoryTest : StringSpec({
 
     "delete should delete the database entry" {
         val createdRepository =
-            repositoryRepository.create(RepositoryType.GIT, "https://example.com/repo.git", productId, "description")
+            repositoryRepository.create(
+                RepositoryType.GIT,
+                "https://example.com/repo.git",
+                productId,
+                name = "repo",
+                description = "description"
+            )
 
         repositoryRepository.delete(createdRepository.id)
 
@@ -430,7 +658,8 @@ class DaoRepositoryRepositoryTest : StringSpec({
             RepositoryType.GIT,
             "https://example.com/repo.git",
             productId,
-            "description"
+            name = "repo",
+            description = "description"
         )
 
         repositoryRepository.get(repository.id) shouldBe repository
@@ -441,7 +670,8 @@ class DaoRepositoryRepositoryTest : StringSpec({
             RepositoryType.GIT,
             "https://example.com/repo.git",
             productId,
-            "description"
+            name = "repo",
+            description = "description"
         )
 
         val expectedHierarchy = Hierarchy(repository, fixtures.product, fixtures.organization)

--- a/dao/src/test/kotlin/repositories/repository/DaoRepositoryRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/repository/DaoRepositoryRepositoryTest.kt
@@ -176,7 +176,7 @@ class DaoRepositoryRepositoryTest : StringSpec({
         fixtures.createRepository(url = "https://example.com/repo3.git")
         fixtures.createRepository(url = "https://example.com/repo4.git")
 
-        repositoryRepository.list(urlFilter = FilterParameter("repository.git$")) shouldBe ListQueryResult(
+        repositoryRepository.list(filter = FilterParameter("repository.git$")) shouldBe ListQueryResult(
             data = listOf(
                 Repository(
                     id = repo1.id,
@@ -211,7 +211,7 @@ class DaoRepositoryRepositoryTest : StringSpec({
             url = "https://subdomain.example.com/repo.git"
         )
 
-        val result = repositoryRepository.list(urlFilter = FilterParameter("example\\.com"))
+        val result = repositoryRepository.list(filter = FilterParameter("example\\.com"))
 
         result shouldBe ListQueryResult(
             data = listOf(
@@ -242,6 +242,23 @@ class DaoRepositoryRepositoryTest : StringSpec({
             ),
             params = ListQueryParameters.DEFAULT,
             totalCount = 3
+        )
+    }
+
+    "list should filter by repository name as well as url" {
+        val namedRepository = fixtures.createRepository(
+            url = "https://example.com/repo1.git",
+            name = "Internal tools"
+        )
+        fixtures.createRepository(
+            url = "https://example.com/repo2.git",
+            name = "Customer portal"
+        )
+
+        repositoryRepository.list(filter = FilterParameter("^Internal")) shouldBe ListQueryResult(
+            data = listOf(namedRepository),
+            params = ListQueryParameters.DEFAULT,
+            totalCount = 1
         )
     }
 
@@ -481,6 +498,38 @@ class DaoRepositoryRepositoryTest : StringSpec({
                     ),
                     params = parameters,
                     totalCount = 2
+                )
+    }
+
+    "listForProduct should filter by repository name as well as url" {
+        val parameters = ListQueryParameters(
+            sortFields = listOf(OrderField("url", OrderDirection.DESCENDING)),
+            limit = 10
+        )
+
+        val otherProd = fixtures.createProduct(name = "otherProduct")
+
+        val namedRepository = fixtures.createRepository(
+            url = "https://example.com/repo1.git",
+            productId = productId,
+            name = "Repository display name"
+        )
+        fixtures.createRepository(
+            url = "https://example.com/repo2.git",
+            productId = productId,
+            name = "Another repository"
+        )
+        fixtures.createRepository(
+            url = "https://example.com/repo3.git",
+            productId = otherProd.id,
+            name = "Repository display name"
+        )
+
+        repositoryRepository.listForProduct(productId, parameters, FilterParameter("^Repository display")) shouldBe
+                ListQueryResult(
+                    data = listOf(namedRepository),
+                    params = parameters,
+                    totalCount = 1
                 )
     }
 

--- a/dao/src/test/kotlin/utils/ListQueryTest.kt
+++ b/dao/src/test/kotlin/utils/ListQueryTest.kt
@@ -105,19 +105,22 @@ class ListQueryTest : StringSpec() {
                 RepositoryType.GIT,
                 repositoryUrl.appendIndex(1),
                 product.id,
-                description
+                name = null,
+                description = description
             )
             val repo2 = repositoryRepository.create(
                 RepositoryType.SUBVERSION,
                 repositoryUrl.appendIndex(2),
                 product.id,
-                description
+                name = null,
+                description = description
             )
             val repo3 = repositoryRepository.create(
                 RepositoryType.GIT,
                 repositoryUrl.appendIndex(3),
                 product.id,
-                description
+                name = null,
+                description = description
             )
 
             val parameters = ListQueryParameters(
@@ -157,7 +160,8 @@ class ListQueryTest : StringSpec() {
                     RepositoryType.GIT,
                     "https://repo.example.org/run.git",
                     product.id,
-                    "description"
+                    name = null,
+                    description = "description"
                 )
             val runs = (1..3).map { idx ->
                 ortRunRepository.create(

--- a/dao/src/testFixtures/kotlin/DatabaseTestExtension.kt
+++ b/dao/src/testFixtures/kotlin/DatabaseTestExtension.kt
@@ -55,7 +55,7 @@ import org.testcontainers.postgresql.PostgreSQLContainer
  * see [this Kotest issue](https://github.com/kotest/kotest/issues/3555).
  */
 open class DatabaseTestExtension : BeforeSpecListener, AfterSpecListener, BeforeEachListener, AfterEachListener {
-    private val postgres = PostgreSQLContainer("postgres:14").apply {
+    private val postgres = PostgreSQLContainer("postgres:15").apply {
         startupAttempts = 1
     }
 

--- a/dao/src/testFixtures/kotlin/Fixtures.kt
+++ b/dao/src/testFixtures/kotlin/Fixtures.kt
@@ -140,8 +140,9 @@ class Fixtures(private val db: Database) {
         type: RepositoryType = RepositoryType.GIT,
         url: String = "https://example.com/repo.git",
         productId: Long = product.id,
+        name: String? = null,
         description: String? = "description"
-    ) = repositoryRepository.create(type, url, productId, description)
+    ) = repositoryRepository.create(type, url, productId, name = name, description = description)
 
     fun createOrtRun(
         repositoryId: Long = repository.id,

--- a/model/src/commonMain/kotlin/Repository.kt
+++ b/model/src/commonMain/kotlin/Repository.kt
@@ -49,7 +49,12 @@ data class Repository(
     val url: String,
 
     /**
-    * The description of the repository.
-    * */
+     * The name of the repository.
+     */
+    val name: String? = null,
+
+    /**
+     * The description of the repository.
+     */
     val description: String? = null
 )

--- a/model/src/commonMain/kotlin/repositories/RepositoryRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/RepositoryRepository.kt
@@ -55,12 +55,12 @@ interface RepositoryRepository {
     fun getHierarchy(id: Long): Hierarchy
 
     /**
-     * List all repositories according to the given [parameters]. Optionally, a [urlFilter] on the repository URL and a
-     * [hierarchyFilter] can be provided.
+     * List all repositories according to the given [parameters]. Optionally, a [filter] on the repository name or URL
+     * and a [hierarchyFilter] can be provided.
      */
     fun list(
         parameters: ListQueryParameters = ListQueryParameters.DEFAULT,
-        urlFilter: FilterParameter? = null,
+        filter: FilterParameter? = null,
         hierarchyFilter: HierarchyFilter = HierarchyFilter.WILDCARD
     ): ListQueryResult<Repository>
 

--- a/model/src/commonMain/kotlin/repositories/RepositoryRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/RepositoryRepository.kt
@@ -35,7 +35,13 @@ interface RepositoryRepository {
     /**
      * Create a repository.
      */
-    fun create(type: RepositoryType, url: String, productId: Long, description: String?): Repository
+    fun create(
+        type: RepositoryType,
+        url: String,
+        productId: Long,
+        name: String?,
+        description: String?
+    ): Repository
 
     /**
      * Get a repository by [id]. Returns null if the repository is not found.
@@ -74,6 +80,7 @@ interface RepositoryRepository {
         id: Long,
         type: OptionalValue<RepositoryType> = OptionalValue.Absent,
         url: OptionalValue<String> = OptionalValue.Absent,
+        name: OptionalValue<String?> = OptionalValue.Absent,
         description: OptionalValue<String?> = OptionalValue.Absent,
         productId: OptionalValue<Long> = OptionalValue.Absent
     ): Repository

--- a/services/hierarchy/src/main/kotlin/ProductService.kt
+++ b/services/hierarchy/src/main/kotlin/ProductService.kt
@@ -63,9 +63,16 @@ class ProductService(
         type: RepositoryType,
         url: String,
         productId: Long,
+        name: String?,
         description: String?
     ): Repository = db.dbQuery {
-        repositoryRepository.create(type, url, productId, description = description)
+        repositoryRepository.create(
+            type = type,
+            url = url,
+            productId = productId,
+            name = name,
+            description = description
+        )
     }
 
     /**

--- a/services/hierarchy/src/main/kotlin/ProductService.kt
+++ b/services/hierarchy/src/main/kotlin/ProductService.kt
@@ -65,7 +65,7 @@ class ProductService(
         productId: Long,
         description: String?
     ): Repository = db.dbQuery {
-        repositoryRepository.create(type, url, productId, description)
+        repositoryRepository.create(type, url, productId, description = description)
     }
 
     /**

--- a/services/hierarchy/src/main/kotlin/ProductService.kt
+++ b/services/hierarchy/src/main/kotlin/ProductService.kt
@@ -105,17 +105,21 @@ class ProductService(
 
     /**
      * List all repositories for a [product][productId] that are visible to a specific [user][userId] according to the
-     * given [parameters] and [urlFilter].
+     * given [parameters] and [filter], which is applied to the repository name or URL.
      */
     suspend fun listRepositoriesForProductAndUser(
         productId: Long,
         userId: String,
         parameters: ListQueryParameters = ListQueryParameters.DEFAULT,
-        urlFilter: FilterParameter? = null
+        filter: FilterParameter? = null
     ): ListQueryResult<Repository> = getProduct(productId)?.let { product ->
-        val filter = authorizationService.filterHierarchyIds(userId, RepositoryRole.READER, ProductId(product.id))
+        val hierarchyFilter = authorizationService.filterHierarchyIds(
+            userId,
+            RepositoryRole.READER,
+            ProductId(product.id)
+        )
         db.dbQuery {
-            repositoryRepository.list(parameters, urlFilter, filter)
+            repositoryRepository.list(parameters, filter, hierarchyFilter)
         }
     } ?: ListQueryResult(emptyList(), parameters, 0)
 

--- a/services/hierarchy/src/main/kotlin/RepositoryService.kt
+++ b/services/hierarchy/src/main/kotlin/RepositoryService.kt
@@ -137,7 +137,8 @@ class RepositoryService(
         type: OptionalValue<RepositoryType> = OptionalValue.Absent,
         url: OptionalValue<String> = OptionalValue.Absent,
         description: OptionalValue<String?> = OptionalValue.Absent,
-        productId: OptionalValue<Long> = OptionalValue.Absent
+        productId: OptionalValue<Long> = OptionalValue.Absent,
+        name: OptionalValue<String?> = OptionalValue.Absent
     ): Repository = db.dbQuery {
         var isMove = false
         productId.ifPresent { newProductId ->
@@ -150,6 +151,7 @@ class RepositoryService(
             id = repositoryId,
             type = type,
             url = url,
+            name = name,
             description = description,
             productId = productId
         ).also {

--- a/services/hierarchy/src/main/kotlin/RepositoryService.kt
+++ b/services/hierarchy/src/main/kotlin/RepositoryService.kt
@@ -146,7 +146,13 @@ class RepositoryService(
             }
         }
 
-        repositoryRepository.update(repositoryId, type, url, description, productId).also {
+        repositoryRepository.update(
+            id = repositoryId,
+            type = type,
+            url = url,
+            description = description,
+            productId = productId
+        ).also {
             if (isMove) {
                 runBlocking {
                     // Because of the change in the hierarchical structure, role assignments may now be inconsistent.

--- a/services/hierarchy/src/test/kotlin/ProductServiceTest.kt
+++ b/services/hierarchy/src/test/kotlin/ProductServiceTest.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.apoapsis.ortserver.services
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
@@ -30,6 +31,7 @@ import io.mockk.mockk
 
 import org.eclipse.apoapsis.ortserver.components.authorization.rights.RepositoryRole
 import org.eclipse.apoapsis.ortserver.components.authorization.service.AuthorizationService
+import org.eclipse.apoapsis.ortserver.dao.UniqueConstraintException
 import org.eclipse.apoapsis.ortserver.dao.repositories.ortrun.DaoOrtRunRepository
 import org.eclipse.apoapsis.ortserver.dao.repositories.product.DaoProductRepository
 import org.eclipse.apoapsis.ortserver.dao.repositories.repository.DaoRepositoryRepository
@@ -40,6 +42,7 @@ import org.eclipse.apoapsis.ortserver.model.HierarchyLevel
 import org.eclipse.apoapsis.ortserver.model.OrganizationId
 import org.eclipse.apoapsis.ortserver.model.ProductId
 import org.eclipse.apoapsis.ortserver.model.RepositoryId
+import org.eclipse.apoapsis.ortserver.model.RepositoryType
 import org.eclipse.apoapsis.ortserver.model.util.HierarchyFilter
 
 import org.jetbrains.exposed.v1.jdbc.Database
@@ -84,6 +87,73 @@ class ProductServiceTest : WordSpec({
             fixtures.repositoryRepository.listForProduct(product.id).totalCount shouldBe 0
             fixtures.ortRunRepository.listForRepository(repo1.id).totalCount shouldBe 0
             fixtures.ortRunRepository.listForRepository(repo2.id).totalCount shouldBe 0
+        }
+    }
+
+    "createRepository" should {
+        "create a repository" {
+            val service = ProductService(db, productRepository, repositoryRepository, ortRunRepository, mockk())
+            val product = fixtures.createProduct(name = "Named Product")
+
+            val repository = service.createRepository(
+                type = RepositoryType.GIT,
+                url = "https://example.com/named-service-repo.git",
+                productId = product.id,
+                description = "Repository description",
+                name = "Repository name"
+            )
+
+            repository.productId shouldBe product.id
+            repository.name shouldBe "Repository name"
+            repository.description shouldBe "Repository description"
+            repositoryRepository.get(repository.id)?.name shouldBe "Repository name"
+        }
+
+        "allow creating repositories with the same url if their names differ" {
+            val service = ProductService(db, productRepository, repositoryRepository, ortRunRepository, mockk())
+            val product = fixtures.createProduct(name = "Named Product")
+
+            val repository1 = service.createRepository(
+                type = RepositoryType.GIT,
+                url = "https://example.com/shared-url.git",
+                productId = product.id,
+                name = "Repository name 1",
+                description = "Repository description"
+            )
+            val repository2 = service.createRepository(
+                type = RepositoryType.GIT,
+                url = "https://example.com/shared-url.git",
+                productId = product.id,
+                name = "Repository name 2",
+                description = "Repository description"
+            )
+
+            repository1.url shouldBe repository2.url
+            repository1.name shouldBe "Repository name 1"
+            repository2.name shouldBe "Repository name 2"
+        }
+
+        "reject creating repositories with the same url and name" {
+            val service = ProductService(db, productRepository, repositoryRepository, ortRunRepository, mockk())
+            val product = fixtures.createProduct(name = "Named Product")
+
+            service.createRepository(
+                type = RepositoryType.GIT,
+                url = "https://example.com/shared-url.git",
+                productId = product.id,
+                name = "Repository name",
+                description = "Repository description"
+            )
+
+            shouldThrow<UniqueConstraintException> {
+                service.createRepository(
+                    type = RepositoryType.GIT,
+                    url = "https://example.com/shared-url.git",
+                    productId = product.id,
+                    name = "Repository name",
+                    description = "Repository description"
+                )
+            }
         }
     }
 

--- a/services/hierarchy/src/test/kotlin/RepositoryServiceTest.kt
+++ b/services/hierarchy/src/test/kotlin/RepositoryServiceTest.kt
@@ -277,6 +277,7 @@ class RepositoryServiceTest : WordSpec({
             val repository = fixtures.createRepository(
                 type = RepositoryType.GIT,
                 url = "https://example.com/repo.git",
+                name = "Initial repository name",
                 description = "Initial description"
             )
 
@@ -284,11 +285,13 @@ class RepositoryServiceTest : WordSpec({
                 repositoryId = repository.id,
                 type = RepositoryType.MERCURIAL.asPresent(),
                 url = "https://example.com/updated-repo.git".asPresent(),
+                name = "Updated repository name".asPresent(),
                 description = "Updated description".asPresent()
             )
 
             updatedRepository.type shouldBe RepositoryType.MERCURIAL
             updatedRepository.url shouldBe "https://example.com/updated-repo.git"
+            updatedRepository.name shouldBe "Updated repository name"
             updatedRepository.description shouldBe "Updated description"
 
             service.getRepository(repository.id) shouldBe updatedRepository

--- a/ui/src/components/siblings.tsx
+++ b/ui/src/components/siblings.tsx
@@ -224,7 +224,7 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
                     }}
                   >
                     <div className='grid w-full grid-cols-6 items-center gap-2'>
-                      <div className='col-span-5'>{repo.url}</div>
+                      <div className='col-span-5'>{repo.name || repo.url}</div>
                       {repo.id === Number(params.repoId) && (
                         <Check className='ml-auto h-4 w-4' />
                       )}

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repository-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repository-table.tsx
@@ -80,42 +80,48 @@ export const ProductRepositoryTable = () => {
 
   const columns = useMemo(
     () => [
-      columnHelper.accessor('url', {
-        id: 'repository',
-        header: 'Repositories',
-        size: 300,
-        cell: ({ row }) => (
-          <>
-            <Link
-              className='block font-semibold text-blue-400 hover:underline'
-              to={
-                '/organizations/$orgId/products/$productId/repositories/$repoId'
-              }
-              params={{
-                orgId: row.original.organizationId.toString(),
-                productId: row.original.productId.toString(),
-                repoId: row.original.id.toString(),
-              }}
-            >
-              {row.original.name || row.original.url}
-            </Link>
-            <div className='text-muted-foreground text-sm md:inline'>
-              {row.original.type}
-              {row.original.description ? ` | ${row.original.description}` : ''}
-            </div>
-          </>
-        ),
-        meta: {
-          filter: {
-            filterVariant: 'regex',
-            setFilterValue: (value: string | undefined) => {
-              navigate({
-                search: { ...search, page: 1, filter: value },
-              });
+      columnHelper.accessor(
+        (repository) => `${repository.name ?? ''} ${repository.url}`.trim(),
+        {
+          id: 'repository',
+          header: 'Repositories',
+          size: 300,
+          cell: ({ row }) => (
+            <>
+              <Link
+                className='block font-semibold text-blue-400 hover:underline'
+                to={
+                  '/organizations/$orgId/products/$productId/repositories/$repoId'
+                }
+                params={{
+                  orgId: row.original.organizationId.toString(),
+                  productId: row.original.productId.toString(),
+                  repoId: row.original.id.toString(),
+                }}
+              >
+                {row.original.name && <div>{row.original.name}</div>}
+                <div>{row.original.url}</div>
+              </Link>
+              <div className='text-muted-foreground text-sm md:inline'>
+                {row.original.type}
+                {row.original.description
+                  ? ` | ${row.original.description}`
+                  : ''}
+              </div>
+            </>
+          ),
+          meta: {
+            filter: {
+              filterVariant: 'regex',
+              setFilterValue: (value: string | undefined) => {
+                navigate({
+                  search: { ...search, page: 1, filter: value },
+                });
+              },
             },
           },
-        },
-      }),
+        }
+      ),
       columnHelper.display({
         id: 'runs',
         header: 'Runs',

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repository-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repository-table.tsx
@@ -97,7 +97,7 @@ export const ProductRepositoryTable = () => {
                 repoId: row.original.id.toString(),
               }}
             >
-              {row.original.url}
+              {row.original.name || row.original.url}
             </Link>
             <div className='text-muted-foreground text-sm md:inline'>
               {row.original.type}

--- a/ui/src/routes/organizations/$orgId/products/$productId/create-repository/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/create-repository/index.tsx
@@ -25,8 +25,7 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import { postRepositoryMutation } from '@/api/@tanstack/react-query.gen';
-import { zRepositoryType } from '@/api/zod.gen';
-import { asOptionalField } from '@/components/form/as-optional-field.ts';
+import { zRepository, zRepositoryType } from '@/api/zod.gen';
 import { OptionalInput } from '@/components/form/optional-input.tsx';
 import { Button } from '@/components/ui/button';
 import {
@@ -57,10 +56,11 @@ import { ApiError } from '@/lib/api-error';
 import { toast, toastError } from '@/lib/toast';
 import { getRepositoryTypeLabel } from '@/lib/types';
 
-const formSchema = z.object({
-  url: z.url(),
-  description: asOptionalField(z.string().min(1)),
-  type: zRepositoryType,
+const formSchema = zRepository.pick({
+  description: true,
+  name: true,
+  type: true,
+  url: true,
 });
 
 const CreateRepositoryPage = () => {
@@ -94,6 +94,8 @@ const CreateRepositoryPage = () => {
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
+      description: '',
+      name: '',
       url: '',
       type: 'GIT',
     },
@@ -103,9 +105,10 @@ const CreateRepositoryPage = () => {
     await mutateAsync({
       path: { productId: Number.parseInt(params.productId) },
       body: {
-        url: values.url,
         description: values.description,
+        name: values.name,
         type: values.type,
+        url: values.url,
       },
     });
   }
@@ -126,6 +129,19 @@ const CreateRepositoryPage = () => {
                   <FormLabel>URL</FormLabel>
                   <FormControl autoFocus>
                     <Input {...field} />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name='name'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Name</FormLabel>
+                  <FormControl>
+                    <OptionalInput {...field} />
                   </FormControl>
                   <FormMessage />
                 </FormItem>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/runs/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/runs/index.tsx
@@ -82,32 +82,35 @@ const RepositoryRunsComponent = () => {
 
   return (
     <div className='flex flex-col gap-4'>
-      <div className='grid grid-cols-1 gap-4 md:grid-cols-4'>
-        <Card className='col-span-1 md:col-span-3'>
-          <CardHeader>
-            <CardTitle>
-              <span className='font-normal'>
-                {getRepositoryTypeLabel(repo.type)} repository
-              </span>{' '}
-              <Link
-                className='font-semibold break-all hover:text-blue-400 hover:underline'
-                to={repo.url}
-                target='_blank'
-              >
-                {repo.url}
-              </Link>
-            </CardTitle>
-            <CardDescription>{repo.description}</CardDescription>
-          </CardHeader>
-        </Card>
-        <Card>
-          <CardHeader>
-            <CardDescription>
-              Repository ID: <span className='font-bold'>{repo.id}</span>
-            </CardDescription>
-          </CardHeader>
-        </Card>
-      </div>
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            <div className='flex justify-between'>
+              <span>{repo.name}</span>
+              <div>
+                <span className='text-sm font-normal'>
+                  {getRepositoryTypeLabel(repo.type)} repository
+                </span>{' '}
+                <Link
+                  className='text-sm font-semibold break-all hover:text-blue-400 hover:underline'
+                  to={repo.url}
+                  target='_blank'
+                >
+                  {repo.url}
+                </Link>
+              </div>
+            </div>
+          </CardTitle>
+          <CardDescription>
+            <div className='flex justify-between'>
+              {repo.description}
+              <div>
+                Repository ID: <span className='font-bold'>{repo.id}</span>
+              </div>
+            </div>
+          </CardDescription>
+        </CardHeader>
+      </Card>
       <JobDurations
         repoId={params.repoId}
         pageIndex={pageIndex}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/settings/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/settings/index.tsx
@@ -33,8 +33,9 @@ import {
   getRepositoryOptions,
   patchRepositoryMutation,
 } from '@/api/@tanstack/react-query.gen';
-import { zRepositoryType } from '@/api/zod.gen';
+import { zRepository, zRepositoryType } from '@/api/zod.gen';
 import { DeleteDialog } from '@/components/delete-dialog';
+import { OptionalInput } from '@/components/form/optional-input.tsx';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -64,10 +65,11 @@ import { toast, toastError } from '@/lib/toast';
 import { getRepositoryTypeLabel } from '@/lib/types';
 import { MoveRepository } from '../../-components/move-repository';
 
-const formSchema = z.object({
-  url: z.string(),
-  description: z.string().optional(),
-  type: zRepositoryType,
+const formSchema = zRepository.pick({
+  description: true,
+  name: true,
+  type: true,
+  url: true,
 });
 
 const RepositorySettingsPage = () => {
@@ -110,8 +112,9 @@ const RepositorySettingsPage = () => {
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
     defaultValues: {
-      url: repository.url,
       description: repository.description || '',
+      name: repository.name || '',
+      url: repository.url,
       type: repository.type,
     },
   });
@@ -122,9 +125,10 @@ const RepositorySettingsPage = () => {
         repositoryId: repository.id,
       },
       body: {
-        url: values.url,
         description: values.description,
+        name: values.name,
         type: values.type,
+        url: values.url,
       },
     });
   }
@@ -177,12 +181,25 @@ const RepositorySettingsPage = () => {
               />
               <FormField
                 control={form.control}
+                name='name'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
+                    <FormControl>
+                      <OptionalInput {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
                 name='description'
                 render={({ field }) => (
                   <FormItem>
                     <FormLabel>Description</FormLabel>
                     <FormControl>
-                      <Input {...field} />
+                      <OptionalInput {...field} />
                     </FormControl>
                     <FormMessage />
                   </FormItem>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/route.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/route.tsx
@@ -45,7 +45,7 @@ export const Route = createFileRoute(
       repositoryId
     );
 
-    context.breadcrumbs.repo = repo.url;
+    context.breadcrumbs.repo = repo.name || repo.url;
     context.permissions.repository = repositoryPermissions;
   },
   component: Layout,


### PR DESCRIPTION
### 1. Adding a new repository: an optional name can be given
<img width="1104" height="476" alt="Screenshot from 2026-04-08 11-23-46" src="https://github.com/user-attachments/assets/e96e444e-8572-4812-ad7e-d15fac03b8f8" />

### 2. Editing repository details: you can add/modify/delete the name
<img width="1104" height="476" alt="Screenshot from 2026-04-08 11-25-02" src="https://github.com/user-attachments/assets/1359b03b-148d-4433-b3cf-e20791161515" />

### 3. The name (if given) is seen in the repository details page and breadcrumb
<img width="1324" height="537" alt="Screenshot from 2026-04-08 11-25-33" src="https://github.com/user-attachments/assets/c55ef6d0-54e5-4b65-a0d5-bfdfe9b71738" />

### 4. In product repositories table, name is also shown in case it exists
<img width="1100" height="281" alt="Screenshot from 2026-04-15 13-08-55" src="https://github.com/user-attachments/assets/28f93f5d-e648-4800-9e31-bbaa01805efe" />

Please see the commits for details.

NOTE1: @sschuberth I didn't yet remove the repository ID - maybe @hanna-modica could tell if it's still needed for the CLI usage? We could provide with something handier for copying the URL needed for the CLI.

NOTE2: Although the API commit is marked as breaking (as it changes the API), it is not breaking as such, as the PR only adds an optional `name` to the GET/CREATE/UPDATE repository endpoints, and no back-filling to the database is needed.

NOTE3: This PR also resolves #1368 by relaxing the uniqueness requirement of the repositories: now triplet `(product_id, url, name)` must be unique, so there can be multiple repositories with the same URL inside a product if their names differ. It was also tested manually in the UI that creating a repository with the same URL and omitting the name gives is prevented:

<img width="375" height="243" alt="Screenshot from 2026-04-14 06-25-06" src="https://github.com/user-attachments/assets/6c59af1a-4224-468b-a689-fc1057fcaf58" />