### PR TITLE
ui: Improve plugin templates handling

### DIFF
--- a/ui/src/routes/admin/plugins/$pluginType/$pluginId/create-template/index.tsx
+++ b/ui/src/routes/admin/plugins/$pluginType/$pluginId/create-template/index.tsx
@@ -55,6 +55,7 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
 import { ApiError } from '@/lib/api-error';
 import { toast, toastError } from '@/lib/toast';
 import { getPluginTypeLabel } from '@/lib/types';
@@ -63,7 +64,7 @@ import { Route as LayoutRoute } from '../../../route.tsx';
 function optionTypeToZodType(type: PluginOptionType): ZodType {
   switch (type) {
     case 'BOOLEAN':
-      return z.boolean();
+      return z.boolean().default(false);
     case 'INTEGER':
       return z.coerce.number();
     case 'LONG':
@@ -124,7 +125,8 @@ const CreateTemplate = () => {
       [templateName]: '',
       ...(plugin?.options?.reduce(
         (acc, option) => {
-          acc[option.name] = option.defaultValue ?? '';
+          acc[option.name] =
+            option.type === 'BOOLEAN' ? false : (option.defaultValue ?? '');
           acc[`${option.name}_isFinal`] = false;
           acc[`${option.name}_isNotSet`] = true;
           return acc;
@@ -273,9 +275,12 @@ const CreateTemplate = () => {
                       render={({ field }) => (
                         <FormControl>
                           {option.type === 'BOOLEAN' ? (
-                            <Checkbox
-                              checked={field.value as CheckedState}
-                              onCheckedChange={field.onChange}
+                            <Switch
+                              checked={field.value as boolean}
+                              onCheckedChange={(checked) => {
+                                field.onChange(checked);
+                                form.setValue(`${option.name}_isNotSet`, false);
+                              }}
                             />
                           ) : option.isRequired ? (
                             <Input
@@ -331,7 +336,7 @@ const CreateTemplate = () => {
                             onCheckedChange={field.onChange}
                             disabled={Boolean(isNotSet)}
                           />
-                          isFinal
+                          <p className='text-sm'>Final</p>
                         </label>
                       )}
                     />
@@ -360,7 +365,7 @@ const CreateTemplate = () => {
                               }
                             }}
                           />
-                          undefined
+                          <p className='text-sm'>Undefined</p>
                         </label>
                       )}
                     />
@@ -383,12 +388,8 @@ const CreateTemplate = () => {
               );
             })}
           </CardContent>
-          <CardFooter>
-            <Button
-              type='submit'
-              disabled={isCreateTemplatePending}
-              className='mt-4'
-            >
+          <CardFooter className='mt-6 gap-4'>
+            <Button type='submit' disabled={isCreateTemplatePending}>
               {isCreateTemplatePending ? (
                 <>
                   <span className='sr-only'>Creating Template...</span>
@@ -397,6 +398,22 @@ const CreateTemplate = () => {
               ) : (
                 'Create Template'
               )}
+            </Button>
+            <Button
+              type='button'
+              variant='outline'
+              onClick={() =>
+                navigate({
+                  to: '/admin/plugins/$pluginType/$pluginId',
+                  params: {
+                    pluginType: params.pluginType,
+                    pluginId: params.pluginId,
+                  },
+                })
+              }
+              disabled={isCreateTemplatePending}
+            >
+              Cancel
             </Button>
           </CardFooter>
         </form>

--- a/ui/src/routes/admin/plugins/$pluginType/$pluginId/create-template/index.tsx
+++ b/ui/src/routes/admin/plugins/$pluginType/$pluginId/create-template/index.tsx
@@ -26,6 +26,7 @@ import {
   useNavigate,
 } from '@tanstack/react-router';
 import { Loader2 } from 'lucide-react';
+import { ChangeEvent } from 'react';
 import { useForm } from 'react-hook-form';
 import { z, ZodType } from 'zod';
 
@@ -132,6 +133,14 @@ const CreateTemplate = () => {
       ) || {}),
     },
   });
