### PR TITLE
feat(ui): Add the environment config path to the ORT run

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/default-values.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/default-values.ts
@@ -174,6 +174,7 @@ export function defaultValues(
     },
     labels: undefined,
     jobConfigContext: '',
+    environmentConfigPath: '',
   };
 
   // Default values for the form are either taken from "baseDefaults" or,
@@ -305,6 +306,8 @@ export function defaultValues(
         labels: convertMapToArray(ortRun.labels || {}),
         jobConfigContext:
           ortRun.jobConfigContext || baseDefaults.jobConfigContext,
+        environmentConfigPath:
+          ortRun.environmentConfigPath || baseDefaults.environmentConfigPath,
       }
     : baseDefaults;
 }

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/payload.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/payload.ts
@@ -332,5 +332,6 @@ export function formValuesToPayload(
     },
     labels,
     jobConfigContext: values.jobConfigContext,
+    environmentConfigPath: values.environmentConfigPath,
   };
 }

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/run-schema.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/run-schema.ts
@@ -169,6 +169,7 @@ export const createRunFormSchema = (
     }),
     labels: z.array(keyValueSchema).optional(),
     jobConfigContext: z.string().optional(),
+    environmentConfigPath: z.string().optional(),
   });
 };
 

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -268,6 +268,25 @@ const CreateRunPage = () => {
             />
             <FormField
               control={form.control}
+              name='environmentConfigPath'
+              render={({ field }) => (
+                <FormItem className='pt-4'>
+                  <FormLabel>Environment configuration path</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder='(optional)' />
+                  </FormControl>
+                  <FormDescription>
+                    The optional path to an environment configuration file. If
+                    this is not defined, the environment configuration is read
+                    from the default location
+                    <InlineCode>.ort.env.yml</InlineCode>.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
               name='jobConfigs.ruleSet'
               render={({ field }) => (
                 <FormItem className='pt-4'>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/index.tsx
@@ -97,6 +97,16 @@ const ConfigComponent = () => {
                 )}
             </div>
           )}
+          {ortRun.environmentConfigPath && (
+            <div className='flex items-center gap-1 text-sm'>
+              <Label className='font-semibold'>
+                Environment configuration path:
+              </Label>
+              {ortRun.environmentConfigPath && (
+                <div>{ortRun.environmentConfigPath}</div>
+              )}
+            </div>
+          )}
           {(() => {
             const labels = ortRun.labels;
             const hasLabels = Object.keys(labels).length > 0;


### PR DESCRIPTION
This parameter is the optional path to an environment configuration file. If this is not defined, the environment configuration is read from the default location `.ort.env.yml`.

Fixes #4051.