### PR TITLE
Distinguish empty states for detected licenses

### DIFF
--- a/ui/src/components/data-table-cards/data-table-cards.tsx
+++ b/ui/src/components/data-table-cards/data-table-cards.tsx
@@ -69,6 +69,7 @@ export function DataTableCards<TData>({
           rows={table.getRowModel().rows}
           renderSubComponent={renderSubComponent}
           columnSizing={columnSizing}
+          columnCount={table.getVisibleLeafColumns().length}
         />
       </Table>
       {table.getRowModel().rows?.length > 0 && (

--- a/ui/src/components/data-table/data-table-body.tsx
+++ b/ui/src/components/data-table/data-table-body.tsx
@@ -27,6 +27,7 @@ interface DataTableBodyProps<TData> {
   renderSubComponent?: (props: { row: Row<TData> }) => React.ReactElement;
   columnSizing?: Record<string, number>;
   columnCount: number;
+  noResultsContent?: React.ReactNode;
 }
 
 export function DataTableBody<TData>({
@@ -34,6 +35,7 @@ export function DataTableBody<TData>({
   renderSubComponent,
   columnSizing,
   columnCount,
+  noResultsContent,
 }: DataTableBodyProps<TData>) {
   return (
     <TableBody>
@@ -75,7 +77,9 @@ export function DataTableBody<TData>({
       ) : (
         <TableRow>
           <TableCell colSpan={columnCount || 1} className='h-24 text-center'>
-            No results.
+            {noResultsContent ?? (
+              <div className='text-muted-foreground text-sm'>No results.</div>
+            )}
           </TableCell>
         </TableRow>
       )}

--- a/ui/src/components/data-table/data-table-body.tsx
+++ b/ui/src/components/data-table/data-table-body.tsx
@@ -26,12 +26,14 @@ interface DataTableBodyProps<TData> {
   rows: Row<TData>[];
   renderSubComponent?: (props: { row: Row<TData> }) => React.ReactElement;
   columnSizing?: Record<string, number>;
+  columnCount: number;
 }
 
 export function DataTableBody<TData>({
   rows,
   renderSubComponent,
   columnSizing,
+  columnCount,
 }: DataTableBodyProps<TData>) {
   return (
     <TableBody>
@@ -72,7 +74,7 @@ export function DataTableBody<TData>({
         ))
       ) : (
         <TableRow>
-          <TableCell colSpan={rows.length || 1} className='h-24 text-center'>
+          <TableCell colSpan={columnCount || 1} className='h-24 text-center'>
             No results.
           </TableCell>
         </TableRow>

--- a/ui/src/components/data-table/data-table.tsx
+++ b/ui/src/components/data-table/data-table.tsx
@@ -74,6 +74,7 @@ export function DataTable<TData>({
           rows={table.getRowModel().rows}
           renderSubComponent={renderSubComponent}
           columnSizing={columnSizing}
+          columnCount={table.getVisibleLeafColumns().length}
         />
       </Table>
       {table.getRowModel().rows?.length > 0 && (

--- a/ui/src/components/data-table/data-table.tsx
+++ b/ui/src/components/data-table/data-table.tsx
@@ -34,6 +34,7 @@ export const DEFAULT_PAGE_SIZE = 10;
 interface DataTableProps<TData> extends React.HTMLAttributes<HTMLDivElement> {
   table: TanstackTable<TData>;
   renderSubComponent?: (props: { row: Row<TData> }) => React.ReactElement;
+  noResultsContent?: React.ReactNode;
   setCurrentPageOptions: (page: number) => LinkOptions;
   setPageSizeOptions: (pageSize: number) => LinkOptions;
   /**
@@ -48,6 +49,7 @@ interface DataTableProps<TData> extends React.HTMLAttributes<HTMLDivElement> {
 export function DataTable<TData>({
   table,
   renderSubComponent,
+  noResultsContent,
   className,
   setCurrentPageOptions,
   setPageSizeOptions,
@@ -75,6 +77,7 @@ export function DataTable<TData>({
           renderSubComponent={renderSubComponent}
           columnSizing={columnSizing}
           columnCount={table.getVisibleLeafColumns().length}
+          noResultsContent={noResultsContent}
         />
       </Table>
       {table.getRowModel().rows?.length > 0 && (

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/license-findings-view.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/license-findings-view.tsx
@@ -251,6 +251,13 @@ export const LicenseFindingsView = () => {
     totalDetectedLicenses.pagination.totalCount !==
     detectedLicenseFindings.pagination.totalCount;
   const matching = `, ${detectedLicenseFindings.pagination.totalCount} matching filters`;
+  const scannerWasIncludedInRun = ortRun.jobs.scanner != null;
+  const noResultsContent = !scannerWasIncludedInRun ? (
+    <div className='text-muted-foreground text-sm'>
+      No detected licenses are available because the scanner job was not enabled
+      for this run.
+    </div>
+  ) : undefined;
 
   return (
     <Card className='h-fit'>
@@ -268,6 +275,7 @@ export const LicenseFindingsView = () => {
       <CardContent>
         <DataTable
           table={table}
+          noResultsContent={noResultsContent}
           renderSubComponent={({ row }) =>
             renderSubComponent({ row, runId: ortRun.id })
           }


### PR DESCRIPTION
#### Empty state due to no findings / no filtered findings / scanner failure

<img width="1182" height="440" alt="Screenshot from 2026-04-29 15-04-50" src="https://github.com/user-attachments/assets/c2f65488-b34d-4876-a70a-eecfb93d495a" />

#### Empty state due to scanner not being run as part of the ORT run

<img width="1182" height="440" alt="Screenshot from 2026-04-29 15-04-22" src="https://github.com/user-attachments/assets/707c1ad1-0abf-4661-b4e1-a61382ec9f7b" />

Please see the commits for details.

@sschuberth I decided not to implement your proposal for linking to run creation form with the scanner enabled - at this stage - due to it being a bit complicated and leaving open questions - specifically, what scanners to enable and with what options. However, the PR passes the optional "empty state" message as a `ReactNode` so in future, the message can be tailored for different purposes - including links, buttons, special formatting etc. So the feature is future-ready, and the tailored empty-state message can be used for any table in our UI.