### PR TITLE
ui: Allow to specify environment configuration for each supported package manager

### DIFF
--- a/ui/src/lib/environment-definition-fields.tsx
+++ b/ui/src/lib/environment-definition-fields.tsx
@@ -1,0 +1,268 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { ReactNode } from 'react';
+
+import {
+  conanEnvironmentDefinitions,
+  EnvironmentDefinitionEntry,
+  gradleEnvironmentDefinitions,
+  mavenEnvironmentDefinitions,
+  npmAuthModes,
+  npmEnvironmentDefinitions,
+  nugetAuthModes,
+  nugetEnvironmentDefinitions,
+  yarnAuthModes,
+  yarnEnvironmentDefinitions,
+} from '@/lib/types';
+
+type ServiceFieldDef = { type: 'service' };
+
+type StringFieldDef = {
+  type: 'string';
+  label: string;
+  description: ReactNode;
+  optional?: boolean;
+};
+
+type BooleanFieldDef = {
+  type: 'boolean';
+  label: string;
+  description: ReactNode;
+};
+
+type EnumFieldDef = {
+  type: 'enum';
+  label: string;
+  description: string;
+  values: readonly string[];
+  placeholder: string;
+};
+
+export type FieldDef =
+  | ServiceFieldDef
+  | StringFieldDef
+  | BooleanFieldDef
+  | EnumFieldDef;
+
+export type FieldEntry = { key: string; def: FieldDef };
+
+export type EnvironmentDefinitionSchema = {
+  key: string;
+  label: string;
+  defaultEntries: EnvironmentDefinitionEntry[];
+  fields: FieldEntry[];
+};
+
+export const ENVIRONMENT_DEFINITION_SCHEMAS: EnvironmentDefinitionSchema[] = [
+  {
+    key: 'conan',
+    label: 'Conan',
+    defaultEntries: conanEnvironmentDefinitions['conan'] ?? [],
+    fields: [
+      { key: 'service', def: { type: 'service' } },
+      {
+        key: 'name',
+        def: {
+          type: 'string',
+          label: 'Remote name',
+          description: (
+            <>
+              Name of the Conan remote, used in commands like{' '}
+              <code>conan list</code>.
+            </>
+          ),
+        },
+      },
+      {
+        key: 'url',
+        def: {
+          type: 'string',
+          label: 'URL',
+          description:
+            'URL for Conan to search for recipes and binaries. Falls back to the infrastructure service URL if not set.',
+          optional: true,
+        },
+      },
+      {
+        key: 'verifySsl',
+        def: {
+          type: 'boolean',
+          label: 'Verify SSL',
+          description: 'Verify the SSL certificate of the remote URL.',
+        },
+      },
+    ],
+  },
+  {
+    key: 'gradle',
+    label: 'Gradle',
+    defaultEntries: gradleEnvironmentDefinitions['gradle'] ?? [],
+    fields: [{ key: 'service', def: { type: 'service' } }],
+  },
+  {
+    key: 'maven',
+    label: 'Maven',
+    defaultEntries: mavenEnvironmentDefinitions['maven'] ?? [],
+    fields: [
+      { key: 'service', def: { type: 'service' } },
+      {
+        key: 'id',
+        def: {
+          type: 'string',
+          label: 'ID',
+          description: (
+            <>
+              Repository ID referenced in <code>pom.xml</code> files. Appears as
+              the <code>&lt;id&gt;</code> of the corresponding server in
+              Maven&apos;s <code>settings.xml</code>.
+            </>
+          ),
+        },
+      },
+      {
+        key: 'mirrorOf',
+        def: {
+          type: 'string',
+          label: 'Mirror of',
+          description: (
+            <>
+              If set, adds this entry to the <code>&lt;mirrors&gt;</code>{' '}
+              section of <code>settings.xml</code>. Value is the repository ID
+              to mirror (e.g. <code>central</code>, or <code>*</code> for all
+              repositories).
+            </>
+          ),
+          optional: true,
+        },
+      },
+    ],
+  },
+  {
+    key: 'npm',
+    label: 'NPM',
+    defaultEntries: npmEnvironmentDefinitions['npm'] ?? [],
+    fields: [
+      { key: 'service', def: { type: 'service' } },
+      {
+        key: 'scope',
+        def: {
+          type: 'string',
+          label: 'Scope',
+          description: 'Optional NPM scope that this configuration applies to.',
+          optional: true,
+        },
+      },
+      {
+        key: 'email',
+        def: {
+          type: 'string',
+          label: 'Email',
+          description: 'Optional email address used by the NPM registry.',
+          optional: true,
+        },
+      },
+      {
+        key: 'authMode',
+        def: {
+          type: 'enum',
+          label: 'Authorization mode',
+          description: 'Pick how the NPM registry authenticates requests.',
+          values: npmAuthModes,
+          placeholder: 'Select the authorization mode',
+        },
+      },
+    ],
+  },
+  {
+    key: 'nuget',
+    label: 'NuGet',
+    defaultEntries: nugetEnvironmentDefinitions['nuget'] ?? [],
+    fields: [
+      { key: 'service', def: { type: 'service' } },
+      {
+        key: 'sourceName',
+        def: {
+          type: 'string',
+          label: 'Source name',
+          description: 'The name to assign to the package source.',
+        },
+      },
+      {
+        key: 'sourcePath',
+        def: {
+          type: 'string',
+          label: 'Source path',
+          description: 'The path or URL of the package source.',
+        },
+      },
+      {
+        key: 'sourceProtocolVersion',
+        def: {
+          type: 'string',
+          label: 'Source protocol version',
+          description:
+            'NuGet server protocol version (e.g. 3). Defaults to 2 for non-JSON source URLs. Requires NuGet 3.0+.',
+          optional: true,
+        },
+      },
+      {
+        key: 'authMode',
+        def: {
+          type: 'enum',
+          label: 'Authorization mode',
+          description: 'Authentication type for this package source.',
+          values: nugetAuthModes,
+          placeholder: 'Select the authorization mode',
+        },
+      },
+    ],
+  },
+  {
+    key: 'yarn',
+    label: 'Yarn',
+    defaultEntries: yarnEnvironmentDefinitions['yarn'] ?? [],
+    fields: [
+      { key: 'service', def: { type: 'service' } },
+      {
+        key: 'authMode',
+        def: {
+          type: 'enum',
+          label: 'Authorization mode',
+          description: 'Authentication method for this private registry.',
+          values: yarnAuthModes,
+          placeholder: 'Select the authorization mode',
+        },
+      },
+      {
+        key: 'alwaysAuth',
+        def: {
+          type: 'boolean',
+          label: 'Always authenticate',
+          description: (
+            <>
+              Always send authentication information to the registry via the{' '}
+              <code>npmAlwaysAuth</code> property.
+            </>
+          ),
+        },
+      },
+    ],
+  },
+];

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -69,6 +69,14 @@ const gradleEnvironmentDefinition = z
   .object({ service: z.string() })
   .catchall(z.string());
 
+const mavenEnvironmentDefinition = z
+  .object({
+    service: z.string(),
+    id: z.string(),
+    mirrorOf: z.string().optional(),
+  })
+  .catchall(z.string());
+
 export enum NuGetAuthMode {
   PASSWORD = 'PASSWORD',
   API_KEY = 'API_KEY',
@@ -89,6 +97,7 @@ const nugetEnvironmentDefinition = z
 const environmentDefinitionValidators: Record<string, z.ZodTypeAny> = {
   conan: conanEnvironmentDefinition,
   gradle: gradleEnvironmentDefinition,
+  maven: mavenEnvironmentDefinition,
   npm: npmEnvironmentDefinition,
   nuget: nugetEnvironmentDefinition,
 };
@@ -145,6 +154,10 @@ export const conanEnvironmentDefinitions: EnvironmentDefinitions = {
 
 export const gradleEnvironmentDefinitions: EnvironmentDefinitions = {
   gradle: [{ service: '' }],
+};
+
+export const mavenEnvironmentDefinitions: EnvironmentDefinitions = {
+  maven: [{ service: '', id: '', mirrorOf: '' }],
 };
 
 export const nugetEnvironmentDefinitions: EnvironmentDefinitions = {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -65,9 +65,27 @@ const conanEnvironmentDefinition = z
   })
   .catchall(z.string());
 
+export enum NuGetAuthMode {
+  PASSWORD = 'PASSWORD',
+  API_KEY = 'API_KEY',
+}
+
+export const nugetAuthModes = Object.values(NuGetAuthMode) as NuGetAuthMode[];
+
+const nugetEnvironmentDefinition = z
+  .object({
+    service: z.string(),
+    sourceName: z.string(),
+    sourcePath: z.string(),
+    sourceProtocolVersion: z.string().optional(),
+    authMode: z.enum(NuGetAuthMode),
+  })
+  .catchall(z.string());
+
 const environmentDefinitionValidators: Record<string, z.ZodTypeAny> = {
-  npm: npmEnvironmentDefinition,
   conan: conanEnvironmentDefinition,
+  npm: npmEnvironmentDefinition,
+  nuget: nugetEnvironmentDefinition,
 };
 
 export const environmentDefinitionsSchema =
@@ -116,6 +134,18 @@ export const conanEnvironmentDefinitions: EnvironmentDefinitions = {
       name: '',
       url: '',
       verifySsl: 'true',
+    },
+  ],
+};
+
+export const nugetEnvironmentDefinitions: EnvironmentDefinitions = {
+  nuget: [
+    {
+      service: '',
+      sourceName: '',
+      sourcePath: '',
+      sourceProtocolVersion: '',
+      authMode: NuGetAuthMode.API_KEY,
     },
   ],
 };

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -65,6 +65,10 @@ const conanEnvironmentDefinition = z
   })
   .catchall(z.string());
 
+const gradleEnvironmentDefinition = z
+  .object({ service: z.string() })
+  .catchall(z.string());
+
 export enum NuGetAuthMode {
   PASSWORD = 'PASSWORD',
   API_KEY = 'API_KEY',
@@ -84,6 +88,7 @@ const nugetEnvironmentDefinition = z
 
 const environmentDefinitionValidators: Record<string, z.ZodTypeAny> = {
   conan: conanEnvironmentDefinition,
+  gradle: gradleEnvironmentDefinition,
   npm: npmEnvironmentDefinition,
   nuget: nugetEnvironmentDefinition,
 };
@@ -136,6 +141,10 @@ export const conanEnvironmentDefinitions: EnvironmentDefinitions = {
       verifySsl: 'true',
     },
   ],
+};
+
+export const gradleEnvironmentDefinitions: EnvironmentDefinitions = {
+  gradle: [{ service: '' }],
 };
 
 export const nugetEnvironmentDefinitions: EnvironmentDefinitions = {

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -56,8 +56,18 @@ const npmEnvironmentDefinition = z
   })
   .catchall(z.string());
 
+const conanEnvironmentDefinition = z
+  .object({
+    service: z.string(),
+    name: z.string(),
+    url: z.string().optional(),
+    verifySsl: z.string().optional(),
+  })
+  .catchall(z.string());
+
 const environmentDefinitionValidators: Record<string, z.ZodTypeAny> = {
   npm: npmEnvironmentDefinition,
+  conan: conanEnvironmentDefinition,
 };
 
 export const environmentDefinitionsSchema =
@@ -95,6 +105,17 @@ export const npmEnvironmentDefinitions: EnvironmentDefinitions = {
       scope: '',
       email: '',
       authMode: NpmAuthMode.PASSWORD,
+    },
+  ],
+};
+
+export const conanEnvironmentDefinitions: EnvironmentDefinitions = {
+  conan: [
+    {
+      service: '',
+      name: '',
+      url: '',
+      verifySsl: 'true',
     },
   ],
 };

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -94,12 +94,28 @@ const nugetEnvironmentDefinition = z
   })
   .catchall(z.string());
 
+export enum YarnAuthMode {
+  AUTH_IDENT = 'AUTH_IDENT',
+  AUTH_TOKEN = 'AUTH_TOKEN',
+}
+
+export const yarnAuthModes = Object.values(YarnAuthMode) as YarnAuthMode[];
+
+const yarnEnvironmentDefinition = z
+  .object({
+    service: z.string(),
+    authMode: z.enum(YarnAuthMode),
+    alwaysAuth: z.string().optional(),
+  })
+  .catchall(z.string());
+
 const environmentDefinitionValidators: Record<string, z.ZodTypeAny> = {
   conan: conanEnvironmentDefinition,
   gradle: gradleEnvironmentDefinition,
   maven: mavenEnvironmentDefinition,
   npm: npmEnvironmentDefinition,
   nuget: nugetEnvironmentDefinition,
+  yarn: yarnEnvironmentDefinition,
 };
 
 export const environmentDefinitionsSchema =
@@ -168,6 +184,16 @@ export const nugetEnvironmentDefinitions: EnvironmentDefinitions = {
       sourcePath: '',
       sourceProtocolVersion: '',
       authMode: NuGetAuthMode.API_KEY,
+    },
+  ],
+};
+
+export const yarnEnvironmentDefinitions: EnvironmentDefinitions = {
+  yarn: [
+    {
+      service: '',
+      authMode: YarnAuthMode.AUTH_TOKEN,
+      alwaysAuth: 'true',
     },
   ],
 };

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
@@ -19,7 +19,7 @@
 
 import { useParams } from '@tanstack/react-router';
 import { PlusIcon, TrashIcon } from 'lucide-react';
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useFieldArray, UseFormReturn } from 'react-hook-form';
 
 import { InfrastructureService } from '@/api';
@@ -30,7 +30,6 @@ import {
   AccordionTrigger,
 } from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardTitle } from '@/components/ui/card';
 import {
   FormControl,
   FormDescription,
@@ -56,13 +55,8 @@ import {
   ProductPermissions,
   RepositoryPermissions,
 } from '@/lib/permissions.ts';
-import {
-  EnvironmentDefinitions,
-  NpmAuthMode,
-  npmAuthModes,
-  npmEnvironmentDefinitions,
-} from '@/lib/types';
 import { CreateRunFormValues } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components';
+import { EnvironmentDefinitionsFields } from './environment-definitions';
 import { PackageManagerField } from './package-manager-field';
 
 type AnalyzerFieldsProps = {
@@ -120,31 +114,6 @@ export const AnalyzerFields = ({
       shouldDirty: false,
     });
   }, [form, infrastructureServices]);
