### PR TITLE
build: Switch to `devEngines.packageManager`

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -4,7 +4,12 @@
   "version": "0.0.0",
   "type": "module",
   "license": "Apache-2.0",
-  "packageManager": "pnpm@11.0.8",
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "11.0.8"
+    }
+  },
   "scripts": {
     "dev": "vite",
     "test": "vitest",

--- a/website/package.json
+++ b/website/package.json
@@ -2,7 +2,12 @@
   "name": "ort-server",
   "version": "0.0.0",
   "private": true,
-  "packageManager": "pnpm@11.0.8",
+  "devEngines": {
+    "packageManager": {
+      "name": "pnpm",
+      "version": "11.0.8"
+    }
+  },
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",


### PR DESCRIPTION
Define the pnpm version to using the new `devEngines.packageManager` [1] property instead of `packageManager`. As for dependencies, use a pinned version instead of a version range.

[1]: https://pnpm.io/package_json#devenginespackagemanager