### PR TITLE
Add support for configuring advisor plugin options in the UI

### DIFF
--- a/ui/src/components/form/plugin-multi-select-field.tsx
+++ b/ui/src/components/form/plugin-multi-select-field.tsx
@@ -167,6 +167,7 @@ export const PluginMultiSelectField = <
                               <Checkbox
                                 checked={field.value as CheckedState}
                                 onCheckedChange={field.onChange}
+                                disabled={option.isFixed}
                               />
                             ) : option.isRequired ? (
                               <Input
@@ -178,6 +179,7 @@ export const PluginMultiSelectField = <
                                     : 'text'
                                 }
                                 value={field.value}
+                                disabled={option.isFixed}
                               />
                             ) : (
                               <OptionalInput
@@ -189,9 +191,16 @@ export const PluginMultiSelectField = <
                                     : 'text'
                                 }
                                 value={field.value}
+                                disabled={option.isFixed}
                               />
                             )}
                           </FormControl>
+                          {option.isFixed && (
+                            <FormDescription className='text-muted-foreground font-semibold text-yellow-700'>
+                              This option is set by an administrator and cannot
+                              be changed.
+                            </FormDescription>
+                          )}
                         </FormItem>
                       )}
                     />

--- a/ui/src/components/form/plugin-multi-select-field.tsx
+++ b/ui/src/components/form/plugin-multi-select-field.tsx
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { CheckedState } from '@radix-ui/react-checkbox';
+import React from 'react';
+import {
+  FieldPathByValue,
+  FieldPathValue,
+  FieldValues,
+  Path,
+  UseFormReturn,
+} from 'react-hook-form';
+
+import { PreconfiguredPluginDescriptor } from '@/api';
+import { OptionalInput } from '@/components/form/optional-input.tsx';
+import { Badge } from '@/components/ui/badge.tsx';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input.tsx';
+import { Label } from '@/components/ui/label';
+import { Separator } from '@/components/ui/separator';
+import { cn } from '@/lib/utils';
+
+type PluginMultiSelectFieldProps<
+  TFieldValues extends FieldValues,
+  TName extends FieldPathByValue<TFieldValues, Array<string>>,
+> = {
+  form: UseFormReturn<TFieldValues, TName>;
+  name: TName;
+  configName: TName;
+  label?: string;
+  description?: React.ReactNode;
+  plugins: readonly PreconfiguredPluginDescriptor[];
+  className?: string;
+};
+
+export const PluginMultiSelectField = <
+  TFieldValues extends FieldValues,
+  TName extends FieldPathByValue<TFieldValues, Array<string>>,
+>({
+  form,
+  name,
+  configName,
+  label,
+  description,
+  plugins,
+  className,
+}: PluginMultiSelectFieldProps<TFieldValues, TName>) => {
+  return (
+    <FormField
+      control={form.control}
+      name={name}
+      render={({ field }) => (
+        <FormItem
+          className={cn(
+            'mb-4 flex flex-col justify-between rounded-lg border p-4',
+            className
+          )}
+        >
+          <FormLabel>{label}</FormLabel>
+          <FormDescription className='pb-4'>{description}</FormDescription>
+          <div className='flex items-center space-x-3'>
+            <Checkbox
+              id='check-all-items'
+              checked={
+                plugins.every((plugin) =>
+                  form.getValues(name).includes(plugin.id)
+                )
+                  ? true
+                  : plugins.some((plugin) =>
+                        form.getValues(name).includes(plugin.id)
+                      )
+                    ? 'indeterminate'
+                    : false
+              }
+              onCheckedChange={(checked) => {
+                const enabledItems = checked
+                  ? plugins.map((plugin) => plugin.id)
+                  : [];
+                form.setValue(
+                  name,
+                  // TypeScript doesn't get this, but TName extends FieldPathByValue<TFieldValues, Array<string>>,
+                  // so the field behind TName is always an Array<string>
+                  // and options.map((option) => option.id) is also Array<string>,
+                  // so this type cast is safe.
+                  enabledItems as FieldPathValue<TFieldValues, TName>
+                );
+              }}
+            />
+            <Label htmlFor='check-all-items' className='font-bold'>
+              Enable/disable all
+            </Label>
+          </div>
+          <Separator />
+          {plugins.map((plugin) => (
+            <FormItem
+              key={plugin.id}
+              className='flex flex-row items-start space-y-0 space-x-3'
+            >
+              <FormControl>
+                <Checkbox
+                  checked={field.value?.includes(plugin.id)}
+                  onCheckedChange={(checked) => {
+                    return checked
+                      ? field.onChange([...field.value, plugin.id])
+                      : field.onChange(
+                          field.value?.filter(
+                            (value: string) => value !== plugin.id
+                          )
+                        );
+                  }}
+                />
+              </FormControl>
+              <div className='flex flex-col'>
+                <FormLabel className='font-normal'>
+                  {plugin.displayName}
+                </FormLabel>
+                {plugin.description != null && (
+                  <FormDescription className='pb-4'>
+                    {plugin.description}
+                  </FormDescription>
+                )}
+                {field.value?.includes(plugin.id) &&
+                  plugin.options.map((option) => (
+                    <FormField
+                      control={form.control}
+                      key={option.name}
+                      name={
+                        `${configName}.${plugin.id}.options.${option.name}` as Path<TFieldValues>
+                      }
+                      render={({ field }) => (
+                        <FormItem className='flex flex-col space-y-1'>
+                          <FormLabel className='mt-2'>
+                            {option.name}
+                            <Badge className='ml-2 bg-blue-200 text-black'>
+                              {option.type}
+                            </Badge>
+                          </FormLabel>
+                          <FormDescription>
+                            {option.description}
+                          </FormDescription>
+                          <FormControl>
+                            {option.type === 'BOOLEAN' ? (
+                              <Checkbox
+                                checked={field.value as CheckedState}
+                                onCheckedChange={field.onChange}
+                              />
+                            ) : option.isRequired ? (
+                              <Input
+                                {...field}
+                                type={
+                                  option.type === 'INTEGER' ||
+                                  option.type === 'LONG'
+                                    ? 'number'
+                                    : 'text'
+                                }
+                                value={field.value}
+                              />
+                            ) : (
+                              <OptionalInput
+                                {...field}
+                                type={
+                                  option.type === 'INTEGER' ||
+                                  option.type === 'LONG'
+                                    ? 'number'
+                                    : 'text'
+                                }
+                                value={field.value}
+                              />
+                            )}
+                          </FormControl>
+                        </FormItem>
+                      )}
+                    />
+                  ))}
+              </div>
+            </FormItem>
+          ))}
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+};

--- a/ui/src/components/form/plugin-multi-select-field.tsx
+++ b/ui/src/components/form/plugin-multi-select-field.tsx
@@ -27,7 +27,7 @@ import {
   UseFormReturn,
 } from 'react-hook-form';
 
-import { PreconfiguredPluginDescriptor } from '@/api';
+import { PreconfiguredPluginDescriptor, Secret } from '@/api';
 import { OptionalInput } from '@/components/form/optional-input.tsx';
 import { Badge } from '@/components/ui/badge.tsx';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -41,6 +41,13 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input.tsx';
 import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select.tsx';
 import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
 
@@ -54,6 +61,7 @@ type PluginMultiSelectFieldProps<
   label?: string;
   description?: React.ReactNode;
   plugins: readonly PreconfiguredPluginDescriptor[];
+  secrets: readonly Secret[];
   className?: string;
 };
 
@@ -67,6 +75,7 @@ export const PluginMultiSelectField = <
   label,
   description,
   plugins,
+  secrets,
   className,
 }: PluginMultiSelectFieldProps<TFieldValues, TName>) => {
   return (
@@ -149,7 +158,7 @@ export const PluginMultiSelectField = <
                       control={form.control}
                       key={option.name}
                       name={
-                        `${configName}.${plugin.id}.options.${option.name}` as Path<TFieldValues>
+                        `${configName}.${plugin.id}.${option.type === 'SECRET' ? 'secrets' : 'options'}.${option.name}` as Path<TFieldValues>
                       }
                       render={({ field }) => (
                         <FormItem className='flex flex-col space-y-1'>
@@ -169,6 +178,47 @@ export const PluginMultiSelectField = <
                                 onCheckedChange={field.onChange}
                                 disabled={option.isFixed}
                               />
+                            ) : option.type == 'SECRET' ? (
+                              secrets.length === 0 ? (
+                                <FormMessage className='font-semibold text-red-600'>
+                                  No secrets available. Create a new secret to
+                                  be able to use this option.
+                                </FormMessage>
+                              ) : (
+                                <Select
+                                  onValueChange={field.onChange}
+                                  defaultValue={undefined}
+                                  value={field.value}
+                                  disabled={option.isFixed}
+                                >
+                                  <SelectTrigger>
+                                    <SelectValue placeholder='Select a secret' />
+                                  </SelectTrigger>
+                                  <SelectContent>
+                                    {secrets.map((secret) => (
+                                      <SelectItem
+                                        key={secret.name}
+                                        value={secret.name}
+                                      >
+                                        {secret.name}
+                                      </SelectItem>
+                                    ))}
+                                  </SelectContent>
+                                  {field.value &&
+                                    !secrets.some(
+                                      (secret) => secret.name === field.value
+                                    ) && (
+                                      <FormMessage className='font-semibold text-red-600'>
+                                        The selected secret '{field.value}' does
+                                        not exist. The value could come from a
+                                        previous run or could be a default value
+                                        set by an administrator. Select a valid
+                                        secret or create a new secret with this
+                                        name.
+                                      </FormMessage>
+                                    )}
+                                </Select>
+                              )
                             ) : option.isRequired ? (
                               <Input
                                 {...field}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/advisor-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/advisor-fields.tsx
@@ -20,7 +20,7 @@
 import { UseFormReturn } from 'react-hook-form';
 
 import { PreconfiguredPluginDescriptor } from '@/api';
-import { MultiSelectField } from '@/components/form/multi-select-field';
+import { PluginMultiSelectField } from '@/components/form/plugin-multi-select-field.tsx';
 import {
   AccordionContent,
   AccordionItem,
@@ -51,12 +51,6 @@ export const AdvisorFields = ({
   advisorPlugins,
   isSuperuser,
 }: AdvisorFieldsProps) => {
-  const advisorOptions = advisorPlugins.map((plugin) => ({
-    id: plugin.id,
-    label: plugin.displayName,
-    description: plugin.description,
-  }));
-
   return (
     <div className='flex flex-row align-middle'>
       <FormField
@@ -96,12 +90,13 @@ export const AdvisorFields = ({
               </FormItem>
             )}
           />
-          <MultiSelectField
+          <PluginMultiSelectField
             form={form}
             name='jobConfigs.advisor.advisors'
+            configName='jobConfigs.advisor.config'
             label='Enabled advisors'
             description={<>Select the advisors enabled for this run.</>}
-            options={advisorOptions}
+            plugins={advisorPlugins}
           />
           {isSuperuser && (
             <FormField

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/advisor-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/advisor-fields.tsx
@@ -19,7 +19,7 @@
 
 import { UseFormReturn } from 'react-hook-form';
 
-import { PreconfiguredPluginDescriptor } from '@/api';
+import { PreconfiguredPluginDescriptor, Secret } from '@/api';
 import { PluginMultiSelectField } from '@/components/form/plugin-multi-select-field.tsx';
 import {
   AccordionContent,
@@ -41,6 +41,7 @@ type AdvisorFieldsProps = {
   value: string;
   onToggle: () => void;
   advisorPlugins: PreconfiguredPluginDescriptor[];
+  secrets: Secret[];
   isSuperuser: boolean;
 };
 
@@ -49,6 +50,7 @@ export const AdvisorFields = ({
   value,
   onToggle,
   advisorPlugins,
+  secrets,
   isSuperuser,
 }: AdvisorFieldsProps) => {
   return (
@@ -97,6 +99,7 @@ export const AdvisorFields = ({
             label='Enabled advisors'
             description={<>Select the advisors enabled for this run.</>}
             plugins={advisorPlugins}
+            secrets={secrets}
           />
           {isSuperuser && (
             <FormField

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
@@ -18,13 +18,16 @@
  */
 
 import { FieldErrors } from 'react-hook-form';
-import { z } from 'zod';
+import { z, ZodType } from 'zod';
 
 import {
   AnalyzerJobConfiguration,
   InfrastructureService,
   OrtRun,
+  PluginConfig,
+  PluginOptionType,
   PostRepositoryRun,
+  PreconfiguredPluginDescriptor,
   ReporterJobConfiguration,
 } from '@/api';
 import { zInfrastructureService } from '@/api/zod.gen';
@@ -62,7 +65,62 @@ const environmentVariableSchema = z.object({
   value: z.string().min(1).nullable().optional(),
 });
 
-export const createRunFormSchema = () => {
+function optionTypeToZodType(type: PluginOptionType): ZodType {
+  switch (type) {
+    case 'BOOLEAN':
+      return z.boolean();
+    case 'INTEGER':
+      return z.coerce.string();
+    case 'LONG':
+      return z.coerce.string();
+    case 'SECRET':
+      return z.string();
+    case 'STRING':
+      return z.string();
+    case 'STRING_LIST':
+      return z.array(z.string());
+    default:
+      throw new Error(`Unsupported option type: ${type}`);
+  }
+}
+
+const createPluginConfigSchema = (plugin: PreconfiguredPluginDescriptor) => {
+  const optionsSchema: Record<string, z.ZodTypeAny> = {};
+  const secretsSchema: Record<string, z.ZodTypeAny> = {};
+
+  plugin.options?.forEach((option) => {
+    let schema = optionTypeToZodType(option.type);
+    if (option.isNullable) {
+      schema = schema.nullable();
+    }
+    if (!option.isRequired) {
+      schema = schema.optional();
+    }
+
+    if (option.type == 'SECRET') {
+      secretsSchema[option.name] = schema;
+    } else {
+      optionsSchema[option.name] = schema;
+    }
+  });
+
+  return z
+    .object({
+      options: z.object(optionsSchema).optional(),
+      secrets: z.object(secretsSchema).optional(),
+    })
+    .optional();
+};
+
+export const createRunFormSchema = (
+  advisorPlugins: PreconfiguredPluginDescriptor[]
+) => {
+  const advisorConfigSchema: Record<string, z.ZodTypeAny> = {};
+
+  advisorPlugins.forEach((plugin) => {
+    advisorConfigSchema[plugin.id] = createPluginConfigSchema(plugin);
+  });
+
   return z.object({
     revision: z.string(),
     path: z.string(),
@@ -118,6 +176,7 @@ export const createRunFormSchema = () => {
         skipExcluded: z.boolean(),
         keepAliveWorker: z.boolean(),
         advisors: z.array(z.string()),
+        config: z.object(advisorConfigSchema).optional(),
       }),
       scanner: z.object({
         enabled: z.boolean(),
@@ -430,6 +489,9 @@ export function defaultValues(
             advisors:
               ortRun.jobConfigs.advisor?.advisors ||
               baseDefaults.jobConfigs.advisor.advisors,
+            config: ortRun.jobConfigs.advisor?.config as
+              | Record<string, unknown>
+              | undefined,
             keepAliveWorker:
               (ortRun.jobConfigs.advisor?.keepAliveWorker && isSuperuser) ||
               baseDefaults.jobConfigs.advisor.keepAliveWorker,
@@ -629,10 +691,70 @@ export function formValuesToPayload(
   // Advisor configuration
   //
 
+  function createAdvisorPluginConfig(
+    config: Record<string, unknown> | undefined,
+    advisors: string[]
+  ): { [key: string]: PluginConfig } | undefined {
+    if (!config) return undefined;
+
+    const filtered = Object.fromEntries(
+      Object.entries(config)
+        .filter(([key]) => advisors.includes(key))
+        .map(([key, value]) => {
+          if (value && typeof value === 'object') {
+            const pluginConfig = value as Record<string, unknown>;
+            const convertedConfig: PluginConfig = {
+              options: {},
+              secrets: {},
+            };
+
+            if (
+              pluginConfig.options &&
+              typeof pluginConfig.options === 'object'
+            ) {
+              convertedConfig.options = Object.fromEntries(
+                Object.entries(pluginConfig.options as Record<string, unknown>)
+                  .filter(
+                    ([, optValue]) =>
+                      optValue !== undefined && optValue !== null
+                  )
+                  .map(([optKey, optValue]) => [optKey, String(optValue)])
+              );
+            }
+
+            if (
+              pluginConfig.secrets &&
+              typeof pluginConfig.secrets === 'object'
+            ) {
+              convertedConfig.secrets = Object.fromEntries(
+                Object.entries(pluginConfig.secrets as Record<string, unknown>)
+                  .filter(
+                    ([, secValue]) =>
+                      secValue !== undefined && secValue !== null
+                  )
+                  .map(([secKey, secValue]) => [secKey, String(secValue)])
+              );
+            }
+
+            return [key, convertedConfig];
+          }
+          return [key, value];
+        })
+    );
+
+    return Object.keys(filtered).length > 0
+      ? (filtered as { [key: string]: PluginConfig })
+      : undefined;
+  }
+
   const advisorConfig = values.jobConfigs.advisor.enabled
     ? {
         skipExcluded: values.jobConfigs.advisor.skipExcluded,
         advisors: values.jobConfigs.advisor.advisors,
+        config: createAdvisorPluginConfig(
+          values.jobConfigs.advisor.config,
+          values.jobConfigs.advisor.advisors
+        ),
         keepAliveWorker: values.jobConfigs.advisor.keepAliveWorker || undefined,
       }
     : undefined;

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
@@ -62,95 +62,99 @@ const environmentVariableSchema = z.object({
   value: z.string().min(1).nullable().optional(),
 });
 
-export const createRunFormSchema = z.object({
-  revision: z.string(),
-  path: z.string(),
-  jobConfigs: z.object({
-    analyzer: z.object({
-      enabled: z.boolean(),
-      repositoryConfigPath: z.string().optional(),
-      allowDynamicVersions: z.boolean(),
-      skipExcluded: z.boolean(),
-      environmentDefinitionsEnabled: z.boolean(),
-      environmentDefinitions: environmentDefinitionsSchema.optional(),
-      environmentVariables: z.array(environmentVariableSchema).optional(),
-      infrastructureServices: z.array(zInfrastructureService).optional(),
-      keepAliveWorker: z.boolean(),
-      packageManagers: z
-        .object({
-          Bazel: packageManagerOptionsSchema,
-          Bower: packageManagerOptionsSchema,
-          Bundler: packageManagerOptionsSchema,
-          Cargo: packageManagerOptionsSchema,
-          Carthage: packageManagerOptionsSchema,
-          CocoaPods: packageManagerOptionsSchema,
-          Composer: packageManagerOptionsSchema,
-          Conan: packageManagerOptionsSchema,
-          Gleam: packageManagerOptionsSchema,
-          GoMod: packageManagerOptionsSchema,
-          Gradle: packageManagerOptionsSchema,
-          GradleInspector: packageManagerOptionsSchema,
-          Maven: packageManagerOptionsSchema,
-          NPM: packageManagerOptionsSchema,
-          NuGet: packageManagerOptionsSchema,
-          PIP: packageManagerOptionsSchema,
-          Pipenv: packageManagerOptionsSchema,
-          PNPM: packageManagerOptionsSchema,
-          Poetry: packageManagerOptionsSchema,
-          Pub: packageManagerOptionsSchema,
-          SBT: packageManagerOptionsSchema,
-          SPDX: packageManagerOptionsSchema,
-          SpdxDocumentFile: packageManagerOptionsSchema,
-          Stack: packageManagerOptionsSchema,
-          SwiftPM: packageManagerOptionsSchema,
-          Tycho: packageManagerOptionsSchema,
-          Yarn: packageManagerOptionsSchema,
-          Yarn2: packageManagerOptionsSchema,
-        })
-        .refine((schema) => {
-          // Ensure that not both Gradle and GradleInspector are enabled at the same time.
-          return !(schema.Gradle.enabled && schema.GradleInspector.enabled);
-        }, '"Gradle Legacy" and "Gradle" cannot be enabled at the same time.'),
-    }),
-    advisor: z.object({
-      enabled: z.boolean(),
-      skipExcluded: z.boolean(),
-      keepAliveWorker: z.boolean(),
-      advisors: z.array(z.string()),
-    }),
-    scanner: z.object({
-      enabled: z.boolean(),
-      skipConcluded: z.boolean(),
-      skipExcluded: z.boolean(),
-      keepAliveWorker: z.boolean(),
-    }),
-    evaluator: z.object({
-      enabled: z.boolean(),
+export const createRunFormSchema = () => {
+  return z.object({
+    revision: z.string(),
+    path: z.string(),
+    jobConfigs: z.object({
+      analyzer: z.object({
+        enabled: z.boolean(),
+        repositoryConfigPath: z.string().optional(),
+        allowDynamicVersions: z.boolean(),
+        skipExcluded: z.boolean(),
+        environmentDefinitionsEnabled: z.boolean(),
+        environmentDefinitions: environmentDefinitionsSchema.optional(),
+        environmentVariables: z.array(environmentVariableSchema).optional(),
+        infrastructureServices: z.array(zInfrastructureService).optional(),
+        keepAliveWorker: z.boolean(),
+        packageManagers: z
+          .object({
+            Bazel: packageManagerOptionsSchema,
+            Bower: packageManagerOptionsSchema,
+            Bundler: packageManagerOptionsSchema,
+            Cargo: packageManagerOptionsSchema,
+            Carthage: packageManagerOptionsSchema,
+            CocoaPods: packageManagerOptionsSchema,
+            Composer: packageManagerOptionsSchema,
+            Conan: packageManagerOptionsSchema,
+            Gleam: packageManagerOptionsSchema,
+            GoMod: packageManagerOptionsSchema,
+            Gradle: packageManagerOptionsSchema,
+            GradleInspector: packageManagerOptionsSchema,
+            Maven: packageManagerOptionsSchema,
+            NPM: packageManagerOptionsSchema,
+            NuGet: packageManagerOptionsSchema,
+            PIP: packageManagerOptionsSchema,
+            Pipenv: packageManagerOptionsSchema,
+            PNPM: packageManagerOptionsSchema,
+            Poetry: packageManagerOptionsSchema,
+            Pub: packageManagerOptionsSchema,
+            SBT: packageManagerOptionsSchema,
+            SPDX: packageManagerOptionsSchema,
+            SpdxDocumentFile: packageManagerOptionsSchema,
+            Stack: packageManagerOptionsSchema,
+            SwiftPM: packageManagerOptionsSchema,
+            Tycho: packageManagerOptionsSchema,
+            Yarn: packageManagerOptionsSchema,
+            Yarn2: packageManagerOptionsSchema,
+          })
+          .refine((schema) => {
+            // Ensure that not both Gradle and GradleInspector are enabled at the same time.
+            return !(schema.Gradle.enabled && schema.GradleInspector.enabled);
+          }, '"Gradle Legacy" and "Gradle" cannot be enabled at the same time.'),
+      }),
+      advisor: z.object({
+        enabled: z.boolean(),
+        skipExcluded: z.boolean(),
+        keepAliveWorker: z.boolean(),
+        advisors: z.array(z.string()),
+      }),
+      scanner: z.object({
+        enabled: z.boolean(),
+        skipConcluded: z.boolean(),
+        skipExcluded: z.boolean(),
+        keepAliveWorker: z.boolean(),
+      }),
+      evaluator: z.object({
+        enabled: z.boolean(),
+        ruleSet: z.string().optional(),
+        licenseClassificationsFile: z.string().optional(),
+        copyrightGarbageFile: z.string().optional(),
+        resolutionsFile: z.string().optional(),
+        keepAliveWorker: z.boolean(),
+      }),
+      reporter: z.object({
+        enabled: z.boolean(),
+        formats: z.array(z.string()),
+        deduplicateDependencyTree: z.boolean().optional(),
+        keepAliveWorker: z.boolean(),
+      }),
+      notifier: z.object({
+        enabled: z.boolean(),
+        recipientAddresses: z.array(z.object({ email: z.string() })).optional(),
+        keepAliveWorker: z.boolean(),
+      }),
+      parameters: z.array(keyValueSchema).optional(),
       ruleSet: z.string().optional(),
-      licenseClassificationsFile: z.string().optional(),
-      copyrightGarbageFile: z.string().optional(),
-      resolutionsFile: z.string().optional(),
-      keepAliveWorker: z.boolean(),
     }),
-    reporter: z.object({
-      enabled: z.boolean(),
-      formats: z.array(z.string()),
-      deduplicateDependencyTree: z.boolean().optional(),
-      keepAliveWorker: z.boolean(),
-    }),
-    notifier: z.object({
-      enabled: z.boolean(),
-      recipientAddresses: z.array(z.object({ email: z.string() })).optional(),
-      keepAliveWorker: z.boolean(),
-    }),
-    parameters: z.array(keyValueSchema).optional(),
-    ruleSet: z.string().optional(),
-  }),
-  labels: z.array(keyValueSchema).optional(),
-  jobConfigContext: z.string().optional(),
-});
+    labels: z.array(keyValueSchema).optional(),
+    jobConfigContext: z.string().optional(),
+  });
+};
 
-export type CreateRunFormValues = z.infer<typeof createRunFormSchema>;
+export type CreateRunFormValues = z.infer<
+  ReturnType<typeof createRunFormSchema>
+>;
 
 /**
  * Converts an object map coming from the back-end to an array of key-value pairs.
@@ -239,7 +243,7 @@ export const flattenErrors = (
 export function defaultValues(
   ortRun: OrtRun | null,
   isSuperuser: boolean
-): z.infer<typeof createRunFormSchema> {
+): z.infer<ReturnType<typeof createRunFormSchema>> {
   /**
    * Constructs the default options for a package manager, either as a blank set of options
    * or from an earlier ORT run if rerun functionality is used.
@@ -500,7 +504,7 @@ export function defaultValues(
  * to the API. This function converts form values to correct payload to create an ORT run.
  */
 export function formValuesToPayload(
-  values: z.infer<typeof createRunFormSchema>
+  values: z.infer<ReturnType<typeof createRunFormSchema>>
 ): PostRepositoryRun {
   /**
    * A helper function to get the enabled package managers from the form values.

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
@@ -296,11 +296,49 @@ export const flattenErrors = (
 };
 
 /**
+ * Merge the plugin configs from the last run with the default plugin configs. The configs from the last run take
+ * precedence.
+ */
+function mergePluginConfigs(
+  lastRunConfig: { [p: string]: PluginConfig } | null | undefined,
+  defaultConfig: Record<string, PluginConfig>
+): Record<string, PluginConfig> {
+  const merged: Record<string, PluginConfig> = {};
+
+  for (const pluginId of Object.keys(defaultConfig)) {
+    const defaultPlugin = defaultConfig[pluginId];
+    const ortPlugin = lastRunConfig?.[pluginId];
+
+    merged[pluginId] = {
+      options: {
+        ...(defaultPlugin?.options ?? {}),
+        ...(ortPlugin?.options ?? {}),
+      },
+      secrets: {
+        ...(defaultPlugin?.secrets ?? {}),
+        ...(ortPlugin?.secrets ?? {}),
+      },
+    };
+  }
+
+  if (lastRunConfig) {
+    for (const pluginId of Object.keys(lastRunConfig)) {
+      if (!merged[pluginId] && lastRunConfig[pluginId]) {
+        merged[pluginId] = lastRunConfig[pluginId];
+      }
+    }
+  }
+
+  return merged;
+}
+
+/**
  * Get the default values for the create run form. The form can be provided with a previously run
  * ORT run, in which case the values from it are used as defaults. Otherwise uses base defaults.
  */
 export function defaultValues(
   ortRun: OrtRun | null,
+  advisorPlugins: PreconfiguredPluginDescriptor[],
   isSuperuser: boolean
 ): z.infer<ReturnType<typeof createRunFormSchema>> {
   /**
@@ -348,6 +386,27 @@ export function defaultValues(
         return config?.options?.deduplicateDependencyTree === 'true';
       })
     : false;
+
+  const advisorDefaultConfig = advisorPlugins.reduce(
+    (acc, plugin) => {
+      const options: Record<string, string> = {};
+      const secrets: Record<string, string> = {};
+
+      plugin.options?.forEach((option) => {
+        if (option.defaultValue !== undefined) {
+          if (option.type === 'SECRET') {
+            secrets[option.name] = String(option.defaultValue);
+          } else {
+            options[option.name] = String(option.defaultValue);
+          }
+        }
+      });
+
+      acc[plugin.id] = { options: options, secrets: secrets };
+      return acc;
+    },
+    {} as Record<string, PluginConfig>
+  );
 
   // Default values for the form: edit only these, not the defaultValues object.
   const baseDefaults = {
@@ -398,6 +457,7 @@ export function defaultValues(
         enabled: true,
         skipExcluded: true,
         advisors: ['OSV', 'VulnerableCode'],
+        config: advisorDefaultConfig,
         keepAliveWorker: false,
       },
       scanner: {
@@ -489,9 +549,10 @@ export function defaultValues(
             advisors:
               ortRun.jobConfigs.advisor?.advisors ||
               baseDefaults.jobConfigs.advisor.advisors,
-            config: ortRun.jobConfigs.advisor?.config as
-              | Record<string, unknown>
-              | undefined,
+            config: mergePluginConfigs(
+              ortRun?.jobConfigs?.advisor?.config,
+              advisorDefaultConfig
+            ),
             keepAliveWorker:
               (ortRun.jobConfigs.advisor?.keepAliveWorker && isSuperuser) ||
               baseDefaults.jobConfigs.advisor.keepAliveWorker,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -122,8 +122,10 @@ const CreateRunPage = () => {
     },
   });
 
-  const form = useForm({
-    resolver: zodResolver(createRunFormSchema),
+  const formSchema = createRunFormSchema();
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
     defaultValues: defaultValues(ortRun?.data ?? null, isSuperuser),
   });
 

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -122,7 +122,7 @@ const CreateRunPage = () => {
     },
   });
 
-  const formSchema = createRunFormSchema();
+  const formSchema = createRunFormSchema(advisorPlugins);
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -126,7 +126,11 @@ const CreateRunPage = () => {
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
-    defaultValues: defaultValues(ortRun?.data ?? null, isSuperuser),
+    defaultValues: defaultValues(
+      ortRun?.data ?? null,
+      advisorPlugins,
+      isSuperuser
+    ),
   });
 
   const watchedValues = form.watch();

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -26,7 +26,11 @@ import { useFieldArray, useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import { postRepositoryRunMutation } from '@/api/@tanstack/react-query.gen';
-import { getPluginsForRepository, getRepositoryRun } from '@/api/sdk.gen';
+import {
+  getAvailableRepositorySecrets,
+  getPluginsForRepository,
+  getRepositoryRun,
+} from '@/api/sdk.gen';
 import { CopyToClipboard } from '@/components/copy-to-clipboard';
 import { InlineCode } from '@/components/typography.tsx';
 import { Accordion } from '@/components/ui/accordion';
@@ -71,7 +75,7 @@ import {
 const CreateRunPage = () => {
   const navigate = useNavigate();
   const params = Route.useParams();
-  const { ortRun, plugins } = Route.useLoaderData();
+  const { ortRun, plugins, secrets } = Route.useLoaderData();
   const [isTest, setIsTest] = useState(false);
   const isSuperuser = useUser().isSuperuser || false;
   const permissions = Route.useRouteContext().permissions;
@@ -432,6 +436,7 @@ const CreateRunPage = () => {
                 value='advisor'
                 onToggle={() => toggleAccordionOpen('advisor')}
                 advisorPlugins={advisorPlugins}
+                secrets={secrets.data || []}
                 isSuperuser={isSuperuser}
               />
               <ScannerFields
@@ -547,7 +552,7 @@ export const Route = createFileRoute(
   // the query will not be run. This corresponds to the "New run" case, where a new
   // ORT Run is created from scratch, using all defaults.
   loader: async ({ params, deps: { rerunIndex } }) => {
-    const [ortRun, plugins] = await Promise.all([
+    const [ortRun, plugins, secrets] = await Promise.all([
       rerunIndex !== undefined
         ? getRepositoryRun({
             path: {
@@ -561,11 +566,17 @@ export const Route = createFileRoute(
           repositoryId: Number.parseInt(params.repoId),
         },
       }),
+      getAvailableRepositorySecrets({
+        path: {
+          repositoryId: Number.parseInt(params.repoId),
+        },
+      }),
     ]);
 
     return {
       ortRun,
       plugins,
+      secrets,
     };
   },
   component: CreateRunPage,


### PR DESCRIPTION
Add support for configuring plugin options for advisor plugins in the UI.
The forms are generated from the plugin descriptors and take default values and plugin config templates into account.

This is based on #3251, support for other plugin types will be added in follow-up commits.

Example for advisor plugins:

<img width="1069" height="1072" alt="image" src="https://github.com/user-attachments/assets/b98f15cb-964b-4475-ac6d-f785b73ff50a" />

This is a first version that will help to identify required improvements and missing functionality.