### PR TITLE
Filter packages table by dependency type

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
@@ -842,7 +842,8 @@ fun ApiPackageFilters.mapToModel(): PackageFilters =
     PackageFilters(
         identifier = identifier?.mapToModel { it },
         purl = purl?.mapToModel { it },
-        processedDeclaredLicense = processedDeclaredLicense?.mapToModel { it }
+        processedDeclaredLicense = processedDeclaredLicense?.mapToModel { it },
+        isDirectDependency = isDirectDependency
     )
 
 fun ApiRuleViolationFilters.mapToModel(): RuleViolationFilters = RuleViolationFilters(resolved = resolved)

--- a/api/v1/model/src/commonMain/kotlin/Package.kt
+++ b/api/v1/model/src/commonMain/kotlin/Package.kt
@@ -55,5 +55,8 @@ data class PackageFilters(
     val purl: FilterOperatorAndValue<String>? = null,
 
     /** Set of SPDX license expressions to filter with. Null if not set. */
-    val processedDeclaredLicense: FilterOperatorAndValue<Set<String>>? = null
+    val processedDeclaredLicense: FilterOperatorAndValue<Set<String>>? = null,
+
+    /** Filter by dependency type. True = direct, false = transitive, null = all. */
+    val isDirectDependency: Boolean? = null
 )

--- a/core/src/main/kotlin/api/RunsRoute.kt
+++ b/core/src/main/kotlin/api/RunsRoute.kt
@@ -524,7 +524,8 @@ private fun ApplicationCall.packageFilters(): PackageFilters =
     PackageFilters(
         identifier = parameters["identifier"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) },
         purl = parameters["purl"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) },
