### PR TITLE
build: Fix the logic to opt-in to the experimental serialization API

### DIFF
--- a/buildSrc/src/main/kotlin/ort-server-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-kotlin-conventions.gradle.kts
@@ -54,18 +54,18 @@ detekt {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-    if (!name.startsWith("compileKotlin")) return@configureEach
-
-    val hasSerializationPlugin = plugins.hasPlugin(libs.plugins.kotlinSerialization.get().pluginId)
-
-    val optInRequirements = listOfNotNull(
-        "kotlinx.serialization.ExperimentalSerializationApi".takeIf { hasSerializationPlugin }
-    )
+    val serializationOptIn = libraries.elements.map { files ->
+        buildList {
+            if (files.any { it.asFile.name.startsWith("kotlinx-serialization-core") }) {
+                add("kotlinx.serialization.ExperimentalSerializationApi")
+            }
+        }
+    }
 
     compilerOptions {
         allWarningsAsErrors = true
         freeCompilerArgs.addAll("-Xconsistent-data-class-copy-visibility")
-        optIn = optInRequirements
+        optIn = serializationOptIn
     }
 }
 


### PR DESCRIPTION
The previous approach checked if the serialization plugin is applied to a module, but this fails the compilation for source sets which do not have the serialization library on the classpath. Therefore, the compiler options were only applied if the task name started with "compileKotlin", but as a result tasks like `compileRoutesKotlin` were not configured correctly.

Instead of changing the filter logic which might break again with later changes, apply the opt-in to all compilations that have `kotlinx-serialization-core` on the classpath.