### PR TITLE
fix(secrets): Scope in-use check to the secret's hierarchy level

### DIFF
--- a/components/infrastructure-services/backend/src/main/kotlin/InfrastructureServiceService.kt
+++ b/components/infrastructure-services/backend/src/main/kotlin/InfrastructureServiceService.kt
@@ -214,13 +214,20 @@ class InfrastructureServiceService(
     }
 
     /**
-     * Return a list with the [InfrastructureService]s that are associated with the name of the given
-     * [Secret][secretName].
+     * Return a list with the [InfrastructureService]s that reference the given [secretName] at the given hierarchy
+     * [id]. Only services at the same hierarchy level are checked, as secrets with the same name at different levels
+     * are independent.
      */
-    suspend fun listForSecret(secretName: String): List<InfrastructureService> = db.dbQuery {
+    suspend fun listForSecret(secretName: String, id: HierarchyId): List<InfrastructureService> = db.dbQuery {
+        val hierarchyFilter = when (id) {
+            is OrganizationId -> InfrastructureServicesTable.organizationId eq id.value
+            is ProductId -> InfrastructureServicesTable.productId eq id.value
+            is RepositoryId -> InfrastructureServicesTable.repositoryId eq id.value
+        }
+        val secretFilter = InfrastructureServicesTable.usernameSecret eq secretName or
+                (InfrastructureServicesTable.passwordSecret eq secretName)
         list(ListQueryParameters.DEFAULT) {
-            InfrastructureServicesTable.usernameSecret eq secretName or
-                    (InfrastructureServicesTable.passwordSecret eq secretName)
+            secretFilter and hierarchyFilter
         }
     }
 

--- a/compositions/secrets-routes/src/main/kotlin/routes/DeleteOrganizationSecret.kt
+++ b/compositions/secrets-routes/src/main/kotlin/routes/DeleteOrganizationSecret.kt
@@ -67,7 +67,7 @@ internal fun Route.deleteOrganizationSecret(
         return@delete
     }
 
-    val infrastructureServices = infrastructureServiceService.listForSecret(secret.name)
+    val infrastructureServices = infrastructureServiceService.listForSecret(secret.name, organizationId)
     if (infrastructureServices.isNotEmpty()) {
         call.respondError(
             HttpStatusCode.Conflict,

--- a/compositions/secrets-routes/src/main/kotlin/routes/DeleteProductSecret.kt
+++ b/compositions/secrets-routes/src/main/kotlin/routes/DeleteProductSecret.kt
@@ -66,7 +66,7 @@ internal fun Route.deleteProductSecret(
         return@delete
     }
 
-    val infrastructureServices = infrastructureServiceService.listForSecret(secret.name)
+    val infrastructureServices = infrastructureServiceService.listForSecret(secret.name, productId)
     if (infrastructureServices.isNotEmpty()) {
         call.respondError(
             HttpStatusCode.Conflict,

--- a/compositions/secrets-routes/src/main/kotlin/routes/DeleteRepositorySecret.kt
+++ b/compositions/secrets-routes/src/main/kotlin/routes/DeleteRepositorySecret.kt
@@ -66,7 +66,7 @@ internal fun Route.deleteRepositorySecret(
         return@delete
     }
 
-    val infrastructureServices = infrastructureServiceService.listForSecret(secret.name)
+    val infrastructureServices = infrastructureServiceService.listForSecret(secret.name, repositoryId)
     if (infrastructureServices.isNotEmpty()) {
         call.respondError(
             HttpStatusCode.Conflict,

--- a/compositions/secrets-routes/src/test/kotlin/routes/DeleteOrganizationSecretIntegrationTest.kt
+++ b/compositions/secrets-routes/src/test/kotlin/routes/DeleteOrganizationSecretIntegrationTest.kt
@@ -35,6 +35,7 @@ import java.util.EnumSet
 import org.eclipse.apoapsis.ortserver.compositions.secretsroutes.SecretsRoutesIntegrationTest
 import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.OrganizationId
+import org.eclipse.apoapsis.ortserver.model.ProductId
 import org.eclipse.apoapsis.ortserver.model.repositories.SecretRepository
 import org.eclipse.apoapsis.ortserver.secrets.Path
 import org.eclipse.apoapsis.ortserver.secrets.SecretsProviderFactoryForTesting
@@ -42,9 +43,11 @@ import org.eclipse.apoapsis.ortserver.shared.apimodel.ErrorResponse
 
 class DeleteOrganizationSecretIntegrationTest : SecretsRoutesIntegrationTest({
     var orgId = 0L
+    var prodId = 0L
 
     beforeEach {
         orgId = dbExtension.fixtures.organization.id
+        prodId = dbExtension.fixtures.product.id
     }
 
     "DeleteOrganizationSecret" should {
@@ -94,6 +97,36 @@ class DeleteOrganizationSecretIntegrationTest : SecretsRoutesIntegrationTest({
                         HttpStatusCode.InternalServerError
 
                 secretRepository.getByIdAndName(OrganizationId(orgId), secret.name) shouldBe secret
+            }
+        }
+
+        "not block deletion when a secret with the same name at a different hierarchy level is referenced" {
+            secretsRoutesTestApplication { client ->
+                val secretName = "sharedName"
+                val orgSecret = secretRepository.createOrganizationSecret(
+                    orgId,
+                    path = "org-path",
+                    name = secretName
+                )
+                secretRepository.createProductSecret(prodId, path = "product-path", name = secretName)
+
+                infrastructureServiceService.createForId(
+                    ProductId(prodId),
+                    name = "productService",
+                    url = "http://example.org/service",
+                    description = null,
+                    usernameSecretRef = secretName,
+                    passwordSecretRef = secretName,
+                    credentialsTypes = EnumSet.of(CredentialsType.NETRC_FILE)
+                )
+
+                client.delete("/organizations/$orgId/secrets/$secretName") shouldHaveStatus
+                        HttpStatusCode.NoContent
+
+                secretRepository.getByIdAndName(OrganizationId(orgId), secretName) shouldBe null
+
+                val provider = SecretsProviderFactoryForTesting.instance()
+                provider.readSecret(Path(orgSecret.path)) should beNull()
             }
         }
     }

--- a/compositions/secrets-routes/src/test/kotlin/routes/DeleteProductSecretIntegrationTest.kt
+++ b/compositions/secrets-routes/src/test/kotlin/routes/DeleteProductSecretIntegrationTest.kt
@@ -34,6 +34,7 @@ import java.util.EnumSet
 
 import org.eclipse.apoapsis.ortserver.compositions.secretsroutes.SecretsRoutesIntegrationTest
 import org.eclipse.apoapsis.ortserver.model.CredentialsType
+import org.eclipse.apoapsis.ortserver.model.OrganizationId
 import org.eclipse.apoapsis.ortserver.model.ProductId
 import org.eclipse.apoapsis.ortserver.model.repositories.SecretRepository
 import org.eclipse.apoapsis.ortserver.secrets.Path
@@ -42,11 +43,13 @@ import org.eclipse.apoapsis.ortserver.shared.apimodel.ErrorResponse
 
 class DeleteProductSecretIntegrationTest : SecretsRoutesIntegrationTest({
     var prodId = 0L
+    var orgId = 0L
 
     val secretErrorPath = "error-path"
 
     beforeEach {
         prodId = dbExtension.fixtures.product.id
+        orgId = dbExtension.fixtures.organization.id
     }
 
     "DeleteProductSecret" should {
@@ -96,6 +99,36 @@ class DeleteProductSecretIntegrationTest : SecretsRoutesIntegrationTest({
                         HttpStatusCode.InternalServerError
 
                 secretRepository.getByIdAndName(ProductId(prodId), secret.name) shouldBe secret
+            }
+        }
+
+        "not block deletion when a same-named secret at a different hierarchy level is referenced" {
+            secretsRoutesTestApplication { client ->
+                val secretName = "sharedName"
+                val productSecret = secretRepository.createProductSecret(
+                    prodId,
+                    path = "product-path",
+                    name = secretName
+                )
+                secretRepository.createOrganizationSecret(orgId, path = "org-path", name = secretName)
+
+                infrastructureServiceService.createForId(
+                    OrganizationId(orgId),
+                    name = "orgService",
+                    url = "http://example.org/service",
+                    description = null,
+                    usernameSecretRef = secretName,
+                    passwordSecretRef = secretName,
+                    credentialsTypes = EnumSet.of(CredentialsType.NETRC_FILE)
+                )
+
+                client.delete("/products/$prodId/secrets/$secretName") shouldHaveStatus
+                        HttpStatusCode.NoContent
+
+                secretRepository.getByIdAndName(ProductId(prodId), secretName) shouldBe null
+
+                val provider = SecretsProviderFactoryForTesting.instance()
+                provider.readSecret(Path(productSecret.path)) should beNull()
             }
         }
     }

--- a/compositions/secrets-routes/src/test/kotlin/routes/DeleteRepositorySecretIntegrationTest.kt
+++ b/compositions/secrets-routes/src/test/kotlin/routes/DeleteRepositorySecretIntegrationTest.kt
@@ -34,6 +34,7 @@ import java.util.EnumSet
 
 import org.eclipse.apoapsis.ortserver.compositions.secretsroutes.SecretsRoutesIntegrationTest
 import org.eclipse.apoapsis.ortserver.model.CredentialsType
+import org.eclipse.apoapsis.ortserver.model.OrganizationId
 import org.eclipse.apoapsis.ortserver.model.RepositoryId
 import org.eclipse.apoapsis.ortserver.model.repositories.SecretRepository
 import org.eclipse.apoapsis.ortserver.secrets.Path
@@ -42,9 +43,11 @@ import org.eclipse.apoapsis.ortserver.shared.apimodel.ErrorResponse
 
 class DeleteRepositorySecretIntegrationTest : SecretsRoutesIntegrationTest({
     var repoId = 0L
+    var orgId = 0L
 
     beforeEach {
         repoId = dbExtension.fixtures.repository.id
+        orgId = dbExtension.fixtures.organization.id
     }
 
     "DeleteRepositorySecret" should {
@@ -94,6 +97,36 @@ class DeleteRepositorySecretIntegrationTest : SecretsRoutesIntegrationTest({
                         HttpStatusCode.InternalServerError
 
                 secretRepository.getByIdAndName(RepositoryId(repoId), secret.name) shouldBe secret
+            }
+        }
+
+        "not block deletion when a same-named secret at a different hierarchy level is referenced" {
+            secretsRoutesTestApplication { client ->
+                val secretName = "sharedName"
+                val repoSecret = secretRepository.createRepositorySecret(
+                    repoId,
+                    path = "repo-path",
+                    name = secretName
+                )
+                secretRepository.createOrganizationSecret(orgId, path = "org-path", name = secretName)
+
+                infrastructureServiceService.createForId(
+                    OrganizationId(orgId),
+                    name = "orgService",
+                    url = "http://example.org/service",
+                    description = null,
+                    usernameSecretRef = secretName,
+                    passwordSecretRef = secretName,
+                    credentialsTypes = EnumSet.of(CredentialsType.NETRC_FILE)
+                )
+
+                client.delete("/repositories/$repoId/secrets/$secretName") shouldHaveStatus
+                        HttpStatusCode.NoContent
+
+                secretRepository.getByIdAndName(RepositoryId(repoId), secretName) shouldBe null
+
+                val provider = SecretsProviderFactoryForTesting.instance()
+                provider.readSecret(Path(repoSecret.path)) should beNull()
             }
         }
     }

--- a/transport/rabbitmq/src/test/kotlin/RabbitMqMessageReceiverFactoryTest.kt
+++ b/transport/rabbitmq/src/test/kotlin/RabbitMqMessageReceiverFactoryTest.kt
@@ -51,7 +51,7 @@ class RabbitMqMessageReceiverFactoryTest : StringSpec({
             val channel = connection.createChannel().also {
                 it.queueDeclare(
                     /* queue = */ TEST_QUEUE_NAME,
-                    /* durable = */ false,
+                    /* durable = */ true,
                     /* exclusive = */ false,
                     /* autoDelete = */ false,
                     /* arguments = */ emptyMap()
@@ -98,7 +98,7 @@ class RabbitMqMessageReceiverFactoryTest : StringSpec({
             val channel = connection.createChannel().also {
                 it.queueDeclare(
                     /* queue = */ TEST_QUEUE_NAME,
-                    /* durable = */ false,
+                    /* durable = */ true,
                     /* exclusive = */ false,
                     /* autoDelete = */ false,
                     /* arguments = */ emptyMap()
@@ -140,7 +140,7 @@ class RabbitMqMessageReceiverFactoryTest : StringSpec({
             val channel = connection.createChannel().also {
                 it.queueDeclare(
                     /* queue = */ TEST_QUEUE_NAME,
-                    /* durable = */ false,
+                    /* durable = */ true,
                     /* exclusive = */ false,
                     /* autoDelete = */ false,
                     /* arguments = */ emptyMap()

--- a/transport/rabbitmq/src/test/kotlin/RabbitMqMessageSenderFactoryTest.kt
+++ b/transport/rabbitmq/src/test/kotlin/RabbitMqMessageSenderFactoryTest.kt
@@ -68,7 +68,7 @@ class RabbitMqMessageSenderFactoryTest : StringSpec({
                 connection.createChannel().also {
                     it.queueDeclare(
                         /* queue = */ TEST_QUEUE_NAME,
-                        /* durable = */ false,
+                        /* durable = */ true,
                         /* exclusive = */ false,
                         /* autoDelete = */ false,
                         /* arguments = */ emptyMap()

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-create-run-utils.ts
@@ -241,6 +241,23 @@ export function defaultValues(
   isSuperuser: boolean
 ): z.infer<typeof createRunFormSchema> {
   /**
+   * Looks up a key in package manager options case-insensitively. Old runs (e.g. triggered via
+   * GitHub Actions) may have stored package manager names in all-caps (e.g. "SPDXDOCUMENTFILE"),
+   * so case-insensitive matching is needed to stay compatible when rerunning those old runs.
+   */
+  const findPackageManagerOptionsKey = (
+    options: Record<string, unknown> | undefined,
+    packageManagerId: string
+  ) => {
+    if (!options) return undefined;
+    const idLower = packageManagerId.toLowerCase();
+    const matchingKey = Object.keys(options).find(
+      (key) => key.toLowerCase() === idLower
+    );
+    return matchingKey ? options[matchingKey] : undefined;
+  };
+
+  /**
    * Constructs the default options for a package manager, either as a blank set of options
    * or from an earlier ORT run if rerun functionality is used.
    *
@@ -253,20 +270,30 @@ export function defaultValues(
     enabledByDefault: boolean = true
   ) => {
     if (ortRun) {
+      const enabledPackageManagers =
+        ortRun.jobConfigs.analyzer?.enabledPackageManagers;
+      const pmOptions = ortRun.jobConfigs.analyzer?.packageManagerOptions as
+        | Record<string, unknown>
+        | undefined;
+      const matchedOptions = findPackageManagerOptionsKey(
+        pmOptions,
+        packageManagerId
+      ) as
+        | {
+            mustRunAfter?: PackageManagerId[];
+            options?: Record<string, string>;
+          }
+        | undefined;
       return {
         enabled:
-          ortRun.jobConfigs.analyzer?.enabledPackageManagers === undefined
+          enabledPackageManagers == null
             ? enabledByDefault
-            : ortRun.jobConfigs.analyzer?.enabledPackageManagers?.includes(
-                packageManagerId
-              ) || false,
+            : enabledPackageManagers.some(
+                (pm) => pm.toLowerCase() === packageManagerId.toLowerCase()
+              ),
         mustRunAfter:
-          (ortRun.jobConfigs.analyzer?.packageManagerOptions?.[packageManagerId]
-            ?.mustRunAfter as PackageManagerId[]) || [],
-        options: convertMapToArray(
-          ortRun.jobConfigs.analyzer?.packageManagerOptions?.[packageManagerId]
-            ?.options || {}
-        ),
+          (matchedOptions?.mustRunAfter as PackageManagerId[]) || [],
+        options: convertMapToArray(matchedOptions?.options || {}),
       };
     }
     return {


### PR DESCRIPTION
Only check infrastructure services at the same hierarchy level when deleting a secret, as same-named secrets at different levels are independent.