### PR TITLE
Add Git and Bazel credential helpers to the workers' base image

### DIFF
--- a/docker/Base.Dockerfile
+++ b/docker/Base.Dockerfile
@@ -41,6 +41,18 @@ RUN mkdir -p $BAZEL_HOME/bin \
     && mv $BAZEL_HOME/bin/credentialhelper.kexe $BAZEL_HOME/bin/bazel-credential-helper \
     && chmod a+x $BAZEL_HOME/bin/bazel-credential-helper
 
+ENV GIT_HOME=/opt/git
+
+RUN mkdir -p $GIT_HOME/bin \
+    && if [ "$(arch)" = "aarch64" ]; then \
+    curl -L https://github.com/eclipse-apoapsis/ort-server-credential-helper/releases/download/$CREDENTIAL_HELPER_VERSION/git-credential-helper-linux-arm64.tar.gz -o /tmp/git-credential-helper.tar.gz; \
+    else \
+    curl -L https://github.com/eclipse-apoapsis/ort-server-credential-helper/releases/download/$CREDENTIAL_HELPER_VERSION/git-credential-helper-linux-x64.tar.gz -o /tmp/git-credential-helper.tar.gz; \
+    fi \
+    && tar xvzf /tmp/git-credential-helper.tar.gz --directory=$GIT_HOME/bin/ \
+    && mv $GIT_HOME/bin/credentialhelper.kexe $GIT_HOME/bin/git-credential-helper \
+    && chmod a+x $GIT_HOME/bin/git-credential-helper
+
 FROM eclipse-temurin:$TEMURIN_VERSION
 
 ENV LANG=en_US.UTF-8
@@ -116,5 +128,6 @@ USER $USER
 WORKDIR $HOME
 
 COPY --from=credential-helper --chown=$USERNAME:$USERNAME /opt/bazel /opt/bazel
+COPY --from=credential-helper --chown=$USERNAME:$USERNAME /opt/git /opt/git
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/docker/Base.Dockerfile
+++ b/docker/Base.Dockerfile
@@ -21,7 +21,25 @@
 # This is a common base image for all ORT Server images requiring Java. It provides some base functionality like
 # setting file permissions for the user, setting up certificates, etc. And, it defines the temurin base image.
 
+ARG CREDENTIAL_HELPER_VERSION=0.2.0
 ARG TEMURIN_VERSION=21.0.10_7-jdk-jammy@sha256:25d1276565738d3c805e632a4542c3a7598866ef967f4def6544c15de3a74b14
+
+FROM alpine:3.21 AS credential-helper
+
+ARG CREDENTIAL_HELPER_VERSION
+ENV BAZEL_HOME=/opt/bazel
+
+RUN apk add --no-cache curl ca-certificates
+
+RUN mkdir -p $BAZEL_HOME/bin \
+    && if [ "$(arch)" = "aarch64" ]; then \
+    curl -L https://github.com/eclipse-apoapsis/ort-server-credential-helper/releases/download/$CREDENTIAL_HELPER_VERSION/bazel-credential-helper-linux-arm64.tar.gz -o /tmp/bazel-credential-helper.tar.gz; \
+    else \
+    curl -L https://github.com/eclipse-apoapsis/ort-server-credential-helper/releases/download/$CREDENTIAL_HELPER_VERSION/bazel-credential-helper-linux-x64.tar.gz -o /tmp/bazel-credential-helper.tar.gz; \
+    fi \
+    && tar xvzf /tmp/bazel-credential-helper.tar.gz --directory=$BAZEL_HOME/bin/ \
+    && mv $BAZEL_HOME/bin/credentialhelper.kexe $BAZEL_HOME/bin/bazel-credential-helper \
+    && chmod a+x $BAZEL_HOME/bin/bazel-credential-helper
 
 FROM eclipse-temurin:$TEMURIN_VERSION
 
@@ -96,5 +114,7 @@ RUN /etc/scripts/export_proxy_certificates.sh /tmp/certificates/ \
 
 USER $USER
 WORKDIR $HOME
+
+COPY --from=credential-helper --chown=$USERNAME:$USERNAME /opt/bazel /opt/bazel
 
 ENTRYPOINT [ "/bin/bash" ]

