### PR TITLE
Store the ORT server version for each run

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
@@ -426,7 +426,8 @@ fun OrtRun.mapToApi(jobs: ApiJobs) =
         resolvedJobConfigContext = resolvedJobConfigContext,
         environmentConfigPath = environmentConfigPath,
         traceId = traceId,
-        userDisplayName = userDisplayName?.mapToApi()
+        userDisplayName = userDisplayName?.mapToApi(),
+        ortServerVersion = ortServerVersion
     )
 
 fun OrtRun.mapToApiSummary(jobs: ApiJobSummaries) =
@@ -447,7 +448,8 @@ fun OrtRun.mapToApiSummary(jobs: ApiJobSummaries) =
         jobConfigContext = jobConfigContext,
         resolvedJobConfigContext = resolvedJobConfigContext,
         environmentConfigPath = environmentConfigPath,
-        userDisplayName = userDisplayName?.mapToApi()
+        userDisplayName = userDisplayName?.mapToApi(),
+        ortServerVersion = ortServerVersion
     )
 
 fun OrtRunSummary.mapToApi() =
@@ -468,7 +470,8 @@ fun OrtRunSummary.mapToApi() =
         jobConfigContext = jobConfigContext,
         resolvedJobConfigContext = resolvedJobConfigContext,
         environmentConfigPath = environmentConfigPath,
-        userDisplayName = userDisplayName?.mapToApi()
+        userDisplayName = userDisplayName?.mapToApi(),
+        ortServerVersion = ortServerVersion
     )
 
 fun JobSummaries.mapToApi() =

--- a/api/v1/model/src/commonMain/kotlin/OrtRun.kt
+++ b/api/v1/model/src/commonMain/kotlin/OrtRun.kt
@@ -137,7 +137,12 @@ data class OrtRun(
     /**
      * The display name of the user that triggered the scan.
      */
-    val userDisplayName: UserDisplayName? = null
+    val userDisplayName: UserDisplayName? = null,
+
+    /**
+     * The version of the ORT Server that was active when this run was created.
+     */
+    val ortServerVersion: String? = null
 )
 
 /**

--- a/api/v1/model/src/commonMain/kotlin/OrtRunSummary.kt
+++ b/api/v1/model/src/commonMain/kotlin/OrtRunSummary.kt
@@ -117,7 +117,12 @@ data class OrtRunSummary(
     /**
      * The display name of the user that triggered this run.
      */
-    val userDisplayName: UserDisplayName? = null
+    val userDisplayName: UserDisplayName? = null,
+
+    /**
+     * The version of the ORT Server that was active when this run was created.
+     */
+    val ortServerVersion: String? = null
 )
 
 /**

--- a/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
@@ -121,6 +121,7 @@ import org.eclipse.apoapsis.ortserver.shared.apimodel.valueOrThrow
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.shouldHaveBody
 import org.eclipse.apoapsis.ortserver.transport.OrchestratorEndpoint
 import org.eclipse.apoapsis.ortserver.transport.testing.MessageSenderFactoryForTesting
+import org.eclipse.apoapsis.ortserver.utils.system.ORT_SERVER_VERSION
 import org.eclipse.apoapsis.ortserver.utils.test.Integration
 
 @Suppress("LargeClass")
@@ -772,6 +773,8 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
 
                 run.jobConfigs.parameters shouldBe parameters
                 run.jobConfigs.ruleSet shouldBe ruleSet
+
+                run.ortServerVersion shouldBe ORT_SERVER_VERSION
             }
         }
 

--- a/dao/build.gradle.kts
+++ b/dao/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     implementation(projects.config.configSpi)
     implementation(projects.model)
     implementation(projects.utils.config)
+    implementation(projects.utils.system)
 
     api(libs.exposedDao)
     api(libs.exposedJdbc)

--- a/dao/src/main/kotlin/repositories/ortrun/DaoOrtRunRepository.kt
+++ b/dao/src/main/kotlin/repositories/ortrun/DaoOrtRunRepository.kt
@@ -45,6 +45,7 @@ import org.eclipse.apoapsis.ortserver.model.runs.Issue
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
 import org.eclipse.apoapsis.ortserver.model.util.OptionalValue
+import org.eclipse.apoapsis.ortserver.utils.system.ORT_SERVER_VERSION
 
 import org.jetbrains.exposed.v1.core.JoinType
 import org.jetbrains.exposed.v1.core.Op
@@ -100,6 +101,7 @@ class DaoOrtRunRepository(private val db: Database) : OrtRunRepository {
             this.traceId = traceId
             this.environmentConfigPath = environmentConfigPath
             this.userDisplayName = UserDisplayNameDao.insertOrUpdate(userDisplayName)
+            this.ortServerVersion = ORT_SERVER_VERSION
         }.mapToModel()
     }
 

--- a/dao/src/main/kotlin/repositories/ortrun/OrtRunsTable.kt
+++ b/dao/src/main/kotlin/repositories/ortrun/OrtRunsTable.kt
@@ -86,6 +86,7 @@ object OrtRunsTable : SortableTable("ort_runs") {
     val traceId = text("trace_id").nullable()
     val environmentConfigPath = text("environment_config_path").nullable()
     val userDisplayName = reference("user_id", UserDisplayNamesTable.id).nullable()
+    val ortServerVersion = text("ort_server_version").nullable()
 
     /** Get the id of the analyzer run for the given ORT run [id]. Returns `null` if no run is found. */
     fun getAnalyzerRunIdById(id: Long): Long? =
