### PR TITLE
ci: Run pnpm from the project dir to fix corepack version detection

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -123,13 +123,16 @@ jobs:
       run: corepack enable
 
     - name: Install dependencies
-      run: pnpm -C ui install
+      working-directory: ui
+      run: pnpm install
 
     - name: Build UI
-      run: pnpm -C ui build
+      working-directory: ui
+      run: pnpm build
 
     - name: Test UI
-      run: pnpm -C ui test
+      working-directory: ui
+      run: pnpm test
 
   test:
     needs: build
@@ -247,13 +250,16 @@ jobs:
       run: corepack enable
 
     - name: Install dependencies
-      run: pnpm -C ui install
+      working-directory: ui
+      run: pnpm install
 
     - name: Generate API client and routes
-      run: pnpm -C ui generate:api && pnpm -C ui generate:routes
+      working-directory: ui
+      run: pnpm generate:api && pnpm generate:routes
 
     - name: Install Playwright Browsers
-      run: pnpm -C ui exec playwright install --with-deps
+      working-directory: ui
+      run: pnpm exec playwright install --with-deps
 
     - name: Start core services
       run: docker compose up -d core
@@ -280,13 +286,14 @@ jobs:
       env:
         VITE_UI_URL: http://127.0.0.1:8082/
         VITE_CLIENT_ID: ort-server-ui
+      working-directory: ui
       run: |
         # Exit on error, undefined variables, and pipe failures
         set -euo pipefail
 
         # Start the Vite dev server in the background
         # The dev server is needed because Playwright tests run against a live server
-        pnpm -C ui dev --host 0.0.0.0 --port 8082 > ui-dev.log 2>&1 &
+        pnpm dev --host 0.0.0.0 --port 8082 > ui-dev.log 2>&1 &
         UI_DEV_PID=$!
 
         # Set up cleanup to ensure the background dev server process is killed on exit
@@ -325,7 +332,7 @@ jobs:
           sleep 2
         done
 
-        pnpm -C ui test:e2e
+        pnpm test:e2e
 
     - name: Upload UI dev log
       if: success() || failure()

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -33,10 +33,12 @@ jobs:
       run: corepack enable
 
     - name: Install dependencies
-      run: pnpm -C website install --frozen-lockfile
+      working-directory: website
+      run: pnpm install --frozen-lockfile
 
     - name: Test build
-      run: pnpm -C website build
+      working-directory: website
+      run: pnpm build
 
     - name: Setup Pages
       uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -79,10 +79,12 @@ jobs:
       run: corepack enable
 
     - name: Install dependencies
-      run: pnpm -C ui install --dev
+      working-directory: ui
+      run: pnpm install --dev
 
     - name: Run ESLint
-      run: pnpm -C ui lint
+      working-directory: ui
+      run: pnpm lint
 
   prettier-ui:
     runs-on: ubuntu-24.04
@@ -100,10 +102,12 @@ jobs:
       run: corepack enable
 
     - name: Install dependencies
-      run: pnpm -C ui install --dev
+      working-directory: ui
+      run: pnpm install --dev
 
     - name: Run Prettier
-      run: pnpm -C ui format:check
+      working-directory: ui
+      run: pnpm format:check
 
   prettier-website:
     runs-on: ubuntu-24.04
@@ -121,10 +125,12 @@ jobs:
       run: corepack enable
 
     - name: Install dependencies
-      run: pnpm -C website install --dev
+      working-directory: website
+      run: pnpm install --dev
 
     - name: Run Prettier
-      run: pnpm -C website format:check
+      working-directory: website
+      run: pnpm format:check
 
   renovate-validation:
     runs-on: ubuntu-24.04

--- a/.github/workflows/website-test.yml
+++ b/.github/workflows/website-test.yml
@@ -30,7 +30,9 @@ jobs:
       run: corepack enable
 
     - name: Install dependencies
-      run: pnpm -C website install --frozen-lockfile
+      working-directory: website
+      run: pnpm install --frozen-lockfile
 
     - name: Test build
-      run: pnpm -C website build
+      working-directory: website
+      run: pnpm build


### PR DESCRIPTION
Set the working directory when running pnpm as corepack picks up the version from the `package.json` in the current directory. Otherwise, it might install the wrong version which then causes the version check of pnpm to fail.