### PR TITLE
ui: License coloring

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -50,6 +50,7 @@
     "clsx": "2.1.1",
     "cmdk": "1.1.1",
     "debounce": "3.0.0",
+    "license-expressions": "0.8.0",
     "lucide-react": "1.7.0",
     "oidc-client-ts": "3.5.0",
     "packageurl-js": "2.0.1",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       debounce:
         specifier: 3.0.0
         version: 3.0.0
+      license-expressions:
+        specifier: 0.8.0
+        version: 0.8.0
       lucide-react:
         specifier: 1.7.0
         version: 1.7.0(react@19.2.4)
@@ -2514,6 +2517,10 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  license-expressions@0.8.0:
+    resolution: {integrity: sha512-igpPGD08Z/oyfDog4CmKxZqBqeZNHGwTf4FhMU4jqYoEkxjL5hpjiXF26rVi68moePsFOE1mgC0/uSqKJzz4tA==}
+    hasBin: true
+
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
     engines: {node: '>= 12.0.0'}
@@ -3091,6 +3098,18 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  spdx-correct@3.2.0:
+    resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
+
+  spdx-exceptions@2.5.0:
+    resolution: {integrity: sha512-PiU42r+xO4UbUS1buo3LPJkjlO7430Xn5SVAhdpzzsPHsjbYVflnnFdATgabnLude+Cqu25p6N+g2lw/PFsa4w==}
+
+  spdx-expression-parse@3.0.1:
+    resolution: {integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==}
+
+  spdx-license-ids@3.0.23:
+    resolution: {integrity: sha512-CWLcCCH7VLu13TgOH+r8p1O/Znwhqv/dbb6lqWy67G+pT1kHmeD/+V36AVb/vq8QMIQwVShJ6Ssl5FPh0fuSdw==}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -5658,6 +5677,10 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  license-expressions@0.8.0:
+    dependencies:
+      spdx-correct: 3.2.0
+
   lightningcss-android-arm64@1.32.0:
     optional: true
 
@@ -6291,6 +6314,20 @@ snapshots:
   source-map@0.7.6: {}
 
   space-separated-tokens@2.0.2: {}
+
+  spdx-correct@3.2.0:
+    dependencies:
+      spdx-expression-parse: 3.0.1
+      spdx-license-ids: 3.0.23
+
+  spdx-exceptions@2.5.0: {}
+
+  spdx-expression-parse@3.0.1:
+    dependencies:
+      spdx-exceptions: 2.5.0
+      spdx-license-ids: 3.0.23
+
+  spdx-license-ids@3.0.23: {}
 
   stackback@0.0.2: {}
 

--- a/ui/src/components/licenses/index.ts
+++ b/ui/src/components/licenses/index.ts
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+export { SpdxExpressionBadgeGroup } from '@/components/licenses/spdx-expression-badge-group';

--- a/ui/src/components/licenses/license-badge.tsx
+++ b/ui/src/components/licenses/license-badge.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import * as React from 'react';
+
+import { Badge } from '@/components/ui/badge';
+import { getLicenseBadgeColors } from '@/helpers/licenses/license-colors';
+import { cn } from '@/lib/utils';
+
+type LicenseBadgeProps = Omit<
+  React.ComponentProps<typeof Badge>,
+  'children'
+> & {
+  license: string;
+};
+
+export function LicenseBadge({
+  license,
+  className,
+  title,
+  style,
+  ...props
+}: LicenseBadgeProps) {
+  const colors = getLicenseBadgeColors(license);
+
+  return (
+    <Badge
+      variant='small'
+      className={cn(
+        'max-w-full align-middle text-[0.7rem] leading-4 font-medium',
+        className
+      )}
+      title={title ?? license}
+      style={{
+        backgroundColor: colors.backgroundColor,
+        borderColor: colors.borderColor,
+        color: colors.color,
+        ...style,
+      }}
+      {...props}
+    >
+      {license}
+    </Badge>
+  );
+}