-        processedDeclaredLicense = processedDeclaredLicense()
+        processedDeclaredLicense = processedDeclaredLicense(),
+        isDirectDependency = parameters["isDirectDependency"]?.lowercase()?.toBooleanStrictOrNull()
     )
 
 /**

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -492,6 +492,11 @@ val getRunPackages: RouteConfig.() -> Unit = {
                     "license expressions, e.g. '-,MIT'."
         }
 
+        queryParameter<Boolean>("isDirectDependency") {
+            description = "Filter packages by dependency type. true = direct, false = transitive, omit for all."
+            required = false
+        }
+
         standardListQueryParameters()
     }
 
@@ -575,7 +580,8 @@ val getRunPackages: RouteConfig.() -> Unit = {
                             processedDeclaredLicense = FilterOperatorAndValue(
                                 operator = ComparisonOperator.IN,
                                 value = setOf("Apache-2.0")
-                            )
+                            ),
+                            isDirectDependency = true
                         )
                     )
                 }

--- a/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
@@ -28,6 +28,7 @@ import io.kotest.engine.spec.tempdir
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.shouldBeSingleton
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.file.aFile
@@ -1350,6 +1351,116 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     ),
                     identifier = FilterOperatorAndValue(ComparisonOperator.ILIKE, "example3")
                 )
+            }
+        }
+
+        "allow filtering by direct dependencies" {
+            integrationTestApplication {
+                val ortRun = dbExtension.fixtures.createOrtRun(
+                    repositoryId = repositoryId,
+                    revision = "revision",
+                    jobConfigurations = JobConfigurations()
+                )
+
+                val analyzerJob = dbExtension.fixtures.createAnalyzerJob(
+                    ortRunId = ortRun.id,
+                    configuration = AnalyzerJobConfiguration()
+                )
+
+                val identifier1 = Identifier("Maven", "com.example", "example", "1.0")
+                val identifier2 = Identifier("Maven", "com.example", "example2", "1.0")
+
+                val project = dbExtension.fixtures.getProject()
+
+                dbExtension.fixtures.createAnalyzerRun(
+                    analyzerJobId = analyzerJob.id,
+                    projects = setOf(project),
+                    packages = setOf(
+                        dbExtension.fixtures.generatePackage(identifier1),
+                        dbExtension.fixtures.generatePackage(identifier2)
+                    ),
+                    issues = emptyList(),
+                    dependencyGraphs = emptyMap(),
+                    shortestDependencyPaths = mapOf(
+                        identifier1 to listOf(
+                            ShortestDependencyPath(
+                                project.identifier,
+                                "compileClassPath",
+                                emptyList()
+                            )
+                        ),
+                        identifier2 to listOf(
+                            ShortestDependencyPath(
+                                project.identifier,
+                                "compileClassPath",
+                                listOf(identifier1)
+                            )
+                        )
+                    )
+                )
+
+                val response = superuserClient.get("/api/v1/runs/${ortRun.id}/packages?isDirectDependency=true")
+
+                response shouldHaveStatus HttpStatusCode.OK
+                val packages = response.body<PagedSearchResponse<ApiPackage, PackageFilters>>()
+
+                packages.data.map { it.identifier } shouldContainExactly listOf(identifier1.mapToApi())
+                packages.filters shouldBe PackageFilters(isDirectDependency = true)
+            }
+        }
+
+        "allow filtering by transitive dependencies" {
+            integrationTestApplication {
+                val ortRun = dbExtension.fixtures.createOrtRun(
+                    repositoryId = repositoryId,
+                    revision = "revision",
+                    jobConfigurations = JobConfigurations()
+                )
+
+                val analyzerJob = dbExtension.fixtures.createAnalyzerJob(
+                    ortRunId = ortRun.id,
+                    configuration = AnalyzerJobConfiguration()
+                )
+
+                val identifier1 = Identifier("Maven", "com.example", "example", "1.0")
+                val identifier2 = Identifier("Maven", "com.example", "example2", "1.0")
+
+                val project = dbExtension.fixtures.getProject()
+
+                dbExtension.fixtures.createAnalyzerRun(
+                    analyzerJobId = analyzerJob.id,
+                    projects = setOf(project),
+                    packages = setOf(
+                        dbExtension.fixtures.generatePackage(identifier1),
+                        dbExtension.fixtures.generatePackage(identifier2)
+                    ),
+                    issues = emptyList(),
+                    dependencyGraphs = emptyMap(),
+                    shortestDependencyPaths = mapOf(
+                        identifier1 to listOf(
+                            ShortestDependencyPath(
+                                project.identifier,
+                                "compileClassPath",
+                                emptyList()
+                            )
+                        ),
+                        identifier2 to listOf(
+                            ShortestDependencyPath(
+                                project.identifier,
+                                "compileClassPath",
+                                listOf(identifier1)
+                            )
+                        )
+                    )
+                )
+
+                val response = superuserClient.get("/api/v1/runs/${ortRun.id}/packages?isDirectDependency=false")
+
+                response shouldHaveStatus HttpStatusCode.OK
+                val packages = response.body<PagedSearchResponse<ApiPackage, PackageFilters>>()
+
+                packages.data.map { it.identifier } shouldContainExactly listOf(identifier2.mapToApi())
+                packages.filters shouldBe PackageFilters(isDirectDependency = false)
             }
         }
 

--- a/model/src/commonMain/kotlin/runs/Package.kt
+++ b/model/src/commonMain/kotlin/runs/Package.kt
@@ -52,5 +52,8 @@ data class PackageFilters(
     val purl: FilterOperatorAndValue<String>? = null,
 
     /** Set of SPDX license expressions to filter with. Null if not set. */
-    val processedDeclaredLicense: FilterOperatorAndValue<Set<String>>? = null
+    val processedDeclaredLicense: FilterOperatorAndValue<Set<String>>? = null,
+
+    /** Filter by dependency type. True = direct, false = transitive, null = all. */
+    val isDirectDependency: Boolean? = null
 )

