### PR TITLE
View license detections with Software Heritage service

### DIFF
--- a/LICENSES/CC-BY-4.0.txt
+++ b/LICENSES/CC-BY-4.0.txt
@@ -1,0 +1,396 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.
+

--- a/REUSE.toml
+++ b/REUSE.toml
@@ -206,6 +206,11 @@ SPDX-FileCopyrightText = "2024 The ORT Server Authors (See <https://github.com/e
 SPDX-License-Identifier = "Apache-2.0"
 
 [[annotations]]
+path = "ui/src/assets/software-heritage-logo.svg"
+SPDX-FileCopyrightText = "Software Heritage (see <https://www.softwareheritage.org/communication-kit/>)"
+SPDX-License-Identifier = "CC-BY-4.0"
+
+[[annotations]]
 path = "ui/src/assets/spdx-logo-color.svg"
 SPDX-FileCopyrightText = "2011 The Linux Foundation"
 SPDX-License-Identifier = "CC-BY-3.0"

--- a/ui/src/assets/software-heritage-logo.svg
+++ b/ui/src/assets/software-heritage-logo.svg
@@ -1,0 +1,46 @@
+<svg
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   viewBox="0 0 78.27025 77.394997"
+   width="78.270248"
+   height="77.394997">
+  <defs>
+    <linearGradient
+       id="g" x1="0" y1="0" x2="1" y2="0"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(61.305366,0,0,-61.305366,13.87633,76.436119)">
+      <stop style="stop-opacity:1;stop-color:#ec1c28" offset="0"/>
+      <stop style="stop-opacity:1;stop-color:#ec1c28" offset="0.331971"/>
+      <stop style="stop-opacity:1;stop-color:#fbc81f" offset="1"/>
+    </linearGradient>
+    <linearGradient xlink:href="#g" id="g943" gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(61.308309,0,0,-61.305366,12.56513,76.436119)"
+       x1="0" y1="0" x2="1" y2="0"/>
+  </defs>
+  <g transform="matrix(1.25,0,0,-1.25,-15.706625,134.2425)">
+    <path d="m 30.5745,68.987 1.337,-1.343 4.826,1.607 -1.61,-4.823 1.34,-1.34 2.95,8.844 z" style="fill:url(#g);stroke:none"/>
+    <path d="m 27.1875,67.914 5.746,-10.675 1.252,1.252 -5.747,10.674 z" style="fill:url(#g);stroke:none"/>
+    <path d="m 24.6355,57.152 1.608,4.823 -1.34,1.34 -2.949,-8.846 8.842,2.949 -1.338,1.343 z" style="fill:url(#g);stroke:none"/>
+    <path d="m 44.0115,65.874 2.274,-5.144 h 1.894 l -4.167,8.935 -4.17,-8.038 1.895,-0.154 z" style="fill:url(#g);stroke:none"/>
+    <path d="m 38.2145,58.771 12,-3.485 v 1.77 l -12,3.484 z" style="fill:url(#g);stroke:none"/>
+    <path d="m 44.0115,49.269 -2.273,4.461 h -1.895 l 4.169,-8.252 4.167,8.379 -1.896,-0.018 z" style="fill:url(#g);stroke:none"/>
+    <path d="m 57.2875,69.377 -8.843,2.95 2.945,-8.844 1.342,1.338 -1.607,4.825 4.823,-1.609 z" style="fill:url(#g);stroke:none"/>
+    <path d="m 61.8845,67.095 -10.674,-5.748 1.251,-1.25 10.675,5.746 z" style="fill:url(#g);stroke:none"/>
+    <path d="m 61.6155,62.367 1.609,-4.822 -4.822,1.607 -1.34,-1.34 8.843,-2.948 -2.948,8.842 z" style="fill:url(#g);stroke:none"/>
+    <path d="m 58.2145,81.089 -8.219,-4.168 8.396,-4.17 0.033,1.896 -4.653,2.274 4.443,2.273 z" style="fill:url(#g);stroke:none"/>
+    <path d="m 61.6055,70.73 3.486,12 h -1.771 l -3.484,-12 z" style="fill:url(#g);stroke:none"/>
+    <path d="m 67.2145,72.752 7.967,4.169 -8.522,4.168 -0.095,-1.896 4.873,-2.272 -4.223,-2.274 z" style="fill:url(#g);stroke:none"/>
+    <path d="m 56.8935,84.299 -1.339,1.342 -4.824,-1.608 1.608,4.823 -1.34,1.341 -2.948,-8.844 z" style="fill:url(#g);stroke:none"/>
+    <path d="m 60.2805,85.371 -5.746,10.675 -1.253,-1.253 5.748,-10.673 z" style="fill:url(#g);stroke:none"/>
+    <path d="m 62.8315,96.134 -1.608,-4.823 1.341,-1.339 2.947,8.843 -8.842,-2.949 1.339,-1.341 z" style="fill:url(#g);stroke:none"/>
+    <path d="m 45.7295,91.364 -2.274,-4.365 -2.274,4.731 h -1.894 l 4.168,-8.521 4.17,8.245 z" style="fill:url(#g);stroke:none"/>
+    <path d="m 50.2145,94.515 -12,3.485 v -1.77 l 12,-3.485 z" style="fill:url(#g);stroke:none"/>
+    <path d="m 43.4555,103.603 2.274,-4.873 h 1.895 l -4.169,8.664 -4.169,-8.175 1.896,-0.083 z" style="fill:url(#g);stroke:none"/>
+    <path d="m 36.0765,89.803 -1.341,-1.34 1.608,-4.823 -4.823,1.608 -1.34,-1.34 8.844,-2.949 z" style="fill:url(#g);stroke:none"/>
+    <path d="m 25.5825,86.192 10.674,5.746 -1.251,1.251 -10.675,-5.746 z" style="fill:url(#g);stroke:none"/>
+    <path d="m 25.8505,90.918 -1.608,4.823 4.824,-1.608 1.339,1.341 -8.844,2.948 2.949,-8.844 z" style="fill:url(#g);stroke:none"/>
+    <path d="m 29.2145,72.196 8.338,4.169 -8.338,4.169 v -1.896 l 4.547,-2.273 -4.547,-2.274 z" style="fill:url(#g);stroke:none"/>
+    <path d="m 24.1455,70.73 3.485,11 h -1.769 l -3.485,-11 z" style="fill:url(#g);stroke:none"/>
+    <path d="m 12.5653,76.365 8.3384,4.169 V 78.638 L 16.356482,76.365 20.9037,74.091 v -1.895 z" style="fill:url(#g943);stroke:none"/>
+  </g>
+</svg>