--- a/ui/src/components/licenses/spdx-expression-badge-group.tsx
+++ b/ui/src/components/licenses/spdx-expression-badge-group.tsx
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { LicenseBadge } from '@/components/licenses/license-badge';
+import {
+  parseLicenseExpression,
+  type SpdxConjunctionNode,
+  type SpdxExpressionNode,
+  type SpdxLicenseNode,
+} from '@/helpers/licenses/spdx-expression';
+import { cn } from '@/lib/utils';
+
+type SpdxExpressionBadgeGroupProps = React.ComponentProps<'span'> & {
+  expression: string | null | undefined;
+};
+
+const expressionWrapperClassName =
+  'inline-flex max-w-full flex-wrap items-center gap-1';
+
+function licenseNodeToString(node: SpdxLicenseNode): string {
+  if (node.kind === 'license-ref') {
+    return node.documentRef
+      ? `${node.documentRef}:${node.licenseRef}`
+      : node.licenseRef;
+  }
+
+  return node.exception
+    ? `${node.license} WITH ${node.exception}`
+    : node.license;
+}
+
+function needsParentheses(
+  parent: SpdxConjunctionNode,
+  child: SpdxExpressionNode
+): boolean {
+  return (
+    child.kind === 'conjunction' &&
+    parent.conjunction === 'and' &&
+    child.conjunction === 'or'
+  );
+}
+
+function renderExpressionNode(
+  node: SpdxExpressionNode,
+  parent?: SpdxConjunctionNode
+): React.ReactNode {
+  if (node.kind !== 'conjunction') {
+    return <LicenseBadge license={licenseNodeToString(node)} />;
+  }
+
+  const renderedGroup = (
+    <>
+      {renderExpressionNode(node.left, node)}
+      <span className='text-muted-foreground text-xs font-medium uppercase'>
+        {node.conjunction}
+      </span>
+      {renderExpressionNode(node.right, node)}
+    </>
+  );
+
+  if (parent && needsParentheses(parent, node)) {
+    return (
+      <>
+        <span className='text-muted-foreground text-xs font-medium'>(</span>
+        {renderedGroup}
+        <span className='text-muted-foreground text-xs font-medium'>)</span>
+      </>
+    );
+  }
+
+  return renderedGroup;
+}
+
+export function SpdxExpressionBadgeGroup({
+  expression,
+  className,
+  title,
+  ...props
+}: SpdxExpressionBadgeGroupProps) {
+  if (!expression?.trim()) {
+    return null;
+  }
+
+  const parsedExpression = parseLicenseExpression(expression);
+
+  if (parsedExpression.kind === 'invalid') {
+    return (
+      <span className={cn(expressionWrapperClassName, className)}>
+        <LicenseBadge license={parsedExpression.rawExpression.trim()} />
+      </span>
+    );
+  }
+
+  if (parsedExpression.kind === 'atomic') {
+    return (
+      <span className={cn(expressionWrapperClassName, className)}>
+        <LicenseBadge
+          license={licenseNodeToString(parsedExpression.node)}
+          title={title ?? parsedExpression.normalizedExpression}
+          {...props}
+        />
+      </span>
+    );
+  }
+
+  return (
+    <span
+      className={cn(expressionWrapperClassName, className)}
+      title={title ?? parsedExpression.normalizedExpression}
+      {...props}
+    >
+      {renderExpressionNode(parsedExpression.node)}
+    </span>
+  );
+}
+
+//
+// Unit tests for SPDX expression badge rendering.
+//
+
+if (import.meta.vitest) {
+  const { describe, it, expect } = import.meta.vitest;
+
+  describe('SpdxExpressionBadgeGroup', () => {
+    it('renders a single badge for an atomic SPDX expression', () => {
+      const markup = renderToStaticMarkup(
+        <SpdxExpressionBadgeGroup expression='MIT' />
+      );
+
+      expect(markup).toContain('MIT');
+      expect(markup.match(/data-slot="badge"/g)?.length).toBe(1);
+      expect(markup).not.toContain('AND');
+      expect(markup).not.toContain('OR');
+    });
+
+    it('renders conjunctions between multiple badges', () => {
+      const markup = renderToStaticMarkup(
+        <SpdxExpressionBadgeGroup expression='MIT AND Apache-2.0' />
+      );
+
+      expect(markup).toContain('MIT');
+      expect(markup).toContain('Apache-2.0');
+      expect(markup).toContain('and');
+      expect(markup.match(/data-slot="badge"/g)?.length).toBe(2);
+    });
+
+    it('renders parentheses when an OR group is nested inside an AND group', () => {
+      const markup = renderToStaticMarkup(
+        <SpdxExpressionBadgeGroup expression='MIT AND (Apache-2.0 OR BSD-3-Clause)' />
+      );
+
+      expect(markup).toContain('(');
+      expect(markup).toContain(')');
+      expect(markup).toContain('MIT');
+      expect(markup).toContain('Apache-2.0');
+      expect(markup).toContain('BSD-3-Clause');
+      expect(markup.match(/data-slot="badge"/g)?.length).toBe(3);
+    });
+
+    it('renders WITH expressions as a single badge', () => {
+      const markup = renderToStaticMarkup(
+        <SpdxExpressionBadgeGroup expression='GPL-2.0-only WITH Classpath-exception-2.0' />
+      );
+
+      expect(markup).toContain('GPL-2.0-only WITH Classpath-exception-2.0');
+      expect(markup.match(/data-slot="badge"/g)?.length).toBe(1);
+    });
+
+    it('renders deprecated GPL plus syntax as its normalized atomic badge', () => {
+      const markup = renderToStaticMarkup(
+        <SpdxExpressionBadgeGroup expression='GPL-2.0+' />
+      );
+
+      expect(markup).toContain('GPL-2.0-or-later');
+      expect(markup.match(/data-slot="badge"/g)?.length).toBe(1);
+    });
+
+    it('falls back to a single badge for invalid expressions', () => {
+      const markup = renderToStaticMarkup(
+        <SpdxExpressionBadgeGroup expression='MIT OR (' />
+      );
+
+      expect(markup).toContain('MIT OR (');
+      expect(markup.match(/data-slot="badge"/g)?.length).toBe(1);
+      expect(markup).not.toContain(
+        'class="text-muted-foreground text-xs font-medium uppercase"'
+      );
+    });
+  });
+}

