### PR TITLE
feat(workers): Generate package manager config files only in analyzer

### DIFF
--- a/workers/analyzer/src/main/kotlin/AnalyzerComponent.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerComponent.kt
@@ -93,7 +93,7 @@ class AnalyzerComponent : EndpointComponent<AnalyzerRequest>(AnalyzerEndpoint) {
         databaseModule(),
         ortRunServiceModule(),
         workerContextModule(),
-        buildEnvironmentModule()
+        buildEnvironmentModule(includePackageManagerGenerators = true)
     )
 
     private fun analyzerModule(): Module = module {

--- a/workers/common/src/main/kotlin/env/EnvironmentModule.kt
+++ b/workers/common/src/main/kotlin/env/EnvironmentModule.kt
@@ -34,8 +34,11 @@ import org.koin.dsl.module
 /**
  * Return a [Module] with bean definitions that provide an [EnvironmentService] instance and its dependencies. This
  * module can be used by worker implementations that need to set up a build environment.
+ *
+ * If [includePackageManagerGenerators] is `true`, generators for package manager-specific configuration files are
+ * included.
  */
-fun buildEnvironmentModule(): Module = module {
+fun buildEnvironmentModule(includePackageManagerGenerators: Boolean = false): Module = module {
     single<SecretRepository> { DaoSecretRepository(get()) }
 
     singleOf(::EnvironmentDefinitionFactory)
@@ -45,16 +48,19 @@ fun buildEnvironmentModule(): Module = module {
         EnvironmentService(
             get(),
             get(),
-            listOf(
-                ConanGenerator(),
-                GitConfigGenerator.create(get()),
-                GitCredentialsGenerator(),
-                GradleInitGenerator(),
-                MavenSettingsGenerator(),
-                NpmRcGenerator(),
-                NuGetGenerator(),
-                YarnRcGenerator()
-            ),
+            buildList {
+                add(GitConfigGenerator.create(get()))
+                add(GitCredentialsGenerator())
+
+                if (includePackageManagerGenerators) {
+                    add(ConanGenerator())
+                    add(GradleInitGenerator())
+                    add(MavenSettingsGenerator())
+                    add(NpmRcGenerator())
+                    add(NuGetGenerator())
+                    add(YarnRcGenerator())
+                }
+            },
             get(),
             get()
         )


### PR DESCRIPTION
If any infrastructure services are defined, all implementations of `EnvironmentConfigGenerator` were invoked by the analyzer, scanner, and reporter workers. As a result, package manager specific files like `.npmrc` were generated in all of those workers, even though they are only required by the analyzer.

To avoid generating unneeded files, make the generation of package manager specific files optional and enable it only in the analyzer worker.