### PR TITLE
deps: Replace wiremock-standalone dependency

### DIFF
--- a/clients/keycloak/build.gradle.kts
+++ b/clients/keycloak/build.gradle.kts
@@ -42,7 +42,7 @@ dependencies {
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
-    testImplementation(libs.wiremockStandalone)
+    testImplementation(libs.wiremock)
 
     testFixturesApi(libs.kotestFrameworkEngine)
     testFixturesApi(libs.testContainersKeycloak)

--- a/config/github/build.gradle.kts
+++ b/config/github/build.gradle.kts
@@ -41,5 +41,5 @@ dependencies {
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
-    testImplementation(libs.wiremockStandalone)
+    testImplementation(libs.wiremock)
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,7 +65,7 @@ schemaKenerator = "2.7.2"
 slf4j = "2.0.17"
 testContainers = "2.0.5"
 typesafeConfig = "1.4.6"
-wiremock = "3.0.1"
+wiremock = "3.13.2"
 
 [plugins]
 buildConfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildConfigPlugin" }
@@ -143,7 +143,7 @@ testContainersPostgresql = { module = "org.testcontainers:testcontainers-postgre
 testContainersRabbitMq = { module = "org.testcontainers:testcontainers-rabbitmq", version.ref = "testContainers" }
 testContainersVault = { module = "org.testcontainers:testcontainers-vault", version.ref = "testContainers" }
 typesafeConfig = { module = "com.typesafe:config", version.ref = "typesafeConfig" }
-wiremockStandalone = { module = "com.github.tomakehurst:wiremock-standalone", version.ref = "wiremock" }
+wiremock = { module = "org.wiremock:wiremock", version.ref = "wiremock" }
 
 [bundles]
 flyway = ["flywayCore", "flywayPostgresql"]

--- a/logaccess/elasticsearch/build.gradle.kts
+++ b/logaccess/elasticsearch/build.gradle.kts
@@ -43,5 +43,5 @@ dependencies {
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
     testImplementation(libs.typesafeConfig)
-    testImplementation(libs.wiremockStandalone)
+    testImplementation(libs.wiremock)
 }

--- a/logaccess/loki/build.gradle.kts
+++ b/logaccess/loki/build.gradle.kts
@@ -46,5 +46,5 @@ dependencies {
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
-    testImplementation(libs.wiremockStandalone)
+    testImplementation(libs.wiremock)
 }

--- a/secrets/vault/build.gradle.kts
+++ b/secrets/vault/build.gradle.kts
@@ -45,5 +45,5 @@ dependencies {
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
     testImplementation(libs.testContainersVault)
-    testImplementation(libs.wiremockStandalone)
+    testImplementation(libs.wiremock)
 }


### PR DESCRIPTION
For the tests, the basic `org.wiremock:wiremock` dependency is sufficient, which is significantly smaller.