--- a/ui/src/helpers/licenses/license-colors.ts
+++ b/ui/src/helpers/licenses/license-colors.ts
@@ -1,0 +1,385 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { normalizeLicenseExpression } from '@/helpers/licenses/spdx-expression';
+
+type RgbColor = {
+  red: number;
+  green: number;
+  blue: number;
+};
+
+export type LicenseBadgeColors = {
+  backgroundColor: string;
+  borderColor: string;
+  color: 'black' | 'white';
+};
+
+type ParsedLicenseToken = {
+  normalizedToken: string;
+  family: string;
+  majorVersion?: number;
+  minorVersion?: number;
+  qualifier: string;
+};
+
+/**
+ * Generate a stable 32-bit hash for a string.
+ *
+ * This is the primitive used to make all color decisions deterministic. If the
+ * project ever wants a different overall distribution of colors, this is one of
+ * the few places worth reconsidering.
+ */
+function hashString(value: string): number {
+  let hash = 2166136261;
+
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+
+  return hash >>> 0;
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function getSignedOffset(seed: string, magnitude: number): number {
+  const hash = hashString(seed);
+  const direction = hash % 2 === 0 ? -1 : 1;
+  const offset = hash % (magnitude + 1);
+
+  return direction * offset;
+}
+
+/**
+ * Split a license-like token into the pieces that drive color selection.
+ *
+ * Tuning notes:
+ * - `family` is the dominant input for hue, so license families such as Apache
+ *   and LGPL remain visually grouped.
+ * - `majorVersion` and `minorVersion` are used only as small hue offsets so
+ *   close versions stay close in color.
+ * - `qualifier` captures suffixes such as `only`, `or-later`, and similar
+ *   trailing markers. These intentionally affect the final color only slightly.
+ * - `WITH` exceptions are ignored for family extraction because they should not
+ *   move the base license family into a completely different color region.
+ */
+function parseLicenseToken(license: string): ParsedLicenseToken {
+  const normalizedToken = normalizeLicenseExpression(license.trim());
+  const tokenWithoutException =
+    normalizedToken.split(/\s+WITH\s+/i)[0] || normalizedToken;
+  const familyMatch = tokenWithoutException.match(
+    /^(.*?)(?:-(\d+(?:\.\d+)*).*)?$/
+  );
+  const family = familyMatch?.[1] || tokenWithoutException;
+  const versionString = familyMatch?.[2];
+  const [majorVersion, minorVersion] = versionString
+    ? versionString.split('.').map((part) => Number.parseInt(part, 10))
+    : [undefined, undefined];
+  const qualifierStartIndex = versionString
+    ? tokenWithoutException.indexOf(versionString) + versionString.length
+    : family.length;
+  const qualifier = tokenWithoutException
+    .slice(qualifierStartIndex)
+    .replace(/^[-\s:]+/, '')
+    .trim();
+
+  return {
+    normalizedToken,
+    family: family || normalizedToken,
+    majorVersion,
+    minorVersion,
+    qualifier,
+  };
+}
+
+/**
+ * Map a parsed license token into a hue angle in the HSL color space.
+ *
+ * Tuning notes:
+ * - `familyHue` defines the broad color family. Changing the modulus or moving
+ *   away from HSL hue-based grouping would have the largest visual impact.
+ * - `majorVersion * 9` and `minorVersion * 3` are intentionally small offsets.
+ *   Increase them to make versions more visually distinct; decrease them to
+ *   keep version families tighter.
+ * - `qualifierOffset` is deliberately tiny so `-only` and `-or-later` remain
+ *   close to the same base license.
+ */
+function getLicenseHue(token: ParsedLicenseToken): number {
+  const familyHue = hashString(token.family) % 360;
+  const majorOffset =
+    token.majorVersion !== undefined ? token.majorVersion * 9 : 0;
+  const minorOffset =
+    token.minorVersion !== undefined ? token.minorVersion * 3 : 0;
+  const qualifierOffset = token.qualifier
+    ? getSignedOffset(`${token.family}:${token.qualifier}`, 4)
+    : 0;
+
+  return (familyHue + majorOffset + minorOffset + qualifierOffset + 360) % 360;
+}
+
+/**
+ * Choose badge saturation for a license family.
+ *
+ * This is kept in a narrow range to avoid loud / fully saturated colors in the
+ * UI. Broaden the range if the badges should become more vivid.
+ */
+function getLicenseSaturation(token: ParsedLicenseToken): number {
+  return 58 + (hashString(`${token.family}:s`) % 8);
+}
+
+/**
+ * Choose badge lightness for a license family.
+ *
+ * The current range intentionally favors light backgrounds so black text is
+ * usually sufficient. If the design moves toward darker badges, this is the
+ * main function to revisit together with the text-color contrast policy.
+ */
+function getLicenseLightness(token: ParsedLicenseToken): number {
+  const qualifierOffset = token.qualifier
+    ? getSignedOffset(`${token.normalizedToken}:l`, 2)
+    : 0;
+
+  return clamp(85 + qualifierOffset, 82, 88);
+}
+
+/**
+ * Convert an HSL color into RGB for CSS output and contrast calculations.
+ */
+function hslToRgb(
+  hue: number,
+  saturation: number,
+  lightness: number
+): RgbColor {
+  const normalizedHue = hue / 360;
+  const normalizedSaturation = saturation / 100;
+  const normalizedLightness = lightness / 100;
+
+  if (normalizedSaturation === 0) {
+    const value = Math.round(normalizedLightness * 255);
+
+    return { red: value, green: value, blue: value };
+  }
+
+  const hueToRgb = (p: number, q: number, t: number) => {
+    let normalizedT = t;
+
+    if (normalizedT < 0) normalizedT += 1;
+    if (normalizedT > 1) normalizedT -= 1;
+    if (normalizedT < 1 / 6) return p + (q - p) * 6 * normalizedT;
+    if (normalizedT < 1 / 2) return q;
+    if (normalizedT < 2 / 3) return p + (q - p) * (2 / 3 - normalizedT) * 6;
+
+    return p;
+  };
+
+  const q =
+    normalizedLightness < 0.5
+      ? normalizedLightness * (1 + normalizedSaturation)
+      : normalizedLightness +
+        normalizedSaturation -
+        normalizedLightness * normalizedSaturation;
+  const p = 2 * normalizedLightness - q;
+
+  return {
+    red: Math.round(hueToRgb(p, q, normalizedHue + 1 / 3) * 255),
+    green: Math.round(hueToRgb(p, q, normalizedHue) * 255),
+    blue: Math.round(hueToRgb(p, q, normalizedHue - 1 / 3) * 255),
+  };
+}
+
+/**
+ * Calculate the WCAG relative luminance of an RGB color.
+ */
+function getRelativeLuminance({ red, green, blue }: RgbColor): number {
+  const normalizeChannel = (channel: number) => {
+    const normalized = channel / 255;
+
+    return normalized <= 0.03928
+      ? normalized / 12.92
+      : ((normalized + 0.055) / 1.055) ** 2.4;
+  };
+
+  const linearRed = normalizeChannel(red);
+  const linearGreen = normalizeChannel(green);
+  const linearBlue = normalizeChannel(blue);
+
+  return 0.2126 * linearRed + 0.7152 * linearGreen + 0.0722 * linearBlue;
+}
+
+/**
+ * Calculate the contrast ratio between two RGB colors.
+ *
+ * The result is used to choose black vs. white text for the final badge.
+ *
+ * Reference: https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html
+ * WCAG AA reuires text/background contrast of at least 4.5:1 for normal text, and
+ * the contrast calculation is based on relative luminance with the standard ratio formula:
+ *   (lighter + 0.05) / (darker + 0.05)
+ */
+function getContrastRatio(first: RgbColor, second: RgbColor): number {
+  const firstLuminance = getRelativeLuminance(first);
+  const secondLuminance = getRelativeLuminance(second);
+  const lighter = Math.max(firstLuminance, secondLuminance);
+  const darker = Math.min(firstLuminance, secondLuminance);
+
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function toRgbCss(color: RgbColor): string {
+  return `rgb(${color.red}, ${color.green}, ${color.blue})`;
+}
+
+/**
+ * Create the final badge colors for a license string.
+ *
+ * Algorithm summary:
+ * - Normalize the input so equivalent license spellings map to the same color.
+ * - Derive a base hue from the license family.
+ * - Apply small hue shifts from version and qualifier information.
+ * - Keep saturation and lightness in restrained ranges for readable badges.
+ * - Create a slightly darker border from the same base color.
+ * - Choose black or white text based on whichever yields the stronger
+ *   contrast ratio.
+ *
+ * Primary tuning knobs:
+ * - `getLicenseHue()` for family grouping and version spacing
+ * - `getLicenseSaturation()` for vividness
+ * - `getLicenseLightness()` for how light or dark the badges feel
+ * - the border deltas below (`- 10`) for edge definition
+ */
+export function getLicenseBadgeColors(license: string): LicenseBadgeColors {
+  const token = parseLicenseToken(license);
+  const backgroundRgb = hslToRgb(
+    getLicenseHue(token),
+    getLicenseSaturation(token),
+    getLicenseLightness(token)
+  );
+  const borderRgb = hslToRgb(
+    getLicenseHue(token),
+    clamp(getLicenseSaturation(token) - 10, 30, 100),
+    clamp(getLicenseLightness(token) - 10, 30, 100)
+  );
+  const black = { red: 0, green: 0, blue: 0 };
+  const white = { red: 255, green: 255, blue: 255 };
+  const blackContrast = getContrastRatio(backgroundRgb, black);
+  const whiteContrast = getContrastRatio(backgroundRgb, white);
+
+  return {
+    backgroundColor: toRgbCss(backgroundRgb),
+    borderColor: toRgbCss(borderRgb),
+    color: blackContrast >= whiteContrast ? 'black' : 'white',
+  };
+}
+
+//
+// Unit tests for license color helpers.
+//
+
+if (import.meta.vitest) {
+  const { describe, it, expect } = import.meta.vitest;
+
+  const parseRgbCss = (value: string): RgbColor => {
+    const match = value.match(/^rgb\((\d+), (\d+), (\d+)\)$/);
+
+    if (!match) {
+      throw new Error(`Unexpected rgb color value: ${value}`);
+    }
+
+    return {
+      red: Number.parseInt(match[1] ?? '', 10),
+      green: Number.parseInt(match[2] ?? '', 10),
+      blue: Number.parseInt(match[3] ?? '', 10),
+    };
+  };
+
+  describe('getLicenseBadgeColors', () => {
+    it('returns deterministic colors for the same license', () => {
+      expect(getLicenseBadgeColors('MIT')).toEqual(
+        getLicenseBadgeColors('MIT')
+      );
+    });
+
+    it('normalizes loosely formatted input before generating colors', () => {
+      expect(getLicenseBadgeColors('Apache 2')).toEqual(
+        getLicenseBadgeColors('Apache-2.0')
+      );
+    });
+
+    it('keeps related Apache licenses visually close', () => {
+      expect(getLicenseBadgeColors('Apache-1.0').backgroundColor).not.toEqual(
+        getLicenseBadgeColors('Apache-2.0').backgroundColor
+      );
+      expect(getLicenseBadgeColors('Apache-1.0').color).toBe('black');
+      expect(getLicenseBadgeColors('Apache-2.0').color).toBe('black');
+    });
+
+    it('keeps related LGPL licenses visually close', () => {
+      expect(getLicenseBadgeColors('LGPL-2.0').backgroundColor).not.toEqual(
+        getLicenseBadgeColors('LGPL-2.1-only').backgroundColor
+      );
+      expect(getLicenseBadgeColors('LGPL-2.0').color).toBe('black');
+      expect(getLicenseBadgeColors('LGPL-2.1-only').color).toBe('black');
+    });
+
+    it('keeps related license families closer than unrelated ones in hue space', () => {
+      const apacheOneHue = getLicenseHue(parseLicenseToken('Apache-1.0'));
+      const apacheTwoHue = getLicenseHue(parseLicenseToken('Apache-2.0'));
+      const mitHue = getLicenseHue(parseLicenseToken('MIT'));
+      const apacheDistance = Math.abs(apacheOneHue - apacheTwoHue);
+      const unrelatedDistance = Math.abs(apacheOneHue - mitHue);
+
+      expect(apacheDistance).toBeLessThan(unrelatedDistance);
+    });
+
+    it('returns CSS rgb colors for background and border', () => {
+      const result = getLicenseBadgeColors('BSD-3-Clause');
+
+      expect(result.backgroundColor).toMatch(/^rgb\(\d+, \d+, \d+\)$/);
+      expect(result.borderColor).toMatch(/^rgb\(\d+, \d+, \d+\)$/);
+      expect(['black', 'white']).toContain(result.color);
+    });
+
+    it('keeps badge contrast at or above normal-text WCAG AA against the chosen text color', () => {
+      const samples = [
+        'Apache-2.0',
+        'Apache-1.0',
+        'LGPL-2.1-only',
+        'GPL-2.0-or-later',
+        'MIT',
+        'BSD-3-Clause',
+      ];
+
+      samples.forEach((license) => {
+        const colors = getLicenseBadgeColors(license);
+        const backgroundRgb = parseRgbCss(colors.backgroundColor);
+        const foregroundRgb =
+          colors.color === 'black'
+            ? { red: 0, green: 0, blue: 0 }
+            : { red: 255, green: 255, blue: 255 };
+
+        expect(
+          getContrastRatio(backgroundRgb, foregroundRgb)
+        ).toBeGreaterThanOrEqual(4.5);
+      });
+    });
+  });
+}

--- a/ui/src/helpers/licenses/spdx-expression.ts
+++ b/ui/src/helpers/licenses/spdx-expression.ts
@@ -1,0 +1,359 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import {
+  normalize as normalizeSpdx,
+  parse as parseSpdx,
+  type ParsedSpdxExpression,
+} from 'license-expressions';
+
+export type SpdxLicenseNode =
+  | {
+      kind: 'license';
+      license: string;
+      exception?: string;
+    }
+  | {
+      kind: 'license-ref';
+      licenseRef: string;
+      documentRef?: string;
+    };
+
+export type SpdxConjunctionNode = {
+  kind: 'conjunction';
+  conjunction: 'and' | 'or';
+  left: SpdxExpressionNode;
+  right: SpdxExpressionNode;
+};
+
+export type SpdxExpressionNode = SpdxLicenseNode | SpdxConjunctionNode;
+
+export type ParsedSpdxExpressionResult =
+  | {
+      kind: 'atomic';
+      rawExpression: string;
+      normalizedExpression: string;
+      node: SpdxLicenseNode;
+    }
+  | {
+      kind: 'compound';
+      rawExpression: string;
+      normalizedExpression: string;
+      node: SpdxConjunctionNode;
+    }
+  | {
+      kind: 'invalid';
+      rawExpression: string;
+      normalizedExpression: string;
+      error: string;
+    };
+
+const DEFAULT_PARSE_OPTIONS = {
+  strictSyntax: false,
+  upgradeGPLVariants: true,
+};
+
+function mapParsedNode(node: ParsedSpdxExpression): SpdxExpressionNode {
+  if ('conjunction' in node) {
+    return {
+      kind: 'conjunction',
+      conjunction: node.conjunction,
+      left: mapParsedNode(node.left),
+      right: mapParsedNode(node.right),
+    };
+  }
+
+  if ('licenseRef' in node) {
+    return {
+      kind: 'license-ref',
+      licenseRef: node.licenseRef,
+      documentRef: node.documentRef,
+    };
+  }
+
+  return {
+    kind: 'license',
+    license: node.license,
+    exception: node.exception,
+  };
+}
+
+export function normalizeLicenseExpression(expression: string): string {
+  const trimmedExpression = expression.trim();
+
+  if (trimmedExpression.length === 0) {
+    return '';
+  }
+
+  try {
+    return normalizeSpdx(trimmedExpression);
+  } catch {
+    return trimmedExpression;
+  }
+}
+
+export function parseLicenseExpression(
+  expression: string
+): ParsedSpdxExpressionResult {
+  const trimmedExpression = expression.trim();
+
+  if (trimmedExpression.length === 0) {
+    return {
+      kind: 'invalid',
+      rawExpression: expression,
+      normalizedExpression: '',
+      error: 'License expression is empty.',
+    };
+  }
+
+  try {
+    const parsedExpression = parseSpdx(
+      trimmedExpression,
+      DEFAULT_PARSE_OPTIONS
+    );
+    const mappedExpression = mapParsedNode(parsedExpression);
+    const normalizedExpression = normalizeLicenseExpression(trimmedExpression);
+
+    if (mappedExpression.kind === 'conjunction') {
+      return {
+        kind: 'compound',
+        rawExpression: expression,
+        normalizedExpression,
+        node: mappedExpression,
+      };
+    }
+
+    return {
+      kind: 'atomic',
+      rawExpression: expression,
+      normalizedExpression,
+      node: mappedExpression,
+    };
+  } catch (error) {
+    return {
+      kind: 'invalid',
+      rawExpression: expression,
+      normalizedExpression: trimmedExpression,
+      error:
+        error instanceof Error
+          ? error.message
+          : 'Failed to parse license expression.',
+    };
+  }
+}
+
+export function isAtomicLicenseExpression(expression: string): boolean {
+  return parseLicenseExpression(expression).kind === 'atomic';
+}
+
+//
+// Unit tests for SPDX expression parsing helpers.
+//
+
+if (import.meta.vitest) {
+  const { describe, it, expect } = import.meta.vitest;
+
+  describe('normalizeLicenseExpression', () => {
+    it('normalizes valid SPDX expressions', () => {
+      expect(normalizeLicenseExpression('  mit or apache-2.0  ')).toBe(
+        'Apache-2.0 OR MIT'
+      );
+    });
+
+    it('normalizes deprecated GPL plus syntax', () => {
+      expect(normalizeLicenseExpression('GPL-2.0+')).toBe('GPL-2.0-or-later');
+    });
+
+    it('returns a trimmed original string for invalid expressions', () => {
+      expect(normalizeLicenseExpression(' MIT OR ( ')).toBe('MIT OR (');
+    });
+  });
+
+  describe('parseLicenseExpression', () => {
+    it('parses a single SPDX license identifier as an atomic expression', () => {
+      expect(parseLicenseExpression('MIT')).toEqual({
+        kind: 'atomic',
+        rawExpression: 'MIT',
+        normalizedExpression: 'MIT',
+        node: {
+          kind: 'license',
+          license: 'MIT',
+          exception: undefined,
+        },
+      });
+    });
+
+    it('parses SPDX expressions with AND / OR into conjunction nodes', () => {
+      expect(parseLicenseExpression('MIT AND Apache-2.0')).toEqual({
+        kind: 'compound',
+        rawExpression: 'MIT AND Apache-2.0',
+        normalizedExpression: 'Apache-2.0 AND MIT',
+        node: {
+          kind: 'conjunction',
+          conjunction: 'and',
+          left: {
+            kind: 'license',
+            license: 'MIT',
+            exception: undefined,
+          },
+          right: {
+            kind: 'license',
+            license: 'Apache-2.0',
+            exception: undefined,
+          },
+        },
+      });
+    });
+
+    it('parses nested SPDX expressions recursively', () => {
+      expect(
+        parseLicenseExpression('MIT AND (Apache-2.0 OR BSD-3-Clause)')
+      ).toEqual({
+        kind: 'compound',
+        rawExpression: 'MIT AND (Apache-2.0 OR BSD-3-Clause)',
+        normalizedExpression: 'MIT AND (Apache-2.0 OR BSD-3-Clause)',
+        node: {
+          kind: 'conjunction',
+          conjunction: 'and',
+          left: {
+            kind: 'license',
+            license: 'MIT',
+            exception: undefined,
+          },
+          right: {
+            kind: 'conjunction',
+            conjunction: 'or',
+            left: {
+              kind: 'license',
+              license: 'Apache-2.0',
+              exception: undefined,
+            },
+            right: {
+              kind: 'license',
+              license: 'BSD-3-Clause',
+              exception: undefined,
+            },
+          },
+        },
+      });
+    });
+
+    it('parses WITH exceptions as atomic license nodes', () => {
+      expect(
+        parseLicenseExpression('GPL-2.0-only WITH Classpath-exception-2.0')
+      ).toEqual({
+        kind: 'atomic',
+        rawExpression: 'GPL-2.0-only WITH Classpath-exception-2.0',
+        normalizedExpression: 'GPL-2.0-only WITH Classpath-exception-2.0',
+        node: {
+          kind: 'license',
+          license: 'GPL-2.0-only',
+          exception: 'Classpath-exception-2.0',
+        },
+      });
+    });
+
+    it('upgrades deprecated GPL plus syntax during parsing', () => {
+      expect(parseLicenseExpression('GPL-2.0+')).toEqual({
+        kind: 'atomic',
+        rawExpression: 'GPL-2.0+',
+        normalizedExpression: 'GPL-2.0-or-later',
+        node: {
+          kind: 'license',
+          license: 'GPL-2.0-or-later',
+          exception: undefined,
+        },
+      });
+    });
+
+    it('accepts lower-case operators and normalizes them', () => {
+      expect(parseLicenseExpression('mit or apache-2.0')).toEqual({
+        kind: 'compound',
+        rawExpression: 'mit or apache-2.0',
+        normalizedExpression: 'Apache-2.0 OR MIT',
+        node: {
+          kind: 'conjunction',
+          conjunction: 'or',
+          left: {
+            kind: 'license',
+            license: 'MIT',
+            exception: undefined,
+          },
+          right: {
+            kind: 'license',
+            license: 'Apache-2.0',
+            exception: undefined,
+          },
+        },
+      });
+    });
+
+    it('supports custom LicenseRef identifiers', () => {
+      expect(parseLicenseExpression('DocumentRef-foo:LicenseRef-bar')).toEqual({
+        kind: 'atomic',
+        rawExpression: 'DocumentRef-foo:LicenseRef-bar',
+        normalizedExpression: 'DocumentRef-foo:LicenseRef-bar',
+        node: {
+          kind: 'license-ref',
+          documentRef: 'DocumentRef-foo',
+          licenseRef: 'LicenseRef-bar',
+        },
+      });
+    });
+
+    it('returns an invalid result instead of throwing for bad input', () => {
+      const result = parseLicenseExpression('MIT OR (');
+
+      expect(result.kind).toBe('invalid');
+      expect(result.rawExpression).toBe('MIT OR (');
+      expect(result.normalizedExpression).toBe('MIT OR (');
+
+      if (result.kind === 'invalid') {
+        expect(result.error.length).toBeGreaterThan(0);
+      }
+    });
+
+    it('returns an invalid result for an empty expression', () => {
+      expect(parseLicenseExpression('   ')).toEqual({
+        kind: 'invalid',
+        rawExpression: '   ',
+        normalizedExpression: '',
+        error: 'License expression is empty.',
+      });
+    });
+  });
+
+  describe('isAtomicLicenseExpression', () => {
+    it('returns true for a single SPDX license', () => {
+      expect(isAtomicLicenseExpression('Apache-2.0')).toBe(true);
+    });
+
+    it('returns false for compound expressions', () => {
+      expect(isAtomicLicenseExpression('Apache-2.0 OR MIT')).toBe(false);
+    });
+
+    it('returns false for invalid expressions', () => {
+      expect(isAtomicLicenseExpression('MIT OR (')).toBe(false);
+    });
+
+    it('returns true for normalized GPL plus syntax because it remains atomic', () => {
+      expect(isAtomicLicenseExpression('GPL-2.0+')).toBe(true);
+    });
+  });
+}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
@@ -42,6 +42,7 @@ import { CopyToClipboard } from '@/components/copy-to-clipboard';
 import { DataTableCards } from '@/components/data-table-cards/data-table-cards';
 import { MarkItems } from '@/components/data-table/mark-items';
 import { DependencyPaths } from '@/components/dependency-paths';
+import { SpdxExpressionBadgeGroup } from '@/components/licenses';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { PackageCuration } from '@/components/package-curation';
 import { RenderProperty } from '@/components/render-property';
@@ -88,6 +89,14 @@ const defaultPageSize = 10;
 
 const columnHelper = createColumnHelper<Package>();
 
+const LicenseList = ({ licenses }: { licenses: string[] }) => (
+  <div className='flex flex-wrap gap-1'>
+    {licenses.map((license) => (
+      <SpdxExpressionBadgeGroup key={license} expression={license} />
+    ))}
+  </div>
+);
+
 // Component to render a single package card in the list.
 const PackageCard = ({ pkg }: { pkg: Package }) => {
   const packageIdType = useUserSettingsStore((state) => state.packageIdType);
@@ -123,7 +132,7 @@ const PackageCard = ({ pkg }: { pkg: Package }) => {
       {declaredLicenses.length > 0 ? (
         <div className='flex gap-2 text-sm'>
           <div className='text-muted-foreground'>Declared License:</div>
-          <div className='wrap-break-word'>{declaredLicenses.join(',')}</div>
+          <LicenseList licenses={declaredLicenses} />
         </div>
       ) : (
         <div className='text-muted-foreground italic'>No declared license</div>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
@@ -42,6 +42,7 @@ import {
 import { BreakableString } from '@/components/breakable-string';
 import { DataTableCards } from '@/components/data-table-cards/data-table-cards';
 import { MarkItems } from '@/components/data-table/mark-items';
+import { SpdxExpressionBadgeGroup } from '@/components/licenses';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { RenderProperty } from '@/components/render-property';
 import { Button } from '@/components/ui/button';
@@ -69,6 +70,14 @@ import {
 const defaultPageSize = 10;
 
 const columnHelper = createColumnHelper<Project>();
+
+const LicenseList = ({ licenses }: { licenses: string[] }) => (
+  <div className='flex flex-wrap gap-1'>
+    {licenses.map((license) => (
+      <SpdxExpressionBadgeGroup key={license} expression={license} />
+    ))}
+  </div>
+);
 
 // Component to render a single project card in the list.
 const ProjectCard = ({ project }: { project: Project }) => {
@@ -109,9 +118,7 @@ const ProjectCard = ({ project }: { project: Project }) => {
       {declaredLicenses.length > 0 ? (
         <div className='flex gap-2 text-sm'>
           <div className='font-semibold'>Declared License: </div>
-          <div className='text-muted-foreground wrap-break-word'>
-            {declaredLicenses.join(', ')}
-          </div>
+          <LicenseList licenses={declaredLicenses} />
         </div>
       ) : (
         <div className='text-muted-foreground italic'>No declared license</div>
@@ -136,20 +143,31 @@ const renderSubComponent = ({ row }: { row: Row<Project> }) => {
       <div>
         <div className='font-semibold'>Processed Declared License</div>
         <div className='ml-2'>
-          <RenderProperty
-            label='SPDX expression'
-            value={project.processedDeclaredLicense.spdxExpression}
-          />
+          <div className='space-y-1'>
+            <div className='text-sm font-semibold'>SPDX expression</div>
+            {project.processedDeclaredLicense.spdxExpression ? (
+              <SpdxExpressionBadgeGroup
+                expression={project.processedDeclaredLicense.spdxExpression}
+              />
+            ) : (
+              <div className='text-muted-foreground italic'>No value</div>
+            )}
+          </div>
           <RenderProperty
             label='Mapped licenses'
             value={project.processedDeclaredLicense.mappedLicenses}
             type='keyvalue'
           />
-          <RenderProperty
-            label='Unmapped licenses'
-            value={project.processedDeclaredLicense.unmappedLicenses}
-            type='array'
-          />
+          <div className='space-y-1'>
+            <div className='text-sm font-semibold'>Unmapped licenses</div>
+            {project.processedDeclaredLicense.unmappedLicenses.length > 0 ? (
+              <LicenseList
+                licenses={project.processedDeclaredLicense.unmappedLicenses}
+              />
+            ) : (
+              <div className='text-muted-foreground italic'>No value</div>
+            )}
+          </div>
         </div>
       </div>
 

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -36,6 +36,6 @@ export default defineConfig({
   test: {
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     exclude: ['tests/**'],
-    includeSource: ['src/**/*.ts'],
+    includeSource: ['src/**/*.{ts,tsx}'],
   },
 });


### PR DESCRIPTION
<img width="1128" height="565" alt="Screenshot from 2026-04-09 11-22-25" src="https://github.com/user-attachments/assets/f89b4e95-a976-4021-aa12-dc10aeacbe7a" />

Please see the commits for details.