@@ -120,6 +121,7 @@ class OrtRunDao(id: EntityID<Long>) : LongEntity(id) {
     var vcsProcessedId by OrtRunsTable.vcsProcessedId
     var environmentConfigPath by OrtRunsTable.environmentConfigPath
     var userDisplayName by UserDisplayNameDao optionalReferencedOn OrtRunsTable.userDisplayName
+    var ortServerVersion by OrtRunsTable.ortServerVersion
 
     val advisorJob by AdvisorJobDao optionalBackReferencedOn AdvisorJobsTable.ortRunId
     val analyzerJob by AnalyzerJobDao optionalBackReferencedOn AnalyzerJobsTable.ortRunId
@@ -154,7 +156,8 @@ class OrtRunDao(id: EntityID<Long>) : LongEntity(id) {
         resolvedJobConfigContext = resolvedJobConfigContext,
         traceId = traceId,
         environmentConfigPath = environmentConfigPath,
-        userDisplayName = userDisplayName?.mapToModel()
+        userDisplayName = userDisplayName?.mapToModel(),
+        ortServerVersion = ortServerVersion
     )
 
     /**
@@ -187,7 +190,8 @@ class OrtRunDao(id: EntityID<Long>) : LongEntity(id) {
             jobConfigContext = jobConfigContext,
             resolvedJobConfigContext = resolvedJobConfigContext,
             environmentConfigPath = environmentConfigPath,
-            userDisplayName = userDisplayName?.mapToModel()
+            userDisplayName = userDisplayName?.mapToModel(),
+            ortServerVersion = ortServerVersion
         )
     }
 }

--- a/dao/src/main/resources/db/migration/V144__addOrtServerVersionToOrtRuns.sql
+++ b/dao/src/main/resources/db/migration/V144__addOrtServerVersionToOrtRuns.sql
@@ -1,0 +1,1 @@
+ALTER TABLE ort_runs ADD COLUMN ort_server_version TEXT NULL;

--- a/dao/src/test/kotlin/repositories/ortrun/DaoOrtRunRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/ortrun/DaoOrtRunRepositoryTest.kt
@@ -60,6 +60,7 @@ import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
 import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
 import org.eclipse.apoapsis.ortserver.model.util.OrderField
 import org.eclipse.apoapsis.ortserver.model.util.asPresent
+import org.eclipse.apoapsis.ortserver.utils.system.ORT_SERVER_VERSION
 
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.select
@@ -143,7 +144,8 @@ class DaoOrtRunRepositoryTest : WordSpec({
                 repositoryConfigId = null,
                 issues = emptyList(),
                 traceId = traceId,
-                environmentConfigPath = environmentConfigPath
+                environmentConfigPath = environmentConfigPath,
+                ortServerVersion = ORT_SERVER_VERSION
             )
         }
 

--- a/model/src/commonMain/kotlin/OrtRun.kt
+++ b/model/src/commonMain/kotlin/OrtRun.kt
@@ -156,7 +156,12 @@ data class OrtRun(
     /**
      * Name of the user that triggered this run.
      */
-    val userDisplayName: UserDisplayName? = null
+    val userDisplayName: UserDisplayName? = null,
+
+    /**
+     * The version of the ORT Server that was active when this run was created.
+     */
+    val ortServerVersion: String? = null
 )
 
 enum class OrtRunStatus(

--- a/model/src/commonMain/kotlin/OrtRunSummary.kt
+++ b/model/src/commonMain/kotlin/OrtRunSummary.kt
@@ -114,7 +114,12 @@ data class OrtRunSummary(
     /**
      * The display name of the user that triggered this run.
      */
-    val userDisplayName: UserDisplayName? = null
+    val userDisplayName: UserDisplayName? = null,
+
+    /**
+     * The version of the ORT Server that was active when this run was created.
+     */
+    val ortServerVersion: String? = null
 )
 
 /**


### PR DESCRIPTION
See the commit messages for details.

The version is shown in the run details bar:

<img width="1418" height="86" alt="image" src="https://github.com/user-attachments/assets/6a6eb2fe-98d2-4170-9bdc-4a622e9c6f94" />
