### PR TITLE
fix(secrets): Scope in-use check to the secret's hierarchy level

### DIFF
--- a/components/infrastructure-services/backend/src/main/kotlin/InfrastructureServiceService.kt
+++ b/components/infrastructure-services/backend/src/main/kotlin/InfrastructureServiceService.kt
@@ -25,6 +25,9 @@ import org.eclipse.apoapsis.ortserver.dao.UniqueConstraintException
 import org.eclipse.apoapsis.ortserver.dao.blockingQuery
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
 import org.eclipse.apoapsis.ortserver.dao.findSingle
+import org.eclipse.apoapsis.ortserver.dao.repositories.product.ProductsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.repository.RepositoriesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.secret.SecretsTable
 import org.eclipse.apoapsis.ortserver.dao.utils.apply
 import org.eclipse.apoapsis.ortserver.dao.utils.listQuery
 import org.eclipse.apoapsis.ortserver.model.CredentialsType
@@ -43,6 +46,8 @@ import org.jetbrains.exposed.v1.core.Op
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.inSubQuery
+import org.jetbrains.exposed.v1.core.isNotNull
+import org.jetbrains.exposed.v1.core.notInSubQuery
 import org.jetbrains.exposed.v1.core.or
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
@@ -214,14 +219,136 @@ class InfrastructureServiceService(
     }
 
     /**
-     * Return a list with the [InfrastructureService]s that are associated with the name of the given
-     * [Secret][secretName].
+     * Return a list with the [InfrastructureService]s referencing [secretName] at [id]'s hierarchy level,
+     * including lower-level services that would inherit the secret via hierarchy resolution.
      */
