### PR TITLE
Scanner image improvements

### DIFF
--- a/workers/scanner/docker/Scanner.Dockerfile
+++ b/workers/scanner/docker/Scanner.Dockerfile
@@ -49,6 +49,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     pkg-config \
     python3 \
     python3-pip \
+    python3-venv \
     sudo \
     unzip \
     xz-utils \
@@ -88,7 +89,8 @@ WORKDIR $HOME
 
 # Use pip to install ScanCode
 RUN curl -Os https://raw.githubusercontent.com/nexB/scancode-toolkit/v$SCANCODE_VERSION/requirements.txt && \
-    pip install -U --constraint requirements.txt scancode-toolkit==$SCANCODE_VERSION && \
+    python3 -m venv /opt/scancode && \
+    /opt/scancode/bin/pip install --constraint requirements.txt scancode-toolkit==$SCANCODE_VERSION && \
     rm requirements.txt
 
-ENV PATH="/home/ort/.local/bin:${PATH}"
+ENV PATH="/opt/scancode/bin:${PATH}"

--- a/workers/scanner/docker/Scanner.Dockerfile
+++ b/workers/scanner/docker/Scanner.Dockerfile
@@ -64,7 +64,8 @@ ARG SCANCODE_VERSION=32.5.0
 # Install Askalono
 RUN curl -LOs https://github.com/amzn/askalono/releases/download/$ASKALONO_VERSION/askalono-Linux.zip && \
     mkdir /opt/askalono && \
-    unzip askalono-Linux.zip -d /opt/askalono
+    unzip askalono-Linux.zip -d /opt/askalono && \
+    rm askalono-Linux.zip
 
 ENV PATH=$PATH:/opt/askalono
 

--- a/workers/scanner/docker/Scanner.Dockerfile
+++ b/workers/scanner/docker/Scanner.Dockerfile
@@ -84,6 +84,8 @@ RUN rbenv install $RUBY_VERSION -v \
     && rbenv global $RUBY_VERSION \
     && gem install licensee:$LICENSEE_VERSION
 
+WORKDIR $HOME
+
 # Use pip to install ScanCode
 RUN curl -Os https://raw.githubusercontent.com/nexB/scancode-toolkit/v$SCANCODE_VERSION/requirements.txt && \
     pip install -U --constraint requirements.txt scancode-toolkit==$SCANCODE_VERSION && \


### PR DESCRIPTION
See the commit messages for details.

Installing ScanCode to a virtualenv increases the image size from 2.2GB to 2.25GB which should be acceptable.