--- a/services/ort-run/src/main/kotlin/PackageService.kt
+++ b/services/ort-run/src/main/kotlin/PackageService.kt
@@ -46,8 +46,11 @@ import org.jetbrains.exposed.v1.core.Count
 import org.jetbrains.exposed.v1.core.CustomFunction
 import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.TextColumnType
+import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.core.inSubQuery
+import org.jetbrains.exposed.v1.core.not
 import org.jetbrains.exposed.v1.core.notInList
 import org.jetbrains.exposed.v1.core.stringLiteral
 import org.jetbrains.exposed.v1.jdbc.Database
@@ -115,6 +118,26 @@ class PackageService(private val db: Database, private val ortRunService: OrtRun
                         query.andWhere { ProcessedDeclaredLicensesTable.spdxExpression notInList filter.value }
 
                     else -> {}
+                }
+            }
+
+            filters.isDirectDependency?.let { filter ->
+                 // The subquery keeps the existing query shape unchanged and applies the new filter as an
+                 // existence check, rather than joining a one-to-many-per-package table into the main query,
+                 // because extending the main join tree would duplicate package rows and make counting,
+                 // pagination, and sorting more fragile.
+                val directPackageIdsSubquery = ShortestDependencyPathsTable
+                    .innerJoin(AnalyzerRunsTable)
+                    .innerJoin(AnalyzerJobsTable)
+                    .select(ShortestDependencyPathsTable.packageId)
+                    .where {
+                        (AnalyzerJobsTable.ortRunId eq ortRunId) and
+                            (ShortestDependencyPathsTable.path eq emptyList())
+                    }
+
+                when (filter) {
+                    true -> query.andWhere { PackagesTable.id inSubQuery directPackageIdsSubquery }
+                    false -> query.andWhere { not(PackagesTable.id inSubQuery directPackageIdsSubquery) }
                 }
             }
 

--- a/services/ort-run/src/test/kotlin/PackageServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/PackageServiceTest.kt
@@ -59,6 +59,7 @@ import org.eclipse.apoapsis.ortserver.model.util.OrderField
 
 import org.jetbrains.exposed.v1.jdbc.Database
 
