### PR TITLE
feat: Add support for advisor's provider-level issues

### DIFF
--- a/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
@@ -662,6 +662,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     endTime = Clock.System.now().toDatabasePrecision(),
                     environment = generateAdvisorEnvironment(),
                     config = generateAdvisorConfiguration(),
+                    providerIssues = emptySet(),
                     results = generateAdvisorResult()
                 )
 
@@ -724,6 +725,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     endTime = Clock.System.now().toDatabasePrecision(),
                     environment = generateAdvisorEnvironment(),
                     config = generateAdvisorConfiguration(),
+                    providerIssues = emptySet(),
                     results = generateAdvisorResult()
                 )
 
@@ -801,6 +803,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     endTime = Clock.System.now().toDatabasePrecision(),
                     environment = generateAdvisorEnvironment(),
                     config = generateAdvisorConfiguration(),
+                    providerIssues = emptySet(),
                     results = generateAdvisorResult()
                 )
 
@@ -1038,6 +1041,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                             )
                         )
                     ),
+                    providerIssues = emptySet(),
                     results = mapOf(
                         Identifier("Maven", "namespace", "name", "1.0.0") to listOf(
                             AdvisorResult(
@@ -2233,6 +2237,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                             )
                         )
                     ),
+                    providerIssues = emptySet(),
                     results = mapOf(
                         Identifier("NPM", "com.example", "example2", "1.0") to listOf(
                             AdvisorResult(

--- a/dao/src/main/kotlin/repositories/advisorrun/AdvisorRunsTable.kt
+++ b/dao/src/main/kotlin/repositories/advisorrun/AdvisorRunsTable.kt
@@ -72,6 +72,7 @@ class AdvisorRunDao(id: EntityID<Long>) : LongEntity(id) {
             endTime = endTime,
             environment = environment.mapToModel(),
             config = advisorConfiguration.mapToModel(),
+            providerIssues = runIssues.filter { it.identifier == null }.toSet(),
             results = results.associate { it.mapToModel(runIssues) }
         )
     }

--- a/dao/src/main/kotlin/repositories/advisorrun/AdvisorRunsTable.kt
+++ b/dao/src/main/kotlin/repositories/advisorrun/AdvisorRunsTable.kt
@@ -72,6 +72,7 @@ class AdvisorRunDao(id: EntityID<Long>) : LongEntity(id) {
             endTime = endTime,
             environment = environment.mapToModel(),
             config = advisorConfiguration.mapToModel(),
+            providerIssues = runIssues.filterTo(mutableSetOf()) { it.identifier == null },
             results = results.associate { it.mapToModel(runIssues) }
         )
     }

--- a/dao/src/main/kotlin/repositories/advisorrun/DaoAdvisorRunRepository.kt
+++ b/dao/src/main/kotlin/repositories/advisorrun/DaoAdvisorRunRepository.kt
@@ -31,6 +31,7 @@ import org.eclipse.apoapsis.ortserver.dao.tables.shared.OrtRunIssueDao
 import org.eclipse.apoapsis.ortserver.model.repositories.AdvisorRunRepository
 import org.eclipse.apoapsis.ortserver.model.runs.Environment
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
+import org.eclipse.apoapsis.ortserver.model.runs.Issue
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.AdvisorConfiguration
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.AdvisorResult
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.AdvisorRun
@@ -49,6 +50,7 @@ class DaoAdvisorRunRepository(private val db: Database) : AdvisorRunRepository {
         endTime: Instant,
         environment: Environment,
         config: AdvisorConfiguration,
+        providerIssues: Set<Issue>,
         results: Map<Identifier, List<AdvisorResult>>
     ): AdvisorRun = db.blockingQuery {
         val environmentDao = EnvironmentDao.getOrPut(environment)
@@ -88,6 +90,13 @@ class DaoAdvisorRunRepository(private val db: Database) : AdvisorRunRepository {
                     )
                 }
             }
+        }
+
+        providerIssues.forEach { issue ->
+            OrtRunIssueDao.createByIssue(
+                advisorJobDao.ortRun.id.value,
+                issue.copy(worker = AdvisorRunDao.ISSUE_WORKER_TYPE)
+            )
         }
 
         advisorRunDao.mapToModel()

