### PR TITLE
build(gradle): Disable Detekt's HTML and Markdown reports

### DIFF
--- a/buildSrc/src/main/kotlin/ort-server-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-kotlin-conventions.gradle.kts
@@ -73,6 +73,14 @@ tasks.withType<Detekt>().configureEach {
     exclude {
         "/build/generated/" in it.file.absoluteFile.invariantSeparatorsPath
     }
+
+    reports {
+        // Disable these as they have issues with Gradle task output caching due to contained timestamps.
+        html.required = false
+        markdown.required = false
+
+        sarif.required = true
+    }
 }
 
 tasks.register("detektAll") {


### PR DESCRIPTION
Detekt's tasks with type-resolution seem to depend on the report output of the tasks without type-resolution. As some of the reports contain timestamps, their content changes even if there are no new findings. Avoid this case of unnecessary Detekt task reruns by disabling these unneeded reports.