+@Suppress("LargeClass")
 class PackageServiceTest : WordSpec() {
     private val dbExtension = extension(DatabaseTestExtension())
 
@@ -509,6 +510,104 @@ class PackageServiceTest : WordSpec() {
                     identifier shouldBe Identifier("NPM", "com.example", "example2", "1.0").mapToApi()
                     processedDeclaredLicense.spdxExpression shouldBe "MIT"
                 }
+            }
+
+            "allow filtering by direct dependencies" {
+                val project = fixtures.getProject()
+                val directIdentifier = Identifier("Maven", "com.example", "direct", "1.0")
+                val transitiveIdentifier = Identifier("Maven", "com.example", "transitive", "1.0")
+
+                val ortRunId = createAnalyzerRunWithPackages(
+                    projects = setOf(project),
+                    packages = setOf(
+                        fixtures.generatePackage(directIdentifier),
+                        fixtures.generatePackage(transitiveIdentifier)
+                    ),
+                    shortestPaths = mapOf(
+                        directIdentifier to listOf(
+                            ShortestDependencyPath(project.identifier, "compileClasspath", emptyList())
+                        ),
+                        transitiveIdentifier to listOf(
+                            ShortestDependencyPath(project.identifier, "compileClasspath", listOf(directIdentifier))
+                        )
+                    )
+                ).id
+
+                val results = service.listForOrtRunId(
+                    ortRunId,
+                    filters = PackageFilters(isDirectDependency = true)
+                )
+
+                results.totalCount shouldBe 1
+                results.data.shouldBeSingleton {
+                    it.identifier shouldBe directIdentifier.mapToApi()
+                }
+            }
+
+            "allow filtering by transitive dependencies" {
+                val project = fixtures.getProject()
+                val directIdentifier = Identifier("Maven", "com.example", "direct", "1.0")
+                val transitiveIdentifier = Identifier("Maven", "com.example", "transitive", "1.0")
+
+                val ortRunId = createAnalyzerRunWithPackages(
+                    projects = setOf(project),
+                    packages = setOf(
+                        fixtures.generatePackage(directIdentifier),
+                        fixtures.generatePackage(transitiveIdentifier)
+                    ),
+                    shortestPaths = mapOf(
+                        directIdentifier to listOf(
+                            ShortestDependencyPath(project.identifier, "compileClasspath", emptyList())
+                        ),
+                        transitiveIdentifier to listOf(
+                            ShortestDependencyPath(project.identifier, "compileClasspath", listOf(directIdentifier))
+                        )
+                    )
+                ).id
+
+                val results = service.listForOrtRunId(
+                    ortRunId,
+                    filters = PackageFilters(isDirectDependency = false)
+                )
+
+                results.totalCount shouldBe 1
+                results.data.shouldBeSingleton {
+                    it.identifier shouldBe transitiveIdentifier.mapToApi()
+                }
+            }
+
+            "not change results when isDirectDependency is null" {
+                val project = fixtures.getProject()
+                val directIdentifier = Identifier("Maven", "com.example", "direct", "1.0")
+                val transitiveIdentifier = Identifier("Maven", "com.example", "transitive", "1.0")
+
+                val ortRunId = createAnalyzerRunWithPackages(
+                    projects = setOf(project),
+                    packages = setOf(
+                        fixtures.generatePackage(directIdentifier),
+                        fixtures.generatePackage(transitiveIdentifier)
+                    ),
+                    shortestPaths = mapOf(
+                        directIdentifier to listOf(
+                            ShortestDependencyPath(project.identifier, "compileClasspath", emptyList())
+                        ),
+                        transitiveIdentifier to listOf(
+                            ShortestDependencyPath(project.identifier, "compileClasspath", listOf(directIdentifier))
+                        )
+                    )
+                ).id
+
+                val results = service.listForOrtRunId(
+                    ortRunId,
+                    ListQueryParameters(listOf(OrderField("identifier", OrderDirection.ASCENDING))),
+                    PackageFilters(isDirectDependency = null)
+                )
+
+                results.totalCount shouldBe 2
+                results.data.map { it.identifier.mapToModel() } shouldContainInOrder listOf(
+                    directIdentifier,
+                    transitiveIdentifier
+                )
             }
 
             "apply curations and include applied curations" {

--- a/ui/src/@types/@tanstack/react-table.d.ts
+++ b/ui/src/@types/@tanstack/react-table.d.ts
@@ -55,6 +55,21 @@ declare module '@tanstack/react-table' {
     align?: 'start' | 'end' | 'center';
   };
 
+  type SingleSelectFilter<TValue> = {
+    filterVariant: 'single-select';
+    selectOptions: {
+      label: string;
+      value: TValue;
+      icon?: React.ComponentType<{ className?: string }>;
+    }[];
+    setSelected: (selected: TValue | undefined) => void;
+    align?: 'start' | 'end' | 'center';
+  };
+
   // Define the Filter type as a union of the filter variants
-  type Filter = TextFilter | SelectFilter<TValue>;
+  type Filter =
+    | TextFilter
+    | RegexFilter
+    | SelectFilter<TValue>
+    | SingleSelectFilter<TValue>;
 }

--- a/ui/src/components/data-table/data-table-filter.tsx
+++ b/ui/src/components/data-table/data-table-filter.tsx
@@ -21,11 +21,13 @@ import {
   Column,
   RegexFilter,
   SelectFilter,
+  SingleSelectFilter,
   TextFilter,
 } from '@tanstack/react-table';
 
 import { FilterMultiSelect } from '@/components/data-table/filter-multi-select';
 import { FilterRegex } from '@/components/data-table/filter-regex';