-    suspend fun listForSecret(secretName: String): List<InfrastructureService> = db.dbQuery {
+    suspend fun listForSecret(secretName: String, id: HierarchyId): List<InfrastructureService> = db.dbQuery {
+        val secretFilter = (InfrastructureServicesTable.usernameSecret eq secretName) or
+                (InfrastructureServicesTable.passwordSecret eq secretName)
+
         list(ListQueryParameters.DEFAULT) {
-            InfrastructureServicesTable.usernameSecret eq secretName or
-                    (InfrastructureServicesTable.passwordSecret eq secretName)
+            secretFilter and when (id) {
+                is OrganizationId -> servicesAffectedByOrgSecretDeletion(secretName, id)
+                is ProductId -> servicesAffectedByProductSecretDeletion(secretName, id)
+                is RepositoryId -> servicesAffectedByRepoSecretDeletion(secretName, id)
+            }
         }
+    }
+
+    /**
+     * Return the filter condition for services affected when an organization-level secret named [secretName] is
+     * deleted. Services at the product or repository level that have their own secret with the same name are
+     * excluded, as they would not be affected by the deletion.
+     */
+    private fun servicesAffectedByOrgSecretDeletion(secretName: String, id: OrganizationId): Op<Boolean> {
+        val productsInOrg = ProductsTable
+            .select(ProductsTable.id)
+            .where { ProductsTable.organizationId eq id.value }
+
+        val productsWithOwnSecret = SecretsTable
+            .select(SecretsTable.productId)
+            .where {
+                SecretsTable.productId.isNotNull() and
+                        (SecretsTable.name eq secretName) and
+                        (SecretsTable.productId inSubQuery productsInOrg)
+            }
+
+        val reposInOrg = RepositoriesTable
+            .select(RepositoriesTable.id)
+            .where { RepositoriesTable.productId inSubQuery productsInOrg }
+
+        val reposWithOwnSecret = SecretsTable
+            .select(SecretsTable.repositoryId)
+            .where {
+                SecretsTable.repositoryId.isNotNull() and
+                        (SecretsTable.name eq secretName) and
+                        (SecretsTable.repositoryId inSubQuery reposInOrg)
+            }
+
+        val reposShieldedByProductSecret = RepositoriesTable
+            .select(RepositoriesTable.id)
+            .where { RepositoriesTable.productId inSubQuery productsWithOwnSecret }
+
+        val productLevelCondition =
+            (InfrastructureServicesTable.productId inSubQuery productsInOrg) and
+                (InfrastructureServicesTable.productId notInSubQuery productsWithOwnSecret)
+
+        val repoLevelCondition =
+            (InfrastructureServicesTable.repositoryId inSubQuery reposInOrg) and
+                (InfrastructureServicesTable.repositoryId notInSubQuery reposWithOwnSecret) and
+                (InfrastructureServicesTable.repositoryId notInSubQuery reposShieldedByProductSecret)
+
+        return (InfrastructureServicesTable.organizationId eq id.value) or
+            productLevelCondition or
+            repoLevelCondition
+    }
+
+    /**
+     * Return the filter condition for services affected when a product-level secret named [secretName] is deleted.
+     * Returns [Op.FALSE] if a same-named secret exists at the organization level, as that secret would take over.
+     */
+    private fun servicesAffectedByProductSecretDeletion(secretName: String, id: ProductId): Op<Boolean> {
+        val productOrgId = ProductsTable
+            .select(ProductsTable.organizationId)
+            .where { ProductsTable.id eq id.value }
+
+        val orgFallbackExists = SecretsTable
+            .select(SecretsTable.name)
+            .where {
+                SecretsTable.organizationId.isNotNull() and
+                        (SecretsTable.name eq secretName) and
+                        (SecretsTable.organizationId inSubQuery productOrgId)
+            }
+            .any()
+
+        if (orgFallbackExists) return Op.FALSE
+
+        val reposInProduct = RepositoriesTable
+            .select(RepositoriesTable.id)
+            .where { RepositoriesTable.productId eq id.value }
+
+        val reposWithOwnSecret = SecretsTable
+            .select(SecretsTable.repositoryId)
+            .where {
+                SecretsTable.repositoryId.isNotNull() and
+                        (SecretsTable.name eq secretName) and
+                        (SecretsTable.repositoryId inSubQuery reposInProduct)
+            }
+
+        val repoLevelCondition =
+            (InfrastructureServicesTable.repositoryId inSubQuery reposInProduct) and
+                (InfrastructureServicesTable.repositoryId notInSubQuery reposWithOwnSecret)
+
+        return (InfrastructureServicesTable.productId eq id.value) or repoLevelCondition
+    }
+
+    /**
+     * Return the filter condition for services affected when a repository-level secret named [secretName] is deleted.
+     * Returns [Op.FALSE] if a same-named secret exists at the product or organization level, as that secret would
+     * take over.
+     */
+    private fun servicesAffectedByRepoSecretDeletion(secretName: String, id: RepositoryId): Op<Boolean> {
+        val repoProductId = RepositoriesTable
+            .select(RepositoriesTable.productId)
+            .where { RepositoriesTable.id eq id.value }
+
+        val productOrgId = ProductsTable
+            .select(ProductsTable.organizationId)
+            .where { ProductsTable.id inSubQuery repoProductId }
+
+        val productFallback =
+            SecretsTable.productId.isNotNull() and (SecretsTable.productId inSubQuery repoProductId)
+
+        val orgFallback =
+            SecretsTable.organizationId.isNotNull() and
+                (SecretsTable.organizationId inSubQuery productOrgId)
+
+        val fallbackSecretExists = SecretsTable
+            .select(SecretsTable.name)
+            .where { (SecretsTable.name eq secretName) and (productFallback or orgFallback) }
+            .any()
+
+        return if (fallbackSecretExists) Op.FALSE else InfrastructureServicesTable.repositoryId eq id.value
     }
 
     private fun getDaoForId(id: HierarchyId, name: String): InfrastructureServicesDao? =

--- a/components/infrastructure-services/backend/src/test/kotlin/InfrastructureServiceServiceIntegrationTest.kt
+++ b/components/infrastructure-services/backend/src/test/kotlin/InfrastructureServiceServiceIntegrationTest.kt
@@ -61,6 +61,7 @@ private const val SERVICE_NAME = "TestInfrastructureService"
 private const val SERVICE_URL = "https://repo.example.org/infra/test"
 private const val SERVICE_DESC = "This is a test infrastructure service"
 
+@Suppress("LargeClass")
 class InfrastructureServiceServiceIntegrationTest : WordSpec({
     val dbExtension = extension(DatabaseTestExtension())
 
@@ -404,6 +405,218 @@ class InfrastructureServiceServiceIntegrationTest : WordSpec({
             )
 
             services.data shouldContainExactly expectedServices.take(4)
+        }
+    }
+
+    "listForSecret" should {
+        "return services at the same level referencing the secret" {
+            createInfrastructureService(createInfrastructureService(organization = organization))
+
+            val results = service.listForSecret(orgUserSecret.name, OrganizationId(organization.id))
+
+            results.map { it.name } shouldContainOnly listOf(SERVICE_NAME)
+        }
+
+        "return an empty list when no service references the secret" {
+            createInfrastructureService(createInfrastructureService(organization = organization))
+
+            val results = service.listForSecret("unrelated-secret", OrganizationId(organization.id))
+
+            results should beEmpty()
+        }
+
+        "return product services inheriting an org secret" {
+            val orgOnlySecret = createOrganizationSecret("org-only")
+            val productService = createInfrastructureService(
+                SERVICE_NAME,
+                usernameSecret = orgOnlySecret.name,
+                passwordSecret = orgPassSecret.name,
+                product = product
+            )
+            createInfrastructureService(productService)
+
+            val results = service.listForSecret(orgOnlySecret.name, OrganizationId(organization.id))
+
+            results.map { it.name } shouldContainOnly listOf(SERVICE_NAME)
+        }
+
+        "not return product services when a product secret shadows the org secret" {
+            val productService = createInfrastructureService(
+                SERVICE_NAME,
+                usernameSecret = prodUserSecret.name,
+                passwordSecret = prodPassSecret.name,
+                product = product
+            )
+            createInfrastructureService(productService)
+
+            val results = service.listForSecret(prodUserSecret.name, OrganizationId(organization.id))
+
+            results should beEmpty()
+        }
+
+        "return repo services inheriting an org secret" {
+            val orgOnlySecret = createOrganizationSecret("org-only")
+            val repoService = createInfrastructureService(
+                SERVICE_NAME,
+                usernameSecret = orgOnlySecret.name,
+                passwordSecret = orgPassSecret.name,
+                repository = repository
+            )
+            createInfrastructureService(repoService)
+
+            val results = service.listForSecret(orgOnlySecret.name, OrganizationId(organization.id))
+
+            results.map { it.name } shouldContainOnly listOf(SERVICE_NAME)
+        }
+
+        "not return repo services when a repo secret shadows the org secret" {
+            val repoService = createInfrastructureService(
+                SERVICE_NAME,
+                usernameSecret = repoUserSecret.name,
+                passwordSecret = repoPassSecret.name,
+                repository = repository
+            )
+            createInfrastructureService(repoService)
+
+            val results = service.listForSecret(repoUserSecret.name, OrganizationId(organization.id))
+
+            results should beEmpty()
+        }
+
+        "not return repo services when a product secret shields the org secret" {
+            val repoService = createInfrastructureService(
+                SERVICE_NAME,
+                usernameSecret = prodUserSecret.name,
+                passwordSecret = prodPassSecret.name,
+                repository = repository
+            )
+            createInfrastructureService(repoService)
+
+            val results = service.listForSecret(prodUserSecret.name, OrganizationId(organization.id))
+
+            results should beEmpty()
+        }
+
+        "return repo services inheriting a product secret" {
+            val prodOnlySecret = createProductSecret("prod-only")
+            val repoService = createInfrastructureService(
+                SERVICE_NAME,
+                usernameSecret = prodOnlySecret.name,
+                passwordSecret = prodPassSecret.name,
+                repository = repository
+            )
+            createInfrastructureService(repoService)
+
+            val results = service.listForSecret(prodOnlySecret.name, ProductId(product.id))
+
+            results.map { it.name } shouldContainOnly listOf(SERVICE_NAME)
+        }
+
+        "not return repo services when a repo secret shadows the product secret" {
+            val repoService = createInfrastructureService(
+                SERVICE_NAME,
+                usernameSecret = repoUserSecret.name,
+                passwordSecret = repoPassSecret.name,
+                repository = repository
+            )
+            createInfrastructureService(repoService)
+
+            val results = service.listForSecret(repoUserSecret.name, ProductId(product.id))
+
+            results should beEmpty()
+        }
+
+        "not return product services when an org secret shadows the product secret" {
+            val productService = createInfrastructureService(
+                SERVICE_NAME,
+                usernameSecret = prodUserSecret.name,
+                passwordSecret = prodPassSecret.name,
+                product = product
+            )
+            createInfrastructureService(productService)
+
+            val results = service.listForSecret(prodUserSecret.name, ProductId(product.id))
+
+            results should beEmpty()
+        }
+
+        "return product services when no fallback secret exists at the org level" {
+            val prodOnlySecret = createProductSecret("prod-only")
+            val productService = createInfrastructureService(
+                SERVICE_NAME,
+                usernameSecret = prodOnlySecret.name,
+                passwordSecret = prodPassSecret.name,
+                product = product
+            )
+            createInfrastructureService(productService)
+
+            val results = service.listForSecret(prodOnlySecret.name, ProductId(product.id))
+
+            results.map { it.name } shouldContainOnly listOf(SERVICE_NAME)
+        }
+
+        "not return repo services when a product secret shadows the repository secret" {
+            val repoService = createInfrastructureService(
+                SERVICE_NAME,
+                usernameSecret = repoUserSecret.name,
+                passwordSecret = repoPassSecret.name,
+                repository = repository
+            )
+            createInfrastructureService(repoService)
+
+            // prodUserSecret has the same name "user" as repoUserSecret, so it serves as a fallback.
+            val results = service.listForSecret(repoUserSecret.name, RepositoryId(repository.id))
+
+            results should beEmpty()
+        }
+
+        "not return repo services when an org secret shadows the repository secret" {
+            val sharedName = "shared-secret"
+            createOrganizationSecret(sharedName)
+            createRepositorySecret(sharedName)
+            val repoService = createInfrastructureService(
+                SERVICE_NAME,
+                usernameSecret = sharedName,
+                passwordSecret = repoPassSecret.name,
+                repository = repository
+            )
+            createInfrastructureService(repoService)
+
+            val results = service.listForSecret(sharedName, RepositoryId(repository.id))
+
+            results should beEmpty()
+        }
+
+        "return repo services when no fallback secret exists for the repository secret" {
+            val repoOnlySecret = createRepositorySecret("repo-only")
+            val repoService = createInfrastructureService(
+                SERVICE_NAME,
+                usernameSecret = repoOnlySecret.name,
+                passwordSecret = repoPassSecret.name,
+                repository = repository
+            )
+            createInfrastructureService(repoService)
+
+            val results = service.listForSecret(repoOnlySecret.name, RepositoryId(repository.id))
+
+            results.map { it.name } shouldContainOnly listOf(SERVICE_NAME)
+        }
+
+        "not return services from a different organization" {
+            val otherOrg = fixtures.createOrganization("other-org")
+            val otherOrgUserSecret = createOrganizationSecret("user", otherOrg.id)
+            val otherOrgPassSecret = createOrganizationSecret("pass", otherOrg.id)
+            val otherOrgService = createInfrastructureService(
+                SERVICE_NAME,
+                usernameSecret = otherOrgUserSecret.name,
+                passwordSecret = otherOrgPassSecret.name,
+                organization = otherOrg
+            )
+            createInfrastructureService(otherOrgService)
+
+            val results = service.listForSecret(orgUserSecret.name, OrganizationId(organization.id))
+
+            results should beEmpty()
         }
     }
 

--- a/compositions/secrets-routes/src/main/kotlin/routes/DeleteOrganizationSecret.kt
+++ b/compositions/secrets-routes/src/main/kotlin/routes/DeleteOrganizationSecret.kt
@@ -67,7 +67,7 @@ internal fun Route.deleteOrganizationSecret(
         return@delete
     }
 
-    val infrastructureServices = infrastructureServiceService.listForSecret(secret.name)
+    val infrastructureServices = infrastructureServiceService.listForSecret(secret.name, organizationId)
     if (infrastructureServices.isNotEmpty()) {
         call.respondError(
             HttpStatusCode.Conflict,

--- a/compositions/secrets-routes/src/main/kotlin/routes/DeleteProductSecret.kt
+++ b/compositions/secrets-routes/src/main/kotlin/routes/DeleteProductSecret.kt
@@ -66,7 +66,7 @@ internal fun Route.deleteProductSecret(
         return@delete
     }
 
-    val infrastructureServices = infrastructureServiceService.listForSecret(secret.name)
+    val infrastructureServices = infrastructureServiceService.listForSecret(secret.name, productId)
     if (infrastructureServices.isNotEmpty()) {
         call.respondError(
             HttpStatusCode.Conflict,

--- a/compositions/secrets-routes/src/main/kotlin/routes/DeleteRepositorySecret.kt
+++ b/compositions/secrets-routes/src/main/kotlin/routes/DeleteRepositorySecret.kt
@@ -66,7 +66,7 @@ internal fun Route.deleteRepositorySecret(
         return@delete
     }
 
-    val infrastructureServices = infrastructureServiceService.listForSecret(secret.name)
+    val infrastructureServices = infrastructureServiceService.listForSecret(secret.name, repositoryId)
     if (infrastructureServices.isNotEmpty()) {
         call.respondError(
             HttpStatusCode.Conflict,

--- a/compositions/secrets-routes/src/test/kotlin/routes/DeleteOrganizationSecretIntegrationTest.kt
+++ b/compositions/secrets-routes/src/test/kotlin/routes/DeleteOrganizationSecretIntegrationTest.kt
@@ -35,6 +35,7 @@ import java.util.EnumSet
 import org.eclipse.apoapsis.ortserver.compositions.secretsroutes.SecretsRoutesIntegrationTest
 import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.OrganizationId
+import org.eclipse.apoapsis.ortserver.model.ProductId
 import org.eclipse.apoapsis.ortserver.model.repositories.SecretRepository
 import org.eclipse.apoapsis.ortserver.secrets.Path
 import org.eclipse.apoapsis.ortserver.secrets.SecretsProviderFactoryForTesting
@@ -42,9 +43,11 @@ import org.eclipse.apoapsis.ortserver.shared.apimodel.ErrorResponse
 
 class DeleteOrganizationSecretIntegrationTest : SecretsRoutesIntegrationTest({
     var orgId = 0L
+    var prodId = 0L
 
     beforeEach {
         orgId = dbExtension.fixtures.organization.id
+        prodId = dbExtension.fixtures.product.id
     }
 
     "DeleteOrganizationSecret" should {
@@ -62,7 +65,7 @@ class DeleteOrganizationSecretIntegrationTest : SecretsRoutesIntegrationTest({
             }
         }
 
-        "respond with 'Conflict' when secret is in use" {
+        "respond with Conflict when secret is in use" {
             secretsRoutesTestApplication { client ->
                 val userSecret = secretRepository.createOrganizationSecret(orgId, path = "user", name = "user").name
                 val passSecret = secretRepository.createOrganizationSecret(orgId, path = "pass", name = "pass").name
@@ -94,6 +97,36 @@ class DeleteOrganizationSecretIntegrationTest : SecretsRoutesIntegrationTest({
                         HttpStatusCode.InternalServerError
 
                 secretRepository.getByIdAndName(OrganizationId(orgId), secret.name) shouldBe secret
+            }
+        }
+
+        "not block deletion when a same-named secret exists at a different level" {
+            secretsRoutesTestApplication { client ->
+                val secretName = "sharedName"
+                val orgSecret = secretRepository.createOrganizationSecret(
+                    orgId,
+                    path = "org-path",
+                    name = secretName
+                )
+                secretRepository.createProductSecret(prodId, path = "product-path", name = secretName)
+
+                infrastructureServiceService.createForId(
+                    ProductId(prodId),
+                    name = "productService",
+                    url = "http://example.org/service",
+                    description = null,
+                    usernameSecretRef = secretName,
+                    passwordSecretRef = secretName,
+                    credentialsTypes = EnumSet.of(CredentialsType.NETRC_FILE)
+                )
+
+                client.delete("/organizations/$orgId/secrets/$secretName") shouldHaveStatus
+                        HttpStatusCode.NoContent
+
+                secretRepository.getByIdAndName(OrganizationId(orgId), secretName) shouldBe null
+
+                val provider = SecretsProviderFactoryForTesting.instance()
+                provider.readSecret(Path(orgSecret.path)) should beNull()
             }
         }
     }

--- a/compositions/secrets-routes/src/test/kotlin/routes/DeleteProductSecretIntegrationTest.kt
+++ b/compositions/secrets-routes/src/test/kotlin/routes/DeleteProductSecretIntegrationTest.kt
@@ -34,6 +34,7 @@ import java.util.EnumSet
 
 import org.eclipse.apoapsis.ortserver.compositions.secretsroutes.SecretsRoutesIntegrationTest
 import org.eclipse.apoapsis.ortserver.model.CredentialsType
+import org.eclipse.apoapsis.ortserver.model.OrganizationId
 import org.eclipse.apoapsis.ortserver.model.ProductId
 import org.eclipse.apoapsis.ortserver.model.repositories.SecretRepository
 import org.eclipse.apoapsis.ortserver.secrets.Path
@@ -42,11 +43,11 @@ import org.eclipse.apoapsis.ortserver.shared.apimodel.ErrorResponse
 
 class DeleteProductSecretIntegrationTest : SecretsRoutesIntegrationTest({
     var prodId = 0L
-
-    val secretErrorPath = "error-path"
+    var orgId = 0L
 
     beforeEach {
         prodId = dbExtension.fixtures.product.id
+        orgId = dbExtension.fixtures.organization.id
     }
 
     "DeleteProductSecret" should {
@@ -96,6 +97,36 @@ class DeleteProductSecretIntegrationTest : SecretsRoutesIntegrationTest({
                         HttpStatusCode.InternalServerError
 
                 secretRepository.getByIdAndName(ProductId(prodId), secret.name) shouldBe secret
+            }
+        }
+
+        "not block deletion when a same-named secret exists at a different level" {
+            secretsRoutesTestApplication { client ->
+                val secretName = "sharedName"
+                val productSecret = secretRepository.createProductSecret(
+                    prodId,
+                    path = "product-path",
+                    name = secretName
+                )
+                secretRepository.createOrganizationSecret(orgId, path = "org-path", name = secretName)
+
+                infrastructureServiceService.createForId(
+                    OrganizationId(orgId),
+                    name = "orgService",
+                    url = "http://example.org/service",
+                    description = null,
+                    usernameSecretRef = secretName,
+                    passwordSecretRef = secretName,
+                    credentialsTypes = EnumSet.of(CredentialsType.NETRC_FILE)
+                )
+
+                client.delete("/products/$prodId/secrets/$secretName") shouldHaveStatus
+                        HttpStatusCode.NoContent
+
+                secretRepository.getByIdAndName(ProductId(prodId), secretName) shouldBe null
+
+                val provider = SecretsProviderFactoryForTesting.instance()
+                provider.readSecret(Path(productSecret.path)) should beNull()
             }
         }
     }

--- a/compositions/secrets-routes/src/test/kotlin/routes/DeleteRepositorySecretIntegrationTest.kt
+++ b/compositions/secrets-routes/src/test/kotlin/routes/DeleteRepositorySecretIntegrationTest.kt
@@ -34,6 +34,7 @@ import java.util.EnumSet
 
 import org.eclipse.apoapsis.ortserver.compositions.secretsroutes.SecretsRoutesIntegrationTest
 import org.eclipse.apoapsis.ortserver.model.CredentialsType
+import org.eclipse.apoapsis.ortserver.model.OrganizationId
 import org.eclipse.apoapsis.ortserver.model.RepositoryId
 import org.eclipse.apoapsis.ortserver.model.repositories.SecretRepository
 import org.eclipse.apoapsis.ortserver.secrets.Path
@@ -42,9 +43,11 @@ import org.eclipse.apoapsis.ortserver.shared.apimodel.ErrorResponse
 
 class DeleteRepositorySecretIntegrationTest : SecretsRoutesIntegrationTest({
     var repoId = 0L
+    var orgId = 0L
 
     beforeEach {
         repoId = dbExtension.fixtures.repository.id
+        orgId = dbExtension.fixtures.organization.id
     }
 
     "DeleteRepositorySecret" should {
@@ -94,6 +97,36 @@ class DeleteRepositorySecretIntegrationTest : SecretsRoutesIntegrationTest({
                         HttpStatusCode.InternalServerError
 
                 secretRepository.getByIdAndName(RepositoryId(repoId), secret.name) shouldBe secret
+            }
+        }
+
+        "not block deletion when a same-named secret exists at a different level" {
+            secretsRoutesTestApplication { client ->
+                val secretName = "sharedName"
+                val repoSecret = secretRepository.createRepositorySecret(
+                    repoId,
+                    path = "repo-path",
+                    name = secretName
+                )
+                secretRepository.createOrganizationSecret(orgId, path = "org-path", name = secretName)
+
+                infrastructureServiceService.createForId(
+                    OrganizationId(orgId),
+                    name = "orgService",
+                    url = "http://example.org/service",
+                    description = null,
+                    usernameSecretRef = secretName,
+                    passwordSecretRef = secretName,
+                    credentialsTypes = EnumSet.of(CredentialsType.NETRC_FILE)
+                )
+
+                client.delete("/repositories/$repoId/secrets/$secretName") shouldHaveStatus
+                        HttpStatusCode.NoContent
+
+                secretRepository.getByIdAndName(RepositoryId(repoId), secretName) shouldBe null
+
+                val provider = SecretsProviderFactoryForTesting.instance()
+                provider.readSecret(Path(repoSecret.path)) should beNull()
             }
         }
     }


### PR DESCRIPTION
Only check infrastructure services at the same hierarchy level when deleting a secret, as same-named secrets at different levels are independent.