--- a/dao/src/test/kotlin/repositories/advisorrun/DaoAdvisorRunRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/advisorrun/DaoAdvisorRunRepositoryTest.kt
@@ -107,6 +107,7 @@ private fun DaoAdvisorRunRepository.create(advisorJobId: Long, advisorRun: Advis
     endTime = advisorRun.endTime,
     environment = advisorRun.environment,
     config = advisorRun.config,
+    providerIssues = advisorRun.providerIssues,
     results = advisorRun.results.mapValues { (_, results) -> results.map { it.withPlainIssues() } }
 )
 
@@ -179,6 +180,14 @@ private val otherIssue = Issue(
     worker = "advisor"
 )
 
+private val providerIssue = Issue(
+    timestamp = Clock.System.now().toDatabasePrecision(),
+    source = "Advisor",
+    message = "Failed to create provider 'OSS Index'",
+    severity = Severity.ERROR,
+    worker = "advisor"
+)
+
 private val vulnerability = Vulnerability(
     externalId = "external-id",
     summary = "summary",
@@ -217,6 +226,7 @@ private val advisorRun = AdvisorRun(
     endTime = Clock.System.now().toDatabasePrecision(),
     environment = environment,
     config = advisorConfiguration,
+    providerIssues = setOf(providerIssue),
     results = mapOf(identifier to listOf(advisorResult), otherIdentifier to listOf(otherAdvisorResult))
 )
 

--- a/dao/src/testFixtures/kotlin/Fixtures.kt
+++ b/dao/src/testFixtures/kotlin/Fixtures.kt
@@ -321,6 +321,7 @@ class Fixtures(private val db: Database) {
                 )
             )
         ),
+        providerIssues = emptySet(),
         results = results
     )
 

--- a/model/src/commonMain/kotlin/repositories/AdvisorRunRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/AdvisorRunRepository.kt
@@ -23,6 +23,7 @@ import kotlin.time.Instant
 
 import org.eclipse.apoapsis.ortserver.model.runs.Environment
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
+import org.eclipse.apoapsis.ortserver.model.runs.Issue
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.AdvisorConfiguration
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.AdvisorResult
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.AdvisorRun
@@ -40,6 +41,7 @@ interface AdvisorRunRepository {
         endTime: Instant,
         environment: Environment,
         config: AdvisorConfiguration,
+        providerIssues: Set<Issue> = emptySet(),
         results: Map<Identifier, List<AdvisorResult>>
     ): AdvisorRun
 

--- a/model/src/commonMain/kotlin/repositories/AdvisorRunRepository.kt
+++ b/model/src/commonMain/kotlin/repositories/AdvisorRunRepository.kt
@@ -23,6 +23,7 @@ import kotlin.time.Instant
 
 import org.eclipse.apoapsis.ortserver.model.runs.Environment
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
+import org.eclipse.apoapsis.ortserver.model.runs.Issue
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.AdvisorConfiguration
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.AdvisorResult
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.AdvisorRun
@@ -40,6 +41,7 @@ interface AdvisorRunRepository {
         endTime: Instant,
         environment: Environment,
         config: AdvisorConfiguration,
+        providerIssues: Set<Issue>,
         results: Map<Identifier, List<AdvisorResult>>
     ): AdvisorRun
 

