### PR TITLE
fix(ui): Adjust padding and margins in plugin and advisor fields

### DIFF
--- a/ui/src/components/form/plugin-multi-select-field.tsx
+++ b/ui/src/components/form/plugin-multi-select-field.tsx
@@ -123,7 +123,7 @@ export const PluginMultiSelectField = <
               Enable/disable all
             </Label>
           </div>
-          <Separator />
+          <Separator className='my-2' />
           {plugins.map((plugin) => (
             <FormItem
               key={plugin.id}
@@ -143,7 +143,7 @@ export const PluginMultiSelectField = <
                   }}
                 />
               </FormControl>
-              <div className='flex flex-col'>
+              <div className='flex flex-col space-y-2'>
                 <FormLabel className='font-normal'>
                   {plugin.displayName}
                 </FormLabel>
@@ -161,10 +161,13 @@ export const PluginMultiSelectField = <
                         `${configName}.${plugin.id}.${option.type === 'SECRET' ? 'secrets' : 'options'}.${option.name}` as Path<TFieldValues>
                       }
                       render={({ field }) => (
-                        <FormItem className='flex flex-col space-y-1'>
-                          <FormLabel className='mt-2'>
+                        <FormItem className='ml-4 flex flex-col space-y-0.5 pb-4'>
+                          <FormLabel>
                             {option.name}
-                            <Badge className='ml-2 bg-blue-200 text-black'>
+                            <Badge
+                              variant='small'
+                              className='bg-blue-200 text-black'
+                            >
                               {option.type}
                             </Badge>
                           </FormLabel>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/advisor-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/advisor-fields.tsx
@@ -76,7 +76,7 @@ export const AdvisorFields = ({
             name='jobConfigs.advisor.skipExcluded'
             render={({ field }) => (
               <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
-                <div className='space-y-0.5'>
+                <div className='space-y-2'>
                   <FormLabel>Skip excluded</FormLabel>
                   <FormDescription>
                     A flag to control whether excluded scopes and paths should


### PR DESCRIPTION
This PR addresses the spacing inconsistencies reported in the issue, using the spacing between "Enabled advisors" and the text below as the standard reference.

- Vertical Spacing: Unified vertical distance between elements to maintain consistency across the view.
- Properties with Badges: Fixed excessive spacing after property names caused by the badge height.
- Subitems: Added margin-left to subitems to improve visual hierarchy and indentation.

<img width="1186" height="792" alt="image" src="https://github.com/user-attachments/assets/4b3f1c4c-c3d5-4f6b-9e1f-d7c7ed102fc3" />


Resolves #4894.