### PR TITLE
Performance improvements for detected licenses endpoints

### DIFF
--- a/components/license-findings/backend/src/main/kotlin/LicenseFindingService.kt
+++ b/components/license-findings/backend/src/main/kotlin/LicenseFindingService.kt
@@ -28,21 +28,18 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesAnaly
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.scannerjob.ScannerJobsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsPackageProvenancesTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsScanResultsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.LicenseFindingsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.PackageProvenancesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.ScanResultPackageProvenancesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.ScanResultsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.ScanSummariesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
-import org.eclipse.apoapsis.ortserver.dao.tables.shared.RemoteArtifactsTable
-import org.eclipse.apoapsis.ortserver.dao.tables.shared.VcsInfoTable
 import org.eclipse.apoapsis.ortserver.dao.utils.applyILike
 import org.eclipse.apoapsis.ortserver.dao.utils.toSortOrder
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
 
-import org.jetbrains.exposed.v1.core.Alias
 import org.jetbrains.exposed.v1.core.Count
 import org.jetbrains.exposed.v1.core.CustomFunction
 import org.jetbrains.exposed.v1.core.Join
@@ -53,9 +50,7 @@ import org.jetbrains.exposed.v1.core.TextColumnType
 import org.jetbrains.exposed.v1.core.alias
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.core.isNotNull
 import org.jetbrains.exposed.v1.core.min
