### PR TITLE
docs(core): Fix example for Maven environment definition

### DIFF
--- a/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RepositoriesDocs.kt
@@ -87,7 +87,7 @@ internal val fullJobConfigurations = JobConfigurations(
             environmentDefinitions = mapOf(
                 "maven" to listOf(
                     mapOf(
-                        "keycloak/service" to "Artifactory",
+                        "service" to "Artifactory",
                         "id" to "repo"
                     )
                 )


### PR DESCRIPTION
The "keycloak/" prefix was added in 3d6f4fc by accident.