--- a/workers/common/src/main/kotlin/env/BazelGenerator.kt
+++ b/workers/common/src/main/kotlin/env/BazelGenerator.kt
@@ -31,7 +31,7 @@ internal const val BAZEL_RC_FILE_NAME = ".bazelrc"
  * class generates the file with the credentials to be consumed by this Credential Helper. The file uses the same syntax
  * as Git's .git-credentials file (https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage). To activate the
  * Credential Helper in Bazel, it has to be referenced in a .bazelrc file in the home directory. This generator creates
- * this file as well. It assumes that the Credential Helper is installed under the path /opt/bazel - this has to be
+ * this file as well. It assumes that the Credential Helper is installed under the path /opt/bazel/bin - this has to be
  * aligned with the build of the container images.
  */
 class BazelGenerator : EnvironmentConfigGenerator<BazelDefinition> {
@@ -47,7 +47,7 @@ class BazelGenerator : EnvironmentConfigGenerator<BazelDefinition> {
         }
 
         builder.buildInUserHome(BAZEL_RC_FILE_NAME) {
-            println("common --credential_helper=/opt/bazel/bazel_cred_wrapper.sh")
+            println("common --credential_helper=/opt/bazel/bin/bazel-credential-helper")
         }
     }
 }

--- a/workers/common/src/main/kotlin/env/EnvironmentModule.kt
+++ b/workers/common/src/main/kotlin/env/EnvironmentModule.kt
@@ -53,6 +53,7 @@ fun buildEnvironmentModule(includePackageManagerGenerators: Boolean = false): Mo
                 add(GitCredentialsGenerator())
 
                 if (includePackageManagerGenerators) {
+                    add(BazelGenerator())
                     add(ConanGenerator())
                     add(GradleInitGenerator())
                     add(MavenSettingsGenerator())

--- a/workers/common/src/main/kotlin/env/GitConfigGenerator.kt
+++ b/workers/common/src/main/kotlin/env/GitConfigGenerator.kt
@@ -97,7 +97,8 @@ class GitConfigGenerator(private val gitConfigUrlInsteadOfPairs: Map<String, Str
                     // If there are any Git credentials defined, create a `[credential]` section.
                     if (hasCredentials) {
                         println("[credential]")
-                        println("\thelper = store")
+                        println("\thelper = /opt/git/bin/git-credential-helper")
+                        println("\tuseHttpPath = true")
                         GeneratorLogger.entryAdded("[credential]\n\thelper = store", GIT_CONFIG_FILE_NAME)
                     }
 

--- a/workers/common/src/test/kotlin/env/BazelGeneratorTest.kt
+++ b/workers/common/src/test/kotlin/env/BazelGeneratorTest.kt
@@ -105,7 +105,7 @@ class BazelGeneratorTest : WordSpec({
 
 private fun MockConfigFileBuilder.checkBazelRcFileContent() {
     val expectedLines = listOf(
-        "common --credential_helper=/opt/bazel/bazel_cred_wrapper.sh"
+        "common --credential_helper=/opt/bazel/bin/bazel-credential-helper"
     )
     val lines = generatedLinesFor(homeFileName = BAZEL_RC_FILE_NAME)
     lines shouldContainExactly expectedLines

--- a/workers/common/src/test/kotlin/env/GitConfigGeneratorTest.kt
+++ b/workers/common/src/test/kotlin/env/GitConfigGeneratorTest.kt
@@ -87,7 +87,8 @@ class GitConfigGeneratorTest : WordSpec({
 
             lines shouldContainExactly listOf(
                 "[credential]",
-                "\thelper = store"
+                "\thelper = /opt/git/bin/git-credential-helper",
+                "\tuseHttpPath = true"
             )
         }
 
@@ -113,7 +114,8 @@ class GitConfigGeneratorTest : WordSpec({
 
             lines shouldContainExactly listOf(
                 "[credential]",
-                "\thelper = store",
+                "\thelper = /opt/git/bin/git-credential-helper",
+                "\tuseHttpPath = true",
                 "[url \"https://github.com\"]",
                 "\tinsteadOf = \"ssh://git@github.com\"",
                 "[url \"https://github.com/\"]",


### PR DESCRIPTION
Please have a look at the individual commit messages for the details.