-
-  const cloneEnvironmentDefinitions = (
-    definitions: EnvironmentDefinitions | undefined
-  ): EnvironmentDefinitions | undefined => {
-    if (!definitions) {
-      return undefined;
-    }
-    return Object.fromEntries(
-      Object.entries(definitions).map(([key, entries]) => [
-        key,
-        entries.map((entry) => ({ ...entry })),
-      ])
-    ) as EnvironmentDefinitions;
-  };
-
-  const environmentDefinitionsEnabled =
-    form.watch('jobConfigs.analyzer.environmentDefinitionsEnabled') ?? false;
-
-  const environmentDefinitionsBackup = useRef<
-    EnvironmentDefinitions | undefined
-  >(
-    cloneEnvironmentDefinitions(
-      form.getValues('jobConfigs.analyzer.environmentDefinitions')
-    )
-  );
 
   return (
     <div className='flex flex-row align-middle'>
@@ -390,183 +359,10 @@ export const AnalyzerFields = ({
               </Button>
             </div>
           </div>
-          <div className='flex flex-col gap-2'>
-            <h3>Environment configuration</h3>
-            <FormField
-              control={form.control}
-              name='jobConfigs.analyzer.environmentDefinitionsEnabled'
-              render={({ field }) => (
-                <FormItem className='flex flex-row items-center justify-between rounded-lg border p-4'>
-                  <div className='space-y-0.5'>
-                    <FormLabel>Enable NPM environment definition</FormLabel>
-                  </div>
-                  <FormControl>
-                    <Switch
-                      checked={field.value}
-                      onCheckedChange={(checked) => {
-                        field.onChange(checked);
-                        const currentDefinitions = form.getValues(
-                          'jobConfigs.analyzer.environmentDefinitions'
-                        );
-
-                        if (checked) {
-                          if (
-                            !currentDefinitions ||
-                            Object.keys(currentDefinitions).length === 0
-                          ) {
-                            const definitionsToRestore =
-                              environmentDefinitionsBackup.current ??
-                              npmEnvironmentDefinitions;
-
-                            form.setValue(
-                              'jobConfigs.analyzer.environmentDefinitions',
-                              cloneEnvironmentDefinitions(definitionsToRestore),
-                              { shouldDirty: true }
-                            );
-                          }
-                        } else {
-                          environmentDefinitionsBackup.current =
-                            cloneEnvironmentDefinitions(currentDefinitions);
-                          form.setValue(
-                            'jobConfigs.analyzer.environmentDefinitions',
-                            undefined,
-                            { shouldDirty: true }
-                          );
-                        }
-                      }}
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
-            />
-            {environmentDefinitionsEnabled && (
-              <Card className='p-4'>
-                <CardTitle>NPM</CardTitle>
-                <CardContent className='flex flex-col gap-4'>
-                  <FormField
-                    control={form.control}
-                    name='jobConfigs.analyzer.environmentDefinitions.npm.0.service'
-                    render={({ field }) => {
-                      const selectedValue =
-                        typeof field.value === 'string' &&
-                        field.value.length > 0
-                          ? field.value
-                          : undefined;
-                      return (
-                        <FormItem>
-                          <FormLabel>Service</FormLabel>
-                          <Select
-                            value={selectedValue}
-                            onValueChange={(value) => {
-                              field.onChange(value);
-                            }}
-                          >
-                            <FormControl>
-                              <SelectTrigger className='w-full'>
-                                <SelectValue placeholder='Select an infrastructure service' />
-                              </SelectTrigger>
-                            </FormControl>
-                            <SelectContent>
-                              {infrastructureServices.map((service) => {
-                                const hierarchyLabel = capitalize(
-                                  service.hierarchy
-                                );
-                                const label = `${service.name} (${hierarchyLabel})`;
-                                return (
-                                  <SelectItem
-                                    key={`${service.hierarchy}:${service.name}`}
-                                    value={service.name}
-                                  >
-                                    {label}
-                                  </SelectItem>
-                                );
-                              })}
-                            </SelectContent>
-                          </Select>
-                          <FormDescription>
-                            Select the infrastructure service from a chosen
-                            hierarchy level.
-                          </FormDescription>
-                          <FormMessage />
-                        </FormItem>
-                      );
-                    }}
-                  />
-                  <FormField
-                    control={form.control}
-                    name='jobConfigs.analyzer.environmentDefinitions.npm.0.scope'
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Scope</FormLabel>
-                        <FormControl>
-                          <Input {...field} placeholder='(optional)' />
-                        </FormControl>
-                        <FormDescription>
-                          Optional NPM scope that this configuration applies to.
-                        </FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={form.control}
-                    name='jobConfigs.analyzer.environmentDefinitions.npm.0.email'
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormLabel>Email</FormLabel>
-                        <FormControl>
-                          <Input {...field} placeholder='(optional)' />
-                        </FormControl>
-                        <FormDescription>
-                          Optional email address used by the NPM registry.
-                        </FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                  <FormField
-                    control={form.control}
-                    name='jobConfigs.analyzer.environmentDefinitions.npm.0.authMode'
-                    render={({ field }) => {
-                      const selectedValue =
-                        typeof field.value === 'string' &&
-                        field.value.length > 0
-                          ? (field.value as NpmAuthMode)
-                          : undefined;
-                      return (
-                        <FormItem>
-                          <FormLabel>Authorization mode</FormLabel>
-                          <Select
-                            value={selectedValue}
-                            onValueChange={(value) => {
-                              field.onChange(value);
-                            }}
-                          >
-                            <FormControl>
-                              <SelectTrigger className='w-full'>
-                                <SelectValue placeholder='Select the authorization mode' />
-                              </SelectTrigger>
-                            </FormControl>
-                            <SelectContent>
-                              {npmAuthModes.map((mode) => (
-                                <SelectItem key={mode} value={mode}>
-                                  {mode.replaceAll('_', ' ')}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                          <FormDescription>
-                            Pick how the NPM registry authenticates requests.
-                          </FormDescription>
-                          <FormMessage />
-                        </FormItem>
-                      );
-                    }}
-                  />
-                </CardContent>
-              </Card>
-            )}
-          </div>
+          <EnvironmentDefinitionsFields
+            form={form}
+            infrastructureServices={infrastructureServices}
+          />
           <PackageManagerField form={form} />
           {isSuperuser && (
             <FormField

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/environment-definitions.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/environment-definitions.tsx
@@ -53,6 +53,9 @@ import {
   NuGetAuthMode,
   nugetAuthModes,
   nugetEnvironmentDefinitions,
+  YarnAuthMode,
+  yarnAuthModes,
+  yarnEnvironmentDefinitions,
 } from '@/lib/types';
 import { CreateRunFormValues } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components';
 
@@ -700,6 +703,130 @@ export const EnvironmentDefinitionsFields = ({
                     </FormItem>
                   );
                 }}
+              />
+            </div>
+          </AccordionContent>
+        </AccordionPrimitive.Item>
+        {/* Yarn */}
+        <AccordionPrimitive.Item value='yarn' className='rounded-lg border'>
+          <AccordionPrimitive.Header className='flex flex-row items-center'>
+            <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
+              Enable Yarn environment definition
+              <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
+            </AccordionPrimitive.Trigger>
+            <div className='pr-4'>
+              <Switch
+                checked={enabledDefinitions['yarn'] ?? false}
+                onCheckedChange={(checked) =>
+                  onToggle(
+                    'yarn',
+                    checked,
+                    yarnEnvironmentDefinitions['yarn'] ?? []
+                  )
+                }
+              />
+            </div>
+          </AccordionPrimitive.Header>
+          <AccordionContent>
+            <div className='flex flex-col gap-4 px-4 pb-4'>
+              <FormField
+                control={form.control}
+                name='jobConfigs.analyzer.environmentDefinitions.yarn.0.service'
+                render={({ field }) => {
+                  const selectedValue =
+                    typeof field.value === 'string' && field.value.length > 0
+                      ? field.value
+                      : undefined;
+                  return (
+                    <FormItem>
+                      <FormLabel>Service</FormLabel>
+                      <Select
+                        value={selectedValue}
+                        onValueChange={(value) => field.onChange(value)}
+                      >
+                        <FormControl>
+                          <SelectTrigger className='w-full'>
+                            <SelectValue placeholder='Select an infrastructure service' />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {infrastructureServices.map((service) => (
+                            <SelectItem
+                              key={`${service.hierarchy}:${service.name}`}
+                              value={service.name}
+                            >
+                              {`${service.name} (${capitalize(service.hierarchy)})`}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormDescription>
+                        Select the infrastructure service from a chosen
+                        hierarchy level.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  );
+                }}
+              />
+              <FormField
+                control={form.control}
+                name='jobConfigs.analyzer.environmentDefinitions.yarn.0.authMode'
+                render={({ field }) => {
+                  const selectedValue =
+                    typeof field.value === 'string' && field.value.length > 0
+                      ? (field.value as YarnAuthMode)
+                      : undefined;
+                  return (
+                    <FormItem>
+                      <FormLabel>Authorization mode</FormLabel>
+                      <Select
+                        value={selectedValue}
+                        onValueChange={(value) => field.onChange(value)}
+                      >
+                        <FormControl>
+                          <SelectTrigger className='w-full'>
+                            <SelectValue placeholder='Select the authorization mode' />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {yarnAuthModes.map((mode) => (
+                            <SelectItem key={mode} value={mode}>
+                              {mode.replaceAll('_', ' ')}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormDescription>
+                        Authentication method for this private registry.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  );
+                }}
+              />
+              <FormField
+                control={form.control}
+                name='jobConfigs.analyzer.environmentDefinitions.yarn.0.alwaysAuth'
+                render={({ field }) => (
+                  <FormItem className='flex flex-row items-center justify-between rounded-lg border p-4'>
+                    <div className='space-y-0.5'>
+                      <FormLabel>Always authenticate</FormLabel>
+                      <FormDescription>
+                        Always send authentication information to the registry
+                        via the <code>npmAlwaysAuth</code> property.
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch
+                        checked={(field.value ?? 'true') === 'true'}
+                        onCheckedChange={(checked) =>
+                          field.onChange(checked ? 'true' : 'false')
+                        }
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
               />
             </div>
           </AccordionContent>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/environment-definitions.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/environment-definitions.tsx
@@ -24,6 +24,11 @@ import { UseFormReturn } from 'react-hook-form';
 
 import { Accordion, AccordionContent } from '@/components/ui/accordion';
 import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible';
+import {
   FormControl,
   FormDescription,
   FormField,
@@ -131,707 +136,718 @@ export const EnvironmentDefinitionsFields = ({
   }
 
   return (
-    <div className='flex flex-col gap-2'>
-      <h3>Environment configuration</h3>
-      <div className='mb-2 text-sm text-gray-500'>
-        Configure the credentials for different package managers to access
-        private artifact repositories.
-      </div>
-      <Accordion type='multiple' className='flex flex-col gap-2'>
-        {/* Conan */}
-        <AccordionPrimitive.Item value='conan' className='rounded-lg border'>
-          <AccordionPrimitive.Header className='flex flex-row items-center'>
-            <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
-              Enable Conan environment definition
-              <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
-            </AccordionPrimitive.Trigger>
-            <div className='pr-4'>
-              <Switch
-                checked={enabledDefinitions['conan'] ?? false}
-                onCheckedChange={(checked) =>
-                  onToggle(
-                    'conan',
-                    checked,
-                    conanEnvironmentDefinitions['conan'] ?? []
-                  )
-                }
-              />
-            </div>
-          </AccordionPrimitive.Header>
-          <AccordionContent>
-            <div className='flex flex-col gap-4 px-4 pb-4'>
-              <FormField
-                control={form.control}
-                name='jobConfigs.analyzer.environmentDefinitions.conan.0.service'
-                render={({ field }) => {
-                  const selectedValue =
-                    typeof field.value === 'string' && field.value.length > 0
-                      ? field.value
-                      : undefined;
-                  return (
+    <Collapsible className='flex flex-col gap-2'>
+      <CollapsibleTrigger className='flex w-full items-start justify-between gap-4 text-left [&[data-state=open]>svg]:rotate-180'>
+        <div>
+          <h3>Environment configuration</h3>
+          <p className='mt-1 text-sm text-gray-500'>
+            Configure the credentials for different package managers to access
+            private artifact repositories.
+          </p>
+        </div>
+        <ChevronDownIcon className='text-muted-foreground mt-1 size-4 shrink-0 transition-transform duration-200' />
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <Accordion type='multiple' className='ml-4 flex flex-col gap-2'>
+          {/* Conan */}
+          <AccordionPrimitive.Item value='conan' className='rounded-lg border'>
+            <AccordionPrimitive.Header className='flex flex-row items-center'>
+              <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
+                Conan
+                <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
+              </AccordionPrimitive.Trigger>
+              <div className='pr-4'>
+                <Switch
+                  checked={enabledDefinitions['conan'] ?? false}
+                  onCheckedChange={(checked) =>
+                    onToggle(
+                      'conan',
+                      checked,
+                      conanEnvironmentDefinitions['conan'] ?? []
+                    )
+                  }
+                />
+              </div>
+            </AccordionPrimitive.Header>
+            <AccordionContent>
+              <div className='flex flex-col gap-4 px-4 pb-4'>
+                <FormField
+                  control={form.control}
+                  name='jobConfigs.analyzer.environmentDefinitions.conan.0.service'
+                  render={({ field }) => {
+                    const selectedValue =
+                      typeof field.value === 'string' && field.value.length > 0
+                        ? field.value
+                        : undefined;
+                    return (
+                      <FormItem>
+                        <FormLabel>Service</FormLabel>
+                        <Select
+                          value={selectedValue}
+                          onValueChange={(value) => field.onChange(value)}
+                        >
+                          <FormControl>
+                            <SelectTrigger className='w-full'>
+                              <SelectValue placeholder='Select an infrastructure service' />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {infrastructureServices.map((service) => (
+                              <SelectItem
+                                key={`${service.hierarchy}:${service.name}`}
+                                value={service.name}
+                              >
+                                {`${service.name} (${capitalize(service.hierarchy)})`}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FormDescription>
+                          Select the infrastructure service from a chosen
+                          hierarchy level.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    );
+                  }}
+                />
+                <FormField
+                  control={form.control}
+                  name='jobConfigs.analyzer.environmentDefinitions.conan.0.name'
+                  render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Service</FormLabel>
-                      <Select
-                        value={selectedValue}
-                        onValueChange={(value) => field.onChange(value)}
-                      >
-                        <FormControl>
-                          <SelectTrigger className='w-full'>
-                            <SelectValue placeholder='Select an infrastructure service' />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {infrastructureServices.map((service) => (
-                            <SelectItem
-                              key={`${service.hierarchy}:${service.name}`}
-                              value={service.name}
-                            >
-                              {`${service.name} (${capitalize(service.hierarchy)})`}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                      <FormLabel>Remote name</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
                       <FormDescription>
-                        Select the infrastructure service from a chosen
-                        hierarchy level.
+                        Name of the Conan remote, used in commands like{' '}
+                        <code>conan list</code>.
                       </FormDescription>
                       <FormMessage />
                     </FormItem>
-                  );
-                }}
-              />
-              <FormField
-                control={form.control}
-                name='jobConfigs.analyzer.environmentDefinitions.conan.0.name'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Remote name</FormLabel>
-                    <FormControl>
-                      <Input {...field} />
-                    </FormControl>
-                    <FormDescription>
-                      Name of the Conan remote, used in commands like{' '}
-                      <code>conan list</code>.
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name='jobConfigs.analyzer.environmentDefinitions.conan.0.url'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>URL</FormLabel>
-                    <FormControl>
-                      <Input {...field} placeholder='(optional)' />
-                    </FormControl>
-                    <FormDescription>
-                      URL for Conan to search for recipes and binaries. Falls
-                      back to the infrastructure service URL if not set.
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name='jobConfigs.analyzer.environmentDefinitions.conan.0.verifySsl'
-                render={({ field }) => (
-                  <FormItem className='flex flex-row items-center justify-between rounded-lg border p-4'>
-                    <div className='space-y-0.5'>
-                      <FormLabel>Verify SSL</FormLabel>
-                      <FormDescription>
-                        Verify the SSL certificate of the remote URL.
-                      </FormDescription>
-                    </div>
-                    <FormControl>
-                      <Switch
-                        checked={(field.value ?? 'true') === 'true'}
-                        onCheckedChange={(checked) =>
-                          field.onChange(checked ? 'true' : 'false')
-                        }
-                      />
-                    </FormControl>
-                  </FormItem>
-                )}
-              />
-            </div>
-          </AccordionContent>
-        </AccordionPrimitive.Item>
-        {/* Gradle */}
-        <AccordionPrimitive.Item value='gradle' className='rounded-lg border'>
-          <AccordionPrimitive.Header className='flex flex-row items-center'>
-            <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
-              Enable Gradle environment definition
-              <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
-            </AccordionPrimitive.Trigger>
-            <div className='pr-4'>
-              <Switch
-                checked={enabledDefinitions['gradle'] ?? false}
-                onCheckedChange={(checked) =>
-                  onToggle(
-                    'gradle',
-                    checked,
-                    gradleEnvironmentDefinitions['gradle'] ?? []
-                  )
-                }
-              />
-            </div>
-          </AccordionPrimitive.Header>
-          <AccordionContent>
-            <div className='flex flex-col gap-4 px-4 pb-4'>
-              <FormField
-                control={form.control}
-                name='jobConfigs.analyzer.environmentDefinitions.gradle.0.service'
-                render={({ field }) => {
-                  const selectedValue =
-                    typeof field.value === 'string' && field.value.length > 0
-                      ? field.value
-                      : undefined;
-                  return (
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name='jobConfigs.analyzer.environmentDefinitions.conan.0.url'
+                  render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Service</FormLabel>
-                      <Select
-                        value={selectedValue}
-                        onValueChange={(value) => field.onChange(value)}
-                      >
-                        <FormControl>
-                          <SelectTrigger className='w-full'>
-                            <SelectValue placeholder='Select an infrastructure service' />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {infrastructureServices.map((service) => (
-                            <SelectItem
-                              key={`${service.hierarchy}:${service.name}`}
-                              value={service.name}
-                            >
-                              {`${service.name} (${capitalize(service.hierarchy)})`}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                      <FormLabel>URL</FormLabel>
+                      <FormControl>
+                        <Input {...field} placeholder='(optional)' />
+                      </FormControl>
                       <FormDescription>
-                        Select the infrastructure service from a chosen
-                        hierarchy level.
+                        URL for Conan to search for recipes and binaries. Falls
+                        back to the infrastructure service URL if not set.
                       </FormDescription>
                       <FormMessage />
                     </FormItem>
-                  );
-                }}
-              />
-            </div>
-          </AccordionContent>
-        </AccordionPrimitive.Item>
-        {/* Maven */}
-        <AccordionPrimitive.Item value='maven' className='rounded-lg border'>
-          <AccordionPrimitive.Header className='flex flex-row items-center'>
-            <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
-              Enable Maven environment definition
-              <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
-            </AccordionPrimitive.Trigger>
-            <div className='pr-4'>
-              <Switch
-                checked={enabledDefinitions['maven'] ?? false}
-                onCheckedChange={(checked) =>
-                  onToggle(
-                    'maven',
-                    checked,
-                    mavenEnvironmentDefinitions['maven'] ?? []
-                  )
-                }
-              />
-            </div>
-          </AccordionPrimitive.Header>
-          <AccordionContent>
-            <div className='flex flex-col gap-4 px-4 pb-4'>
-              <FormField
-                control={form.control}
-                name='jobConfigs.analyzer.environmentDefinitions.maven.0.service'
-                render={({ field }) => {
-                  const selectedValue =
-                    typeof field.value === 'string' && field.value.length > 0
-                      ? field.value
-                      : undefined;
-                  return (
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name='jobConfigs.analyzer.environmentDefinitions.conan.0.verifySsl'
+                  render={({ field }) => (
+                    <FormItem className='flex flex-row items-center justify-between rounded-lg border p-4'>
+                      <div className='space-y-0.5'>
+                        <FormLabel>Verify SSL</FormLabel>
+                        <FormDescription>
+                          Verify the SSL certificate of the remote URL.
+                        </FormDescription>
+                      </div>
+                      <FormControl>
+                        <Switch
+                          checked={(field.value ?? 'true') === 'true'}
+                          onCheckedChange={(checked) =>
+                            field.onChange(checked ? 'true' : 'false')
+                          }
+                        />
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </AccordionContent>
+          </AccordionPrimitive.Item>
+          {/* Gradle */}
+          <AccordionPrimitive.Item value='gradle' className='rounded-lg border'>
+            <AccordionPrimitive.Header className='flex flex-row items-center'>
+              <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
+                Gradle
+                <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
+              </AccordionPrimitive.Trigger>
+              <div className='pr-4'>
+                <Switch
+                  checked={enabledDefinitions['gradle'] ?? false}
+                  onCheckedChange={(checked) =>
+                    onToggle(
+                      'gradle',
+                      checked,
+                      gradleEnvironmentDefinitions['gradle'] ?? []
+                    )
+                  }
+                />
+              </div>
+            </AccordionPrimitive.Header>
+            <AccordionContent>
+              <div className='flex flex-col gap-4 px-4 pb-4'>
+                <FormField
+                  control={form.control}
+                  name='jobConfigs.analyzer.environmentDefinitions.gradle.0.service'
+                  render={({ field }) => {
+                    const selectedValue =
+                      typeof field.value === 'string' && field.value.length > 0
+                        ? field.value
+                        : undefined;
+                    return (
+                      <FormItem>
+                        <FormLabel>Service</FormLabel>
+                        <Select
+                          value={selectedValue}
+                          onValueChange={(value) => field.onChange(value)}
+                        >
+                          <FormControl>
+                            <SelectTrigger className='w-full'>
+                              <SelectValue placeholder='Select an infrastructure service' />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {infrastructureServices.map((service) => (
+                              <SelectItem
+                                key={`${service.hierarchy}:${service.name}`}
+                                value={service.name}
+                              >
+                                {`${service.name} (${capitalize(service.hierarchy)})`}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FormDescription>
+                          Select the infrastructure service from a chosen
+                          hierarchy level.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    );
+                  }}
+                />
+              </div>
+            </AccordionContent>
+          </AccordionPrimitive.Item>
+          {/* Maven */}
+          <AccordionPrimitive.Item value='maven' className='rounded-lg border'>
+            <AccordionPrimitive.Header className='flex flex-row items-center'>
+              <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
+                Maven
+                <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
+              </AccordionPrimitive.Trigger>
+              <div className='pr-4'>
+                <Switch
+                  checked={enabledDefinitions['maven'] ?? false}
+                  onCheckedChange={(checked) =>
+                    onToggle(
+                      'maven',
+                      checked,
+                      mavenEnvironmentDefinitions['maven'] ?? []
+                    )
+                  }
+                />
+              </div>
+            </AccordionPrimitive.Header>
+            <AccordionContent>
+              <div className='flex flex-col gap-4 px-4 pb-4'>
+                <FormField
+                  control={form.control}
+                  name='jobConfigs.analyzer.environmentDefinitions.maven.0.service'
+                  render={({ field }) => {
+                    const selectedValue =
+                      typeof field.value === 'string' && field.value.length > 0
+                        ? field.value
+                        : undefined;
+                    return (
+                      <FormItem>
+                        <FormLabel>Service</FormLabel>
+                        <Select
+                          value={selectedValue}
+                          onValueChange={(value) => field.onChange(value)}
+                        >
+                          <FormControl>
+                            <SelectTrigger className='w-full'>
+                              <SelectValue placeholder='Select an infrastructure service' />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {infrastructureServices.map((service) => (
+                              <SelectItem
+                                key={`${service.hierarchy}:${service.name}`}
+                                value={service.name}
+                              >
+                                {`${service.name} (${capitalize(service.hierarchy)})`}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FormDescription>
+                          Select the infrastructure service from a chosen
+                          hierarchy level.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    );
+                  }}
+                />
+                <FormField
+                  control={form.control}
+                  name='jobConfigs.analyzer.environmentDefinitions.maven.0.id'
+                  render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Service</FormLabel>
-                      <Select
-                        value={selectedValue}
-                        onValueChange={(value) => field.onChange(value)}
-                      >
-                        <FormControl>
-                          <SelectTrigger className='w-full'>
-                            <SelectValue placeholder='Select an infrastructure service' />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {infrastructureServices.map((service) => (
-                            <SelectItem
-                              key={`${service.hierarchy}:${service.name}`}
-                              value={service.name}
-                            >
-                              {`${service.name} (${capitalize(service.hierarchy)})`}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                      <FormLabel>ID</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
                       <FormDescription>
-                        Select the infrastructure service from a chosen
-                        hierarchy level.
+                        Repository ID referenced in <code>pom.xml</code> files.
+                        Appears as the <code>&lt;id&gt;</code> of the
+                        corresponding server in Maven&apos;s{' '}
+                        <code>settings.xml</code>.
                       </FormDescription>
                       <FormMessage />
                     </FormItem>
-                  );
-                }}
-              />
-              <FormField
-                control={form.control}
-                name='jobConfigs.analyzer.environmentDefinitions.maven.0.id'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>ID</FormLabel>
-                    <FormControl>
-                      <Input {...field} />
-                    </FormControl>
-                    <FormDescription>
-                      Repository ID referenced in <code>pom.xml</code> files.
-                      Appears as the <code>&lt;id&gt;</code> of the
-                      corresponding server in Maven&apos;s{' '}
-                      <code>settings.xml</code>.
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name='jobConfigs.analyzer.environmentDefinitions.maven.0.mirrorOf'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Mirror of</FormLabel>
-                    <FormControl>
-                      <Input {...field} placeholder='(optional)' />
-                    </FormControl>
-                    <FormDescription>
-                      If set, adds this entry to the{' '}
-                      <code>&lt;mirrors&gt;</code> section of{' '}
-                      <code>settings.xml</code>. Value is the repository ID to
-                      mirror (e.g. <code>central</code>, or <code>*</code> for
-                      all repositories).
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-          </AccordionContent>
-        </AccordionPrimitive.Item>
-        {/* NPM */}
-        <AccordionPrimitive.Item value='npm' className='rounded-lg border'>
-          <AccordionPrimitive.Header className='flex flex-row items-center'>
-            <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
-              Enable NPM environment definition
-              <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
-            </AccordionPrimitive.Trigger>
-            <div className='pr-4'>
-              <Switch
-                checked={enabledDefinitions['npm'] ?? false}
-                onCheckedChange={(checked) =>
-                  onToggle('npm', checked, npmEnvironmentDefinitions.npm ?? [])
-                }
-              />
-            </div>
-          </AccordionPrimitive.Header>
-          <AccordionContent>
-            <div className='flex flex-col gap-4 px-4 pb-4'>
-              <FormField
-                control={form.control}
-                name='jobConfigs.analyzer.environmentDefinitions.npm.0.service'
-                render={({ field }) => {
-                  const selectedValue =
-                    typeof field.value === 'string' && field.value.length > 0
-                      ? field.value
-                      : undefined;
-                  return (
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name='jobConfigs.analyzer.environmentDefinitions.maven.0.mirrorOf'
+                  render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Service</FormLabel>
-                      <Select
-                        value={selectedValue}
-                        onValueChange={(value) => field.onChange(value)}
-                      >
-                        <FormControl>
-                          <SelectTrigger className='w-full'>
-                            <SelectValue placeholder='Select an infrastructure service' />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {infrastructureServices.map((service) => (
-                            <SelectItem
-                              key={`${service.hierarchy}:${service.name}`}
-                              value={service.name}
-                            >
-                              {`${service.name} (${capitalize(service.hierarchy)})`}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                      <FormLabel>Mirror of</FormLabel>
+                      <FormControl>
+                        <Input {...field} placeholder='(optional)' />
+                      </FormControl>
                       <FormDescription>
-                        Select the infrastructure service from a chosen
-                        hierarchy level.
+                        If set, adds this entry to the{' '}
+                        <code>&lt;mirrors&gt;</code> section of{' '}
+                        <code>settings.xml</code>. Value is the repository ID to
+                        mirror (e.g. <code>central</code>, or <code>*</code> for
+                        all repositories).
                       </FormDescription>
                       <FormMessage />
                     </FormItem>
-                  );
-                }}
-              />
-              <FormField
-                control={form.control}
-                name='jobConfigs.analyzer.environmentDefinitions.npm.0.scope'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Scope</FormLabel>
-                    <FormControl>
-                      <Input {...field} placeholder='(optional)' />
-                    </FormControl>
-                    <FormDescription>
-                      Optional NPM scope that this configuration applies to.
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name='jobConfigs.analyzer.environmentDefinitions.npm.0.email'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Email</FormLabel>
-                    <FormControl>
-                      <Input {...field} placeholder='(optional)' />
-                    </FormControl>
-                    <FormDescription>
-                      Optional email address used by the NPM registry.
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name='jobConfigs.analyzer.environmentDefinitions.npm.0.authMode'
-                render={({ field }) => {
-                  const selectedValue =
-                    typeof field.value === 'string' && field.value.length > 0
-                      ? (field.value as NpmAuthMode)
-                      : undefined;
-                  return (
+                  )}
+                />
+              </div>
+            </AccordionContent>
+          </AccordionPrimitive.Item>
+          {/* NPM */}
+          <AccordionPrimitive.Item value='npm' className='rounded-lg border'>
+            <AccordionPrimitive.Header className='flex flex-row items-center'>
+              <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
+                NPM
+                <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
+              </AccordionPrimitive.Trigger>
+              <div className='pr-4'>
+                <Switch
+                  checked={enabledDefinitions['npm'] ?? false}
+                  onCheckedChange={(checked) =>
+                    onToggle(
+                      'npm',
+                      checked,
+                      npmEnvironmentDefinitions.npm ?? []
+                    )
+                  }
+                />
+              </div>
+            </AccordionPrimitive.Header>
+            <AccordionContent>
+              <div className='flex flex-col gap-4 px-4 pb-4'>
+                <FormField
+                  control={form.control}
+                  name='jobConfigs.analyzer.environmentDefinitions.npm.0.service'
+                  render={({ field }) => {
+                    const selectedValue =
+                      typeof field.value === 'string' && field.value.length > 0
+                        ? field.value
+                        : undefined;
+                    return (
+                      <FormItem>
+                        <FormLabel>Service</FormLabel>
+                        <Select
+                          value={selectedValue}
+                          onValueChange={(value) => field.onChange(value)}
+                        >
+                          <FormControl>
+                            <SelectTrigger className='w-full'>
+                              <SelectValue placeholder='Select an infrastructure service' />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {infrastructureServices.map((service) => (
+                              <SelectItem
+                                key={`${service.hierarchy}:${service.name}`}
+                                value={service.name}
+                              >
+                                {`${service.name} (${capitalize(service.hierarchy)})`}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FormDescription>
+                          Select the infrastructure service from a chosen
+                          hierarchy level.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    );
+                  }}
+                />
+                <FormField
+                  control={form.control}
+                  name='jobConfigs.analyzer.environmentDefinitions.npm.0.scope'
+                  render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Authorization mode</FormLabel>
-                      <Select
-                        value={selectedValue}
-                        onValueChange={(value) => field.onChange(value)}
-                      >
-                        <FormControl>
-                          <SelectTrigger className='w-full'>
-                            <SelectValue placeholder='Select the authorization mode' />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {npmAuthModes.map((mode) => (
-                            <SelectItem key={mode} value={mode}>
-                              {mode.replaceAll('_', ' ')}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                      <FormLabel>Scope</FormLabel>
+                      <FormControl>
+                        <Input {...field} placeholder='(optional)' />
+                      </FormControl>
                       <FormDescription>
-                        Pick how the NPM registry authenticates requests.
+                        Optional NPM scope that this configuration applies to.
                       </FormDescription>
                       <FormMessage />
                     </FormItem>
-                  );
-                }}
-              />
-            </div>
-          </AccordionContent>
-        </AccordionPrimitive.Item>
-        {/* NuGet */}
-        <AccordionPrimitive.Item value='nuget' className='rounded-lg border'>
-          <AccordionPrimitive.Header className='flex flex-row items-center'>
-            <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
-              Enable NuGet environment definition
-              <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
-            </AccordionPrimitive.Trigger>
-            <div className='pr-4'>
-              <Switch
-                checked={enabledDefinitions['nuget'] ?? false}
-                onCheckedChange={(checked) =>
-                  onToggle(
-                    'nuget',
-                    checked,
-                    nugetEnvironmentDefinitions['nuget'] ?? []
-                  )
-                }
-              />
-            </div>
-          </AccordionPrimitive.Header>
-          <AccordionContent>
-            <div className='flex flex-col gap-4 px-4 pb-4'>
-              <FormField
-                control={form.control}
-                name='jobConfigs.analyzer.environmentDefinitions.nuget.0.service'
-                render={({ field }) => {
-                  const selectedValue =
-                    typeof field.value === 'string' && field.value.length > 0
-                      ? field.value
-                      : undefined;
-                  return (
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name='jobConfigs.analyzer.environmentDefinitions.npm.0.email'
+                  render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Service</FormLabel>
-                      <Select
-                        value={selectedValue}
-                        onValueChange={(value) => field.onChange(value)}
-                      >
-                        <FormControl>
-                          <SelectTrigger className='w-full'>
-                            <SelectValue placeholder='Select an infrastructure service' />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {infrastructureServices.map((service) => (
-                            <SelectItem
-                              key={`${service.hierarchy}:${service.name}`}
-                              value={service.name}
-                            >
-                              {`${service.name} (${capitalize(service.hierarchy)})`}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                      <FormLabel>Email</FormLabel>
+                      <FormControl>
+                        <Input {...field} placeholder='(optional)' />
+                      </FormControl>
                       <FormDescription>
-                        Select the infrastructure service from a chosen
-                        hierarchy level.
+                        Optional email address used by the NPM registry.
                       </FormDescription>
                       <FormMessage />
                     </FormItem>
-                  );
-                }}
-              />
-              <FormField
-                control={form.control}
-                name='jobConfigs.analyzer.environmentDefinitions.nuget.0.sourceName'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Source name</FormLabel>
-                    <FormControl>
-                      <Input {...field} />
-                    </FormControl>
-                    <FormDescription>
-                      The name to assign to the package source.
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name='jobConfigs.analyzer.environmentDefinitions.nuget.0.sourcePath'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Source path</FormLabel>
-                    <FormControl>
-                      <Input {...field} />
-                    </FormControl>
-                    <FormDescription>
-                      The path or URL of the package source.
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name='jobConfigs.analyzer.environmentDefinitions.nuget.0.sourceProtocolVersion'
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Source protocol version</FormLabel>
-                    <FormControl>
-                      <Input {...field} placeholder='(optional)' />
-                    </FormControl>
-                    <FormDescription>
-                      NuGet server protocol version (e.g. 3). Defaults to 2 for
-                      non-JSON source URLs. Requires NuGet 3.0+.
-                    </FormDescription>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-              <FormField
-                control={form.control}
-                name='jobConfigs.analyzer.environmentDefinitions.nuget.0.authMode'
-                render={({ field }) => {
-                  const selectedValue =
-                    typeof field.value === 'string' && field.value.length > 0
-                      ? (field.value as NuGetAuthMode)
-                      : undefined;
-                  return (
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name='jobConfigs.analyzer.environmentDefinitions.npm.0.authMode'
+                  render={({ field }) => {
+                    const selectedValue =
+                      typeof field.value === 'string' && field.value.length > 0
+                        ? (field.value as NpmAuthMode)
+                        : undefined;
+                    return (
+                      <FormItem>
+                        <FormLabel>Authorization mode</FormLabel>
+                        <Select
+                          value={selectedValue}
+                          onValueChange={(value) => field.onChange(value)}
+                        >
+                          <FormControl>
+                            <SelectTrigger className='w-full'>
+                              <SelectValue placeholder='Select the authorization mode' />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {npmAuthModes.map((mode) => (
+                              <SelectItem key={mode} value={mode}>
+                                {mode.replaceAll('_', ' ')}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FormDescription>
+                          Pick how the NPM registry authenticates requests.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    );
+                  }}
+                />
+              </div>
+            </AccordionContent>
+          </AccordionPrimitive.Item>
+          {/* NuGet */}
+          <AccordionPrimitive.Item value='nuget' className='rounded-lg border'>
+            <AccordionPrimitive.Header className='flex flex-row items-center'>
+              <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
+                NuGet
+                <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
+              </AccordionPrimitive.Trigger>
+              <div className='pr-4'>
+                <Switch
+                  checked={enabledDefinitions['nuget'] ?? false}
+                  onCheckedChange={(checked) =>
+                    onToggle(
+                      'nuget',
+                      checked,
+                      nugetEnvironmentDefinitions['nuget'] ?? []
+                    )
+                  }
+                />
+              </div>
+            </AccordionPrimitive.Header>
+            <AccordionContent>
+              <div className='flex flex-col gap-4 px-4 pb-4'>
+                <FormField
+                  control={form.control}
+                  name='jobConfigs.analyzer.environmentDefinitions.nuget.0.service'
+                  render={({ field }) => {
+                    const selectedValue =
+                      typeof field.value === 'string' && field.value.length > 0
+                        ? field.value
+                        : undefined;
+                    return (
+                      <FormItem>
+                        <FormLabel>Service</FormLabel>
+                        <Select
+                          value={selectedValue}
+                          onValueChange={(value) => field.onChange(value)}
+                        >
+                          <FormControl>
+                            <SelectTrigger className='w-full'>
+                              <SelectValue placeholder='Select an infrastructure service' />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {infrastructureServices.map((service) => (
+                              <SelectItem
+                                key={`${service.hierarchy}:${service.name}`}
+                                value={service.name}
+                              >
+                                {`${service.name} (${capitalize(service.hierarchy)})`}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FormDescription>
+                          Select the infrastructure service from a chosen
+                          hierarchy level.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    );
+                  }}
+                />
+                <FormField
+                  control={form.control}
+                  name='jobConfigs.analyzer.environmentDefinitions.nuget.0.sourceName'
+                  render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Authorization mode</FormLabel>
-                      <Select
-                        value={selectedValue}
-                        onValueChange={(value) => field.onChange(value)}
-                      >
-                        <FormControl>
-                          <SelectTrigger className='w-full'>
-                            <SelectValue placeholder='Select the authorization mode' />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {nugetAuthModes.map((mode) => (
-                            <SelectItem key={mode} value={mode}>
-                              {mode.replaceAll('_', ' ')}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                      <FormLabel>Source name</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
                       <FormDescription>
-                        Authentication type for this package source.
+                        The name to assign to the package source.
                       </FormDescription>
                       <FormMessage />
                     </FormItem>
-                  );
-                }}
-              />
-            </div>
-          </AccordionContent>
-        </AccordionPrimitive.Item>
-        {/* Yarn */}
-        <AccordionPrimitive.Item value='yarn' className='rounded-lg border'>
-          <AccordionPrimitive.Header className='flex flex-row items-center'>
-            <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
-              Enable Yarn environment definition
-              <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
-            </AccordionPrimitive.Trigger>
-            <div className='pr-4'>
-              <Switch
-                checked={enabledDefinitions['yarn'] ?? false}
-                onCheckedChange={(checked) =>
-                  onToggle(
-                    'yarn',
-                    checked,
-                    yarnEnvironmentDefinitions['yarn'] ?? []
-                  )
-                }
-              />
-            </div>
-          </AccordionPrimitive.Header>
-          <AccordionContent>
-            <div className='flex flex-col gap-4 px-4 pb-4'>
-              <FormField
-                control={form.control}
-                name='jobConfigs.analyzer.environmentDefinitions.yarn.0.service'
-                render={({ field }) => {
-                  const selectedValue =
-                    typeof field.value === 'string' && field.value.length > 0
-                      ? field.value
-                      : undefined;
-                  return (
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name='jobConfigs.analyzer.environmentDefinitions.nuget.0.sourcePath'
+                  render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Service</FormLabel>
-                      <Select
-                        value={selectedValue}
-                        onValueChange={(value) => field.onChange(value)}
-                      >
-                        <FormControl>
-                          <SelectTrigger className='w-full'>
-                            <SelectValue placeholder='Select an infrastructure service' />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {infrastructureServices.map((service) => (
-                            <SelectItem
-                              key={`${service.hierarchy}:${service.name}`}
-                              value={service.name}
-                            >
-                              {`${service.name} (${capitalize(service.hierarchy)})`}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                      <FormLabel>Source path</FormLabel>
+                      <FormControl>
+                        <Input {...field} />
+                      </FormControl>
                       <FormDescription>
-                        Select the infrastructure service from a chosen
-                        hierarchy level.
+                        The path or URL of the package source.
                       </FormDescription>
                       <FormMessage />
                     </FormItem>
-                  );
-                }}
-              />
-              <FormField
-                control={form.control}
-                name='jobConfigs.analyzer.environmentDefinitions.yarn.0.authMode'
-                render={({ field }) => {
-                  const selectedValue =
-                    typeof field.value === 'string' && field.value.length > 0
-                      ? (field.value as YarnAuthMode)
-                      : undefined;
-                  return (
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name='jobConfigs.analyzer.environmentDefinitions.nuget.0.sourceProtocolVersion'
+                  render={({ field }) => (
                     <FormItem>
-                      <FormLabel>Authorization mode</FormLabel>
-                      <Select
-                        value={selectedValue}
-                        onValueChange={(value) => field.onChange(value)}
-                      >
-                        <FormControl>
-                          <SelectTrigger className='w-full'>
-                            <SelectValue placeholder='Select the authorization mode' />
-                          </SelectTrigger>
-                        </FormControl>
-                        <SelectContent>
-                          {yarnAuthModes.map((mode) => (
-                            <SelectItem key={mode} value={mode}>
-                              {mode.replaceAll('_', ' ')}
-                            </SelectItem>
-                          ))}
-                        </SelectContent>
-                      </Select>
+                      <FormLabel>Source protocol version</FormLabel>
+                      <FormControl>
+                        <Input {...field} placeholder='(optional)' />
+                      </FormControl>
                       <FormDescription>
-                        Authentication method for this private registry.
+                        NuGet server protocol version (e.g. 3). Defaults to 2
+                        for non-JSON source URLs. Requires NuGet 3.0+.
                       </FormDescription>
                       <FormMessage />
                     </FormItem>
-                  );
-                }}
-              />
-              <FormField
-                control={form.control}
-                name='jobConfigs.analyzer.environmentDefinitions.yarn.0.alwaysAuth'
-                render={({ field }) => (
-                  <FormItem className='flex flex-row items-center justify-between rounded-lg border p-4'>
-                    <div className='space-y-0.5'>
-                      <FormLabel>Always authenticate</FormLabel>
-                      <FormDescription>
-                        Always send authentication information to the registry
-                        via the <code>npmAlwaysAuth</code> property.
-                      </FormDescription>
-                    </div>
-                    <FormControl>
-                      <Switch
-                        checked={(field.value ?? 'true') === 'true'}
-                        onCheckedChange={(checked) =>
-                          field.onChange(checked ? 'true' : 'false')
-                        }
-                      />
-                    </FormControl>
-                  </FormItem>
-                )}
-              />
-            </div>
-          </AccordionContent>
-        </AccordionPrimitive.Item>
-      </Accordion>
-    </div>
+                  )}
+                />
+                <FormField
+                  control={form.control}
+                  name='jobConfigs.analyzer.environmentDefinitions.nuget.0.authMode'
+                  render={({ field }) => {
+                    const selectedValue =
+                      typeof field.value === 'string' && field.value.length > 0
+                        ? (field.value as NuGetAuthMode)
+                        : undefined;
+                    return (
+                      <FormItem>
+                        <FormLabel>Authorization mode</FormLabel>
+                        <Select
+                          value={selectedValue}
+                          onValueChange={(value) => field.onChange(value)}
+                        >
+                          <FormControl>
+                            <SelectTrigger className='w-full'>
+                              <SelectValue placeholder='Select the authorization mode' />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {nugetAuthModes.map((mode) => (
+                              <SelectItem key={mode} value={mode}>
+                                {mode.replaceAll('_', ' ')}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FormDescription>
+                          Authentication type for this package source.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    );
+                  }}
+                />
+              </div>
+            </AccordionContent>
+          </AccordionPrimitive.Item>
+          {/* Yarn */}
+          <AccordionPrimitive.Item value='yarn' className='rounded-lg border'>
+            <AccordionPrimitive.Header className='flex flex-row items-center'>
+              <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
+                Yarn
+                <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
+              </AccordionPrimitive.Trigger>
+              <div className='pr-4'>
+                <Switch
+                  checked={enabledDefinitions['yarn'] ?? false}
+                  onCheckedChange={(checked) =>
+                    onToggle(
+                      'yarn',
+                      checked,
+                      yarnEnvironmentDefinitions['yarn'] ?? []
+                    )
+                  }
+                />
+              </div>
+            </AccordionPrimitive.Header>
+            <AccordionContent>
+              <div className='flex flex-col gap-4 px-4 pb-4'>
+                <FormField
+                  control={form.control}
+                  name='jobConfigs.analyzer.environmentDefinitions.yarn.0.service'
+                  render={({ field }) => {
+                    const selectedValue =
+                      typeof field.value === 'string' && field.value.length > 0
+                        ? field.value
+                        : undefined;
+                    return (
+                      <FormItem>
+                        <FormLabel>Service</FormLabel>
+                        <Select
+                          value={selectedValue}
+                          onValueChange={(value) => field.onChange(value)}
+                        >
+                          <FormControl>
+                            <SelectTrigger className='w-full'>
+                              <SelectValue placeholder='Select an infrastructure service' />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {infrastructureServices.map((service) => (
+                              <SelectItem
+                                key={`${service.hierarchy}:${service.name}`}
+                                value={service.name}
+                              >
+                                {`${service.name} (${capitalize(service.hierarchy)})`}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FormDescription>
+                          Select the infrastructure service from a chosen
+                          hierarchy level.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    );
+                  }}
+                />
+                <FormField
+                  control={form.control}
+                  name='jobConfigs.analyzer.environmentDefinitions.yarn.0.authMode'
+                  render={({ field }) => {
+                    const selectedValue =
+                      typeof field.value === 'string' && field.value.length > 0
+                        ? (field.value as YarnAuthMode)
+                        : undefined;
+                    return (
+                      <FormItem>
+                        <FormLabel>Authorization mode</FormLabel>
+                        <Select
+                          value={selectedValue}
+                          onValueChange={(value) => field.onChange(value)}
+                        >
+                          <FormControl>
+                            <SelectTrigger className='w-full'>
+                              <SelectValue placeholder='Select the authorization mode' />
+                            </SelectTrigger>
+                          </FormControl>
+                          <SelectContent>
+                            {yarnAuthModes.map((mode) => (
+                              <SelectItem key={mode} value={mode}>
+                                {mode.replaceAll('_', ' ')}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                        <FormDescription>
+                          Authentication method for this private registry.
+                        </FormDescription>
+                        <FormMessage />
+                      </FormItem>
+                    );
+                  }}
+                />
+                <FormField
+                  control={form.control}
+                  name='jobConfigs.analyzer.environmentDefinitions.yarn.0.alwaysAuth'
+                  render={({ field }) => (
+                    <FormItem className='flex flex-row items-center justify-between rounded-lg border p-4'>
+                      <div className='space-y-0.5'>
+                        <FormLabel>Always authenticate</FormLabel>
+                        <FormDescription>
+                          Always send authentication information to the registry
+                          via the <code>npmAlwaysAuth</code> property.
+                        </FormDescription>
+                      </div>
+                      <FormControl>
+                        <Switch
+                          checked={(field.value ?? 'true') === 'true'}
+                          onCheckedChange={(checked) =>
+                            field.onChange(checked ? 'true' : 'false')
+                          }
+                        />
+                      </FormControl>
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </AccordionContent>
+          </AccordionPrimitive.Item>
+        </Accordion>
+      </CollapsibleContent>
+    </Collapsible>
   );
 };

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/environment-definitions.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/environment-definitions.tsx
@@ -45,6 +45,7 @@ import { InfrastructureServiceWithHierarchy } from '@/hooks/use-infrastructure-s
 import {
   conanEnvironmentDefinitions,
   EnvironmentDefinitionEntry,
+  gradleEnvironmentDefinitions,
   NpmAuthMode,
   npmAuthModes,
   npmEnvironmentDefinitions,
@@ -250,6 +251,71 @@ export const EnvironmentDefinitionsFields = ({
                     </FormControl>
                   </FormItem>
                 )}
+              />
+            </div>
+          </AccordionContent>
+        </AccordionPrimitive.Item>
+        {/* Gradle */}
+        <AccordionPrimitive.Item value='gradle' className='rounded-lg border'>
+          <AccordionPrimitive.Header className='flex flex-row items-center'>
+            <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
+              Enable Gradle environment definition
+              <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
+            </AccordionPrimitive.Trigger>
+            <div className='pr-4'>
+              <Switch
+                checked={enabledDefinitions['gradle'] ?? false}
+                onCheckedChange={(checked) =>
+                  onToggle(
+                    'gradle',
+                    checked,
+                    gradleEnvironmentDefinitions['gradle'] ?? []
+                  )
+                }
+              />
+            </div>
+          </AccordionPrimitive.Header>
+          <AccordionContent>
+            <div className='flex flex-col gap-4 px-4 pb-4'>
+              <FormField
+                control={form.control}
+                name='jobConfigs.analyzer.environmentDefinitions.gradle.0.service'
+                render={({ field }) => {
+                  const selectedValue =
+                    typeof field.value === 'string' && field.value.length > 0
+                      ? field.value
+                      : undefined;
+                  return (
+                    <FormItem>
+                      <FormLabel>Service</FormLabel>
+                      <Select
+                        value={selectedValue}
+                        onValueChange={(value) => field.onChange(value)}
+                      >
+                        <FormControl>
+                          <SelectTrigger className='w-full'>
+                            <SelectValue placeholder='Select an infrastructure service' />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {infrastructureServices.map((service) => (
+                            <SelectItem
+                              key={`${service.hierarchy}:${service.name}`}
+                              value={service.name}
+                            >
+                              {`${service.name} (${capitalize(service.hierarchy)})`}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormDescription>
+                        Select the infrastructure service from a chosen
+                        hierarchy level.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  );
+                }}
               />
             </div>
           </AccordionContent>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/environment-definitions.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/environment-definitions.tsx
@@ -19,8 +19,8 @@
 
 import * as AccordionPrimitive from '@radix-ui/react-accordion';
 import { ChevronDownIcon } from 'lucide-react';
-import { useRef } from 'react';
-import { UseFormReturn } from 'react-hook-form';
+import { ReactNode, useRef } from 'react';
+import { FieldPath, UseFormReturn } from 'react-hook-form';
 
 import { Accordion, AccordionContent } from '@/components/ui/accordion';
 import {
@@ -48,21 +48,152 @@ import { Switch } from '@/components/ui/switch';
 import { capitalize } from '@/helpers/capitalize';
 import { InfrastructureServiceWithHierarchy } from '@/hooks/use-infrastructure-services';
 import {
-  conanEnvironmentDefinitions,
-  EnvironmentDefinitionEntry,
-  gradleEnvironmentDefinitions,
-  mavenEnvironmentDefinitions,
-  NpmAuthMode,
-  npmAuthModes,
-  npmEnvironmentDefinitions,
-  NuGetAuthMode,
-  nugetAuthModes,
-  nugetEnvironmentDefinitions,
-  YarnAuthMode,
-  yarnAuthModes,
-  yarnEnvironmentDefinitions,
-} from '@/lib/types';
+  ENVIRONMENT_DEFINITION_SCHEMAS,
+  FieldEntry,
+} from '@/lib/environment-definition-fields';
+import { EnvironmentDefinitionEntry } from '@/lib/types';
 import { CreateRunFormValues } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components';
+
+type PackageManagerFieldProps = {
+  pmKey: string;
+  entry: FieldEntry;
+  form: UseFormReturn<CreateRunFormValues>;
+  infrastructureServices: InfrastructureServiceWithHierarchy[];
+};
+
+function PackageManagerField({
+  pmKey,
+  entry,
+  form,
+  infrastructureServices,
+}: PackageManagerFieldProps): ReactNode {
+  const name =
+    `jobConfigs.analyzer.environmentDefinitions.${pmKey}.0.${entry.key}` as FieldPath<CreateRunFormValues>;
+  const { def } = entry;
+
+  if (def.type === 'service') {
+    return (
+      <FormField
+        control={form.control}
+        name={name}
+        render={({ field }) => {
+          const value =
+            typeof field.value === 'string' && field.value.length > 0
+              ? field.value
+              : undefined;
+          return (
+            <FormItem>
+              <FormLabel>Service</FormLabel>
+              <Select value={value} onValueChange={(v) => field.onChange(v)}>
+                <FormControl>
+                  <SelectTrigger className='w-full'>
+                    <SelectValue placeholder='Select an infrastructure service' />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  {infrastructureServices.map((service) => (
+                    <SelectItem
+                      key={`${service.hierarchy}:${service.name}`}
+                      value={service.name}
+                    >
+                      {`${service.name} (${capitalize(service.hierarchy)})`}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <FormDescription>
+                Select the infrastructure service from a chosen hierarchy level.
+              </FormDescription>
+              <FormMessage />
+            </FormItem>
+          );
+        }}
+      />
+    );
+  }
+
+  if (def.type === 'string') {
+    return (
+      <FormField
+        control={form.control}
+        name={name}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>{def.label}</FormLabel>
+            <FormControl>
+              <Input
+                {...field}
+                value={(field.value as string) ?? ''}
+                placeholder={def.optional ? '(optional)' : undefined}
+              />
+            </FormControl>
+            <FormDescription>{def.description}</FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    );
+  }
+
+  if (def.type === 'boolean') {
+    return (
+      <FormField
+        control={form.control}
+        name={name}
+        render={({ field }) => (
+          <FormItem className='flex flex-row items-center justify-between rounded-lg border p-4'>
+            <div className='space-y-0.5'>
+              <FormLabel>{def.label}</FormLabel>
+              <FormDescription>{def.description}</FormDescription>
+            </div>
+            <FormControl>
+              <Switch
+                checked={((field.value as string) ?? 'true') === 'true'}
+                onCheckedChange={(checked) =>
+                  field.onChange(checked ? 'true' : 'false')
+                }
+              />
+            </FormControl>
+          </FormItem>
+        )}
+      />
+    );
+  }
+
+  return (
+    <FormField
+      control={form.control}
+      name={name}
+      render={({ field }) => {
+        const value =
+          typeof field.value === 'string' && field.value.length > 0
+            ? field.value
+            : undefined;
+        return (
+          <FormItem>
+            <FormLabel>{def.label}</FormLabel>
+            <Select value={value} onValueChange={(v) => field.onChange(v)}>
+              <FormControl>
+                <SelectTrigger className='w-full'>
+                  <SelectValue placeholder={def.placeholder} />
+                </SelectTrigger>
+              </FormControl>
+              <SelectContent>
+                {def.values.map((mode) => (
+                  <SelectItem key={mode} value={mode}>
+                    {mode.replaceAll('_', ' ')}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <FormDescription>{def.description}</FormDescription>
+            <FormMessage />
+          </FormItem>
+        );
+      }}
+    />
+  );
+}
 
 type EnvironmentDefinitionsFieldsProps = {
   form: UseFormReturn<CreateRunFormValues>;
@@ -149,703 +280,41 @@ export const EnvironmentDefinitionsFields = ({
       </CollapsibleTrigger>
       <CollapsibleContent>
         <Accordion type='multiple' className='ml-4 flex flex-col gap-2'>
-          {/* Conan */}
-          <AccordionPrimitive.Item value='conan' className='rounded-lg border'>
-            <AccordionPrimitive.Header className='flex flex-row items-center'>
-              <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
-                Conan
-                <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
-              </AccordionPrimitive.Trigger>
-              <div className='pr-4'>
-                <Switch
-                  checked={enabledDefinitions['conan'] ?? false}
-                  onCheckedChange={(checked) =>
-                    onToggle(
-                      'conan',
-                      checked,
-                      conanEnvironmentDefinitions['conan'] ?? []
-                    )
-                  }
-                />
-              </div>
-            </AccordionPrimitive.Header>
-            <AccordionContent>
-              <div className='flex flex-col gap-4 px-4 pb-4'>
-                <FormField
-                  control={form.control}
-                  name='jobConfigs.analyzer.environmentDefinitions.conan.0.service'
-                  render={({ field }) => {
-                    const selectedValue =
-                      typeof field.value === 'string' && field.value.length > 0
-                        ? field.value
-                        : undefined;
-                    return (
-                      <FormItem>
-                        <FormLabel>Service</FormLabel>
-                        <Select
-                          value={selectedValue}
-                          onValueChange={(value) => field.onChange(value)}
-                        >
-                          <FormControl>
-                            <SelectTrigger className='w-full'>
-                              <SelectValue placeholder='Select an infrastructure service' />
-                            </SelectTrigger>
-                          </FormControl>
-                          <SelectContent>
-                            {infrastructureServices.map((service) => (
-                              <SelectItem
-                                key={`${service.hierarchy}:${service.name}`}
-                                value={service.name}
-                              >
-                                {`${service.name} (${capitalize(service.hierarchy)})`}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                        <FormDescription>
-                          Select the infrastructure service from a chosen
-                          hierarchy level.
-                        </FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    );
-                  }}
-                />
-                <FormField
-                  control={form.control}
-                  name='jobConfigs.analyzer.environmentDefinitions.conan.0.name'
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Remote name</FormLabel>
-                      <FormControl>
-                        <Input {...field} />
-                      </FormControl>
-                      <FormDescription>
-                        Name of the Conan remote, used in commands like{' '}
-                        <code>conan list</code>.
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name='jobConfigs.analyzer.environmentDefinitions.conan.0.url'
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>URL</FormLabel>
-                      <FormControl>
-                        <Input {...field} placeholder='(optional)' />
-                      </FormControl>
-                      <FormDescription>
-                        URL for Conan to search for recipes and binaries. Falls
-                        back to the infrastructure service URL if not set.
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name='jobConfigs.analyzer.environmentDefinitions.conan.0.verifySsl'
-                  render={({ field }) => (
-                    <FormItem className='flex flex-row items-center justify-between rounded-lg border p-4'>
-                      <div className='space-y-0.5'>
-                        <FormLabel>Verify SSL</FormLabel>
-                        <FormDescription>
-                          Verify the SSL certificate of the remote URL.
-                        </FormDescription>
-                      </div>
-                      <FormControl>
-                        <Switch
-                          checked={(field.value ?? 'true') === 'true'}
-                          onCheckedChange={(checked) =>
-                            field.onChange(checked ? 'true' : 'false')
-                          }
-                        />
-                      </FormControl>
-                    </FormItem>
-                  )}
-                />
-              </div>
-            </AccordionContent>
-          </AccordionPrimitive.Item>
-          {/* Gradle */}
-          <AccordionPrimitive.Item value='gradle' className='rounded-lg border'>
-            <AccordionPrimitive.Header className='flex flex-row items-center'>
-              <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
-                Gradle
-                <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
-              </AccordionPrimitive.Trigger>
-              <div className='pr-4'>
-                <Switch
-                  checked={enabledDefinitions['gradle'] ?? false}
-                  onCheckedChange={(checked) =>
-                    onToggle(
-                      'gradle',
-                      checked,
-                      gradleEnvironmentDefinitions['gradle'] ?? []
-                    )
-                  }
-                />
-              </div>
-            </AccordionPrimitive.Header>
-            <AccordionContent>
-              <div className='flex flex-col gap-4 px-4 pb-4'>
-                <FormField
-                  control={form.control}
-                  name='jobConfigs.analyzer.environmentDefinitions.gradle.0.service'
-                  render={({ field }) => {
-                    const selectedValue =
-                      typeof field.value === 'string' && field.value.length > 0
-                        ? field.value
-                        : undefined;
-                    return (
-                      <FormItem>
-                        <FormLabel>Service</FormLabel>
-                        <Select
-                          value={selectedValue}
-                          onValueChange={(value) => field.onChange(value)}
-                        >
-                          <FormControl>
-                            <SelectTrigger className='w-full'>
-                              <SelectValue placeholder='Select an infrastructure service' />
-                            </SelectTrigger>
-                          </FormControl>
-                          <SelectContent>
-                            {infrastructureServices.map((service) => (
-                              <SelectItem
-                                key={`${service.hierarchy}:${service.name}`}
-                                value={service.name}
-                              >
-                                {`${service.name} (${capitalize(service.hierarchy)})`}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                        <FormDescription>
-                          Select the infrastructure service from a chosen
-                          hierarchy level.
-                        </FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    );
-                  }}
-                />
-              </div>
-            </AccordionContent>
-          </AccordionPrimitive.Item>
-          {/* Maven */}
-          <AccordionPrimitive.Item value='maven' className='rounded-lg border'>
-            <AccordionPrimitive.Header className='flex flex-row items-center'>
-              <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
-                Maven
-                <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
-              </AccordionPrimitive.Trigger>
-              <div className='pr-4'>
-                <Switch
-                  checked={enabledDefinitions['maven'] ?? false}
-                  onCheckedChange={(checked) =>
-                    onToggle(
-                      'maven',
-                      checked,
-                      mavenEnvironmentDefinitions['maven'] ?? []
-                    )
-                  }
-                />
-              </div>
-            </AccordionPrimitive.Header>
-            <AccordionContent>
-              <div className='flex flex-col gap-4 px-4 pb-4'>
-                <FormField
-                  control={form.control}
-                  name='jobConfigs.analyzer.environmentDefinitions.maven.0.service'
-                  render={({ field }) => {
-                    const selectedValue =
-                      typeof field.value === 'string' && field.value.length > 0
-                        ? field.value
-                        : undefined;
-                    return (
-                      <FormItem>
-                        <FormLabel>Service</FormLabel>
-                        <Select
-                          value={selectedValue}
-                          onValueChange={(value) => field.onChange(value)}
-                        >
-                          <FormControl>
-                            <SelectTrigger className='w-full'>
-                              <SelectValue placeholder='Select an infrastructure service' />
-                            </SelectTrigger>
-                          </FormControl>
-                          <SelectContent>
-                            {infrastructureServices.map((service) => (
-                              <SelectItem
-                                key={`${service.hierarchy}:${service.name}`}
-                                value={service.name}
-                              >
-                                {`${service.name} (${capitalize(service.hierarchy)})`}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                        <FormDescription>
-                          Select the infrastructure service from a chosen
-                          hierarchy level.
-                        </FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    );
-                  }}
-                />
-                <FormField
-                  control={form.control}
-                  name='jobConfigs.analyzer.environmentDefinitions.maven.0.id'
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>ID</FormLabel>
-                      <FormControl>
-                        <Input {...field} />
-                      </FormControl>
-                      <FormDescription>
-                        Repository ID referenced in <code>pom.xml</code> files.
-                        Appears as the <code>&lt;id&gt;</code> of the
-                        corresponding server in Maven&apos;s{' '}
-                        <code>settings.xml</code>.
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name='jobConfigs.analyzer.environmentDefinitions.maven.0.mirrorOf'
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Mirror of</FormLabel>
-                      <FormControl>
-                        <Input {...field} placeholder='(optional)' />
-                      </FormControl>
-                      <FormDescription>
-                        If set, adds this entry to the{' '}
-                        <code>&lt;mirrors&gt;</code> section of{' '}
-                        <code>settings.xml</code>. Value is the repository ID to
-                        mirror (e.g. <code>central</code>, or <code>*</code> for
-                        all repositories).
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-            </AccordionContent>
-          </AccordionPrimitive.Item>
-          {/* NPM */}
-          <AccordionPrimitive.Item value='npm' className='rounded-lg border'>
-            <AccordionPrimitive.Header className='flex flex-row items-center'>
-              <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
-                NPM
-                <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
-              </AccordionPrimitive.Trigger>
-              <div className='pr-4'>
-                <Switch
-                  checked={enabledDefinitions['npm'] ?? false}
-                  onCheckedChange={(checked) =>
-                    onToggle(
-                      'npm',
-                      checked,
-                      npmEnvironmentDefinitions.npm ?? []
-                    )
-                  }
-                />
-              </div>
-            </AccordionPrimitive.Header>
-            <AccordionContent>
-              <div className='flex flex-col gap-4 px-4 pb-4'>
-                <FormField
-                  control={form.control}
-                  name='jobConfigs.analyzer.environmentDefinitions.npm.0.service'
-                  render={({ field }) => {
-                    const selectedValue =
-                      typeof field.value === 'string' && field.value.length > 0
-                        ? field.value
-                        : undefined;
-                    return (
-                      <FormItem>
-                        <FormLabel>Service</FormLabel>
-                        <Select
-                          value={selectedValue}
-                          onValueChange={(value) => field.onChange(value)}
-                        >
-                          <FormControl>
-                            <SelectTrigger className='w-full'>
-                              <SelectValue placeholder='Select an infrastructure service' />
-                            </SelectTrigger>
-                          </FormControl>
-                          <SelectContent>
-                            {infrastructureServices.map((service) => (
-                              <SelectItem
-                                key={`${service.hierarchy}:${service.name}`}
-                                value={service.name}
-                              >
-                                {`${service.name} (${capitalize(service.hierarchy)})`}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                        <FormDescription>
-                          Select the infrastructure service from a chosen
-                          hierarchy level.
-                        </FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    );
-                  }}
-                />
-                <FormField
-                  control={form.control}
-                  name='jobConfigs.analyzer.environmentDefinitions.npm.0.scope'
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Scope</FormLabel>
-                      <FormControl>
-                        <Input {...field} placeholder='(optional)' />
-                      </FormControl>
-                      <FormDescription>
-                        Optional NPM scope that this configuration applies to.
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name='jobConfigs.analyzer.environmentDefinitions.npm.0.email'
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Email</FormLabel>
-                      <FormControl>
-                        <Input {...field} placeholder='(optional)' />
-                      </FormControl>
-                      <FormDescription>
-                        Optional email address used by the NPM registry.
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name='jobConfigs.analyzer.environmentDefinitions.npm.0.authMode'
-                  render={({ field }) => {
-                    const selectedValue =
-                      typeof field.value === 'string' && field.value.length > 0
-                        ? (field.value as NpmAuthMode)
-                        : undefined;
-                    return (
-                      <FormItem>
-                        <FormLabel>Authorization mode</FormLabel>
-                        <Select
-                          value={selectedValue}
-                          onValueChange={(value) => field.onChange(value)}
-                        >
-                          <FormControl>
-                            <SelectTrigger className='w-full'>
-                              <SelectValue placeholder='Select the authorization mode' />
-                            </SelectTrigger>
-                          </FormControl>
-                          <SelectContent>
-                            {npmAuthModes.map((mode) => (
-                              <SelectItem key={mode} value={mode}>
-                                {mode.replaceAll('_', ' ')}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                        <FormDescription>
-                          Pick how the NPM registry authenticates requests.
-                        </FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    );
-                  }}
-                />
-              </div>
-            </AccordionContent>
-          </AccordionPrimitive.Item>
-          {/* NuGet */}
-          <AccordionPrimitive.Item value='nuget' className='rounded-lg border'>
-            <AccordionPrimitive.Header className='flex flex-row items-center'>
-              <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
-                NuGet
-                <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
-              </AccordionPrimitive.Trigger>
-              <div className='pr-4'>
-                <Switch
-                  checked={enabledDefinitions['nuget'] ?? false}
-                  onCheckedChange={(checked) =>
-                    onToggle(
-                      'nuget',
-                      checked,
-                      nugetEnvironmentDefinitions['nuget'] ?? []
-                    )
-                  }
-                />
-              </div>
-            </AccordionPrimitive.Header>
-            <AccordionContent>
-              <div className='flex flex-col gap-4 px-4 pb-4'>
-                <FormField
-                  control={form.control}
-                  name='jobConfigs.analyzer.environmentDefinitions.nuget.0.service'
-                  render={({ field }) => {
-                    const selectedValue =
-                      typeof field.value === 'string' && field.value.length > 0
-                        ? field.value
-                        : undefined;
-                    return (
-                      <FormItem>
-                        <FormLabel>Service</FormLabel>
-                        <Select
-                          value={selectedValue}
-                          onValueChange={(value) => field.onChange(value)}
-                        >
-                          <FormControl>
-                            <SelectTrigger className='w-full'>
-                              <SelectValue placeholder='Select an infrastructure service' />
-                            </SelectTrigger>
-                          </FormControl>
-                          <SelectContent>
-                            {infrastructureServices.map((service) => (
-                              <SelectItem
-                                key={`${service.hierarchy}:${service.name}`}
-                                value={service.name}
-                              >
-                                {`${service.name} (${capitalize(service.hierarchy)})`}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                        <FormDescription>
-                          Select the infrastructure service from a chosen
-                          hierarchy level.
-                        </FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    );
-                  }}
-                />
-                <FormField
-                  control={form.control}
-                  name='jobConfigs.analyzer.environmentDefinitions.nuget.0.sourceName'
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Source name</FormLabel>
-                      <FormControl>
-                        <Input {...field} />
-                      </FormControl>
-                      <FormDescription>
-                        The name to assign to the package source.
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name='jobConfigs.analyzer.environmentDefinitions.nuget.0.sourcePath'
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Source path</FormLabel>
-                      <FormControl>
-                        <Input {...field} />
-                      </FormControl>
-                      <FormDescription>
-                        The path or URL of the package source.
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name='jobConfigs.analyzer.environmentDefinitions.nuget.0.sourceProtocolVersion'
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel>Source protocol version</FormLabel>
-                      <FormControl>
-                        <Input {...field} placeholder='(optional)' />
-                      </FormControl>
-                      <FormDescription>
-                        NuGet server protocol version (e.g. 3). Defaults to 2
-                        for non-JSON source URLs. Requires NuGet 3.0+.
-                      </FormDescription>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-                <FormField
-                  control={form.control}
-                  name='jobConfigs.analyzer.environmentDefinitions.nuget.0.authMode'
-                  render={({ field }) => {
-                    const selectedValue =
-                      typeof field.value === 'string' && field.value.length > 0
-                        ? (field.value as NuGetAuthMode)
-                        : undefined;
-                    return (
-                      <FormItem>
-                        <FormLabel>Authorization mode</FormLabel>
-                        <Select
-                          value={selectedValue}
-                          onValueChange={(value) => field.onChange(value)}
-                        >
-                          <FormControl>
-                            <SelectTrigger className='w-full'>
-                              <SelectValue placeholder='Select the authorization mode' />
-                            </SelectTrigger>
-                          </FormControl>
-                          <SelectContent>
-                            {nugetAuthModes.map((mode) => (
-                              <SelectItem key={mode} value={mode}>
-                                {mode.replaceAll('_', ' ')}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                        <FormDescription>
-                          Authentication type for this package source.
-                        </FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    );
-                  }}
-                />
-              </div>
-            </AccordionContent>
-          </AccordionPrimitive.Item>
-          {/* Yarn */}
-          <AccordionPrimitive.Item value='yarn' className='rounded-lg border'>
-            <AccordionPrimitive.Header className='flex flex-row items-center'>
-              <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
-                Yarn
-                <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
-              </AccordionPrimitive.Trigger>
-              <div className='pr-4'>
-                <Switch
-                  checked={enabledDefinitions['yarn'] ?? false}
-                  onCheckedChange={(checked) =>
-                    onToggle(
-                      'yarn',
-                      checked,
-                      yarnEnvironmentDefinitions['yarn'] ?? []
-                    )
-                  }
-                />
-              </div>
-            </AccordionPrimitive.Header>
-            <AccordionContent>
-              <div className='flex flex-col gap-4 px-4 pb-4'>
-                <FormField
-                  control={form.control}
-                  name='jobConfigs.analyzer.environmentDefinitions.yarn.0.service'
-                  render={({ field }) => {
-                    const selectedValue =
-                      typeof field.value === 'string' && field.value.length > 0
-                        ? field.value
-                        : undefined;
-                    return (
-                      <FormItem>
-                        <FormLabel>Service</FormLabel>
-                        <Select
-                          value={selectedValue}
-                          onValueChange={(value) => field.onChange(value)}
-                        >
-                          <FormControl>
-                            <SelectTrigger className='w-full'>
-                              <SelectValue placeholder='Select an infrastructure service' />
-                            </SelectTrigger>
-                          </FormControl>
-                          <SelectContent>
-                            {infrastructureServices.map((service) => (
-                              <SelectItem
-                                key={`${service.hierarchy}:${service.name}`}
-                                value={service.name}
-                              >
-                                {`${service.name} (${capitalize(service.hierarchy)})`}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                        <FormDescription>
-                          Select the infrastructure service from a chosen
-                          hierarchy level.
-                        </FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    );
-                  }}
-                />
-                <FormField
-                  control={form.control}
-                  name='jobConfigs.analyzer.environmentDefinitions.yarn.0.authMode'
-                  render={({ field }) => {
-                    const selectedValue =
-                      typeof field.value === 'string' && field.value.length > 0
-                        ? (field.value as YarnAuthMode)
-                        : undefined;
-                    return (
-                      <FormItem>
-                        <FormLabel>Authorization mode</FormLabel>
-                        <Select
-                          value={selectedValue}
-                          onValueChange={(value) => field.onChange(value)}
-                        >
-                          <FormControl>
-                            <SelectTrigger className='w-full'>
-                              <SelectValue placeholder='Select the authorization mode' />
-                            </SelectTrigger>
-                          </FormControl>
-                          <SelectContent>
-                            {yarnAuthModes.map((mode) => (
-                              <SelectItem key={mode} value={mode}>
-                                {mode.replaceAll('_', ' ')}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                        <FormDescription>
-                          Authentication method for this private registry.
-                        </FormDescription>
-                        <FormMessage />
-                      </FormItem>
-                    );
-                  }}
-                />
-                <FormField
-                  control={form.control}
-                  name='jobConfigs.analyzer.environmentDefinitions.yarn.0.alwaysAuth'
-                  render={({ field }) => (
-                    <FormItem className='flex flex-row items-center justify-between rounded-lg border p-4'>
-                      <div className='space-y-0.5'>
-                        <FormLabel>Always authenticate</FormLabel>
-                        <FormDescription>
-                          Always send authentication information to the registry
-                          via the <code>npmAlwaysAuth</code> property.
-                        </FormDescription>
-                      </div>
-                      <FormControl>
-                        <Switch
-                          checked={(field.value ?? 'true') === 'true'}
-                          onCheckedChange={(checked) =>
-                            field.onChange(checked ? 'true' : 'false')
-                          }
-                        />
-                      </FormControl>
-                    </FormItem>
-                  )}
-                />
-              </div>
-            </AccordionContent>
-          </AccordionPrimitive.Item>
+          {ENVIRONMENT_DEFINITION_SCHEMAS.map((schema) => (
+            <AccordionPrimitive.Item
+              key={schema.key}
+              value={schema.key}
+              className='rounded-lg border'
+            >
+              <AccordionPrimitive.Header className='flex flex-row items-center'>
+                <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
+                  {schema.label}
+                  <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
+                </AccordionPrimitive.Trigger>
+                <div className='pr-4'>
+                  <Switch
+                    checked={enabledDefinitions[schema.key] ?? false}
+                    onCheckedChange={(checked) =>
+                      onToggle(schema.key, checked, schema.defaultEntries)
+                    }
+                  />
+                </div>
+              </AccordionPrimitive.Header>
+              <AccordionContent>
+                <div className='flex flex-col gap-4 px-4 pb-4'>
+                  {schema.fields.map((entry) => (
+                    <PackageManagerField
+                      key={entry.key}
+                      pmKey={schema.key}
+                      entry={entry}
+                      form={form}
+                      infrastructureServices={infrastructureServices}
+                    />
+                  ))}
+                </div>
+              </AccordionContent>
+            </AccordionPrimitive.Item>
+          ))}
         </Accordion>
       </CollapsibleContent>
     </Collapsible>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/environment-definitions.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/environment-definitions.tsx
@@ -43,6 +43,7 @@ import { Switch } from '@/components/ui/switch';
 import { capitalize } from '@/helpers/capitalize';
 import { InfrastructureServiceWithHierarchy } from '@/hooks/use-infrastructure-services';
 import {
+  conanEnvironmentDefinitions,
   EnvironmentDefinitionEntry,
   NpmAuthMode,
   npmAuthModes,
@@ -129,6 +130,127 @@ export const EnvironmentDefinitionsFields = ({
         private artifact repositories.
       </div>
       <Accordion type='multiple' className='flex flex-col gap-2'>
+        {/* Conan */}
+        <AccordionPrimitive.Item value='conan' className='rounded-lg border'>
+          <AccordionPrimitive.Header className='flex flex-row items-center'>
+            <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
+              Enable Conan environment definition
+              <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
+            </AccordionPrimitive.Trigger>
+            <div className='pr-4'>
+              <Switch
+                checked={enabledDefinitions['conan'] ?? false}
+                onCheckedChange={(checked) =>
+                  onToggle(
+                    'conan',
+                    checked,
+                    conanEnvironmentDefinitions['conan'] ?? []
+                  )
+                }
+              />
+            </div>
+          </AccordionPrimitive.Header>
+          <AccordionContent>
+            <div className='flex flex-col gap-4 px-4 pb-4'>
+              <FormField
+                control={form.control}
+                name='jobConfigs.analyzer.environmentDefinitions.conan.0.service'
+                render={({ field }) => {
+                  const selectedValue =
+                    typeof field.value === 'string' && field.value.length > 0
+                      ? field.value
+                      : undefined;
+                  return (
+                    <FormItem>
+                      <FormLabel>Service</FormLabel>
+                      <Select
+                        value={selectedValue}
+                        onValueChange={(value) => field.onChange(value)}
+                      >
+                        <FormControl>
+                          <SelectTrigger className='w-full'>
+                            <SelectValue placeholder='Select an infrastructure service' />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {infrastructureServices.map((service) => (
+                            <SelectItem
+                              key={`${service.hierarchy}:${service.name}`}
+                              value={service.name}
+                            >
+                              {`${service.name} (${capitalize(service.hierarchy)})`}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormDescription>
+                        Select the infrastructure service from a chosen
+                        hierarchy level.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  );
+                }}
+              />
+              <FormField
+                control={form.control}
+                name='jobConfigs.analyzer.environmentDefinitions.conan.0.name'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Remote name</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormDescription>
+                      Name of the Conan remote, used in commands like{' '}
+                      <code>conan list</code>.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name='jobConfigs.analyzer.environmentDefinitions.conan.0.url'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>URL</FormLabel>
+                    <FormControl>
+                      <Input {...field} placeholder='(optional)' />
+                    </FormControl>
+                    <FormDescription>
+                      URL for Conan to search for recipes and binaries. Falls
+                      back to the infrastructure service URL if not set.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name='jobConfigs.analyzer.environmentDefinitions.conan.0.verifySsl'
+                render={({ field }) => (
+                  <FormItem className='flex flex-row items-center justify-between rounded-lg border p-4'>
+                    <div className='space-y-0.5'>
+                      <FormLabel>Verify SSL</FormLabel>
+                      <FormDescription>
+                        Verify the SSL certificate of the remote URL.
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch
+                        checked={(field.value ?? 'true') === 'true'}
+                        onCheckedChange={(checked) =>
+                          field.onChange(checked ? 'true' : 'false')
+                        }
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+            </div>
+          </AccordionContent>
+        </AccordionPrimitive.Item>
         {/* NPM */}
         <AccordionPrimitive.Item value='npm' className='rounded-lg border'>
           <AccordionPrimitive.Header className='flex flex-row items-center'>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/environment-definitions.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/environment-definitions.tsx
@@ -48,6 +48,9 @@ import {
   NpmAuthMode,
   npmAuthModes,
   npmEnvironmentDefinitions,
+  NuGetAuthMode,
+  nugetAuthModes,
+  nugetEnvironmentDefinitions,
 } from '@/lib/types';
 import { CreateRunFormValues } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components';
 
@@ -371,6 +374,156 @@ export const EnvironmentDefinitionsFields = ({
                       </Select>
                       <FormDescription>
                         Pick how the NPM registry authenticates requests.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  );
+                }}
+              />
+            </div>
+          </AccordionContent>
+        </AccordionPrimitive.Item>
+        {/* NuGet */}
+        <AccordionPrimitive.Item value='nuget' className='rounded-lg border'>
+          <AccordionPrimitive.Header className='flex flex-row items-center'>
+            <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
+              Enable NuGet environment definition
+              <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
+            </AccordionPrimitive.Trigger>
+            <div className='pr-4'>
+              <Switch
+                checked={enabledDefinitions['nuget'] ?? false}
+                onCheckedChange={(checked) =>
+                  onToggle(
+                    'nuget',
+                    checked,
+                    nugetEnvironmentDefinitions['nuget'] ?? []
+                  )
+                }
+              />
+            </div>
+          </AccordionPrimitive.Header>
+          <AccordionContent>
+            <div className='flex flex-col gap-4 px-4 pb-4'>
+              <FormField
+                control={form.control}
+                name='jobConfigs.analyzer.environmentDefinitions.nuget.0.service'
+                render={({ field }) => {
+                  const selectedValue =
+                    typeof field.value === 'string' && field.value.length > 0
+                      ? field.value
+                      : undefined;
+                  return (
+                    <FormItem>
+                      <FormLabel>Service</FormLabel>
+                      <Select
+                        value={selectedValue}
+                        onValueChange={(value) => field.onChange(value)}
+                      >
+                        <FormControl>
+                          <SelectTrigger className='w-full'>
+                            <SelectValue placeholder='Select an infrastructure service' />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {infrastructureServices.map((service) => (
+                            <SelectItem
+                              key={`${service.hierarchy}:${service.name}`}
+                              value={service.name}
+                            >
+                              {`${service.name} (${capitalize(service.hierarchy)})`}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormDescription>
+                        Select the infrastructure service from a chosen
+                        hierarchy level.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  );
+                }}
+              />
+              <FormField
+                control={form.control}
+                name='jobConfigs.analyzer.environmentDefinitions.nuget.0.sourceName'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Source name</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormDescription>
+                      The name to assign to the package source.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name='jobConfigs.analyzer.environmentDefinitions.nuget.0.sourcePath'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Source path</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormDescription>
+                      The path or URL of the package source.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name='jobConfigs.analyzer.environmentDefinitions.nuget.0.sourceProtocolVersion'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Source protocol version</FormLabel>
+                    <FormControl>
+                      <Input {...field} placeholder='(optional)' />
+                    </FormControl>
+                    <FormDescription>
+                      NuGet server protocol version (e.g. 3). Defaults to 2 for
+                      non-JSON source URLs. Requires NuGet 3.0+.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name='jobConfigs.analyzer.environmentDefinitions.nuget.0.authMode'
+                render={({ field }) => {
+                  const selectedValue =
+                    typeof field.value === 'string' && field.value.length > 0
+                      ? (field.value as NuGetAuthMode)
+                      : undefined;
+                  return (
+                    <FormItem>
+                      <FormLabel>Authorization mode</FormLabel>
+                      <Select
+                        value={selectedValue}
+                        onValueChange={(value) => field.onChange(value)}
+                      >
+                        <FormControl>
+                          <SelectTrigger className='w-full'>
+                            <SelectValue placeholder='Select the authorization mode' />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {nugetAuthModes.map((mode) => (
+                            <SelectItem key={mode} value={mode}>
+                              {mode.replaceAll('_', ' ')}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormDescription>
+                        Authentication type for this package source.
                       </FormDescription>
                       <FormMessage />
                     </FormItem>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/environment-definitions.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/environment-definitions.tsx
@@ -1,0 +1,264 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import * as AccordionPrimitive from '@radix-ui/react-accordion';
+import { ChevronDownIcon } from 'lucide-react';
+import { useRef } from 'react';
+import { UseFormReturn } from 'react-hook-form';
+
+import { Accordion, AccordionContent } from '@/components/ui/accordion';
+import {
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Switch } from '@/components/ui/switch';
+import { capitalize } from '@/helpers/capitalize';
+import { InfrastructureServiceWithHierarchy } from '@/hooks/use-infrastructure-services';
+import {
+  EnvironmentDefinitionEntry,
+  NpmAuthMode,
+  npmAuthModes,
+  npmEnvironmentDefinitions,
+} from '@/lib/types';
+import { CreateRunFormValues } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components';
+
+type EnvironmentDefinitionsFieldsProps = {
+  form: UseFormReturn<CreateRunFormValues>;
+  infrastructureServices: InfrastructureServiceWithHierarchy[];
+};
+
+function cloneEntries(
+  entries: EnvironmentDefinitionEntry[] | undefined
+): EnvironmentDefinitionEntry[] | undefined {
+  return entries?.map((entry) => ({ ...entry }));
+}
+
+export const EnvironmentDefinitionsFields = ({
+  form,
+  infrastructureServices,
+}: EnvironmentDefinitionsFieldsProps) => {
+  const definitionBackups = useRef<
+    Record<string, EnvironmentDefinitionEntry[]>
+  >({});
+
+  const enabledDefinitions =
+    form.watch('jobConfigs.analyzer.environmentDefinitionsEnabled') ?? {};
+
+  function setEnabled(packageManager: string, value: boolean) {
+    form.setValue(
+      'jobConfigs.analyzer.environmentDefinitionsEnabled',
+      { ...enabledDefinitions, [packageManager]: value },
+      { shouldDirty: true }
+    );
+  }
+
+  function setEntries(
+    packageManager: string,
+    entries: EnvironmentDefinitionEntry[] | undefined
+  ) {
+    const current =
+      form.getValues('jobConfigs.analyzer.environmentDefinitions') ?? {};
+    const updated = entries
+      ? { ...current, [packageManager]: entries }
+      : Object.fromEntries(
+          Object.entries(current).filter(([k]) => k !== packageManager)
+        );
+    form.setValue(
+      'jobConfigs.analyzer.environmentDefinitions',
+      Object.keys(updated).length > 0 ? updated : undefined,
+      { shouldDirty: true }
+    );
+  }
+
+  function onToggle(
+    packageManager: string,
+    checked: boolean,
+    defaultEntries: EnvironmentDefinitionEntry[]
+  ) {
+    setEnabled(packageManager, checked);
+    if (checked) {
+      setEntries(
+        packageManager,
+        cloneEntries(definitionBackups.current[packageManager]) ??
+          cloneEntries(defaultEntries)
+      );
+    } else {
+      definitionBackups.current[packageManager] =
+        cloneEntries(
+          form.getValues('jobConfigs.analyzer.environmentDefinitions')?.[
+            packageManager
+          ]
+        ) ?? [];
+      setEntries(packageManager, undefined);
+    }
+  }
+
+  return (
+    <div className='flex flex-col gap-2'>
+      <h3>Environment configuration</h3>
+      <div className='mb-2 text-sm text-gray-500'>
+        Configure the credentials for different package managers to access
+        private artifact repositories.
+      </div>
+      <Accordion type='multiple' className='flex flex-col gap-2'>
+        {/* NPM */}
+        <AccordionPrimitive.Item value='npm' className='rounded-lg border'>
+          <AccordionPrimitive.Header className='flex flex-row items-center'>
+            <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
+              Enable NPM environment definition
+              <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
+            </AccordionPrimitive.Trigger>
+            <div className='pr-4'>
+              <Switch
+                checked={enabledDefinitions['npm'] ?? false}
+                onCheckedChange={(checked) =>
+                  onToggle('npm', checked, npmEnvironmentDefinitions.npm ?? [])
+                }
+              />
+            </div>
+          </AccordionPrimitive.Header>
+          <AccordionContent>
+            <div className='flex flex-col gap-4 px-4 pb-4'>
+              <FormField
+                control={form.control}
+                name='jobConfigs.analyzer.environmentDefinitions.npm.0.service'
+                render={({ field }) => {
+                  const selectedValue =
+                    typeof field.value === 'string' && field.value.length > 0
+                      ? field.value
+                      : undefined;
+                  return (
+                    <FormItem>
+                      <FormLabel>Service</FormLabel>
+                      <Select
+                        value={selectedValue}
+                        onValueChange={(value) => field.onChange(value)}
+                      >
+                        <FormControl>
+                          <SelectTrigger className='w-full'>
+                            <SelectValue placeholder='Select an infrastructure service' />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {infrastructureServices.map((service) => (
+                            <SelectItem
+                              key={`${service.hierarchy}:${service.name}`}
+                              value={service.name}
+                            >
+                              {`${service.name} (${capitalize(service.hierarchy)})`}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormDescription>
+                        Select the infrastructure service from a chosen
+                        hierarchy level.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  );
+                }}
+              />
+              <FormField
+                control={form.control}
+                name='jobConfigs.analyzer.environmentDefinitions.npm.0.scope'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Scope</FormLabel>
+                    <FormControl>
+                      <Input {...field} placeholder='(optional)' />
+                    </FormControl>
+                    <FormDescription>
+                      Optional NPM scope that this configuration applies to.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name='jobConfigs.analyzer.environmentDefinitions.npm.0.email'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Email</FormLabel>
+                    <FormControl>
+                      <Input {...field} placeholder='(optional)' />
+                    </FormControl>
+                    <FormDescription>
+                      Optional email address used by the NPM registry.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name='jobConfigs.analyzer.environmentDefinitions.npm.0.authMode'
+                render={({ field }) => {
+                  const selectedValue =
+                    typeof field.value === 'string' && field.value.length > 0
+                      ? (field.value as NpmAuthMode)
+                      : undefined;
+                  return (
+                    <FormItem>
+                      <FormLabel>Authorization mode</FormLabel>
+                      <Select
+                        value={selectedValue}
+                        onValueChange={(value) => field.onChange(value)}
+                      >
+                        <FormControl>
+                          <SelectTrigger className='w-full'>
+                            <SelectValue placeholder='Select the authorization mode' />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {npmAuthModes.map((mode) => (
+                            <SelectItem key={mode} value={mode}>
+                              {mode.replaceAll('_', ' ')}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormDescription>
+                        Pick how the NPM registry authenticates requests.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  );
+                }}
+              />
+            </div>
+          </AccordionContent>
+        </AccordionPrimitive.Item>
+      </Accordion>
+    </div>
+  );
+};

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/environment-definitions.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/environment-definitions.tsx
@@ -46,6 +46,7 @@ import {
   conanEnvironmentDefinitions,
   EnvironmentDefinitionEntry,
   gradleEnvironmentDefinitions,
+  mavenEnvironmentDefinitions,
   NpmAuthMode,
   npmAuthModes,
   npmEnvironmentDefinitions,
@@ -316,6 +317,110 @@ export const EnvironmentDefinitionsFields = ({
                     </FormItem>
                   );
                 }}
+              />
+            </div>
+          </AccordionContent>
+        </AccordionPrimitive.Item>
+        {/* Maven */}
+        <AccordionPrimitive.Item value='maven' className='rounded-lg border'>
+          <AccordionPrimitive.Header className='flex flex-row items-center'>
+            <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
+              Enable Maven environment definition
+              <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
+            </AccordionPrimitive.Trigger>
+            <div className='pr-4'>
+              <Switch
+                checked={enabledDefinitions['maven'] ?? false}
+                onCheckedChange={(checked) =>
+                  onToggle(
+                    'maven',
+                    checked,
+                    mavenEnvironmentDefinitions['maven'] ?? []
+                  )
+                }
+              />
+            </div>
+          </AccordionPrimitive.Header>
+          <AccordionContent>
+            <div className='flex flex-col gap-4 px-4 pb-4'>
+              <FormField
+                control={form.control}
+                name='jobConfigs.analyzer.environmentDefinitions.maven.0.service'
+                render={({ field }) => {
+                  const selectedValue =
+                    typeof field.value === 'string' && field.value.length > 0
+                      ? field.value
+                      : undefined;
+                  return (
+                    <FormItem>
+                      <FormLabel>Service</FormLabel>
+                      <Select
+                        value={selectedValue}
+                        onValueChange={(value) => field.onChange(value)}
+                      >
+                        <FormControl>
+                          <SelectTrigger className='w-full'>
+                            <SelectValue placeholder='Select an infrastructure service' />
+                          </SelectTrigger>
+                        </FormControl>
+                        <SelectContent>
+                          {infrastructureServices.map((service) => (
+                            <SelectItem
+                              key={`${service.hierarchy}:${service.name}`}
+                              value={service.name}
+                            >
+                              {`${service.name} (${capitalize(service.hierarchy)})`}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <FormDescription>
+                        Select the infrastructure service from a chosen
+                        hierarchy level.
+                      </FormDescription>
+                      <FormMessage />
+                    </FormItem>
+                  );
+                }}
+              />
+              <FormField
+                control={form.control}
+                name='jobConfigs.analyzer.environmentDefinitions.maven.0.id'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>ID</FormLabel>
+                    <FormControl>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormDescription>
+                      Repository ID referenced in <code>pom.xml</code> files.
+                      Appears as the <code>&lt;id&gt;</code> of the
+                      corresponding server in Maven&apos;s{' '}
+                      <code>settings.xml</code>.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name='jobConfigs.analyzer.environmentDefinitions.maven.0.mirrorOf'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Mirror of</FormLabel>
+                    <FormControl>
+                      <Input {...field} placeholder='(optional)' />
+                    </FormControl>
+                    <FormDescription>
+                      If set, adds this entry to the{' '}
+                      <code>&lt;mirrors&gt;</code> section of{' '}
+                      <code>settings.xml</code>. Value is the repository ID to
+                      mirror (e.g. <code>central</code>, or <code>*</code> for
+                      all repositories).
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
               />
             </div>
           </AccordionContent>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/default-values.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/default-values.ts
@@ -103,7 +103,7 @@ export function defaultValues(
         allowDynamicVersions: true,
         skipExcluded: true,
         keepAliveWorker: false,
-        environmentDefinitionsEnabled: false,
+        environmentDefinitionsEnabled: {},
         environmentDefinitions: undefined,
         infrastructureServices: [],
         packageManagers: {
@@ -213,7 +213,11 @@ export function defaultValues(
             // defaultPackageManagerOptions gets the options from the previous run already in the
             // baseDefaults object, so those values can be used here.
             packageManagers: baseDefaults.jobConfigs.analyzer.packageManagers,
-            environmentDefinitionsEnabled: hasEnvironmentDefinitions,
+            environmentDefinitionsEnabled: Object.fromEntries(
+              Object.entries(parsedEnvironmentDefinitions ?? {}).map(
+                ([key, entries]) => [key, (entries?.length ?? 0) > 0]
+              )
+            ),
             environmentDefinitions: hasEnvironmentDefinitions
               ? parsedEnvironmentDefinitions
               : undefined,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/payload.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/payload.ts
@@ -102,13 +102,20 @@ export function formValuesToPayload(
   // in the request body. If a job is disabled in the UI, we pass "undefined"
   // as the configuration for that job in the request body, in effect leaving
   // it empty, and thus disabling the job.
+  const allDefinitions = values.jobConfigs.analyzer.environmentDefinitions;
+  const enabledDefinitions =
+    values.jobConfigs.analyzer.environmentDefinitionsEnabled;
+  const filteredDefinitions: NonNullable<typeof allDefinitions> = {};
+  for (const [packageManager, entries] of Object.entries(
+    allDefinitions ?? {}
+  )) {
+    if (enabledDefinitions[packageManager] && entries.length > 0) {
+      filteredDefinitions[packageManager] = entries;
+    }
+  }
   const environmentDefinitions =
-    values.jobConfigs.analyzer.environmentDefinitionsEnabled &&
-    values.jobConfigs.analyzer.environmentDefinitions &&
-    Object.values(values.jobConfigs.analyzer.environmentDefinitions).some(
-      (entries) => entries.length > 0
-    )
-      ? values.jobConfigs.analyzer.environmentDefinitions
+    Object.keys(filteredDefinitions).length > 0
+      ? filteredDefinitions
       : undefined;
 
   const environmentVariables =

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/run-schema.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/run-schema.ts
@@ -57,7 +57,7 @@ export const createRunFormSchema = (
         repositoryConfigPath: z.string().optional(),
         allowDynamicVersions: z.boolean(),
         skipExcluded: z.boolean(),
-        environmentDefinitionsEnabled: z.boolean(),
+        environmentDefinitionsEnabled: z.record(z.string(), z.boolean()),
         environmentDefinitions: environmentDefinitionsSchema.optional(),
         environmentVariables: z.array(environmentVariableSchema).optional(),
         infrastructureServices: z.array(zInfrastructureService).optional(),


### PR DESCRIPTION
#### Keep the form tidier by wrapping the whole section into a collapsible

<img width="1087" height="288" alt="Screenshot from 2026-05-07 18-31-33" src="https://github.com/user-attachments/assets/a463b77f-a44a-4206-b57f-93673aa97ba9" />

#### Opening the collapsible shows each package manager section in its own accordion

<img width="1093" height="448" alt="Screenshot from 2026-05-07 18-31-55" src="https://github.com/user-attachments/assets/ea893964-d160-4080-84ec-93046160d836" />

#### Example of a configuration section for a package manager

<img width="1095" height="714" alt="Screenshot from 2026-05-07 18-32-28" src="https://github.com/user-attachments/assets/7a7333f5-48dd-40b3-9a7b-1240eb1fcea2" />

NOTE1: Field descriptions are taken from back-end code comments in [here](https://github.com/eclipse-apoapsis/ort-server/tree/main/workers/common/src/main/kotlin/env/definition) and certainly need some polishing.

NOTE2: I don't want to turn this description into a slideshow, so any customer of this feature should take the PR and try it out.

NOTE3: @mnonnenmacher already pointed out that the initial assumption of having only one environment configuration per package manager is wrong. The team decided that this PR should really be merged first, anyway, to gain experience (and possible bug reports) from using it, then improve.

Please see the commits for details.