### PR TITLE
fix(orchestrator): Preserve recipient addresses in rerun scenarios

### DIFF
--- a/orchestrator/src/main/kotlin/Orchestrator.kt
+++ b/orchestrator/src/main/kotlin/Orchestrator.kt
@@ -464,7 +464,6 @@ class Orchestrator(
     }
 
     private fun cleanupJobConfigs(jobConfigs: JobConfigurations) = jobConfigs.copy(
-        notifier = jobConfigs.notifier?.copy(recipientAddresses = emptyList()),
         parameters = jobConfigs.parameters - "recipientAddresses"
     )
 }


### PR DESCRIPTION
Previously, the `cleanupJobConfigs` function intentionally cleared the recipient addresses from the notifier configuration when a run completed. This caused the recipient addresses to be lost when a user tried to rerun a previous run, as the UI would fetch the cleaned configuration from the database.

Resolves #4865.