--- a/model/src/commonMain/kotlin/runs/advisor/AdvisorRun.kt
+++ b/model/src/commonMain/kotlin/runs/advisor/AdvisorRun.kt
@@ -23,6 +23,7 @@ import kotlin.time.Instant
 
 import org.eclipse.apoapsis.ortserver.model.runs.Environment
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
+import org.eclipse.apoapsis.ortserver.model.runs.Issue
 
 data class AdvisorRun(
     val id: Long,
@@ -31,5 +32,6 @@ data class AdvisorRun(
     val endTime: Instant,
     val environment: Environment,
     val config: AdvisorConfiguration,
+    val providerIssues: Set<Issue>,
     val results: Map<Identifier, List<AdvisorResult>>
 )

--- a/services/ort-run/src/main/kotlin/OrtMappings.kt
+++ b/services/ort-run/src/main/kotlin/OrtMappings.kt
@@ -197,6 +197,7 @@ fun OrtAdvisorRun.mapToModel(advisorJobId: Long) =
         endTime = endTime.toKotlinInstant(),
         environment = environment.mapToModel(),
         config = config.mapToModel(),
+        providerIssues = providerIssues.mapTo(mutableSetOf()) { it.mapToModel() },
         results = results.entries.associate { (k, v) ->
             k.mapToModel() to v.map { it.mapToModel() }
         }

--- a/services/ort-run/src/main/kotlin/OrtRunService.kt
+++ b/services/ort-run/src/main/kotlin/OrtRunService.kt
@@ -484,6 +484,7 @@ class OrtRunService(
             endTime = advisorRun.endTime,
             environment = advisorRun.environment,
             config = advisorRun.config,
+            providerIssues = advisorRun.providerIssues,
             results = advisorRun.results
         )
     }

--- a/services/ort-run/src/main/kotlin/OrtServerMappings.kt
+++ b/services/ort-run/src/main/kotlin/OrtServerMappings.kt
@@ -220,6 +220,7 @@ fun AdvisorRun.mapToOrt() =
         endTime = endTime.toJavaInstant(),
         environment = environment.mapToOrt(),
         config = config.mapToOrt(),
+        providerIssues = providerIssues.mapTo(mutableSetOf()) { it.mapToOrt() },
         results = results.entries.associateTo(sortedMapOf()) {
             it.key.mapToOrt() to it.value.map(AdvisorResult::mapToOrt)
         }

--- a/services/ort-run/src/test/kotlin/OrtRunServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/OrtRunServiceTest.kt
@@ -583,6 +583,7 @@ class OrtRunServiceTest : WordSpec({
                     variables = emptyMap()
                 ),
                 config = AdvisorConfiguration(emptyMap()),
+                providerIssues = setOf(providerIssue),
                 results = emptyMap()
             )
 
@@ -1051,6 +1052,7 @@ class OrtRunServiceTest : WordSpec({
                     variables = emptyMap()
                 ),
                 config = AdvisorConfiguration(emptyMap()),
+                providerIssues = setOf(providerIssue),
                 results = emptyMap()
             )
 
@@ -1936,3 +1938,11 @@ private val includes = Includes(listOf(pathInclude))
  * service under test.
  */
 private val repositoryConfigurationWithIncludes = OrtTestData.repository.config.copy(includes = includes)
+
+private val providerIssue = Issue(
+    timestamp = Clock.System.now().toDatabasePrecision(),
+    source = "Advisor",
+    message = "Failed to create provider 'OSS Index'",
+    severity = Severity.ERROR,
+    worker = "advisor"
+)

