### PR TITLE
Fix detected licenses showing scan results from wrong run

### DIFF
--- a/components/license-findings/backend/src/main/kotlin/LicenseFindingService.kt
+++ b/components/license-findings/backend/src/main/kotlin/LicenseFindingService.kt
@@ -28,6 +28,7 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesAnaly
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.scannerjob.ScannerJobsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsPackageProvenancesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsScanResultsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.LicenseFindingsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.PackageProvenancesTable
@@ -294,6 +295,12 @@ private fun buildQueryContext(): QueryContext {
         )
         .join(ScannerRunsTable, JoinType.INNER, ScannerRunsPackageProvenancesTable.scannerRunId, ScannerRunsTable.id)
         .join(ScannerJobsTable, JoinType.INNER, ScannerRunsTable.scannerJobId, ScannerJobsTable.id)
+        // Ensures only scan results explicitly associated with the matched scanner run are returned,
+        // preventing results from a different scanner run that shares the same package provenance from leaking in.
+        .join(
+            ScannerRunsScanResultsTable, JoinType.INNER,
+            ScanResultsTable.id, ScannerRunsScanResultsTable.scanResultId
+        ) { ScannerRunsScanResultsTable.scannerRunId eq ScannerRunsTable.id }
         .join(IdentifiersTable, JoinType.INNER, PackageProvenancesTable.identifierId, IdentifiersTable.id)
 
     return QueryContext(join)

--- a/components/license-findings/backend/src/test/kotlin/LicenseFindingServiceTest.kt
+++ b/components/license-findings/backend/src/test/kotlin/LicenseFindingServiceTest.kt
@@ -109,6 +109,18 @@ class LicenseFindingServiceTest : WordSpec() {
                 result.data shouldContainExactly listOf(DetectedLicense("Apache-2.0", 2))
             }
 
