### PR TITLE
ui: Some UX tunings for the plugins page

### DIFF
--- a/ui/src/components/markdown-renderer.tsx
+++ b/ui/src/components/markdown-renderer.tsx
@@ -19,13 +19,19 @@
 
 import Markdown from 'react-markdown';
 
+import { cn } from '@/lib/utils';
+
 type MarkdownRendererProps = {
   markdown?: string;
+  className?: string;
 };
 
-export const MarkdownRenderer = ({ markdown }: MarkdownRendererProps) => {
+export const MarkdownRenderer = ({
+  markdown,
+  className,
+}: MarkdownRendererProps) => {
   return (
-    <div className='prose dark:prose-invert text-sm'>
+    <div className={cn('prose dark:prose-invert text-sm', className)}>
       <Markdown
         components={{
           h1: ({ children }) => (

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -19,7 +19,7 @@
 
 import { z } from 'zod';
 
-import { RepositoryType } from '@/api';
+import { PluginType, RepositoryType } from '@/api';
 import { zEnvironmentConfig } from '@/api/zod.gen';
 
 /**
@@ -237,6 +237,22 @@ export function getRepositoryTypeLabel(type: RepositoryType | string): string {
     return repositoryTypeLabels[type as RepositoryType];
   }
   return type ? `"${type}"` : 'Unset';
+}
+
+const pluginTypeLabels: Record<PluginType, string> = {
+  ADVISOR: 'Advisor',
+  PACKAGE_CONFIGURATION_PROVIDER: 'Package Configuration Provider',
+  PACKAGE_CURATION_PROVIDER: 'Package Curation Provider',
+  PACKAGE_MANAGER: 'Package Manager',
+  REPORTER: 'Reporter',
+  SCANNER: 'Scanner',
+};
+
+export function getPluginTypeLabel(type: PluginType | string): string {
+  if (type in pluginTypeLabels) {
+    return pluginTypeLabels[type as PluginType];
+  }
+  return type ? `"${type}"` : 'Unknown';
 }
 
 // Type and constant for color themes. New themes can be added to the project

--- a/ui/src/routes/admin/plugins/$pluginType/$pluginId/create-template/index.tsx
+++ b/ui/src/routes/admin/plugins/$pluginType/$pluginId/create-template/index.tsx
@@ -56,6 +56,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { ApiError } from '@/lib/api-error';
 import { toast, toastError } from '@/lib/toast';
+import { getPluginTypeLabel } from '@/lib/types';
 import { Route as LayoutRoute } from '../../../route.tsx';
 
 function optionTypeToZodType(type: PluginOptionType): ZodType {
@@ -213,7 +214,7 @@ const CreateTemplate = () => {
         <CardTitle>Create Template</CardTitle>
         <CardDescription>
           Create a new plugin template for the {params.pluginId}{' '}
-          {params.pluginType} plugin.
+          {getPluginTypeLabel(params.pluginType)} plugin.
           <br />
           Options that are set to final can not be overwritten by the user.
           <br />

--- a/ui/src/routes/admin/plugins/$pluginType/$pluginId/index.tsx
+++ b/ui/src/routes/admin/plugins/$pluginType/$pluginId/index.tsx
@@ -69,6 +69,7 @@ import { ApiError } from '@/lib/api-error';
 import { ALL_ITEMS } from '@/lib/constants.ts';
 import { queryClient } from '@/lib/query-client.ts';
 import { toast, toastError } from '@/lib/toast';
+import { getPluginTypeLabel } from '@/lib/types';
 import { Route as LayoutRoute } from '@/routes/admin/plugins/route.tsx';
 
 type PluginTemplateCardProps = {
@@ -463,7 +464,8 @@ const PluginTemplatesComponent = () => {
           {pluginId} Templates ({pluginTemplates.length})
         </CardTitle>
         <CardDescription>
-          Manage plugin templates for the {pluginId} {pluginType} plugin.
+          Manage plugin templates for the {pluginId}{' '}
+          {getPluginTypeLabel(pluginType)} plugin.
         </CardDescription>
         <div className='py-2'>
           <Tooltip>

--- a/ui/src/routes/admin/plugins/index.tsx
+++ b/ui/src/routes/admin/plugins/index.tsx
@@ -28,6 +28,7 @@ import {
   getInstalledPluginsQueryKey,
   restrictPluginMutation,
 } from '@/api/@tanstack/react-query.gen';
+import { MarkdownRenderer } from '@/components/markdown-renderer';
 import { PluginAvailabilityToggle } from '@/components/plugin-availability-toggle';
 import {
   Accordion,
@@ -39,7 +40,6 @@ import { Button } from '@/components/ui/button';
 import {
   Card,
   CardContent,
-  CardDescription,
   CardHeader,
   CardTitle,
 } from '@/components/ui/card.tsx';
@@ -128,7 +128,10 @@ const PluginList = ({
             <CardHeader className='flex items-start justify-between'>
               <div>
                 <CardTitle>{plugin.displayName}</CardTitle>
-                <CardDescription>{plugin.description}</CardDescription>
+                <MarkdownRenderer
+                  markdown={plugin.description}
+                  className='mt-1.5 max-w-none'
+                />
               </div>
               <PluginAvailabilityToggle
                 availability={plugin.availability}

--- a/ui/src/routes/admin/plugins/index.tsx
+++ b/ui/src/routes/admin/plugins/index.tsx
@@ -29,6 +29,12 @@ import {
   restrictPluginMutation,
 } from '@/api/@tanstack/react-query.gen';
 import { PluginAvailabilityToggle } from '@/components/plugin-availability-toggle';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -41,17 +47,19 @@ import { ApiError } from '@/lib/api-error';
 import { queryClient } from '@/lib/query-client.ts';
 import { toast, toastError } from '@/lib/toast';
 
-type PluginListCardProps = {
+type PluginListProps = {
+  value: string;
   title: string;
   description: string;
   plugins: PluginDescriptor[];
 };
 
-const PluginListCard = ({
+const PluginList = ({
+  value,
   title,
   description,
   plugins,
-}: PluginListCardProps) => {
+}: PluginListProps) => {
   const { mutateAsync: enablePlugin, isPending: isEnabling } = useMutation({
     ...enablePluginMutation(),
   });
@@ -105,12 +113,16 @@ const PluginListCard = ({
   };
 
   return (
-    <Card className='mb-4 h-fit'>
-      <CardHeader>
-        <CardTitle>{title}</CardTitle>
-        <CardDescription>{description}</CardDescription>
-      </CardHeader>
-      <CardContent>
+    <AccordionItem value={value}>
+      <AccordionTrigger className='px-6'>
+        <div>
+          <div className='text-base font-semibold'>{title}</div>
+          <div className='text-muted-foreground text-sm font-normal'>
+            {description}
+          </div>
+        </div>
+      </AccordionTrigger>
+      <AccordionContent className='px-12'>
         {plugins.map((plugin) => (
           <Card key={plugin.id} className='mb-2'>
             <CardHeader className='flex items-start justify-between'>
@@ -141,8 +153,8 @@ const PluginListCard = ({
             </CardContent>
           </Card>
         ))}
-      </CardContent>
-    </Card>
+      </AccordionContent>
+    </AccordionItem>
   );
 };
 
@@ -166,38 +178,44 @@ const PluginsComponent = () => {
   const scanners = plugins?.filter((plugin) => plugin.type === 'SCANNER') || [];
 
   return (
-    <div>
-      <PluginListCard
+    <Accordion type='single' collapsible className='rounded-lg border'>
+      <PluginList
+        value='advisors'
         title='Advisors'
         description='Advisors integrate external vulnerability databases to get information about vulnerabilities in packages.'
         plugins={advisors}
       />
-      <PluginListCard
+      <PluginList
+        value='package-configuration-providers'
         title='Package Configuration Providers'
         description='Providers for package configurations which are used to set path excludes and license finding curations for packages.'
         plugins={packageConfigurationProviders}
       />
-      <PluginListCard
+      <PluginList
+        value='package-curation-providers'
         title='Package Curation Providers'
         description='Providers for package curations which are used to correct metadata of packages.'
         plugins={packageCurationProviders}
       />
-      <PluginListCard
+      <PluginList
+        value='package-managers'
         title='Package Managers'
         description='Package managers are used to detect packages and their dependencies.'
         plugins={packageManagers}
       />
-      <PluginListCard
+      <PluginList
+        value='reporters'
         title='Reporters'
         description='Reporters generate reports like SBOMs from the data collected in a run.'
         plugins={reporters}
       />
-      <PluginListCard
+      <PluginList
+        value='scanners'
         title='Scanners'
         description='Scanners scan packages for license and copyright information.'
         plugins={scanners}
       />
-    </div>
+    </Accordion>
   );
 };
 


### PR DESCRIPTION
#### All plugin types shown in a single compact accordion

<img width="1405" height="488" alt="Screenshot from 2026-04-30 07-12-52" src="https://github.com/user-attachments/assets/6ff1dac3-bc90-4afe-b4d0-8dfc47605cfc" />

#### One plugin type can be opened at a time

<img width="1405" height="813" alt="Screenshot from 2026-04-30 07-13-12" src="https://github.com/user-attachments/assets/9e97c343-1c34-4250-97af-aca42f44c78e" />

#### Render plugin descriptions as markdown to eg. have the links functional

<img width="1178" height="575" alt="Screenshot from 2026-04-30 07-13-40" src="https://github.com/user-attachments/assets/a5dbe9a9-5c2c-48b5-9d5f-b92cefb9497f" />

#### Use descriptive plugin types for templates

<img width="1181" height="218" alt="Screenshot from 2026-04-30 07-41-41" src="https://github.com/user-attachments/assets/6218824a-c046-44b1-99a6-9c2f71e309a0" />

Please see the commits for details.