--- a/services/ort-run/src/test/kotlin/OrtServerMappingsTest.kt
+++ b/services/ort-run/src/test/kotlin/OrtServerMappingsTest.kt
@@ -353,6 +353,13 @@ class OrtServerMappingsTest : WordSpec({
 
             )
 
+            val providerIssue = Issue(
+                timestamp = Instant.fromEpochSeconds(TIME_STAMP_SECONDS),
+                source = "Advisor",
+                message = "Failed to create provider 'OSS Index'",
+                severity = Severity.ERROR
+            )
+
             val advisorRun = AdvisorRun(
                 id = 1L,
                 advisorJobId = 1L,
@@ -360,6 +367,7 @@ class OrtServerMappingsTest : WordSpec({
                 endTime = Instant.fromEpochSeconds(TIME_STAMP_SECONDS),
                 environment = environment,
                 config = advisorConfiguration,
+                providerIssues = setOf(providerIssue),
                 results = mapOf(pkgIdentifier to listOf(advisorResult))
             )
 
@@ -515,6 +523,12 @@ class OrtServerMappingsTest : WordSpec({
                             reason = IssueResolutionReason.SCANNER_ISSUE,
                             comment = "Test issue resolution.",
                             source = ResolutionSource.REPOSITORY_FILE
+                        ),
+                        IssueResolution(
+                            message = providerIssue.message,
+                            reason = IssueResolutionReason.SCANNER_ISSUE,
+                            comment = "Test provider issue resolution.",
+                            source = ResolutionSource.REPOSITORY_FILE
                         )
                     ),
                     ruleViolations = listOf(
@@ -593,6 +607,12 @@ class OrtServerMappingsTest : WordSpec({
                             message = issue.message,
                             reason = IssueResolutionReason.CANT_FIX_ISSUE,
                             comment = "Test issue resolution.",
+                            source = ResolutionSource.REPOSITORY_FILE
+                        ),
+                        IssueResolution(
+                            message = providerIssue.message,
+                            reason = IssueResolutionReason.CANT_FIX_ISSUE,
+                            comment = "Test provider issue resolution.",
                             source = ResolutionSource.REPOSITORY_FILE
                         )
                     ),

--- a/services/ort-run/src/test/kotlin/VulnerabilityServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/VulnerabilityServiceTest.kt
@@ -2405,6 +2405,7 @@ class VulnerabilityServiceTest : WordSpec() {
                     )
                 )
             ),
+            providerIssues = emptySet(),
             results = advisorResults
         )
 

--- a/shared/ort-test-data/src/main/kotlin/OrtTestData.kt
+++ b/shared/ort-test-data/src/main/kotlin/OrtTestData.kt
@@ -202,6 +202,13 @@ object OrtTestData {
         severity = Severity.ERROR
     )
 
+    val providerIssue = Issue(
+        timestamp = Instant.fromEpochSeconds(TIME_STAMP_SECONDS).toJavaInstant(),
+        source = "Advisor",
+        message = "Failed to create provider 'OSS Index'",
+        severity = Severity.ERROR
+    )
+
     val vulnerability = Vulnerability(
         id = "CVE-2023-0001",
         summary = "Example summary.",
@@ -243,6 +250,11 @@ object OrtTestData {
                         message = issue.message,
                         reason = IssueResolutionReason.SCANNER_ISSUE,
                         comment = "Test issue resolution."
+                    ),
+                    IssueResolution(
+                        message = providerIssue.message,
+                        reason = IssueResolutionReason.SCANNER_ISSUE,
+                        comment = "Test provider issue resolution."
                     )
                 ),
                 ruleViolations = listOf(
@@ -464,6 +476,7 @@ object OrtTestData {
         endTime = Instant.fromEpochSeconds(TIME_STAMP_SECONDS).toJavaInstant(),
         environment = environment,
         config = advisorConfiguration,
+        providerIssues = setOf(providerIssue),
         results = advisorResults
     )
 
@@ -572,6 +585,11 @@ object OrtTestData {
                     message = issue.message,
                     reason = IssueResolutionReason.CANT_FIX_ISSUE,
                     comment = "Test issue resolution."
+                ),
+                IssueResolution(
+                    message = providerIssue.message,
+                    reason = IssueResolutionReason.CANT_FIX_ISSUE,
+                    comment = "Test provider issue resolution."
                 )
             ),
             ruleViolations = listOf(

--- a/workers/advisor/src/main/kotlin/AdvisorWorker.kt
+++ b/workers/advisor/src/main/kotlin/AdvisorWorker.kt
@@ -84,7 +84,11 @@ internal class AdvisorWorker(
                 ).advisor
             ) { "ORT Adviser failed to create a result." }
 
-            val allIssues = advisorRun.results.values.flatten().flatMap { it.summary.issues }
+            val allIssues = buildList {
+                addAll(advisorRun.results.values.flatten().flatMap { it.summary.issues })
+                addAll(advisorRun.providerIssues)
+            }
+
             val allVulnerabilities = advisorRun.results.values.flatten().flatMap { it.vulnerabilities }
 
             val resolutionProvider = OrtServerResolutionProvider.create(

--- a/workers/advisor/src/test/kotlin/AdvisorWorkerTest.kt
+++ b/workers/advisor/src/test/kotlin/AdvisorWorkerTest.kt
@@ -417,6 +417,91 @@ class AdvisorWorkerTest : StringSpec({
         }
     }
 
+    "Resolved items should be stored for provider issues" {
+        val providerIssue = Issue(
+            timestamp = Instant.fromEpochSeconds(TIME_STAMP_SECONDS).toJavaInstant(),
+            source = "Advisor",
+            message = "Failed to create provider 'OSS Index'",
+            severity = Severity.ERROR
+        )
+
+        val ortResult = OrtResult.EMPTY.copy(
+            analyzer = OrtAnalyzerRun.EMPTY,
+            repository = OrtResult.EMPTY.repository.copy(
+                config = OrtResult.EMPTY.repository.config.copy(
+                    resolutions = Resolutions(
+                        issues = listOf(
+                            IssueResolution(
+                                message = providerIssue.message,
+                                reason = IssueResolutionReason.CANT_FIX_ISSUE,
+                                comment = "Provider issue resolution."
+                            )
+                        )
+                    )
+                )
+            )
+        )
+
+        val advisorRunResult = OrtResult.EMPTY.copy(
+            advisor = AdvisorRun(
+                startTime = Instant.fromEpochSeconds(TIME_STAMP_SECONDS).toJavaInstant(),
+                endTime = Instant.fromEpochSeconds(TIME_STAMP_SECONDS).toJavaInstant(),
+                environment = OrtTestData.environment,
+                config = OrtTestData.advisorConfiguration,
+                providerIssues = setOf(providerIssue),
+                results = emptyMap()
+            )
+        )
+
+        val ortRun = mockOrtRun()
+
+        mockkStatic(ORT_SERVER_MAPPINGS_FILE)
+        every { ortRun.mapToOrt(any(), any(), any(), any(), any(), any()) } returns ortResult
+
+        val resolvedItemsSlot = slot<ResolvedItemsResult>()
+
+        val ortRunService = mockk<OrtRunService> {
+            every { getAdvisorJob(any()) } returns advisorJob
+            every { getAnalyzerRunForOrtRun(any()) } returns OrtTestData.analyzerRun.mapToModel(ANALYZER_JOB_ID)
+            every { startAdvisorJob(any()) } returns advisorJob
+            every { getOrtRepositoryInformation(any()) } returns mockk()
+            every { getResolvedConfiguration(any()) } returns ResolvedConfiguration()
+            every { storeAdvisorRun(any()) } just runs
+            every { storeResolvedItems(any(), capture(resolvedItemsSlot)) } just runs
+        }
+
+        val context = mockk<WorkerContext> {
+            every { this@mockk.ortRun } returns ortRun
+            every { this@mockk.configManager } returns mockConfigManager()
+            coEvery { resolvePluginConfigSecrets(any()) } returns emptyMap()
+        }
+        val contextFactory = mockContextFactory(context)
+
+        val runner = spyk(createRunner())
+        coEvery { runner.run(any(), any(), any()) } coAnswers { advisorRunResult }
+
+        val worker = AdvisorWorker(
+            db = mockk(),
+            runner = runner,
+            ortRunService = ortRunService,
+            contextFactory = contextFactory,
+            adminConfigService = mockk(relaxed = true),
+            issueResolutionService = mockIssueResolutionService(),
+            vulnerabilityResolutionService = mockVulnerabilityResolutionService()
+        )
+
+        mockkTransaction {
+            val result = worker.run(ADVISOR_JOB_ID, TRACE_ID)
+
+            result shouldBe RunResult.Success
+
+            val resolvedIssue = resolvedItemsSlot.captured.issues.keys.single()
+            resolvedIssue.message shouldBe providerIssue.message
+            resolvedIssue.source shouldBe providerIssue.source
+            resolvedIssue.severity.name shouldBe providerIssue.severity.name
+        }
+    }
+
     "Resolved items should be stored for vulnerabilities resolved via the VulnerabilityResolutionService" {
         val advisorVulnerability = Vulnerability(
             id = "CVE-2023-0002",


### PR DESCRIPTION
Persist the issues and ensure that they are correctly retrieved, and that they are handled in model conversions. Also take them into account when determining run status and when storing resolutions.

Resolves https://github.com/eclipse-apoapsis/ort-server/issues/4647.