### PR TITLE
feat(secrets): Add configurable HTTP timeout for Vault client

### DIFF
--- a/secrets/vault/src/main/kotlin/VaultConfiguration.kt
+++ b/secrets/vault/src/main/kotlin/VaultConfiguration.kt
@@ -21,9 +21,13 @@ package org.eclipse.apoapsis.ortserver.secrets.vault
 
 import com.typesafe.config.Config
 
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.config.Path
 import org.eclipse.apoapsis.ortserver.secrets.vault.model.VaultCredentials
+import org.eclipse.apoapsis.ortserver.utils.config.getLongOrDefault
 import org.eclipse.apoapsis.ortserver.utils.config.getStringOrNull
 
 /**
@@ -54,7 +58,10 @@ data class VaultConfiguration(
      * of multiple tenants. In an environment that uses namespaces, it is necessary to pass the target namespace as
      * a header when sending requests to the Vault service. If this property is not *null*, such a header is added.
      */
-    val namespace: String? = null
+    val namespace: String? = null,
+
+    /** The timeout to be applied to all HTTP requests against the Vault service. */
+    val timeout: Duration = DEFAULT_TIMEOUT
 ) {
     companion object {
         /** Name of the configuration property for the URI of the Vault service. */
@@ -75,8 +82,14 @@ data class VaultConfiguration(
         /** Name of the configuration property defining the namespace to be passed to the vault service. */
         private const val NAMESPACE_PROPERTY = "vaultNamespace"
 
+        /** Name of the configuration property defining the timeout for HTTP requests in seconds. */
+        private const val TIMEOUT_PROPERTY = "vaultHttpTimeoutSec"
+
         /** The default path prefix under which the KV Secrets Engine is available. */
         private const val DEFAULT_PREFIX = "secret"
+
+        /** The default timeout for HTTP requests to the Vault service. */
+        val DEFAULT_TIMEOUT = 10.seconds
 
         /** The separator for hierarchical paths. */
         private const val PATH_SEPARATOR = "/"
@@ -92,7 +105,8 @@ data class VaultConfiguration(
             ),
             rootPath = getOptionalRootPath(configManager),
             prefix = getOptionalPrefix(configManager),
-            namespace = configManager.getStringOrNull(NAMESPACE_PROPERTY)
+            namespace = configManager.getStringOrNull(NAMESPACE_PROPERTY),
+            timeout = configManager.getLongOrDefault(TIMEOUT_PROPERTY, DEFAULT_TIMEOUT.inWholeSeconds).seconds
         )
 
         /**

--- a/secrets/vault/src/main/kotlin/VaultSecretsProvider.kt
+++ b/secrets/vault/src/main/kotlin/VaultSecretsProvider.kt
@@ -25,6 +25,7 @@ import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.client.plugins.HttpSend
+import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.plugins.expectSuccess
@@ -138,6 +139,11 @@ class VaultSecretsProvider(
                         ignoreUnknownKeys = true
                     }
                 )
+            }
+
+            install(HttpTimeout) {
+                requestTimeoutMillis = config.timeout.inWholeMilliseconds
+                socketTimeoutMillis = config.timeout.inWholeMilliseconds
             }
 
             install(HttpRequestRetry) {

--- a/secrets/vault/src/main/resources/application.conf
+++ b/secrets/vault/src/main/resources/application.conf
@@ -22,4 +22,5 @@ secretsProvider {
   vaultRootPath = ${?VAULT_ROOT_PATH}
   vaultPrefix = ${?VAULT_PREFIX}
   vaultNamespace = ${?VAULT_NAMESPACE}
+  vaultHttpTimeoutSec = ${?VAULT_HTTP_TIMEOUT_SEC}
 }


### PR DESCRIPTION
Add a `vaultHttpTimeoutSec` config property to set the HTTP timeout for requests to the Vault service, defaulting to 10 seconds.