### PR TITLE
fix(workers): Add advisors to the Advisor runner Docker image again

### DIFF
--- a/workers/advisor/build.gradle.kts
+++ b/workers/advisor/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     implementation(ortLibs.advisor)
     implementation(ortLibs.ortPlugins.advisors.api)
 
+    runtimeOnly(platform(ortLibs.ortPlugins.advisors))
     runtimeOnly(platform(projects.config))
     runtimeOnly(platform(projects.secrets))
     runtimeOnly(platform(projects.storage))


### PR DESCRIPTION
Due to [1], the Advisor runner Docker image did not contain the advisor plugins jars anymore. Add a new runtime dependency to force the addition of these jars.

[1]: https://github.com/oss-review-toolkit/ort/commit/7f11d2d3f5dba91e12d887413867232afcc05057