--- a/ui/src/lib/software-heritage.ts
+++ b/ui/src/lib/software-heritage.ts
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { PackageURL } from 'packageurl-js';
+
+const SWH_BROWSE_BASE = 'https://archive.softwareheritage.org/browse/content/';
+
+/**
+ * Map a parsed purl to the canonical origin URL used by Software Heritage.
+ * Return null for unsupported package types or missing required fields.
+ */
+function purlToSwhOriginUrl(pkg: PackageURL): string | null {
+  switch (pkg.type) {
+    case 'github':
+      // pkg:github/owner/repo — namespace is owner, name is repo.
+      return pkg.namespace && pkg.name
+        ? `https://github.com/${pkg.namespace}/${pkg.name}`
+        : null;
+    case 'npm': {
+      // pkg:npm/%40scope/name or pkg:npm/name.
+      const name = pkg.namespace ? `${pkg.namespace}/${pkg.name}` : pkg.name;
+      return `https://www.npmjs.com/package/${name}`;
+    }
+    case 'pypi':
+      return `https://pypi.org/project/${pkg.name}`;
+    case 'maven':
+      // SWH archives Maven Central; namespace is groupId with dots.
+      if (pkg.namespace) {
+        const groupPath = pkg.namespace.replace(/\./g, '/');
+        return `https://repo1.maven.org/maven2/${groupPath}/${pkg.name}`;
+      }
+      return null;
+    default:
+      return null;
+  }
+}
+
+/**
+ * Return the SWH browse URL version parameter for a parsed purl.
+ *
+ * Package archives (npm, PyPI, Maven) are indexed as "releases" in SWH.
+ * GitHub refs that look like a 40-char hex SHA map to "revision"; everything
+ * else (tags, branch names) maps to "branch".
+ */
+function swhVersionParam(pkg: PackageURL): Record<string, string> {
+  if (!pkg.version) return {};
+
+  if (pkg.type === 'github') {
+    const isSha = /^[0-9a-f]{40}$/i.test(pkg.version);
+    return isSha ? { revision: pkg.version } : { branch: pkg.version };
+  }
+
+  return { release: pkg.version };
+}
+
+/**
+ * Build a Software Heritage browse URL for a specific file and line range.
+ * Return null if the purl type is not supported.
+ */
+export function buildSwhBrowseUrl(
+  purl: string,
+  path: string,
+  startLine: number,
+  endLine: number
+): string | null {
+  let pkg: PackageURL;
+  try {
+    pkg = PackageURL.fromString(purl);
+  } catch {
+    return null;
+  }
+
+  const originUrl = purlToSwhOriginUrl(pkg);
+  if (!originUrl) return null;
+
+  const params = new URLSearchParams({
+    origin_url: originUrl,
+    path,
+    ...swhVersionParam(pkg),
+  });
+  return `${SWH_BROWSE_BASE}?${params.toString()}#L${startLine}-L${endLine}`;
+}
+
+if (import.meta.vitest) {
+  const { it, expect } = import.meta.vitest;
+
+  it('buildSwhBrowseUrl: github purl with SHA revision', () => {
+    expect(
+      buildSwhBrowseUrl(
+        'pkg:github/owner/repo@abc123def456789012345678901234567890abcd',
+        'src/main.ts',
+        10,
+        20
+      )
+    ).toBe(
+      'https://archive.softwareheritage.org/browse/content/?origin_url=https%3A%2F%2Fgithub.com%2Fowner%2Frepo&path=src%2Fmain.ts&revision=abc123def456789012345678901234567890abcd#L10-L20'
+    );
+  });
+
+  it('buildSwhBrowseUrl: github purl with branch', () => {
+    expect(
+      buildSwhBrowseUrl('pkg:github/owner/repo@main', 'src/main.ts', 1, 5)
+    ).toBe(
+      'https://archive.softwareheritage.org/browse/content/?origin_url=https%3A%2F%2Fgithub.com%2Fowner%2Frepo&path=src%2Fmain.ts&branch=main#L1-L5'
+    );
+  });
+
+  it('buildSwhBrowseUrl: npm unscoped package', () => {
+    expect(buildSwhBrowseUrl('pkg:npm/lodash@4.17.21', 'lodash.js', 1, 5)).toBe(
+      'https://archive.softwareheritage.org/browse/content/?origin_url=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2Flodash&path=lodash.js&release=4.17.21#L1-L5'
+    );
+  });
+
+  it('buildSwhBrowseUrl: npm scoped package', () => {
+    expect(
+      buildSwhBrowseUrl('pkg:npm/%40types/node@18.0.0', 'index.d.ts', 1, 1)
+    ).toBe(
+      'https://archive.softwareheritage.org/browse/content/?origin_url=https%3A%2F%2Fwww.npmjs.com%2Fpackage%2F%40types%2Fnode&path=index.d.ts&release=18.0.0#L1-L1'
+    );
+  });
+
+  it('buildSwhBrowseUrl: pypi package', () => {
+    expect(
+      buildSwhBrowseUrl(
+        'pkg:pypi/requests@2.28.0',
+        'requests/__init__.py',
+        1,
+        10
+      )
+    ).toBe(
+      'https://archive.softwareheritage.org/browse/content/?origin_url=https%3A%2F%2Fpypi.org%2Fproject%2Frequests&path=requests%2F__init__.py&release=2.28.0#L1-L10'
+    );
+  });
+
+  it('buildSwhBrowseUrl: maven package', () => {
+    expect(
+      buildSwhBrowseUrl(
+        'pkg:maven/org.apache.commons/commons-lang3@3.12.0',
+        'src/main/java/Foo.java',
+        5,
+        10
+      )
+    ).toBe(
+      'https://archive.softwareheritage.org/browse/content/?origin_url=https%3A%2F%2Frepo1.maven.org%2Fmaven2%2Forg%2Fapache%2Fcommons%2Fcommons-lang3&path=src%2Fmain%2Fjava%2FFoo.java&release=3.12.0#L5-L10'
+    );
+  });
+
+  it('buildSwhBrowseUrl: unsupported purl type returns null', () => {
+    expect(
+      buildSwhBrowseUrl(
+        'pkg:golang/github.com/user/repo@v1.0.0',
+        'main.go',
+        1,
+        5
+      )
+    ).toBeNull();
+  });
+
+  it('buildSwhBrowseUrl: invalid purl returns null', () => {
+    expect(buildSwhBrowseUrl('not-a-purl', 'main.ts', 1, 5)).toBeNull();
+  });
+
+  it('buildSwhBrowseUrl: maven without namespace returns null', () => {
+    expect(
+      buildSwhBrowseUrl('pkg:maven/some-lib@1.0.0', 'Foo.java', 1, 5)
+    ).toBeNull();
+  });
+
+  it('buildSwhBrowseUrl: github without namespace returns null', () => {
+    expect(
+      buildSwhBrowseUrl('pkg:github/repo@main', 'main.ts', 1, 5)
+    ).toBeNull();
+  });
+}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/detected-license-findings-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/detected-license-findings-table.tsx
@@ -27,9 +27,16 @@ import {
 
 import { LicenseFinding } from '@/api';
 import { getRunDetectedLicenseFindingsOptions } from '@/api/@tanstack/react-query.gen';
+import swhLogo from '@/assets/software-heritage-logo.svg';
 import { BreakableString } from '@/components/breakable-string';
 import { DataTable } from '@/components/data-table/data-table';
 import { LoadingIndicator } from '@/components/loading-indicator';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { buildSwhBrowseUrl } from '@/lib/software-heritage';
 import { toastError } from '@/lib/toast';
 import { formatLineNumber } from '@/lib/utils';
 
@@ -42,12 +49,14 @@ type DetectedLicenseFindingsTableProps = {
   runId: number;
   license: string;
   identifier: string;
+  purl?: string;
 };
 
 export const DetectedLicenseFindingsTable = ({
   runId,
   license,
   identifier,
+  purl,
 }: DetectedLicenseFindingsTableProps) => {
   const search = useSearch({ from: licenseFindingsRoutePath });
   const findingsPageIndex = search.findingsPage ? search.findingsPage - 1 : 0;
@@ -76,7 +85,41 @@ export const DetectedLicenseFindingsTable = ({
     findingColumnHelper.accessor('path', {
       id: 'path',
       header: 'Path',
-      cell: ({ row }) => <BreakableString text={row.original.path} />,
+      cell: ({ row }) => {
+        const url = purl
+          ? buildSwhBrowseUrl(
+              purl,
+              row.original.path,
+              row.original.startLine,
+              row.original.endLine
+            )
+          : null;
+
+        return (
+          <div className='flex items-start gap-2'>
+            <BreakableString text={row.original.path} />
+            {url && (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <a
+                    href={url}
+                    target='_blank'
+                    rel='noopener noreferrer'
+                    className='mt-0.5 shrink-0'
+                  >
+                    <img
+                      src={swhLogo}
+                      alt='Software Heritage'
+                      className='h-4 w-4'
+                    />
+                  </a>
+                </TooltipTrigger>
+                <TooltipContent>View in Software Heritage</TooltipContent>
+              </Tooltip>
+            )}
+          </div>
+        );
+      },
       meta: {
         isGrow: true,
       },

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/detected-license-packages-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/detected-license-packages-table.tsx
@@ -229,6 +229,7 @@ export const DetectedLicensePackagesTable = ({
             runId={runId}
             license={row.original.license}
             identifier={identifierToString(packageRow.original.identifier)}
+            purl={packageRow.original.purl ?? undefined}
           />
         )}
         setCurrentPageOptions={(currentPage) => {


### PR DESCRIPTION
<img width="1097" height="320" alt="Screenshot from 2026-05-05 07-57-44" src="https://github.com/user-attachments/assets/f767a418-07db-4747-b6fc-7ebd30c3c58a" />

<img width="1445" height="753" alt="Screenshot from 2026-05-04 15-28-19" src="https://github.com/user-attachments/assets/c4e35dcf-c8db-4f17-9505-305acea91276" />

This feature will be improved in follow-up PRs, so it's an initial version only.

Please see the commits for details.

@sschuberth the tooltip dimming in the first picture is just a screenshot artefact.