### PR TITLE
Feat/rate limit

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -137,6 +137,7 @@ dependencies {
     implementation(ktorLibs.server.requestValidation)
     implementation(ktorLibs.server.statusPages)
     implementation(libs.bundles.schemaKenerator)
+    implementation(libs.ktorRateLimit)
     implementation(libs.koinKtor)
     implementation(libs.konform)
     implementation(libs.ktorOpenApi)

--- a/core/src/main/kotlin/Application.kt
+++ b/core/src/main/kotlin/Application.kt
@@ -36,6 +36,7 @@ fun Application.module() {
     configureKoin()
     configureAuthentication(get(), get())
     configureLifecycle()
+    configureRateLimit()
     configureStatusPages()
     configureRouting()
     configureSerialization()

--- a/core/src/main/kotlin/plugins/OpenApi.kt
+++ b/core/src/main/kotlin/plugins/OpenApi.kt
@@ -63,6 +63,10 @@ fun Application.configureOpenApi() {
         // Don't show the routes providing the custom json-schemas.
         pathFilter = { _, url -> url.firstOrNull() != "schemas" }
 
+        // Ignore internal RateLimit route selectors to prevent them from appearing in Swagger.
+        // This excludes routes like /api/v1/(RateLimit public)/liveness
+        ignoredRouteSelectorClassNames = setOf("io.ktor.server.plugins.ratelimit.RateLimitRouteSelector")
+
         security {
             defaultSecuritySchemeNames = listOf(AuthenticationProviders.TOKEN_PROVIDER)
             defaultUnauthorizedResponse {

--- a/core/src/main/kotlin/plugins/RateLimit.kt
+++ b/core/src/main/kotlin/plugins/RateLimit.kt
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.core.plugins
+
+import io.ktor.http.HttpHeaders
+import io.ktor.server.application.Application
+import io.ktor.server.application.install
+import io.ktor.server.auth.jwt.JWTCredential
+import io.ktor.server.auth.principal
+import io.ktor.server.config.ApplicationConfig
+import io.ktor.server.plugins.ratelimit.RateLimit
+import io.ktor.server.plugins.ratelimit.RateLimitName
+import io.ktor.server.request.ApplicationRequest
+
+import kotlin.time.Duration.Companion.milliseconds
+
+import org.koin.ktor.ext.inject
+
+fun Application.configureRateLimit() {
+    val config: ApplicationConfig by inject()
+
+    val publicMaxRequests = config.property("ktor.rateLimit.public.maxRequests").getString().toInt()
+    val publicWindowMs = config.property("ktor.rateLimit.public.windowMs").getString().toLong()
+    val authorizedMaxRequests = config.property("ktor.rateLimit.authorized.maxRequests").getString().toInt()
+    val authorizedWindowMs = config.property("ktor.rateLimit.authorized.windowMs").getString().toLong()
+
+    install(RateLimit) {
+        register(RateLimitName("public")) {
+            rateLimiter(limit = publicMaxRequests, refillPeriod = publicWindowMs.milliseconds)
+            requestKey { call ->
+                getRateLimitKey(call.request)
+            }
+        }
+
+        register(RateLimitName("authorized")) {
+            rateLimiter(limit = authorizedMaxRequests, refillPeriod = authorizedWindowMs.milliseconds)
+            requestKey { call ->
+                val jwtPrincipal = call.principal<JWTCredential>()
+                if (jwtPrincipal != null) {
+                    "jwt:${jwtPrincipal.subject}"
+                } else {
+                    getRateLimitKey(call.request)
+                }
+            }
+        }
+    }
+}
+
+private fun getRateLimitKey(request: ApplicationRequest): String {
+    val clientIp = request.headers[HttpHeaders.XForwardedFor]
+        ?: request.local.remoteAddress
+    return "ip:$clientIp"
+}

--- a/core/src/main/kotlin/plugins/Routing.kt
+++ b/core/src/main/kotlin/plugins/Routing.kt
@@ -21,6 +21,8 @@ package org.eclipse.apoapsis.ortserver.core.plugins
 
 import io.ktor.server.application.Application
 import io.ktor.server.auth.authenticate
+import io.ktor.server.plugins.ratelimit.RateLimitName
+import io.ktor.server.plugins.ratelimit.rateLimit
 import io.ktor.server.routing.route
 import io.ktor.server.routing.routing
 
@@ -49,25 +51,29 @@ import org.koin.ktor.ext.get
 fun Application.configureRouting() {
     routing {
         route("api/v1") {
-            authentication()
-            healthChecks()
-            downloads()
+            rateLimit(RateLimitName("public")) {
+                authentication()
+                healthChecks()
+                downloads()
+            }
             authenticate(AuthenticationProviders.TOKEN_PROVIDER) {
-                admin()
-                adminConfigRoutes(get())
-                authorizationRoutes()
-                infrastructureServicesRoutes(get())
-                licenseFindingRoutes(get(), get())
-                organizations()
-                pluginManagerRoutes(get(), get(), get())
-                products()
-                repositories()
-                resolutionRoutes(get(), get(), get())
-                runs()
-                searchRoutes(get())
-                secretsCompositionRoutes(get(), get())
-                secretsRoutes(get(), get())
-                versions()
+                rateLimit(RateLimitName("authorized")) {
+                    admin()
+                    adminConfigRoutes(get())
+                    authorizationRoutes()
+                    infrastructureServicesRoutes(get())
+                    licenseFindingRoutes(get(), get())
+                    organizations()
+                    pluginManagerRoutes(get(), get(), get())
+                    products()
+                    repositories()
+                    resolutionRoutes(get(), get(), get())
+                    runs()
+                    searchRoutes(get())
+                    secretsCompositionRoutes(get(), get())
+                    secretsRoutes(get(), get())
+                    versions()
+                }
             }
         }
     }

--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -39,6 +39,21 @@ ktor {
     allowedHosts = ${?UI_HOSTS}
   }
 
+  rateLimit {
+    public {
+      maxRequests = 100
+      maxRequests = ${?RATE_LIMIT_MAX_REQUESTS}
+      windowMs = 60000
+      windowMs = ${?RATE_LIMIT_WINDOW_MS}
+    }
+    authorized {
+      maxRequests = 1000
+      maxRequests = ${?RATE_LIMIT_AUTHORIZED_MAX_REQUESTS}
+      windowMs = 60000
+      windowMs = ${?RATE_LIMIT_AUTHORIZED_WINDOW_MS}
+    }
+  }
+
   application {
     modules = [ org.eclipse.apoapsis.ortserver.core.ApplicationKt.module ]
   }

--- a/core/src/test/kotlin/ApplicationTest.kt
+++ b/core/src/test/kotlin/ApplicationTest.kt
@@ -45,6 +45,7 @@ fun main(args: Array<String>) = io.ktor.server.netty.EngineMain.main(args)
 fun Application.testModule(db: Database) {
     configureKoin(db, authorizationService = mockk())
     configureTestAuthentication()
+    configureRateLimit()
     configureStatusPages()
     configureRouting()
     configureSerialization()
@@ -59,6 +60,7 @@ fun Application.testModule(db: Database) {
 fun Application.testAuthModule(db: Database) {
     configureKoin(db)
     configureAuthentication(get(), get())
+    configureRateLimit()
     configureStatusPages()
     configureRouting()
     configureSerialization()

--- a/core/src/test/resources/application-test-auth.conf
+++ b/core/src/test/resources/application-test-auth.conf
@@ -28,6 +28,17 @@ ktor {
   cors {
     allowedHosts = "localhost:5173,localhost:8082"
   }
+
+  rateLimit {
+    public {
+      maxRequests = 100
+      windowMs = 60000
+    }
+    authorized {
+      maxRequests = 1000
+      windowMs = 60000
+    }
+  }
 }
 
 jwt {

--- a/core/src/test/resources/application-test.conf
+++ b/core/src/test/resources/application-test.conf
@@ -28,6 +28,17 @@ ktor {
   cors {
     allowedHosts = "localhost:5173,localhost:8082"
   }
+
+  rateLimit {
+    public {
+      maxRequests = 100
+      windowMs = 60000
+    }
+    authorized {
+      maxRequests = 1000
+      windowMs = 60000
+    }
+  }
 }
 
 jwt {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,6 +49,7 @@ kotest = "6.1.11"
 kotestAssertionsKtor = "2.0.0"
 kotlinResult = "2.3.1"
 ktorOpenApi = "5.6.0"
+ktorRateLimit = "3.4.2"
 kubernetesClient = "26.0.0"
 log4j = "2.25.4"
 logback = "1.5.32"
@@ -115,6 +116,7 @@ kotlinxCoroutinesSlf4j = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-sl
 kotlinxSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 ktorOpenApi = { module = "io.github.smiley4:ktor-openapi", version.ref = "ktorOpenApi" }
 ktorSwaggerUi = { module = "io.github.smiley4:ktor-swagger-ui", version.ref = "ktorOpenApi" }
+ktorRateLimit = { module = "io.ktor:ktor-server-rate-limit-jvm", version.ref = "ktorRateLimit" }
 kubernetesClient = { module = "io.kubernetes:client-java", version.ref = "kubernetesClient" }
 kubernetesClientExtended = { module = "io.kubernetes:client-java-extended", version.ref = "kubernetesClient" }
 log4jToSlf4j = { module = "org.apache.logging.log4j:log4j-to-slf4j", version.ref = "log4j" }


### PR DESCRIPTION
Hi. 
This PR introduces a Rate Limiting implementation to enhance API stability. It features a granular configuration that allows for different traffic constraints between authenticated and public routes.

Resolve #4074