-import org.jetbrains.exposed.v1.core.or
 import org.jetbrains.exposed.v1.core.stringLiteral
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.andWhere
@@ -76,14 +71,14 @@ class LicenseFindingService(private val db: Database) {
         parameters: ListQueryParameters,
         licenseFilter: String?
     ): ListQueryResult<DetectedLicense> = db.blockingQuery {
-        val ctx = buildQueryContext(includeAnalyzerData = false)
+        val ctx = buildQueryContext()
         val packageCount = Count(IdentifiersTable.id, distinct = true)
         // Window function gives the total group count in the same query, avoiding running the query twice.
         val totalCount = Count(LicenseFindingsTable.license).over()
 
         val query = ctx.join
             .select(LicenseFindingsTable.license, packageCount, totalCount)
-            .where { (ScannerJobsTable.ortRunId eq ortRunId) and ctx.provenanceCondition() }
+            .where { ScannerJobsTable.ortRunId eq ortRunId }
             .groupBy(LicenseFindingsTable.license)
 
         licenseFilter?.let { query.andWhere { LicenseFindingsTable.license.applyILike(it) } }
@@ -128,10 +123,26 @@ class LicenseFindingService(private val db: Database) {
         purlFilter: String?
     ): ListQueryResult<PackageIdentifier> = db.blockingQuery {
         val ctx = buildQueryContext()
-        val purl = PackagesTable.purl.min().alias("purl")
+
+        // Lateral subquery: fetch one purl per identifier for the current ORT run. Each ORT run has at most one
+        // analyzer run, so LIMIT 1 is a safety net rather than a meaningful filter.
+        val purlSubquery = PackagesTable
+            .join(PackagesAnalyzerRunsTable, JoinType.INNER, PackagesTable.id, PackagesAnalyzerRunsTable.packageId)
+            .join(AnalyzerRunsTable, JoinType.INNER, PackagesAnalyzerRunsTable.analyzerRunId, AnalyzerRunsTable.id)
+            .join(AnalyzerJobsTable, JoinType.INNER, AnalyzerRunsTable.analyzerJobId, AnalyzerJobsTable.id)
+            .select(PackagesTable.purl)
+            .where {
+                (PackagesTable.identifierId eq PackageProvenancesTable.identifierId) and
+                        (AnalyzerJobsTable.ortRunId eq ortRunId)
+            }
+            .limit(1)
+            .alias("purl_sub")
+
+        val join = ctx.join.join(purlSubquery, JoinType.LEFT, lateral = true) { Op.TRUE }
+        val purl = purlSubquery[PackagesTable.purl].min().alias("purl")
         val totalCount = Count(IdentifiersTable.type).over()
 
-        val query = ctx.join
+        val query = join
             .select(
                 IdentifiersTable.type,
                 IdentifiersTable.namespace,
@@ -142,8 +153,7 @@ class LicenseFindingService(private val db: Database) {
             )
             .where {
                 (ScannerJobsTable.ortRunId eq ortRunId) and
-                    (LicenseFindingsTable.license eq license) and
-                    ctx.provenanceCondition()
+                        (LicenseFindingsTable.license eq license)
             }
             .groupBy(
                 IdentifiersTable.type,
@@ -153,7 +163,7 @@ class LicenseFindingService(private val db: Database) {
             )
 
         identifierFilter?.let { query.andWhere { identifierExpression().applyILike(it) } }
-        purlFilter?.let { query.andWhere { PackagesTable.purl.applyILike(it) } }
+        purlFilter?.let { query.andWhere { purlSubquery[PackagesTable.purl].applyILike(it) } }
 
         parameters.sortFields.forEach { orderField ->
             val sortOrder = orderField.direction.toSortOrder()
@@ -200,27 +210,25 @@ class LicenseFindingService(private val db: Database) {
         identifier: String,
         parameters: ListQueryParameters
     ): ListQueryResult<LicenseFinding> = db.blockingQuery {
-        val ctx = buildQueryContext(includeAnalyzerData = false)
+        val ctx = buildQueryContext()
+        val totalCount = Count(LicenseFindingsTable.path).over()
 
-        fun findingsQuery() = ctx.join
+        val query = ctx.join
             .select(
                 LicenseFindingsTable.path,
                 LicenseFindingsTable.startLine,
                 LicenseFindingsTable.endLine,
                 LicenseFindingsTable.score,
                 ScanResultsTable.scannerName,
-                ScanResultsTable.scannerVersion
+                ScanResultsTable.scannerVersion,
+                totalCount
             )
             .where {
                 (ScannerJobsTable.ortRunId eq ortRunId) and
-                    (LicenseFindingsTable.license eq license) and
-                    (identifierExpression() eq identifier) and
-                    ctx.provenanceCondition()
+                        (LicenseFindingsTable.license eq license) and
+                        (identifierExpression() eq identifier)
             }
             .withDistinct()
-
-        val totalCount = findingsQuery().count()
-        val query = findingsQuery()
 
         parameters.sortFields.forEach { orderField ->
             val sortOrder = orderField.direction.toSortOrder()
@@ -256,88 +264,39 @@ class LicenseFindingService(private val db: Database) {
                 )
             },
             params = parameters,
-            totalCount = totalCount
+            totalCount = rows.firstOrNull()?.get(totalCount) ?: 0L
         )
     }
 }
 
-private class QueryContext(
-    val join: Join,
-    private val artifactAlias: Alias<RemoteArtifactsTable>,
-    private val vcsAlias: Alias<VcsInfoTable>
-) {
-    fun provenanceCondition(): Op<Boolean> =
-        (
-            ScanResultsTable.artifactUrl.isNotNull() and
-                (ScanResultsTable.artifactUrl eq artifactAlias[RemoteArtifactsTable.url]) and
-                (ScanResultsTable.artifactHash eq artifactAlias[RemoteArtifactsTable.hashValue]) and
-                (ScanResultsTable.artifactHashAlgorithm eq artifactAlias[RemoteArtifactsTable.hashAlgorithm])
-            ) or (
-            ScanResultsTable.vcsUrl.isNotNull() and
-                (ScanResultsTable.vcsType eq vcsAlias[VcsInfoTable.type]) and
-                (ScanResultsTable.vcsUrl eq vcsAlias[VcsInfoTable.url]) and
-                (ScanResultsTable.vcsRevision eq vcsAlias[VcsInfoTable.revision]) and
-                (vcsAlias[VcsInfoTable.path] eq stringLiteral(""))
-            )
-}
+private class QueryContext(val join: Join)
 
 /**
- * Build the common query context for license findings queries.
- *
- * The [includeAnalyzerData] flag controls whether the four `LEFT JOIN`s for purl lookup are included.
- * Set it to `false` when the purl is not needed, as `packages_analyzer_runs` is a junction table that
- * multiplies rows by the number of analyzer runs a package has been part of, forcing expensive
- * `COUNT(DISTINCT)` to compensate.
+ * Build the common query context for license findings queries. Joins through the
+ * [ScanResultPackageProvenancesTable] junction table to guarantee correct provenance matching at the
+ * DB level.
  */
-private fun buildQueryContext(includeAnalyzerData: Boolean = true): QueryContext {
-    val artifactAlias = RemoteArtifactsTable.alias("artifact")
-    val vcsAlias = VcsInfoTable.alias("vcs")
-
-    val baseJoin = LicenseFindingsTable
+private fun buildQueryContext(): QueryContext {
+    val join = LicenseFindingsTable
         .innerJoin(ScanSummariesTable)
         .join(ScanResultsTable, JoinType.INNER, ScanSummariesTable.id, ScanResultsTable.scanSummaryId)
         .join(
-            ScannerRunsScanResultsTable,
-            JoinType.INNER,
-            ScanResultsTable.id,
-            ScannerRunsScanResultsTable.scanResultId
+            ScanResultPackageProvenancesTable, JoinType.INNER,
+            ScanResultsTable.id, ScanResultPackageProvenancesTable.scanResultId
         )
-        .join(ScannerRunsTable, JoinType.INNER, ScannerRunsScanResultsTable.scannerRunId, ScannerRunsTable.id)
+        .join(
+            PackageProvenancesTable, JoinType.INNER,
+            ScanResultPackageProvenancesTable.packageProvenanceId, PackageProvenancesTable.id
+        )
+        .join(
+            ScannerRunsPackageProvenancesTable, JoinType.INNER,
+            PackageProvenancesTable.id, ScannerRunsPackageProvenancesTable.packageProvenanceId
+        )
+        .join(ScannerRunsTable, JoinType.INNER, ScannerRunsPackageProvenancesTable.scannerRunId, ScannerRunsTable.id)
         .join(ScannerJobsTable, JoinType.INNER, ScannerRunsTable.scannerJobId, ScannerJobsTable.id)
-        .join(
-            ScannerRunsPackageProvenancesTable,
-            JoinType.INNER,
-            ScannerRunsTable.id,
-            ScannerRunsPackageProvenancesTable.scannerRunId
-        )
-        .join(
-            PackageProvenancesTable,
-            JoinType.INNER,
-            ScannerRunsPackageProvenancesTable.packageProvenanceId,
-            PackageProvenancesTable.id
-        )
         .join(IdentifiersTable, JoinType.INNER, PackageProvenancesTable.identifierId, IdentifiersTable.id)
-        .join(artifactAlias, JoinType.LEFT, PackageProvenancesTable.artifactId, artifactAlias[RemoteArtifactsTable.id])
-        .join(vcsAlias, JoinType.LEFT, PackageProvenancesTable.vcsId, vcsAlias[VcsInfoTable.id])
 
-    val join = if (includeAnalyzerData) {
-        baseJoin
-            .join(AnalyzerJobsTable, JoinType.LEFT) {
-                AnalyzerJobsTable.ortRunId eq ScannerJobsTable.ortRunId
-            }
-            .join(AnalyzerRunsTable, JoinType.LEFT) { AnalyzerRunsTable.analyzerJobId eq AnalyzerJobsTable.id }
-            .join(PackagesAnalyzerRunsTable, JoinType.LEFT) {
-                PackagesAnalyzerRunsTable.analyzerRunId eq AnalyzerRunsTable.id
-            }
-            .join(PackagesTable, JoinType.LEFT) {
-                (PackagesTable.id eq PackagesAnalyzerRunsTable.packageId) and
-                    (PackagesTable.identifierId eq PackageProvenancesTable.identifierId)
-            }
-    } else {
-        baseJoin
-    }
-
-    return QueryContext(join, artifactAlias, vcsAlias)
+    return QueryContext(join)
 }
 
 private fun identifierExpression() = CustomFunction<String>(

--- a/components/license-findings/backend/src/test/kotlin/LicenseFindingServiceTest.kt
+++ b/components/license-findings/backend/src/test/kotlin/LicenseFindingServiceTest.kt
@@ -33,6 +33,7 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsSca
 import org.eclipse.apoapsis.ortserver.dao.tables.LicenseFindingDao
 import org.eclipse.apoapsis.ortserver.dao.tables.PackageProvenanceDao
 import org.eclipse.apoapsis.ortserver.dao.tables.ScanResultDao
+import org.eclipse.apoapsis.ortserver.dao.tables.ScanResultPackageProvenancesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.ScanSummaryDao
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifierDao
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.RemoteArtifactDao
@@ -71,6 +72,17 @@ class LicenseFindingServiceTest : WordSpec() {
         }
 
         "getDetectedLicensesForRun" should {
+            "return empty list when no junction table rows exist" {
+                val result = service.getDetectedLicensesForRun(
+                    seed.otherOrtRunId + 999L,
+                    ListQueryParameters(sortFields = listOf(OrderField("license", OrderDirection.ASCENDING))),
+                    null
+                )
+
+                result.totalCount shouldBe 0
+                result.data.shouldBeEmpty()
+            }
+
             "return all licenses with package counts sorted by license ascending" {
                 val result = service.getDetectedLicensesForRun(
                     seed.ortRunId,
@@ -150,6 +162,19 @@ class LicenseFindingServiceTest : WordSpec() {
         }
 
         "getPackagesWithDetectedLicenseForRun" should {
+            "return empty list when no junction table rows exist" {
+                val result = service.getPackagesWithDetectedLicenseForRun(
+                    seed.otherOrtRunId + 999L,
+                    "Apache-2.0",
+                    ListQueryParameters(sortFields = listOf(OrderField("identifier", OrderDirection.ASCENDING))),
+                    null,
+                    null
+                )
+
+                result.totalCount shouldBe 0
+                result.data.shouldBeEmpty()
+            }
+
             "return the package that has the given license" {
                 val result = service.getPackagesWithDetectedLicenseForRun(
                     seed.ortRunId,
@@ -258,6 +283,18 @@ class LicenseFindingServiceTest : WordSpec() {
         }
 
         "getLicenseFindingsForRun" should {
+            "return empty list with zero totalCount when no junction table rows exist" {
+                val result = service.getLicenseFindingsForRun(
+                    seed.otherOrtRunId + 999L,
+                    "Apache-2.0",
+                    seed.artifactIdentifier.toCoordinates(),
+                    ListQueryParameters(sortFields = listOf(OrderField("path", OrderDirection.ASCENDING)))
+                )
+
+                result.totalCount shouldBe 0
+                result.data.shouldBeEmpty()
+            }
+
             "return findings for the given license and package sorted by path" {
                 val result = service.getLicenseFindingsForRun(
                     seed.ortRunId,
@@ -406,13 +443,17 @@ internal fun seedData(fixtures: Fixtures, db: Database, duplicatePackageEntries:
         val otherScannerJob = fixtures.createScannerJob(otherOrtRun.id)
         val otherScannerRun = fixtures.scannerRunRepository.create(otherScannerJob.id)
 
-        createPackageProvenance(scannerRun.id, artifactIdentifier, artifact = artifactProvenance)
-        createPackageProvenance(scannerRun.id, vcsIdentifier, vcs = vcsProvenance)
-        createPackageProvenance(otherScannerRun.id, otherIdentifier, artifact = otherArtifactProvenance)
+        val artifactPackageProvenance =
+            createPackageProvenance(scannerRun.id, artifactIdentifier, artifact = artifactProvenance)
+        val vcsPackageProvenance =
+            createPackageProvenance(scannerRun.id, vcsIdentifier, vcs = vcsProvenance)
+        val otherPackageProvenance =
+            createPackageProvenance(otherScannerRun.id, otherIdentifier, artifact = otherArtifactProvenance)
 
         createArtifactScanResult(
             scannerRun.id,
             artifactProvenance,
+            artifactPackageProvenance.id.value,
             listOf(
                 FindingSeed("Apache-2.0", "LICENSE", 1, 10, 99f),
                 FindingSeed("Apache-2.0", "docs/NOTICE.Apache", 11, 18, 87.5f),
@@ -422,6 +463,7 @@ internal fun seedData(fixtures: Fixtures, db: Database, duplicatePackageEntries:
         createVcsScanResult(
             scannerRun.id,
             vcsProvenance,
+            vcsPackageProvenance.id.value,
             listOf(
                 FindingSeed("Apache-2.0", "THIRD-PARTY.txt", 4, 8, 90f),
                 FindingSeed("MIT", "src/main/resources/license.txt", 5, 7, 91.5f)
@@ -430,6 +472,7 @@ internal fun seedData(fixtures: Fixtures, db: Database, duplicatePackageEntries:
         createArtifactScanResult(
             otherScannerRun.id,
             otherArtifactProvenance,
+            otherPackageProvenance.id.value,
             listOf(FindingSeed("Zlib", "COPYING", 1, 20, 100f))
         )
     }
@@ -459,7 +502,7 @@ private fun createPackageProvenance(
     identifier: Identifier,
     artifact: RemoteArtifact? = null,
     vcs: VcsInfo? = null
-) {
+): PackageProvenanceDao {
     val provenance = PackageProvenanceDao.new {
         this.identifier = IdentifierDao.getOrPut(identifier)
         this.artifact = artifact?.let(RemoteArtifactDao::getOrPut)
@@ -471,11 +514,13 @@ private fun createPackageProvenance(
     }
 
     ScannerRunsPackageProvenancesTable.insertIfNotExists(scannerRunId, provenance.id.value)
+    return provenance
 }
 
 private fun createArtifactScanResult(
     scannerRunId: Long,
     artifact: RemoteArtifact,
+    packageProvenanceId: Long,
     findings: List<FindingSeed>
 ) {
     val scanSummary = createScanSummary(findings)
@@ -495,11 +540,13 @@ private fun createArtifactScanResult(
     }
 
     ScannerRunsScanResultsTable.insertIfNotExists(scannerRunId, scanResult.id.value)
+    ScanResultPackageProvenancesTable.insertIfNotExists(scanResult.id.value, packageProvenanceId)
 }
 
 private fun createVcsScanResult(
     scannerRunId: Long,
     vcs: VcsInfo,
+    packageProvenanceId: Long,
     findings: List<FindingSeed>
 ) {
     val scanSummary = createScanSummary(findings)
@@ -519,6 +566,7 @@ private fun createVcsScanResult(
     }
 
     ScannerRunsScanResultsTable.insertIfNotExists(scannerRunId, scanResult.id.value)
+    ScanResultPackageProvenancesTable.insertIfNotExists(scanResult.id.value, packageProvenanceId)
 }
 
 private fun createScanSummary(findings: List<FindingSeed>): ScanSummaryDao {

--- a/dao/src/main/kotlin/tables/ScanResultPackageProvenancesTable.kt
+++ b/dao/src/main/kotlin/tables/ScanResultPackageProvenancesTable.kt
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.dao.tables
+
+import org.jetbrains.exposed.v1.core.ReferenceOption
+import org.jetbrains.exposed.v1.core.Table
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.selectAll
+
+/**
+ * A junction table to link [ScanResultsTable] with [PackageProvenancesTable].
+ */
+object ScanResultPackageProvenancesTable : Table("scan_result_package_provenances") {
+    val scanResultId = reference("scan_result_id", ScanResultsTable, onDelete = ReferenceOption.CASCADE)
+    val packageProvenanceId =
+        reference("package_provenance_id", PackageProvenancesTable, onDelete = ReferenceOption.CASCADE)
+
+    override val primaryKey: PrimaryKey
+        get() = PrimaryKey(scanResultId, packageProvenanceId, name = "${tableName}_pkey")
+
+    fun insertIfNotExists(scanResultId: Long, packageProvenanceId: Long) {
+        val exists = selectAll().where {
+            ScanResultPackageProvenancesTable.scanResultId eq scanResultId and
+                    (ScanResultPackageProvenancesTable.packageProvenanceId eq packageProvenanceId)
+        }.count() > 0
+
+        if (!exists) {
+            insert {
+                it[ScanResultPackageProvenancesTable.scanResultId] = scanResultId
+                it[ScanResultPackageProvenancesTable.packageProvenanceId] = packageProvenanceId
+            }
+        }
+    }
+}

--- a/dao/src/main/resources/db/migration/V143__scanResultPackageProvenances.sql
+++ b/dao/src/main/resources/db/migration/V143__scanResultPackageProvenances.sql
@@ -1,0 +1,10 @@
+-- Add a table to join scan results to package provenances.
+-- ON DELETE CASCADE on both FKs ensure table rows are deleted
+-- when orphan-removal code is run on the server.
+CREATE TABLE scan_result_package_provenances
+(
+    scan_result_id        bigint REFERENCES scan_results        ON DELETE CASCADE NOT NULL,
+    package_provenance_id bigint REFERENCES package_provenances ON DELETE CASCADE NOT NULL,
+
+    PRIMARY KEY (scan_result_id, package_provenance_id)
+);

--- a/dao/src/test/kotlin/tables/ScanResultPackageProvenancesTableTest.kt
+++ b/dao/src/test/kotlin/tables/ScanResultPackageProvenancesTableTest.kt
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.dao.tables
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import kotlin.time.Clock
+
+import org.eclipse.apoapsis.ortserver.dao.blockingQuery
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifierDao
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.RemoteArtifactDao
+import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
+import org.eclipse.apoapsis.ortserver.model.runs.Identifier
+import org.eclipse.apoapsis.ortserver.model.runs.RemoteArtifact
+
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
+
+class ScanResultPackageProvenancesTableTest : WordSpec() {
+    private val dbExtension = extension(DatabaseTestExtension())
+
+    init {
+        "insertIfNotExists" should {
+            "create a row when none exists" {
+                dbExtension.db.blockingQuery {
+                    val scanResult = createScanResult()
+                    val provenance = createPackageProvenance()
+
+                    ScanResultPackageProvenancesTable.insertIfNotExists(
+                        scanResultId = scanResult.id.value,
+                        packageProvenanceId = provenance.id.value
+                    )
+
+                    val count = ScanResultPackageProvenancesTable.selectAll().where {
+                        (ScanResultPackageProvenancesTable.scanResultId eq scanResult.id) and
+                                (ScanResultPackageProvenancesTable.packageProvenanceId eq provenance.id)
+                    }.count()
+
+                    count shouldBe 1L
+                }
+            }
+
+            "be idempotent on repeated calls" {
+                dbExtension.db.blockingQuery {
+                    val scanResult = createScanResult()
+                    val provenance = createPackageProvenance()
+
+                    repeat(3) {
+                        ScanResultPackageProvenancesTable.insertIfNotExists(
+                            scanResultId = scanResult.id.value,
+                            packageProvenanceId = provenance.id.value
+                        )
+                    }
+
+                    val count = ScanResultPackageProvenancesTable.selectAll().where {
+                        (ScanResultPackageProvenancesTable.scanResultId eq scanResult.id) and
+                                (ScanResultPackageProvenancesTable.packageProvenanceId eq provenance.id)
+                    }.count()
+
+                    count shouldBe 1L
+                }
+            }
+
+            "raise a FK violation for a non-existent scan_result_id" {
+                dbExtension.db.blockingQuery {
+                    val provenance = createPackageProvenance()
+
+                    shouldThrow<Exception> {
+                        ScanResultPackageProvenancesTable.insertIfNotExists(
+                            scanResultId = Long.MAX_VALUE,
+                            packageProvenanceId = provenance.id.value
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun createScanResult(): ScanResultDao =
+        dbExtension.db.blockingQuery {
+            val scanSummary = ScanSummaryDao.new {
+                startTime = Clock.System.now()
+                endTime = Clock.System.now()
+                hash = Clock.System.now().toString()
+            }
+
+            ScanResultDao.new {
+                this.scanSummary = scanSummary
+                this.scannerName = "test-scanner"
+                this.scannerVersion = "1.0.0"
+                this.scannerConfiguration = ""
+                this.artifactUrl = "https://example.com/artifact.zip"
+                this.artifactHash = "abc123"
+                this.artifactHashAlgorithm = "SHA-1"
+            }
+        }
+
+    private fun createPackageProvenance(): PackageProvenanceDao =
+        dbExtension.db.blockingQuery {
+            val identifier = IdentifierDao.getOrPut(
+                Identifier(type = "Maven", namespace = "com.example", name = "lib", version = "1.0")
+            )
+            val artifact = RemoteArtifactDao.getOrPut(
+                RemoteArtifact(url = "https://example.com/artifact.zip", hashValue = "abc123", hashAlgorithm = "SHA-1")
+            )
+
+            PackageProvenanceDao.new {
+                this.identifier = identifier
+                this.artifact = artifact
+            }
+        }
+}

--- a/workers/scanner/src/main/kotlin/OrtServerScanResultStorage.kt
+++ b/workers/scanner/src/main/kotlin/OrtServerScanResultStorage.kt
@@ -27,29 +27,37 @@ import kotlin.time.toKotlinInstant
 import kotlinx.serialization.json.Json
 
 import org.eclipse.apoapsis.ortserver.dao.blockingQuery
+import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsPackageProvenancesTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsScanResultsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.AdditionalScanResultData
 import org.eclipse.apoapsis.ortserver.dao.tables.CopyrightFindingDao
 import org.eclipse.apoapsis.ortserver.dao.tables.LicenseFindingDao
+import org.eclipse.apoapsis.ortserver.dao.tables.PackageProvenancesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.ScanResultDao
 import org.eclipse.apoapsis.ortserver.dao.tables.ScanResultDao.Companion.matchesRemoteArtifact
 import org.eclipse.apoapsis.ortserver.dao.tables.ScanResultDao.Companion.matchesVcsInfo
+import org.eclipse.apoapsis.ortserver.dao.tables.ScanResultPackageProvenancesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.ScanResultsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.ScanSummariesIssuesDao
 import org.eclipse.apoapsis.ortserver.dao.tables.ScanSummariesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.ScanSummaryDao
 import org.eclipse.apoapsis.ortserver.dao.tables.SnippetDao
 import org.eclipse.apoapsis.ortserver.dao.tables.SnippetFindingDao
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.RemoteArtifactsTable
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.VcsInfoTable
 import org.eclipse.apoapsis.ortserver.dao.utils.JsonHashFunction
 import org.eclipse.apoapsis.ortserver.services.ortrun.mapToModel
 import org.eclipse.apoapsis.ortserver.services.ortrun.mapToOrt
 
 import org.jetbrains.exposed.v1.core.Expression
+import org.jetbrains.exposed.v1.core.Op
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.innerJoin
 import org.jetbrains.exposed.v1.core.stringLiteral
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SizedCollection
+import org.jetbrains.exposed.v1.jdbc.select
 
 import org.ossreviewtoolkit.model.ArtifactProvenance
 import org.ossreviewtoolkit.model.Issue
@@ -265,6 +273,68 @@ class OrtServerScanResultStorage(
             scannerRunId = scannerRunId,
             scanResultId = scanResultDao.id.value
         )
+        linkScanResultToPackageProvenances(scanResultDao)
+    }
+
+    /**
+     * For the given [scanResultDao], find all package provenances in this scanner run whose artifact or VCS matches
+     * the scan result's provenance and record direct links in [ScanResultPackageProvenancesTable].
+     *
+     * The lookup is scoped to [scannerRunId] via [ScannerRunsPackageProvenancesTable], so it only touches the
+     * package provenances of this run — not the global table.
+     */
+    private fun linkScanResultToPackageProvenances(scanResultDao: ScanResultDao) {
+        val provenanceMatchCondition: Op<Boolean> =
+            if (scanResultDao.artifactUrl != null) {
+                val url = requireNotNull(scanResultDao.artifactUrl)
+                val hash = requireNotNull(scanResultDao.artifactHash)
+                val hashAlgorithm = requireNotNull(scanResultDao.artifactHashAlgorithm)
+                val artifactId = RemoteArtifactsTable
+                    .select(RemoteArtifactsTable.id)
+                    .where {
+                        (RemoteArtifactsTable.url eq url) and
+                                (RemoteArtifactsTable.hashValue eq hash) and
+                                (RemoteArtifactsTable.hashAlgorithm eq hashAlgorithm)
+                    }
+                    .singleOrNull()
+                    ?.get(RemoteArtifactsTable.id)
+                    ?: return
+
+                PackageProvenancesTable.artifactId eq artifactId
+            } else {
+                val type = requireNotNull(scanResultDao.vcsType)
+                val url = requireNotNull(scanResultDao.vcsUrl)
+                val revision = requireNotNull(scanResultDao.vcsRevision)
+                val vcsId = VcsInfoTable
+                    .select(VcsInfoTable.id)
+                    .where {
+                        (VcsInfoTable.type eq type) and
+                                (VcsInfoTable.url eq url) and
+                                (VcsInfoTable.revision eq revision) and
+                                (VcsInfoTable.path eq "")
+                    }
+                    .singleOrNull()
+                    ?.get(VcsInfoTable.id)
+                    ?: return
+
+                PackageProvenancesTable.vcsId eq vcsId
+            }
+
+        val matchingProvenanceIds =
+            (PackageProvenancesTable innerJoin ScannerRunsPackageProvenancesTable)
+                .select(PackageProvenancesTable.id)
+                .where {
+                    (ScannerRunsPackageProvenancesTable.scannerRunId eq scannerRunId) and
+                            provenanceMatchCondition
+                }
+                .map { it[PackageProvenancesTable.id].value }
+
+        matchingProvenanceIds.forEach { ppId ->
+            ScanResultPackageProvenancesTable.insertIfNotExists(
+                scanResultId = scanResultDao.id.value,
+                packageProvenanceId = ppId
+            )
+        }
     }
 }
 

--- a/workers/scanner/src/test/kotlin/OrtServerScanResultStorageTest.kt
+++ b/workers/scanner/src/test/kotlin/OrtServerScanResultStorageTest.kt
@@ -32,17 +32,32 @@ import io.kotest.matchers.shouldBe
 import org.eclipse.apoapsis.ortserver.dao.blockingQuery
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
 import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunDao
+import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsPackageProvenancesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.PackageProvenanceDao
 import org.eclipse.apoapsis.ortserver.dao.tables.ScanResultDao
+import org.eclipse.apoapsis.ortserver.dao.tables.ScanResultPackageProvenancesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifierDao
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.RemoteArtifactDao
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.VcsInfoDao
 import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
+import org.eclipse.apoapsis.ortserver.model.runs.Identifier
+import org.eclipse.apoapsis.ortserver.model.runs.RemoteArtifact
+import org.eclipse.apoapsis.ortserver.model.runs.VcsInfo
 import org.eclipse.apoapsis.ortserver.model.runs.scanner.ScannerRun
 import org.eclipse.apoapsis.ortserver.services.ortrun.mapToOrt
 import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.SCANNER_VERSION
 import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.createArtifactProvenance
 import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.createIssue
+import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.createRemoteArtifact
 import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.createRepositoryProvenance
 import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.createScanResult
+import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.createVcsInfo
 import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.scannerMatcher
 import org.eclipse.apoapsis.ortserver.workers.scanner.ScanResultFixtures.withoutRelations
+
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.jdbc.selectAll
 
 import org.ossreviewtoolkit.model.ScanResult as OrtScanResult
 
@@ -51,6 +66,70 @@ class OrtServerScanResultStorageTest : WordSpec() {
 
     private lateinit var scanResultStorage: OrtServerScanResultStorage
     private lateinit var scannerRun: ScannerRun
+
+    /**
+     * Create a [PackageProvenanceDao] for the given [artifact] and associate it with [scannerRun].
+     * [namespace] allows creating multiple distinct packages that share the same artifact.
+     */
+    private fun createPackageProvenanceForArtifact(
+        scannerRun: ScannerRun,
+        artifact: RemoteArtifact,
+        namespace: String = "com.example"
+    ): PackageProvenanceDao =
+        dbExtension.db.blockingQuery {
+            val identifier = IdentifierDao.getOrPut(
+                Identifier(type = "Maven", namespace = namespace, name = "lib", version = "1.0")
+            )
+            val artifactDao = RemoteArtifactDao.getOrPut(artifact)
+            val provenance = PackageProvenanceDao.new {
+                this.identifier = identifier
+                this.artifact = artifactDao
+            }
+            ScannerRunsPackageProvenancesTable.insertIfNotExists(scannerRun.id, provenance.id.value)
+            provenance
+        }
+
+    /**
+     * Create a [PackageProvenanceDao] for the given [vcsInfo] and associate it with [scannerRun].
+     */
+    private fun createPackageProvenanceForVcs(
+        scannerRun: ScannerRun,
+        vcsInfo: VcsInfo
+    ): PackageProvenanceDao =
+        dbExtension.db.blockingQuery {
+            val identifier = IdentifierDao.getOrPut(
+                Identifier(type = "Maven", namespace = "com.example", name = "lib", version = "1.0")
+            )
+            val vcsDao = VcsInfoDao.getOrPut(vcsInfo)
+            val provenance = PackageProvenanceDao.new {
+                this.identifier = identifier
+                this.vcs = vcsDao
+                this.resolvedRevision = vcsInfo.revision
+            }
+            ScannerRunsPackageProvenancesTable.insertIfNotExists(scannerRun.id, provenance.id.value)
+            provenance
+        }
+
+    /**
+     * Assert that [ScanResultPackageProvenancesTable] contains a row linking [scanResult] to [packageProvenance].
+     * [run] defaults to the test's [scannerRun].
+     */
+    private fun verifyJunctionRow(
+        scanResult: OrtScanResult,
+        packageProvenance: PackageProvenanceDao,
+        run: ScannerRun = scannerRun
+    ) {
+        dbExtension.db.blockingQuery {
+            val scanResultDao = ScannerRunDao[run.id].scanResults.first {
+                it.scannerName == scanResult.scanner.name
+            }
+            val count = ScanResultPackageProvenancesTable.selectAll().where {
+                (ScanResultPackageProvenancesTable.scanResultId eq scanResultDao.id) and
+                        (ScanResultPackageProvenancesTable.packageProvenanceId eq packageProvenance.id)
+            }.count()
+            count shouldBe 1L
+        }
+    }
 
     /**
      * Return a [Set] with the IDs of all scan summaries assigned to a scan result.
@@ -325,6 +404,58 @@ class OrtServerScanResultStorageTest : WordSpec() {
                 val readResult = scanResultStorage.read(repositoryProvenance.mapToOrt(), scannerMatcher)
                 readResult shouldContain matchingScanResult.withoutRelations()
                 readResult shouldNotContain notMatchingScanResult
+            }
+        }
+
+        "write" should {
+            "link a new artifact-provenance scan result to the matching package provenance" {
+                val remoteArtifact = createRemoteArtifact()
+                val packageProvenance = createPackageProvenanceForArtifact(scannerRun, remoteArtifact)
+                val scanResult = createScanResult("ScanCode", createIssue("source"), createArtifactProvenance())
+
+                scanResultStorage.write(scanResult)
+
+                verifyJunctionRow(scanResult, packageProvenance)
+            }
+
+            "link a new VCS-provenance scan result to the matching package provenance" {
+                val vcsInfo = createVcsInfo()
+                val packageProvenance = createPackageProvenanceForVcs(scannerRun, vcsInfo)
+                val scanResult =
+                    createScanResult("ScanCode", createIssue("source"), createRepositoryProvenance(vcsInfo))
+
+                scanResultStorage.write(scanResult)
+
+                verifyJunctionRow(scanResult, packageProvenance)
+            }
+
+            "link a cached (reused) scan result to the new scanner run's package provenance" {
+                val remoteArtifact = createRemoteArtifact()
+                val scanResult = createScanResult("ScanCode", createIssue("source"), createArtifactProvenance())
+
+                // Write in run 1 (no package provenance yet — no junction row expected).
+                scanResultStorage.write(scanResult)
+
+                // Start run 2, add a package provenance, then read (cache hit path).
+                val scannerRun2 = dbExtension.fixtures.scannerRunRepository.create(dbExtension.fixtures.scannerJob.id)
+                val storage2 = OrtServerScanResultStorage(dbExtension.db, scannerRun2.id)
+                val packageProvenance = createPackageProvenanceForArtifact(scannerRun2, remoteArtifact)
+
+                storage2.write(scanResult)
+
+                verifyJunctionRow(scanResult, packageProvenance, scannerRun2)
+            }
+
+            "link a scan result to all package provenances sharing the same artifact URL" {
+                val remoteArtifact = createRemoteArtifact()
+                val provenance1 = createPackageProvenanceForArtifact(scannerRun, remoteArtifact, namespace = "com.a")
+                val provenance2 = createPackageProvenanceForArtifact(scannerRun, remoteArtifact, namespace = "com.b")
+                val scanResult = createScanResult("ScanCode", createIssue("source"), createArtifactProvenance())
+
+                scanResultStorage.write(scanResult)
+
+                verifyJunctionRow(scanResult, provenance1)
+                verifyJunctionRow(scanResult, provenance2)
             }
         }
 


### PR DESCRIPTION
Two pictures may speak more than tho thousand words: pgAdmin4 `EXPLAIN ANALYZE` results, showing timing and memory budgets. I couldn't find a way to export the data, so these are just partial screenshots, showing the culprit of the problem, and the results of the solution.

#### Current implementation: huge intermediate results (cross-product of two tables), of which 99% are filtered out

<img width="1469" height="758" alt="Screenshot from 2026-04-17 12-09-59" src="https://github.com/user-attachments/assets/0b81e25d-71b8-44e4-b08e-7cbaf826dbeb" />

#### This PR: straight join chain through a new junction table

<img width="1469" height="758" alt="Screenshot from 2026-04-17 12-10-12" src="https://github.com/user-attachments/assets/cda0ef39-f9d7-44f5-b9a0-ff58e3bce97e" />

It is not possible to assess the full performance gains just locally, so the final verdict can be made on deployment server. Locally, the query time (judged from the UI) is notably decreased. Total hash memory consumption went down on this example from 43 MB to 228 kB.

A side effect of this is, old run results (created before this PR) will have only partial results in the detected licenses table. New runs will produce fully populated tables.