+            "not include scan results from a different scanner run sharing the same package provenance" {
+                val cross = seedCrossRunData(fixtures, db)
+
+                val result = service.getDetectedLicensesForRun(
+                    cross.ortRunId2,
+                    ListQueryParameters(sortFields = listOf(OrderField("license", OrderDirection.ASCENDING))),
+                    null
+                )
+
+                result.data.map { it.license } shouldContainExactly listOf("MIT")
+            }
+
             "sort by packageCount descending without throwing" {
                 val result = service.getDetectedLicensesForRun(
                     seed.ortRunId,
@@ -265,6 +277,21 @@ class LicenseFindingServiceTest : WordSpec() {
                 )
             }
 
+            "not include packages whose scan result belongs to a different scanner run" {
+                val cross = seedCrossRunData(fixtures, db)
+
+                val apacheResult = service.getPackagesWithDetectedLicenseForRun(
+                    cross.ortRunId2,
+                    "Apache-2.0",
+                    ListQueryParameters(sortFields = listOf(OrderField("identifier", OrderDirection.ASCENDING))),
+                    null,
+                    null
+                )
+
+                apacheResult.totalCount shouldBe 0
+                apacheResult.data.shouldBeEmpty()
+            }
+
             "sort by purl" {
                 val result = service.getPackagesWithDetectedLicenseForRun(
                     seed.ortRunId,
@@ -358,6 +385,20 @@ class LicenseFindingServiceTest : WordSpec() {
                     "Maven:com.example:missing:1.0",
                     ListQueryParameters(sortFields = listOf(OrderField("path", OrderDirection.ASCENDING)))
                 ).data.shouldBeEmpty()
+            }
+
+            "not return findings from a different scanner run sharing the same package provenance" {
+                val cross = seedCrossRunData(fixtures, db)
+
+                val result = service.getLicenseFindingsForRun(
+                    cross.ortRunId2,
+                    "Apache-2.0",
+                    cross.identifier.toCoordinates(),
+                    ListQueryParameters(sortFields = listOf(OrderField("path", OrderDirection.ASCENDING)))
+                )
+
+                result.totalCount shouldBe 0
+                result.data.shouldBeEmpty()
             }
 
             "not return findings from other ORT runs" {
@@ -487,6 +528,85 @@ internal fun seedData(fixtures: Fixtures, db: Database, duplicatePackageEntries:
         vcsPurl = vcsPurl,
         otherPurl = otherPurl
     )
+}
+
+internal data class CrossRunSeedResult(
+    val ortRunId1: Long,
+    val ortRunId2: Long,
+    val identifier: Identifier
+)
+
+/**
+ * Seeds two ORT runs that share the same package provenance but use different scanners. Used to verify that
+ * results from the first run's scanner do not bleed into the second run's results.
+ *
+ * Run 1 uses "ScanCode" and finds "Apache-2.0". Run 2 uses "Licensee" and finds "MIT".
+ */
+internal fun seedCrossRunData(fixtures: Fixtures, db: Database): CrossRunSeedResult {
+    val identifier = Identifier("Maven", "com.example", "shared-package", "1.0")
+    val artifact = RemoteArtifact(
+        url = "https://example.com/shared-package-1.0.jar",
+        hashValue = "abcdef1234567890abcdef1234567890abcdef12",
+        hashAlgorithm = "SHA-1"
+    )
+
+    val ortRun1 = fixtures.createOrtRun()
+    val ortRun2 = fixtures.createOrtRun()
+
+    db.blockingQuery {
+        val scannerJob1 = fixtures.createScannerJob(ortRun1.id)
+        val scannerRun1 = fixtures.scannerRunRepository.create(scannerJob1.id)
+        val scannerJob2 = fixtures.createScannerJob(ortRun2.id)
+        val scannerRun2 = fixtures.scannerRunRepository.create(scannerJob2.id)
+
+        val packageProvenance = PackageProvenanceDao.new {
+            this.identifier = IdentifierDao.getOrPut(identifier)
+            this.artifact = RemoteArtifactDao.getOrPut(artifact)
+            this.vcs = null
+            this.resolvedRevision = null
+            this.clonedRevision = null
+            this.isFixedRevision = null
+            this.errorMessage = null
+        }
+        ScannerRunsPackageProvenancesTable.insertIfNotExists(scannerRun1.id, packageProvenance.id.value)
+        ScannerRunsPackageProvenancesTable.insertIfNotExists(scannerRun2.id, packageProvenance.id.value)
+
+        // Run 1: ScanCode finds Apache-2.0.
+        val scanResult1 = ScanResultDao.new {
+            artifactUrl = artifact.url
+            artifactHash = artifact.hashValue
+            artifactHashAlgorithm = artifact.hashAlgorithm
+            vcsType = null
+            vcsUrl = null
+            vcsRevision = null
+            this.scanSummary = createScanSummary(listOf(FindingSeed("Apache-2.0", "LICENSE", 1, 10, 99f)))
+            scannerName = "ScanCode"
+            scannerVersion = "32.0"
+            scannerConfiguration = ""
+            additionalScanResultData = null
+        }
+        ScannerRunsScanResultsTable.insertIfNotExists(scannerRun1.id, scanResult1.id.value)
+        ScanResultPackageProvenancesTable.insertIfNotExists(scanResult1.id.value, packageProvenance.id.value)
+
+        // Run 2: Licensee finds MIT on the same package provenance.
+        val scanResult2 = ScanResultDao.new {
+            artifactUrl = artifact.url
+            artifactHash = artifact.hashValue
+            artifactHashAlgorithm = artifact.hashAlgorithm
+            vcsType = null
+            vcsUrl = null
+            vcsRevision = null
+            this.scanSummary = createScanSummary(listOf(FindingSeed("MIT", "LICENSE", 1, 10, 98f)))
+            scannerName = "Licensee"
+            scannerVersion = "9.14"
+            scannerConfiguration = ""
+            additionalScanResultData = null
+        }
+        ScannerRunsScanResultsTable.insertIfNotExists(scannerRun2.id, scanResult2.id.value)
+        ScanResultPackageProvenancesTable.insertIfNotExists(scanResult2.id.value, packageProvenance.id.value)
+    }
+
+    return CrossRunSeedResult(ortRun1.id, ortRun2.id, identifier)
 }
 
 private data class FindingSeed(

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/run-details-bar.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/run-details-bar.tsx
@@ -111,10 +111,11 @@ export const RunDetailsBar = ({ className }: RunDetailsBarProps) => {
   // E.g., if on .../runs/5/config, navigating to run 4 should go to
   // .../runs/4/config instead of /runs/4.
   const buildRunPath = (runIndex: number) => {
-    return location.pathname.replace(
+    const pathname = location.pathname.replace(
       `/runs/${params.runIndex}`,
       `/runs/${runIndex}`
     );
+    return location.searchStr ? `${pathname}${location.searchStr}` : pathname;
   };
 
   return (


### PR DESCRIPTION
This was tested with run 13 using only ScanCode, and run 12 only DOS.

<img width="1140" height="747" alt="Screenshot from 2026-04-29 13-50-18" src="https://github.com/user-attachments/assets/df5a6d67-ded4-48e3-b007-265e097d3cba" />

<img width="1140" height="747" alt="Screenshot from 2026-04-29 13-50-46" src="https://github.com/user-attachments/assets/69fd8416-ba1d-47e3-82d8-2b1226d358ea" />

Please see the commits for details. The latter one fixes one annoying missing feature from switching the run views, which was helpful for producing exactly same views from both runs.