### PR TITLE
Add index on `packages.identifier_id`

### DIFF
--- a/dao/src/main/resources/db/migration/V145__packagesIdentifierIdIndex.sql
+++ b/dao/src/main/resources/db/migration/V145__packagesIdentifierIdIndex.sql
@@ -1,0 +1,3 @@
+-- The lateral subquery in getPackagesWithDetectedLicenseForRun() filters packages by identifier_id
+-- on every outer row; without this index that causes a sequential scan of the entire packages table.
+CREATE INDEX packages_identifier_id ON packages (identifier_id);


### PR DESCRIPTION
PR #4870 already mitigated some performance problems of the "detected licenses" endpoints - the outermost query "fetch deduplicated detected licenses with the corresponding package counts", and the innermost query "fetch license detection data for a license and package" were made more performant.

This PR tries to improve the performance of the middle query "fetch all packages for this detected license", by adding a seemingly missing index to `packages` table, avoiding a scan of the whole packages table for each returned row.

Please see the commit for details.

NOTE: The author has unfortunately no means to assess the effect on performance from this migration on local Docker Compose environment - the real effects are seen on production. If it is seen as not helping considerably, a more invasive approach of adding a junction table, similar to #4870, needs to be taken in a follow-up PR. But this index is still helpful, so the options are not mutually exclusive.