### PR TITLE
chore(core): Remove unused `jwt.roleCacheLifetimeSeconds`

### DIFF
--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -68,8 +68,6 @@ jwt {
   audience = ${?JWT_AUDIENCE}
   realm = "master"
   realm = ${?JWT_REALM}
-  roleCacheLifetimeSeconds = 60
-  roleCacheLifetimeSeconds = ${?JWT_ROLE_CACHE_LIFETIME}
 }
 
 keycloak {


### PR DESCRIPTION
The config option is not used anymore since 3967d04.