+import { FilterSingleSelect } from '@/components/data-table/filter-single-select';
 import { FilterText } from '@/components/data-table/filter-text';
 
 interface DataTableFilterProps<TData, TValue> {
@@ -79,6 +81,23 @@ export function DataTableFilter<TData, TValue>({
         showTitle={showTitle}
         options={selectOptions}
         selected={(columnFilterValue as TValue[]) ?? []}
+        setSelected={setSelected}
+        align={align}
+      />
+    );
+  }
+
+  if (filterVariant === 'single-select') {
+    const { selectOptions, setSelected } = column.columnDef.meta
+      ?.filter as SingleSelectFilter<TValue>;
+    const align = column.columnDef.meta?.filter?.align;
+
+    return (
+      <FilterSingleSelect
+        title={title}
+        showTitle={showTitle}
+        options={selectOptions}
+        selected={columnFilterValue as TValue | undefined}
         setSelected={setSelected}
         align={align}
       />

--- a/ui/src/components/data-table/filter-single-select.tsx
+++ b/ui/src/components/data-table/filter-single-select.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { Filter } from 'lucide-react';
+import * as React from 'react';
+
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group';
+import { cn } from '@/lib/utils';
+
+interface FilterSingleSelectProps<TValue> {
+  title?: string;
+  showTitle?: boolean;
+  options: {
+    label: string;
+    value: TValue;
+    icon?: React.ComponentType<{ className?: string }>;
+  }[];
+  selected?: TValue;
+  setSelected: (selected: TValue | undefined) => void;
+  align?: 'start' | 'end' | 'center';
+}
+
+const ALL_VALUE = '__all__';
+
+export function FilterSingleSelect<TValue>({
+  title,
+  showTitle,
+  options,
+  selected,
+  setSelected,
+  align = 'start',
+}: FilterSingleSelectProps<TValue>) {
+  const radioValue = selected !== undefined ? String(selected) : ALL_VALUE;
+
+  function handleChange(value: string) {
+    if (value === ALL_VALUE) {
+      setSelected(undefined);
+    } else {
+      const option = options.find((o) => String(o.value) === value);
+      if (option) setSelected(option.value);
+    }
+  }
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button variant='ghost' size='narrow' className='font-medium'>
+          {showTitle && <span className='text-sm'>{title}</span>}
+          <Filter
+            className={cn(
+              'size-4',
+              selected !== undefined ? 'text-blue-500' : undefined
+            )}
+          />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent className='w-[200px] p-2' align={align}>
+        <RadioGroup
+          value={radioValue}
+          onValueChange={handleChange}
+          className='gap-1'
+        >
+          <div className='flex items-center gap-2 rounded-sm px-2 py-1.5'>
+            <RadioGroupItem value={ALL_VALUE} id={`${title}-all`} />
+            <Label
+              htmlFor={`${title}-all`}
+              className='cursor-pointer text-sm font-normal'
+            >
+              All
+            </Label>
+          </div>
+          <div className='bg-border mx-2 h-px' />
+          {options.map((option) => {
+            const id = `${title}-${String(option.value)}`;
+            return (
+              <div
+                key={String(option.value)}
+                className='flex items-center gap-2 rounded-sm px-2 py-1.5'
+              >
+                <RadioGroupItem value={String(option.value)} id={id} />
+                {option.icon && (
+                  <option.icon className='text-muted-foreground h-4 w-4' />
+                )}
+                <Label
+                  htmlFor={id}
+                  className='cursor-pointer text-sm font-normal'
+                >
+                  {option.label}
+                </Label>
+              </div>
+            );
+          })}
+        </RadioGroup>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
@@ -77,6 +77,7 @@ import { toastError } from '@/lib/toast';
 import { getRepositoryTypeLabel } from '@/lib/types';
 import {
   declaredLicenseSearchParameterSchema,
+  isDirectDependencySearchParameterSchema,
   markedSearchParameterSchema,
   packageIdentifierSearchParameterSchema,
   PackageIdType,
@@ -335,6 +336,10 @@ const PackagesComponent = () => {
   const pageSize = search.pageSize ? search.pageSize : defaultPageSize;
   const packageId = search.pkgId;
   const declaredLicense = search.declaredLicense;
+  const isDirectDependency =
+    search.isDirectDependency === undefined
+      ? undefined
+      : search.isDirectDependency === 'true';
   const packageIdType = useUserSettingsStore((state) => state.packageIdType);
 
   const { data: ortRun } = useSuspenseQuery({
@@ -377,6 +382,7 @@ const PackagesComponent = () => {
           ? { identifier: packageId }
           : { purl: packageId }),
         processedDeclaredLicense: declaredLicense?.join(','),
+        isDirectDependency,
       },
     }),
   });
@@ -428,6 +434,28 @@ const PackagesComponent = () => {
     // All (hidden) columns that are used for filtering/sorting the main column.
     // They don't render any data, but need to retain their accessor logic, and
     // any special sorting and filtering logic.
+    columnHelper.accessor(() => search.isDirectDependency, {
+      id: 'isDirectDependency',
+      header: 'Dependency Type',
+      meta: {
+        filter: {
+          filterVariant: 'single-select',
+          selectOptions: [
+            { label: 'Direct', value: 'true' },
+            { label: 'Transitive', value: 'false' },
+          ],
+          setSelected: (value: 'true' | 'false' | undefined) => {
+            navigate({
+              search: {
+                ...search,
+                page: 1,
+                isDirectDependency: value,
+              },
+            });
+          },
+        },
+      },
+    }),
     columnHelper.accessor(
       (pkg) => {
         if (packageIdType === 'ORT_ID') {
@@ -502,11 +530,13 @@ const PackagesComponent = () => {
       sorting: search.sortBy,
       expanded: expanded,
       columnFilters: [
+        { id: 'isDirectDependency', value: search.isDirectDependency },
         { id: columnId, value: packageId },
         { id: 'processedDeclaredLicense', value: declaredLicense },
       ],
       // Always hide the columns that are used for filtering/sorting only.
       columnVisibility: {
+        isDirectDependency: false,
         [columnId]: false,
         processedDeclaredLicense: false,
       },
@@ -583,6 +613,7 @@ export const Route = createFileRoute(
     ...sortingSearchParameterSchema.shape,
     ...packageIdentifierSearchParameterSchema.shape,
     ...declaredLicenseSearchParameterSchema.shape,
+    ...isDirectDependencySearchParameterSchema.shape,
     ...markedSearchParameterSchema.shape,
   }),
   loader: async ({ context: { queryClient }, params }) => {

--- a/ui/src/schemas/index.ts
+++ b/ui/src/schemas/index.ts
@@ -157,6 +157,10 @@ export const declaredLicenseSearchParameterSchema = z.object({
     .optional(),
 });
 
+export const isDirectDependencySearchParameterSchema = z.object({
+  isDirectDependency: z.enum(['true', 'false']).optional(),
+});
+
 // Refine validates that the license texts are unique.
 export const detectedLicenseSearchParameterSchema = z.object({
   detectedLicense: z


### PR DESCRIPTION
<img width="1176" height="472" alt="Screenshot from 2026-04-17 06-10-02" src="https://github.com/user-attachments/assets/92c397c2-20ad-49b2-8162-8076bc1ad904" />

<img width="1176" height="472" alt="Screenshot from 2026-04-17 06-11-06" src="https://github.com/user-attachments/assets/be2bb77c-4854-4a60-a53d-0d8b9db149a2" />

The main rule: if a package is listed as a direct dependency of the project _for at least one of the scopes_, then it is considered a direct dependency of the project.

The author has verified from the UI that this logic is applied correctly (for some multi-scope projects).

Please see the commits for details.