+
+  function handleValueChange(optionName: string, value: string) {
+    if (value !== '') {
+      form.setValue(`${optionName}_isNotSet`, false);
+    } else {
+      form.setValue(`${optionName}_isNotSet`, true);
+    }
+  }
 
   const { mutateAsync: createTemplate, isPending: isCreateTemplatePending } =
     useMutation({
@@ -283,7 +292,10 @@ const CreateTemplate = () => {
                                   ? field.value
                                   : ''
                               }
-                              disabled={Boolean(isNotSet)}
+                              onChange={(e) => {
+                                field.onChange(e);
+                                handleValueChange(option.name, e.target.value);
+                              }}
                             />
                           ) : (
                             <OptionalInput
@@ -294,7 +306,10 @@ const CreateTemplate = () => {
                                   ? 'number'
                                   : 'text'
                               }
-                              disabled={isNotSet}
+                              onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                                field.onChange(e);
+                                handleValueChange(option.name, e.target.value);
+                              }}
                             />
                           )}
                         </FormControl>
@@ -333,7 +348,17 @@ const CreateTemplate = () => {
                         >
                           <Checkbox
                             checked={field.value as CheckedState}
-                            onCheckedChange={field.onChange}
+                            onCheckedChange={(checked) => {
+                              field.onChange(checked);
+                              if (checked) {
+                                form.setValue(
+                                  option.name,
+                                  option.type === 'BOOLEAN'
+                                    ? false
+                                    : (option.defaultValue ?? '')
+                                );
+                              }
+                            }}
                           />
                           undefined
                         </label>

--- a/ui/src/routes/admin/plugins/$pluginType/$pluginId/edit-template/$templateName/index.tsx
+++ b/ui/src/routes/admin/plugins/$pluginType/$pluginId/edit-template/$templateName/index.tsx
@@ -1,0 +1,448 @@
+/*
+ * Copyright (C) 2025 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { CheckedState } from '@radix-ui/react-checkbox';
+import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import {
+  createFileRoute,
+  useLoaderData,
+  useNavigate,
+} from '@tanstack/react-router';
+import { Loader2 } from 'lucide-react';
+import { ChangeEvent } from 'react';
+import { Resolver, useForm } from 'react-hook-form';
+import { z, ZodType } from 'zod';
+
+import { PluginOption, PluginOptionTemplate, PluginOptionType } from '@/api';
+import {
+  getPluginTemplateOptions,
+  getPluginTemplateQueryKey,
+  updatePluginTemplateOptionsMutation,
+} from '@/api/@tanstack/react-query.gen';
+import { OptionalInput } from '@/components/form/optional-input';
+import { Badge } from '@/components/ui/badge.tsx';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Switch } from '@/components/ui/switch';
+import { ApiError } from '@/lib/api-error';
+import { queryClient } from '@/lib/query-client';
+import { toast, toastError } from '@/lib/toast';
+import { getPluginTypeLabel } from '@/lib/types';
+import { Route as LayoutRoute } from '../../../../route.tsx';
+
+function optionTypeToZodType(type: PluginOptionType): ZodType {
+  switch (type) {
+    case 'BOOLEAN':
+      return z.boolean().default(false);
+    case 'INTEGER':
+      return z.coerce.number();
+    case 'LONG':
+      return z.coerce.bigint();
+    case 'SECRET':
+      return z.string();
+    case 'STRING':
+      return z.string();
+    case 'STRING_LIST':
+      return z.array(z.string());
+    default:
+      throw new Error(`Unsupported option type: ${type}`);
+  }
+}
+
+function buildFormSchema(options: Array<PluginOption>) {
+  const shape: Record<string, ZodType> = {};
+  for (const opt of options) {
+    let schema = optionTypeToZodType(opt.type);
+    if (opt.isNullable) {
+      schema = schema.nullable();
+    }
+    if (!opt.isRequired) {
+      schema = schema.optional();
+    }
+    shape[opt.name] = schema;
+    shape[`${opt.name}_isFinal`] = z.boolean().default(false);
+    shape[`${opt.name}_isNotSet`] = z.boolean().default(false);
+  }
+  return z.object(shape);
+}
+
+function parseStoredValue(
+  value: string | null | undefined,
+  type: PluginOptionType
+): unknown {
+  if (value === null || value === undefined) return '';
+  switch (type) {
+    case 'BOOLEAN':
+      return value === 'true';
+    case 'INTEGER':
+      return Number(value);
+    case 'LONG':
+      return value;
+    case 'STRING_LIST':
+      return value.split(',');
+    default:
+      return value;
+  }
+}
+
+type FormValues = Record<string, unknown>;
+
+const EditTemplate = () => {
+  const navigate = useNavigate();
+  const { plugins } = useLoaderData({ from: LayoutRoute.id });
+  const params = Route.useParams();
+
+  const plugin = plugins.find(
+    (p) => p.type === params.pluginType && p.id === params.pluginId
+  );
+
+  const { data: template } = useSuspenseQuery({
+    ...getPluginTemplateOptions({
+      path: {
+        pluginType: params.pluginType,
+        pluginId: params.pluginId,
+        templateName: params.templateName,
+      },
+    }),
+  });
+
+  const formSchema = plugin?.options
+    ? buildFormSchema(plugin.options)
+    : z.object({});
+
+  const form = useForm<FormValues>({
+    resolver: zodResolver(formSchema) as unknown as Resolver<FormValues>,
+    values:
+      plugin?.options?.reduce((acc, option) => {
+        const templateOption = template.options.find(
+          (o) => o.option === option.name
+        );
+        acc[option.name] = templateOption
+          ? parseStoredValue(templateOption.value, option.type)
+          : option.type === 'BOOLEAN'
+            ? false
+            : (option.defaultValue ?? '');
+        acc[`${option.name}_isFinal`] = templateOption?.isFinal ?? false;
+        acc[`${option.name}_isNotSet`] = !templateOption;
+        return acc;
+      }, {} as FormValues) ?? {},
+  });
+
+  function handleValueChange(optionName: string, value: string) {
+    if (value !== '') {
+      form.setValue(`${optionName}_isNotSet`, false);
+    } else {
+      form.setValue(`${optionName}_isNotSet`, true);
+    }
+  }
+
+  const { mutateAsync: updateTemplate, isPending: isUpdateTemplatePending } =
+    useMutation({
+      ...updatePluginTemplateOptionsMutation(),
+      onSuccess() {
+        toast.info('Edit Template', {
+          description: `Template updated successfully.`,
+        });
+        queryClient.invalidateQueries({
+          queryKey: getPluginTemplateQueryKey({
+            path: {
+              pluginType: params.pluginType,
+              pluginId: params.pluginId,
+              templateName: params.templateName,
+            },
+          }),
+        });
+        navigate({
+          to: '/admin/plugins/$pluginType/$pluginId',
+          params: {
+            pluginType: params.pluginType,
+            pluginId: params.pluginId,
+          },
+        });
+      },
+      onError(error) {
+        const apiError = error as ApiError;
+        toastError(error.message, apiError);
+      },
+    });
+
+  async function onSubmit(formValues: FormValues) {
+    const requestBody: PluginOptionTemplate[] =
+      plugin?.options
+        ?.filter((option) => !formValues[`${option.name}_isNotSet`])
+        ?.map((option) => {
+          const value = formValues[option.name];
+          const isFinal = Boolean(formValues[`${option.name}_isFinal`]);
+
+          let stringValue: string | null;
+          if (value === null || value === undefined) {
+            stringValue = null;
+          } else if (Array.isArray(value)) {
+            stringValue = value.join(',');
+          } else if (
+            typeof value === 'bigint' ||
+            typeof value === 'number' ||
+            typeof value === 'boolean'
+          ) {
+            stringValue = value.toString();
+          } else {
+            stringValue = value as string;
+          }
+
+          return {
+            option: option.name,
+            type: option.type,
+            value: stringValue,
+            isFinal,
+          };
+        }) ?? [];
+
+    await updateTemplate({
+      path: {
+        pluginType: params.pluginType,
+        pluginId: params.pluginId,
+        templateName: params.templateName,
+      },
+      body: requestBody,
+    });
+  }
+
+  return (
+    <Card className='col-span-2 w-full'>
+      <CardHeader>
+        <CardTitle>Edit Template</CardTitle>
+        <CardDescription>
+          Edit the plugin template for the {params.pluginId}{' '}
+          {getPluginTypeLabel(params.pluginType)} plugin.
+          <br />
+          Options that are set to final can not be overwritten by the user.
+          <br />
+          Options that are set to undefined will not be set in the template.
+        </CardDescription>
+      </CardHeader>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)}>
+          <CardContent className='space-y-4'>
+            <FormItem>
+              <FormLabel>Template Name</FormLabel>
+              <Input value={params.templateName} disabled />
+              <FormDescription>The name of the template.</FormDescription>
+            </FormItem>
+            {plugin?.options?.map((option) => {
+              const isNotSet = form.watch(`${option.name}_isNotSet`);
+
+              return (
+                <FormItem key={option.name}>
+                  <FormLabel>
+                    {option.name}
+                    <Badge className='ml-2 bg-blue-200 text-black'>
+                      {option.type}
+                    </Badge>
+                  </FormLabel>
+                  <div
+                    style={{ display: 'flex', alignItems: 'center', gap: 8 }}
+                  >
+                    <FormField
+                      control={form.control}
+                      name={option.name}
+                      render={({ field }) => (
+                        <FormControl>
+                          {option.type === 'BOOLEAN' ? (
+                            <Switch
+                              checked={field.value as boolean}
+                              onCheckedChange={(checked) => {
+                                field.onChange(checked);
+                                form.setValue(`${option.name}_isNotSet`, false);
+                              }}
+                            />
+                          ) : option.isRequired ? (
+                            <Input
+                              {...field}
+                              type={
+                                option.type === 'INTEGER' ||
+                                option.type === 'LONG'
+                                  ? 'number'
+                                  : 'text'
+                              }
+                              value={
+                                typeof field.value === 'string' ||
+                                typeof field.value === 'number'
+                                  ? field.value
+                                  : ''
+                              }
+                              onChange={(e) => {
+                                field.onChange(e);
+                                handleValueChange(option.name, e.target.value);
+                              }}
+                            />
+                          ) : (
+                            <OptionalInput
+                              {...field}
+                              type={
+                                option.type === 'INTEGER' ||
+                                option.type === 'LONG'
+                                  ? 'number'
+                                  : 'text'
+                              }
+                              onChange={(e: ChangeEvent<HTMLInputElement>) => {
+                                field.onChange(e);
+                                handleValueChange(option.name, e.target.value);
+                              }}
+                            />
+                          )}
+                        </FormControl>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name={`${option.name}_isFinal`}
+                      render={({ field }) => (
+                        <label
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 4,
+                          }}
+                        >
+                          <Checkbox
+                            checked={field.value as CheckedState}
+                            onCheckedChange={field.onChange}
+                            disabled={Boolean(isNotSet)}
+                          />
+                          <p className='text-sm'>Final</p>
+                        </label>
+                      )}
+                    />
+                    <FormField
+                      control={form.control}
+                      name={`${option.name}_isNotSet`}
+                      render={({ field }) => (
+                        <label
+                          style={{
+                            display: 'flex',
+                            alignItems: 'center',
+                            gap: 4,
+                          }}
+                        >
+                          <Checkbox
+                            checked={field.value as CheckedState}
+                            onCheckedChange={(checked) => {
+                              field.onChange(checked);
+                              if (checked) {
+                                form.setValue(
+                                  option.name,
+                                  option.type === 'BOOLEAN'
+                                    ? false
+                                    : (option.defaultValue ?? '')
+                                );
+                              }
+                            }}
+                          />
+                          <p className='text-sm'>Undefined</p>
+                        </label>
+                      )}
+                    />
+                  </div>
+                  <FormDescription>
+                    {option.description}
+                    {option.type === 'SECRET' && (
+                      <>
+                        <br />
+                        <span className='text-red-500'>
+                          Enter the name of the secret, not the value! A secret
+                          with this name must be configured in the context of
+                          the ORT run.
+                        </span>
+                      </>
+                    )}
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              );
+            })}
+          </CardContent>
+          <CardFooter className='mt-6 gap-4'>
+            <Button type='submit' disabled={isUpdateTemplatePending}>
+              {isUpdateTemplatePending ? (
+                <>
+                  <span className='sr-only'>Updating Template...</span>
+                  <Loader2 size={16} className='mx-3 animate-spin' />
+                </>
+              ) : (
+                'Update Template'
+              )}
+            </Button>
+            <Button
+              type='button'
+              variant='outline'
+              onClick={() =>
+                navigate({
+                  to: '/admin/plugins/$pluginType/$pluginId',
+                  params: {
+                    pluginType: params.pluginType,
+                    pluginId: params.pluginId,
+                  },
+                })
+              }
+              disabled={isUpdateTemplatePending}
+            >
+              Cancel
+            </Button>
+          </CardFooter>
+        </form>
+      </Form>
+    </Card>
+  );
+};
+
+export const Route = createFileRoute(
+  '/admin/plugins/$pluginType/$pluginId/edit-template/$templateName/'
+)({
+  loader: async ({ context: { queryClient }, params }) => {
+    await queryClient.ensureQueryData({
+      ...getPluginTemplateOptions({
+        path: {
+          pluginType: params.pluginType,
+          pluginId: params.pluginId,
+          templateName: params.templateName,
+        },
+      }),
+    });
+  },
+  component: EditTemplate,
+});

--- a/ui/src/routes/admin/plugins/$pluginType/$pluginId/index.tsx
+++ b/ui/src/routes/admin/plugins/$pluginType/$pluginId/index.tsx
@@ -41,7 +41,6 @@ import {
   Card,
   CardContent,
   CardDescription,
-  CardFooter,
   CardHeader,
   CardTitle,
 } from '@/components/ui/card.tsx';
@@ -230,8 +229,16 @@ const PluginTemplateCard = ({
 
   return (
     <Card key={template.name} className='mb-2'>
-      <CardHeader className='flex items-start justify-between'>
+      <CardHeader className='flex flex-row items-center justify-between'>
         <CardTitle>{template.name}</CardTitle>
+        <div className='flex items-center gap-1'>
+          <DeleteDialog
+            thingName={'template'}
+            uiComponent={<DeleteIconButton />}
+            onDelete={onDelete}
+            tooltip='Delete Template'
+          />
+        </div>
       </CardHeader>
       <CardContent>
         <div>
@@ -369,17 +376,6 @@ const PluginTemplateCard = ({
           );
         })}
       </CardContent>
-      <CardFooter>
-        Delete Template
-        <span className='ml-2'>
-          <DeleteDialog
-            thingName={'template'}
-            uiComponent={<DeleteIconButton />}
-            onDelete={onDelete}
-            tooltip='Delete Template'
-          />
-        </span>
-      </CardFooter>
     </Card>
   );
 };

--- a/ui/src/routes/admin/plugins/$pluginType/$pluginId/index.tsx
+++ b/ui/src/routes/admin/plugins/$pluginType/$pluginId/index.tsx
@@ -19,7 +19,7 @@
 
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { createFileRoute, Link, useLoaderData } from '@tanstack/react-router';
-import { ChevronsUpDownIcon, Pencil } from 'lucide-react';
+import { Pencil } from 'lucide-react';
 
 import { PluginDescriptor, PluginTemplate } from '@/api';
 import {
@@ -44,20 +44,9 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card.tsx';
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from '@/components/ui/command.tsx';
-import { Option } from '@/components/ui/multiple-selector.tsx';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover.tsx';
+import MultipleSelector, {
+  Option,
+} from '@/components/ui/multiple-selector.tsx';
 import { Switch } from '@/components/ui/switch.tsx';
 import {
   Tooltip,
@@ -259,10 +248,10 @@ const PluginTemplateCard = ({
         </div>
       </CardHeader>
       <CardContent>
-        <div>
-          Global Template
+        <div className='flex items-center gap-2'>
+          <span className='text-sm'>Global Template</span>
           <Switch
-            className='ml-2 data-[state=checked]:bg-green-500'
+            className='data-[state=checked]:bg-green-500'
             checked={template.isGlobal}
             onCheckedChange={() => toggleIsGlobal()}
           />
@@ -281,90 +270,42 @@ const PluginTemplateCard = ({
             ? 'This template is assigned to the following organizations:'
             : 'This template is not assigned to any organizations.'}
         </p>
-
-        <div>
-          {template.organizationIds && template.organizationIds.length > 0 && (
-            <div className='mb-2 flex flex-wrap gap-2'>
-              {template.organizationIds.map((orgId) => {
-                const org = organizationOptions.find(
-                  (o) => o.value === orgId.toString()
-                );
-                return (
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <Badge
-                        asChild
-                        key={orgId}
-                        className='bg-amber-200 text-black'
-                      >
-                        <Button
-                          variant='ghost'
-                          onClick={() => {
-                            removeOrganization({
-                              path: {
-                                pluginType: template.pluginType,
-                                pluginId: template.pluginId,
-                                templateName: template.name,
-                              },
-                              query: { organizationId: orgId.toString() },
-                            });
-                          }}
-                        >
-                          {org ? org.label : orgId}
-                        </Button>
-                      </Badge>
-                    </TooltipTrigger>
-                    <TooltipContent>Remove Organization</TooltipContent>
-                  </Tooltip>
-                );
-              })}
-            </div>
+        <MultipleSelector
+          value={organizationOptions.filter((o) =>
+            template.organizationIds?.includes(Number(o.value))
           )}
-        </div>
-
-        <Popover>
-          <PopoverTrigger asChild>
-            <Button variant='ghost' role='combobox' className='px-1'>
-              Add to Organization
-              <ChevronsUpDownIcon className='ml-2 h-4 w-4 shrink-0 opacity-50' />
-            </Button>
-          </PopoverTrigger>
-          <PopoverContent>
-            <Command>
-              <CommandInput placeholder='Search organization...' />
-              <CommandList>
-                <CommandEmpty>No organization found.</CommandEmpty>
-                <CommandGroup>
-                  {organizationOptions
-                    .filter(
-                      (option) =>
-                        !template.organizationIds?.includes(
-                          Number(option.value)
-                        )
-                    )
-                    .map((option) => (
-                      <CommandItem
-                        key={option.value}
-                        value={option.label}
-                        onSelect={() => {
-                          addOrganization({
-                            path: {
-                              pluginType: template.pluginType,
-                              pluginId: template.pluginId,
-                              templateName: template.name,
-                            },
-                            query: { organizationId: option.value },
-                          });
-                        }}
-                      >
-                        {option.label}
-                      </CommandItem>
-                    ))}
-                </CommandGroup>
-              </CommandList>
-            </Command>
-          </PopoverContent>
-        </Popover>
+          options={organizationOptions}
+          placeholder='Assign organizations...'
+          badgeClassName='bg-amber-200 text-black'
+          onChange={(newSelected) => {
+            const oldIds = template.organizationIds ?? [];
+            const newIds = newSelected.map((o) => Number(o.value));
+            for (const opt of newSelected) {
+              if (!oldIds.includes(Number(opt.value))) {
+                addOrganization({
+                  path: {
+                    pluginType: template.pluginType,
+                    pluginId: template.pluginId,
+                    templateName: template.name,
+                  },
+                  query: { organizationId: opt.value },
+                });
+              }
+            }
+            for (const id of oldIds) {
+              if (!newIds.includes(id)) {
+                removeOrganization({
+                  path: {
+                    pluginType: template.pluginType,
+                    pluginId: template.pluginId,
+                    templateName: template.name,
+                  },
+                  query: { organizationId: id.toString() },
+                });
+              }
+            }
+          }}
+        />
 
         <div className='my-4 border-t' />
 
@@ -373,23 +314,31 @@ const PluginTemplateCard = ({
             (opt) => opt.option === pluginOption.name
           );
           return (
-            <div key={pluginOption.name} className='mb-2'>
-              <strong>{pluginOption.name}:</strong>{' '}
+            <div
+              key={pluginOption.name}
+              className='mb-2 flex items-center gap-2'
+            >
+              <span className='text-sm font-semibold'>
+                {pluginOption.name}:
+              </span>
               {templateOption ? (
                 <>
-                  {templateOption.value}
+                  <span className='text-sm'>{templateOption.value}</span>
+                  <Badge className='bg-blue-200 text-black'>
+                    {pluginOption.type}
+                  </Badge>
                   {templateOption.isFinal && (
-                    <Badge className='ml-2 bg-green-200 text-black'>
-                      Final
-                    </Badge>
+                    <Badge className='bg-green-200 text-black'>Final</Badge>
                   )}
                 </>
               ) : (
-                <Badge className='ml-2 bg-gray-200 text-black'>Not set</Badge>
+                <>
+                  <Badge className='bg-gray-200 text-black'>Not set</Badge>
+                  <Badge className='bg-blue-200 text-black'>
+                    {pluginOption.type}
+                  </Badge>
+                </>
               )}
-              <Badge className='ml-2 bg-blue-200 text-black'>
-                {pluginOption.type}
-              </Badge>
             </div>
           );
         })}

--- a/ui/src/routes/admin/plugins/$pluginType/$pluginId/index.tsx
+++ b/ui/src/routes/admin/plugins/$pluginType/$pluginId/index.tsx
@@ -19,7 +19,7 @@
 
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { createFileRoute, Link, useLoaderData } from '@tanstack/react-router';
-import { ChevronsUpDownIcon } from 'lucide-react';
+import { ChevronsUpDownIcon, Pencil } from 'lucide-react';
 
 import { PluginDescriptor, PluginTemplate } from '@/api';
 import {
@@ -232,6 +232,24 @@ const PluginTemplateCard = ({
       <CardHeader className='flex flex-row items-center justify-between'>
         <CardTitle>{template.name}</CardTitle>
         <div className='flex items-center gap-1'>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button variant='outline' size='sm' className='h-8 px-2' asChild>
+                <Link
+                  to='/admin/plugins/$pluginType/$pluginId/edit-template/$templateName'
+                  params={{
+                    pluginType: template.pluginType,
+                    pluginId: template.pluginId,
+                    templateName: template.name,
+                  }}
+                >
+                  <span className='sr-only'>Edit Template</span>
+                  <Pencil size={16} />
+                </Link>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>Edit Template</TooltipContent>
+          </Tooltip>
           <DeleteDialog
             thingName={'template'}
             uiComponent={<DeleteIconButton />}


### PR DESCRIPTION
This PR includes some visual and usability improvements for the plugin templates handling, most notably new template editing feature for which there already existed an endpoint but no UI yet.
<img width="1129" height="415" alt="Screenshot from 2026-05-08 10-47-45" src="https://github.com/user-attachments/assets/495eb41a-0af3-40cb-bfa8-001a30b0e32d" />

<img width="1179" height="738" alt="Screenshot from 2026-05-08 10-48-31" src="https://github.com/user-attachments/assets/9d2b6e85-9d51-4d00-8eb9-c1830754470f" />

<img width="1179" height="738" alt="Screenshot from 2026-05-08 10-48-46" src="https://github.com/user-attachments/assets/f16fbb26-bbef-4fb5-9fdb-bf0f3952bd1e" />


Please see the commits for details.