### PR TITLE
Switch to back-end data manipulation for run vulnerabilities

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
@@ -851,7 +851,15 @@ fun ApiPackageFilters.mapToModel(): PackageFilters =
 
 fun ApiRuleViolationFilters.mapToModel(): RuleViolationFilters = RuleViolationFilters(resolved = resolved)
 
-fun ApiVulnerabilityFilters.mapToModel(): VulnerabilityFilters = VulnerabilityFilters(resolved = resolved)
+fun ApiVulnerabilityFilters.mapToModel(): VulnerabilityFilters = VulnerabilityFilters(
+    resolved = resolved,
+    rating = rating?.mapToModel { ratingSet ->
+        ratingSet.mapTo(mutableSetOf()) { it.mapToModel() }
+    },
+    identifier = identifier?.mapToModel { it },
+    purl = purl?.mapToModel { it },
+    externalId = externalId?.mapToModel { it }
+)
 
 fun Project.mapToApi() = ApiProject(
     identifier = identifier.mapToApi(),

--- a/api/v1/model/src/commonMain/kotlin/Vulnerability.kt
+++ b/api/v1/model/src/commonMain/kotlin/Vulnerability.kt
@@ -38,5 +38,17 @@ data class VulnerabilityFilters(
      * Filter to only return resolved vulnerabilities. Null if both, resolved an unresolved vulnerabilities should be
      * returned.
      */
-    val resolved: Boolean? = null
+    val resolved: Boolean? = null,
+
+    /** Set of [VulnerabilityRating]s to filter with. */
+    val rating: FilterOperatorAndValue<Set<VulnerabilityRating>>? = null,
+
+    /** Substring filter for identifier. */
+    val identifier: FilterOperatorAndValue<String>? = null,
+
+    /** Substring filter for purl. */
+    val purl: FilterOperatorAndValue<String>? = null,
+
+    /** Substring filter for external ID. */
+    val externalId: FilterOperatorAndValue<String>? = null
 )

--- a/api/v1/model/src/commonMain/kotlin/Vulnerability.kt
+++ b/api/v1/model/src/commonMain/kotlin/Vulnerability.kt
@@ -30,7 +30,7 @@ data class Vulnerability(
 )
 
 /**
- * Filters to apply when querying for rule violations.
+ * Filters to apply when querying for vulnerabilities.
  */
 @Serializable
 data class VulnerabilityFilters(

--- a/core/src/main/kotlin/api/RunsRoute.kt
+++ b/core/src/main/kotlin/api/RunsRoute.kt
@@ -225,7 +225,7 @@ fun Route.runs() = route("runs") {
 
         route("vulnerabilities") {
             get(getRunVulnerabilities, requireRunPermission()) {
-                val pagingOptions = call.pagingOptions(SortProperty("externalId", SortDirection.ASCENDING))
+                val pagingOptions = call.pagingOptions(SortProperty("rating", SortDirection.DESCENDING))
                 val filters = call.vulnerabilityFilters()
 
                 val vulnerabilitiesForOrtRun =

--- a/core/src/main/kotlin/api/RunsRoute.kt
+++ b/core/src/main/kotlin/api/RunsRoute.kt
@@ -48,6 +48,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatus
 import org.eclipse.apoapsis.ortserver.api.v1.model.PackageFilters
 import org.eclipse.apoapsis.ortserver.api.v1.model.RuleViolationFilters
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityFilters
+import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityRating
 import org.eclipse.apoapsis.ortserver.components.authorization.rights.EffectiveRole
 import org.eclipse.apoapsis.ortserver.components.authorization.rights.HierarchyPermissions
 import org.eclipse.apoapsis.ortserver.components.authorization.rights.RepositoryPermission
@@ -549,7 +550,15 @@ private fun ApplicationCall.issueFilters() =
  */
 private fun ApplicationCall.vulnerabilityFilters() =
     VulnerabilityFilters(
-        resolved = parameters["resolved"]?.lowercase()?.toBooleanStrictOrNull()
+        resolved = parameters["resolved"]?.lowercase()?.toBooleanStrictOrNull(),
+        rating = parameters["rating"]?.let { rating ->
+            val (operators, ratings) = rating.split(',').partition { it == "-" }
+            val enums = ratings.mapTo(mutableSetOf()) { findByName<VulnerabilityRating>(it) }
+            FilterOperatorAndValue(if (operators.isEmpty()) ComparisonOperator.IN else ComparisonOperator.NOT_IN, enums)
+        },
+        identifier = parameters["identifier"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) },
+        purl = parameters["purl"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) },
+        externalId = parameters["externalId"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) }
     )
 
 /**

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -288,6 +288,8 @@ val getRunVulnerabilities: RouteConfig.() -> Unit = {
             description = "The ID of the ORT run."
         }
 
+        standardListQueryParameters()
+
         queryParameter<Boolean>("resolved") {
             description =
                 """
@@ -296,7 +298,25 @@ val getRunVulnerabilities: RouteConfig.() -> Unit = {
                 """.trimIndent()
         }
 
-        standardListQueryParameters()
+        queryParameter<String>("rating") {
+            description = "Defines the ratings to filter the results by. This is a comma-separated string with the " +
+                    "following allowed ratings: " + VulnerabilityRating.entries.joinToString { "'$it" } + ". Add a " +
+                    "minus as the first item to exclude packages with the specified ratings, e.g. '-,HIGH'."
+        }
+
+        queryParameter<String>("identifier") {
+            description = "Defines an ORT package identifier to filter the results by. Uses a case-insensitive " +
+                    "substring match."
+        }
+
+        queryParameter<String>("purl") {
+            description = "Defines a purl to filter the results by. Uses a case-insensitive substring match."
+        }
+
+        queryParameter<String>("externalId") {
+            description = "Defines an external ID to filter the results by. Uses a case-insensitive " +
+                    "substring match."
+        }
     }
 
     response {
@@ -348,7 +368,7 @@ val getRunVulnerabilities: RouteConfig.() -> Unit = {
                             limit = 20,
                             offset = 0,
                             totalCount = 1,
-                            sortProperties = listOf(SortProperty("external_id", SortDirection.ASCENDING))
+                            sortProperties = listOf(SortProperty("rating", SortDirection.DESCENDING))
                         )
                     )
                 }

--- a/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
@@ -672,20 +672,10 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                 val vulnerabilities = response.body<PagedResponse<VulnerabilityWithDetails>>()
 
                 vulnerabilities.data shouldHaveSize 2
+                vulnerabilities.pagination.sortProperties shouldBe
+                    listOf(SortProperty("rating", SortDirection.DESCENDING))
 
                 with(vulnerabilities.data[0]) {
-                    vulnerability.externalId shouldBe "CVE-2018-14721"
-                    rating shouldBe VulnerabilityRating.MEDIUM
-
-                    with(identifier) {
-                        type shouldBe "Maven"
-                        namespace shouldBe "com.fasterxml.jackson.core"
-                        name shouldBe "jackson-databind"
-                        version shouldBe "2.9.6"
-                    }
-                }
-
-                with(vulnerabilities.data[1]) {
                     vulnerability.externalId shouldBe "CVE-2021-1234"
                     rating shouldBe VulnerabilityRating.MEDIUM
 
@@ -694,6 +684,18 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                         namespace shouldBe "org.apache.logging.log4j"
                         name shouldBe "log4j-core"
                         version shouldBe "2.14.0"
+                    }
+                }
+
+                with(vulnerabilities.data[1]) {
+                    vulnerability.externalId shouldBe "CVE-2018-14721"
+                    rating shouldBe VulnerabilityRating.MEDIUM
+
+                    with(identifier) {
+                        type shouldBe "Maven"
+                        namespace shouldBe "com.fasterxml.jackson.core"
+                        name shouldBe "jackson-databind"
+                        version shouldBe "2.9.6"
                     }
                 }
             }
@@ -848,6 +850,396 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
 
                     first().resolutions should beEmpty()
                 }
+            }
+        }
+
+        "filter vulnerabilities by externalId" {
+            integrationTestApplication {
+                val ortRun = dbExtension.fixtures.createOrtRun(
+                    repositoryId = repositoryId,
+                    revision = "revision",
+                    jobConfigurations = JobConfigurations()
+                )
+                val advisorJob = dbExtension.fixtures.createAdvisorJob(ortRunId = ortRun.id)
+                dbExtension.fixtures.advisorRunRepository.create(
+                    advisorJobId = advisorJob.id,
+                    startTime = Clock.System.now().toDatabasePrecision(),
+                    endTime = Clock.System.now().toDatabasePrecision(),
+                    environment = generateAdvisorEnvironment(),
+                    config = generateAdvisorConfiguration(),
+                    providerIssues = emptySet(),
+                    results = generateAdvisorResult()
+                )
+
+                val response = superuserClient.get(
+                    "/api/v1/runs/${ortRun.id}/vulnerabilities?externalId=CVE-2018"
+                )
+
+                response shouldHaveStatus HttpStatusCode.OK
+                val vulnerabilities = response.body<PagedResponse<VulnerabilityWithDetails>>()
+
+                vulnerabilities.data shouldHaveSize 1
+                vulnerabilities.data.single().vulnerability.externalId shouldBe "CVE-2018-14721"
+            }
+        }
+
+        "filter vulnerabilities by identifier" {
+            integrationTestApplication {
+                val ortRun = dbExtension.fixtures.createOrtRun(
+                    repositoryId = repositoryId,
+                    revision = "revision",
+                    jobConfigurations = JobConfigurations()
+                )
+                val advisorJob = dbExtension.fixtures.createAdvisorJob(ortRunId = ortRun.id)
+                dbExtension.fixtures.advisorRunRepository.create(
+                    advisorJobId = advisorJob.id,
+                    startTime = Clock.System.now().toDatabasePrecision(),
+                    endTime = Clock.System.now().toDatabasePrecision(),
+                    environment = generateAdvisorEnvironment(),
+                    config = generateAdvisorConfiguration(),
+                    providerIssues = emptySet(),
+                    results = generateAdvisorResult()
+                )
+
+                val response = superuserClient.get(
+                    "/api/v1/runs/${ortRun.id}/vulnerabilities?identifier=jackson-databind"
+                )
+
+                response shouldHaveStatus HttpStatusCode.OK
+                val vulnerabilities = response.body<PagedResponse<VulnerabilityWithDetails>>()
+
+                vulnerabilities.data shouldHaveSize 1
+                vulnerabilities.data.single().identifier.name shouldBe "jackson-databind"
+            }
+        }
+
+        "filter vulnerabilities by rating inclusion" {
+            integrationTestApplication {
+                val ortRun = dbExtension.fixtures.createOrtRun(
+                    repositoryId = repositoryId,
+                    revision = "revision",
+                    jobConfigurations = JobConfigurations()
+                )
+                val advisorJob = dbExtension.fixtures.createAdvisorJob(ortRunId = ortRun.id)
+                dbExtension.fixtures.advisorRunRepository.create(
+                    advisorJobId = advisorJob.id,
+                    startTime = Clock.System.now().toDatabasePrecision(),
+                    endTime = Clock.System.now().toDatabasePrecision(),
+                    environment = generateAdvisorEnvironment(),
+                    config = generateAdvisorConfiguration(),
+                    providerIssues = emptySet(),
+                    results = generateAdvisorResult()
+                )
+
+                val response = superuserClient.get(
+                    "/api/v1/runs/${ortRun.id}/vulnerabilities?rating=MEDIUM"
+                )
+
+                response shouldHaveStatus HttpStatusCode.OK
+                val vulnerabilities = response.body<PagedResponse<VulnerabilityWithDetails>>()
+
+                vulnerabilities.data shouldHaveSize 2
+                vulnerabilities.data.all { it.rating == VulnerabilityRating.MEDIUM } shouldBe true
+            }
+        }
+
+        "sort vulnerabilities by rating" {
+            integrationTestApplication {
+                val ortRun = dbExtension.fixtures.createOrtRun(
+                    repositoryId = repositoryId,
+                    revision = "revision",
+                    jobConfigurations = JobConfigurations()
+                )
+                val advisorJob = dbExtension.fixtures.createAdvisorJob(ortRunId = ortRun.id)
+                dbExtension.fixtures.advisorRunRepository.create(
+                    advisorJobId = advisorJob.id,
+                    startTime = Clock.System.now().toDatabasePrecision(),
+                    endTime = Clock.System.now().toDatabasePrecision(),
+                    environment = generateAdvisorEnvironment(),
+                    config = generateAdvisorConfiguration(),
+                    providerIssues = emptySet(),
+                    results = mapOf(
+                        Identifier("Maven", "org.apache.logging.log4j", "log4j-core", "2.14.0") to listOf(
+                            AdvisorResult(
+                                advisorName = "advisor",
+                                startTime = Clock.System.now().toDatabasePrecision(),
+                                endTime = Clock.System.now().toDatabasePrecision(),
+                                issues = emptyList(),
+                                vulnerabilities = listOf(
+                                    Vulnerability(
+                                        externalId = "CVE-2021-1234",
+                                        summary = "A vulnerability",
+                                        description = "A description",
+                                        references = listOf(
+                                            VulnerabilityReference(
+                                                url = "https://example.com",
+                                                scoringSystem = "CVSS",
+                                                severity = "LOW",
+                                                score = 1.2f,
+                                                vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        ),
+                        Identifier("Maven", "com.fasterxml.jackson.core", "jackson-databind", "2.9.6") to listOf(
+                            AdvisorResult(
+                                advisorName = "advisor",
+                                startTime = Clock.System.now().toDatabasePrecision(),
+                                endTime = Clock.System.now().toDatabasePrecision(),
+                                issues = emptyList(),
+                                vulnerabilities = listOf(
+                                    Vulnerability(
+                                        externalId = "CVE-2018-14721",
+                                        summary = "A vulnerability",
+                                        description = "A description",
+                                        references = listOf(
+                                            VulnerabilityReference(
+                                                url = "https://example.com",
+                                                scoringSystem = "CVSS",
+                                                severity = "HIGH",
+                                                score = 8.2f,
+                                                vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+
+                val response = superuserClient.get(
+                    "/api/v1/runs/${ortRun.id}/vulnerabilities?sort=-rating"
+                )
+
+                response shouldHaveStatus HttpStatusCode.OK
+                val vulnerabilities = response.body<PagedResponse<VulnerabilityWithDetails>>()
+
+                vulnerabilities.pagination.sortProperties shouldBe
+                    listOf(SortProperty("rating", SortDirection.DESCENDING))
+                vulnerabilities.data.map { it.rating } shouldBe
+                    listOf(VulnerabilityRating.HIGH, VulnerabilityRating.LOW)
+                vulnerabilities.data.map { it.vulnerability.externalId } shouldBe
+                    listOf("CVE-2018-14721", "CVE-2021-1234")
+            }
+        }
+
+        "sort vulnerabilities by identifier" {
+            integrationTestApplication {
+                val ortRun = dbExtension.fixtures.createOrtRun(
+                    repositoryId = repositoryId,
+                    revision = "revision",
+                    jobConfigurations = JobConfigurations()
+                )
+                val log4jId = Identifier("Maven", "org.apache.logging.log4j", "log4j-core", "2.14.0")
+                val jacksonId = Identifier("Maven", "com.fasterxml.jackson.core", "jackson-databind", "2.9.6")
+                val advisorJob = dbExtension.fixtures.createAdvisorJob(ortRunId = ortRun.id)
+                dbExtension.fixtures.advisorRunRepository.create(
+                    advisorJobId = advisorJob.id,
+                    startTime = Clock.System.now().toDatabasePrecision(),
+                    endTime = Clock.System.now().toDatabasePrecision(),
+                    environment = generateAdvisorEnvironment(),
+                    config = generateAdvisorConfiguration(),
+                    providerIssues = emptySet(),
+                    results = mapOf(
+                        log4jId to listOf(
+                            AdvisorResult(
+                                advisorName = "advisor",
+                                startTime = Clock.System.now().toDatabasePrecision(),
+                                endTime = Clock.System.now().toDatabasePrecision(),
+                                issues = emptyList(),
+                                vulnerabilities = listOf(
+                                    Vulnerability(
+                                        externalId = "CVE-2021-1234",
+                                        summary = "A vulnerability",
+                                        description = "A description",
+                                        references = listOf(
+                                            VulnerabilityReference(
+                                                url = "https://example.com",
+                                                scoringSystem = "CVSS",
+                                                severity = "LOW",
+                                                score = 1.2f,
+                                                vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        ),
+                        jacksonId to listOf(
+                            AdvisorResult(
+                                advisorName = "advisor",
+                                startTime = Clock.System.now().toDatabasePrecision(),
+                                endTime = Clock.System.now().toDatabasePrecision(),
+                                issues = emptyList(),
+                                vulnerabilities = listOf(
+                                    Vulnerability(
+                                        externalId = "CVE-2018-14721",
+                                        summary = "A vulnerability",
+                                        description = "A description",
+                                        references = listOf(
+                                            VulnerabilityReference(
+                                                url = "https://example.com",
+                                                scoringSystem = "CVSS",
+                                                severity = "HIGH",
+                                                score = 8.2f,
+                                                vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+
+                val response = superuserClient.get(
+                    "/api/v1/runs/${ortRun.id}/vulnerabilities?sort=identifier"
+                )
+
+                response shouldHaveStatus HttpStatusCode.OK
+                val vulnerabilities = response.body<PagedResponse<VulnerabilityWithDetails>>()
+
+                vulnerabilities.pagination.sortProperties shouldBe
+                    listOf(SortProperty("identifier", SortDirection.ASCENDING))
+                vulnerabilities.data.map { it.identifier } shouldBe listOf(
+                    ApiIdentifier(
+                        type = jacksonId.type,
+                        namespace = jacksonId.namespace,
+                        name = jacksonId.name,
+                        version = jacksonId.version
+                    ),
+                    ApiIdentifier(
+                        type = log4jId.type,
+                        namespace = log4jId.namespace,
+                        name = log4jId.name,
+                        version = log4jId.version
+                    )
+                )
+            }
+        }
+
+        "filter vulnerabilities by rating exclusion" {
+            integrationTestApplication {
+                val ortRun = dbExtension.fixtures.createOrtRun(
+                    repositoryId = repositoryId,
+                    revision = "revision",
+                    jobConfigurations = JobConfigurations()
+                )
+                val advisorJob = dbExtension.fixtures.createAdvisorJob(ortRunId = ortRun.id)
+                dbExtension.fixtures.advisorRunRepository.create(
+                    advisorJobId = advisorJob.id,
+                    startTime = Clock.System.now().toDatabasePrecision(),
+                    endTime = Clock.System.now().toDatabasePrecision(),
+                    environment = generateAdvisorEnvironment(),
+                    config = generateAdvisorConfiguration(),
+                    providerIssues = emptySet(),
+                    results = generateAdvisorResult()
+                )
+
+                val response = superuserClient.get(
+                    "/api/v1/runs/${ortRun.id}/vulnerabilities?rating=-,MEDIUM"
+                )
+
+                response shouldHaveStatus HttpStatusCode.OK
+                val vulnerabilities = response.body<PagedResponse<VulnerabilityWithDetails>>()
+
+                vulnerabilities.data should beEmpty()
+            }
+        }
+
+        "filter vulnerabilities by purl" {
+            integrationTestApplication {
+                val ortRun = dbExtension.fixtures.createOrtRun(
+                    repositoryId = repositoryId,
+                    revision = "revision",
+                    jobConfigurations = JobConfigurations()
+                )
+
+                val jacksonId = Identifier("Maven", "com.fasterxml.jackson.core", "jackson-databind", "2.9.6")
+                val log4jId = Identifier("Maven", "org.apache.logging.log4j", "log4j-core", "2.14.0")
+                val pkgJackson = dbExtension.fixtures.generatePackage(jacksonId)
+                val pkgLog4j = dbExtension.fixtures.generatePackage(log4jId)
+
+                val analyzerJob = dbExtension.fixtures.createAnalyzerJob(ortRunId = ortRun.id)
+                dbExtension.fixtures.createAnalyzerRun(
+                    analyzerJobId = analyzerJob.id,
+                    packages = setOf(pkgJackson, pkgLog4j)
+                )
+
+                val advisorJob = dbExtension.fixtures.createAdvisorJob(ortRunId = ortRun.id)
+                dbExtension.fixtures.advisorRunRepository.create(
+                    advisorJobId = advisorJob.id,
+                    startTime = Clock.System.now().toDatabasePrecision(),
+                    endTime = Clock.System.now().toDatabasePrecision(),
+                    environment = generateAdvisorEnvironment(),
+                    config = generateAdvisorConfiguration(),
+                    providerIssues = emptySet(),
+                    results = generateAdvisorResult()
+                )
+
+                val response = superuserClient.get(
+                    "/api/v1/runs/${ortRun.id}/vulnerabilities?purl=jackson"
+                )
+
+                response shouldHaveStatus HttpStatusCode.OK
+                val vulnerabilities = response.body<PagedResponse<VulnerabilityWithDetails>>()
+
+                vulnerabilities.data shouldHaveSize 1
+                vulnerabilities.data.single().vulnerability.externalId shouldBe "CVE-2018-14721"
+                vulnerabilities.data.single().purl shouldBe pkgJackson.purl
+            }
+        }
+
+        "sort vulnerabilities by purl" {
+            integrationTestApplication {
+                val ortRun = dbExtension.fixtures.createOrtRun(
+                    repositoryId = repositoryId,
+                    revision = "revision",
+                    jobConfigurations = JobConfigurations()
+                )
+
+                val jacksonId = Identifier("Maven", "com.fasterxml.jackson.core", "jackson-databind", "2.9.6")
+                val log4jId = Identifier("Maven", "org.apache.logging.log4j", "log4j-core", "2.14.0")
+                val pkgJackson = dbExtension.fixtures.generatePackage(jacksonId).copy(
+                    purl = "pkg:maven/com.fasterxml.jackson.core/jackson-databind@2.9.6"
+                )
+                val pkgLog4j = dbExtension.fixtures.generatePackage(log4jId).copy(
+                    purl = "pkg:maven/org.apache.logging.log4j/log4j-core@2.14.0"
+                )
+
+                val analyzerJob = dbExtension.fixtures.createAnalyzerJob(ortRunId = ortRun.id)
+                dbExtension.fixtures.createAnalyzerRun(
+                    analyzerJobId = analyzerJob.id,
+                    packages = setOf(pkgJackson, pkgLog4j)
+                )
+
+                val advisorJob = dbExtension.fixtures.createAdvisorJob(ortRunId = ortRun.id)
+                dbExtension.fixtures.advisorRunRepository.create(
+                    advisorJobId = advisorJob.id,
+                    startTime = Clock.System.now().toDatabasePrecision(),
+                    endTime = Clock.System.now().toDatabasePrecision(),
+                    environment = generateAdvisorEnvironment(),
+                    config = generateAdvisorConfiguration(),
+                    providerIssues = emptySet(),
+                    results = generateAdvisorResult()
+                )
+
+                val response = superuserClient.get(
+                    "/api/v1/runs/${ortRun.id}/vulnerabilities?sort=purl"
+                )
+
+                response shouldHaveStatus HttpStatusCode.OK
+                val vulnerabilities = response.body<PagedResponse<VulnerabilityWithDetails>>()
+
+                vulnerabilities.pagination.sortProperties shouldBe
+                    listOf(SortProperty("purl", SortDirection.ASCENDING))
+                vulnerabilities.data.map { it.purl } shouldBe listOf(
+                    pkgJackson.purl,
+                    pkgLog4j.purl
+                )
             }
         }
 

--- a/model/src/commonMain/kotlin/VulnerabilityFilters.kt
+++ b/model/src/commonMain/kotlin/VulnerabilityFilters.kt
@@ -19,6 +19,8 @@
 
 package org.eclipse.apoapsis.ortserver.model
 
+import org.eclipse.apoapsis.ortserver.model.util.FilterOperatorAndValue
+
 /**
  * Filters to apply when querying for vulnerabilities.
  */
@@ -27,5 +29,17 @@ data class VulnerabilityFilters(
      * Filter to only return resolved vulnerabilities. Null if both, resolved and unresolved vulnerabilities should be
      * returned.
      */
-    val resolved: Boolean? = null
+    val resolved: Boolean? = null,
+
+    /** Set of [VulnerabilityRating]s to filter with. */
+    val rating: FilterOperatorAndValue<Set<VulnerabilityRating>>? = null,
+
+    /** Substring filter for identifier. */
+    val identifier: FilterOperatorAndValue<String>? = null,
+
+    /** Substring filter for purl. */
+    val purl: FilterOperatorAndValue<String>? = null,
+
+    /** Substring filter for external ID. */
+    val externalId: FilterOperatorAndValue<String>? = null
 )

--- a/services/ort-run/src/main/kotlin/OrtRunVulnerabilityQueryBuilder.kt
+++ b/services/ort-run/src/main/kotlin/OrtRunVulnerabilityQueryBuilder.kt
@@ -1,0 +1,334 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.services.ortrun
+
+import org.eclipse.apoapsis.ortserver.dao.repositories.advisorjob.AdvisorJobsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.AdvisorResultsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.AdvisorResultsVulnerabilitiesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.AdvisorRunsIdentifiersTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.AdvisorRunsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.ResolvedVulnerabilitiesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.VulnerabilitiesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.VulnerabilityReferencesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerjob.AnalyzerJobsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.AnalyzerRunsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesAnalyzerRunsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.ortrun.OrtRunsTable
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
+import org.eclipse.apoapsis.ortserver.dao.utils.applyILike
+import org.eclipse.apoapsis.ortserver.model.VulnerabilityFilters
+import org.eclipse.apoapsis.ortserver.model.util.ComparisonOperator
+
+import org.jetbrains.exposed.v1.core.Case
+import org.jetbrains.exposed.v1.core.CustomFunction
+import org.jetbrains.exposed.v1.core.Expression
+import org.jetbrains.exposed.v1.core.ExpressionWithColumnType
+import org.jetbrains.exposed.v1.core.ExpressionWithColumnTypeAlias
+import org.jetbrains.exposed.v1.core.JoinType
+import org.jetbrains.exposed.v1.core.Op
+import org.jetbrains.exposed.v1.core.QueryAlias
+import org.jetbrains.exposed.v1.core.TextColumnType
+import org.jetbrains.exposed.v1.core.alias
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.concat
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.core.innerJoin
+import org.jetbrains.exposed.v1.core.min
+import org.jetbrains.exposed.v1.core.neq
+import org.jetbrains.exposed.v1.core.not
+import org.jetbrains.exposed.v1.core.notExists
+import org.jetbrains.exposed.v1.core.notInList
+import org.jetbrains.exposed.v1.core.stringLiteral
+import org.jetbrains.exposed.v1.jdbc.select
+
+internal fun buildOrtRunVulnerabilityQueryContext(
+    ortRunId: Long,
+    filters: VulnerabilityFilters
+): OrtRunVulnerabilityQueryContext {
+    val ratingAlias = ratingAlias()
+
+    val bp = buildOrtRunBasePairs(ortRunId)
+    val ratings = buildOrtRunRatingsByVulnerability(bp, ratingAlias)
+    val purls = buildOrtRunPurlByRunIdentifier(bp)
+
+    return buildOrtRunFinalQuery(bp, ratings, purls, ratingAlias, filters)
+}
+
+private class OrtRunBasePairsResult(
+    val alias: QueryAlias,
+    val vulnerabilityId: ExpressionWithColumnTypeAlias<EntityID<Long>>,
+    val identifierId: ExpressionWithColumnTypeAlias<EntityID<Long>>,
+    val ortRunId: ExpressionWithColumnTypeAlias<EntityID<Long>>,
+    val externalId: ExpressionWithColumnTypeAlias<String>,
+    val summary: ExpressionWithColumnTypeAlias<String?>,
+    val description: ExpressionWithColumnTypeAlias<String?>,
+    val advisorName: ExpressionWithColumnTypeAlias<String>
+)
+
+private fun buildOrtRunBasePairs(ortRunId: Long): OrtRunBasePairsResult {
+    val vulnerabilityId = VulnerabilitiesTable.id.alias("run_vulnerability_id")
+    val identifierId = IdentifiersTable.id.alias("run_identifier_id")
+    val runId = OrtRunsTable.id.alias("run_ort_run_id")
+    val externalId = VulnerabilitiesTable.externalId.alias("run_external_id")
+    val summary = VulnerabilitiesTable.summary.alias("run_summary")
+    val description = VulnerabilitiesTable.description.alias("run_description")
+    val advisorName = AdvisorResultsTable.advisorName.alias("run_advisor_name")
+
+    val query = VulnerabilitiesTable
+        .innerJoin(AdvisorResultsVulnerabilitiesTable)
+        .innerJoin(AdvisorResultsTable)
+        .innerJoin(AdvisorRunsIdentifiersTable)
+        .innerJoin(AdvisorRunsTable)
+        .innerJoin(AdvisorJobsTable)
+        .innerJoin(OrtRunsTable)
+        .innerJoin(IdentifiersTable)
+        .select(vulnerabilityId, identifierId, runId, externalId, summary, description, advisorName)
+        .where { OrtRunsTable.id eq ortRunId }
+        .groupBy(VulnerabilitiesTable.id, IdentifiersTable.id, OrtRunsTable.id, AdvisorResultsTable.advisorName)
+        .alias("run_base_pairs")
+
+    return OrtRunBasePairsResult(
+        query,
+        vulnerabilityId,
+        identifierId,
+        runId,
+        externalId,
+        summary,
+        description,
+        advisorName
+    )
+}
+
+private fun buildOrtRunRatingsByVulnerability(
+    bp: OrtRunBasePairsResult,
+    ratingAlias: ExpressionWithColumnTypeAlias<Int?>
+): QueryAlias {
+    val distinctVulnId = bp.alias[bp.vulnerabilityId].alias("run_distinct_vuln_id")
+    val distinctVulns = bp.alias
+        .select(distinctVulnId)
+        .withDistinct()
+        .alias("run_distinct_vulns")
+
+    return VulnerabilityReferencesTable
+        .join(distinctVulns, JoinType.INNER) {
+            VulnerabilityReferencesTable.vulnerabilityId eq distinctVulns[distinctVulnId]
+        }
+        .select(VulnerabilityReferencesTable.vulnerabilityId, ratingAlias)
+        .groupBy(VulnerabilityReferencesTable.vulnerabilityId)
+        .alias("run_ratings_by_vulnerability")
+}
+
+private fun buildOrtRunPurlByRunIdentifier(bp: OrtRunBasePairsResult): PurlResult {
+    val riOrtRunId = bp.alias[bp.ortRunId].alias("run_ri_ort_run_id")
+    val riIdentifierId = bp.alias[bp.identifierId].alias("run_ri_identifier_id")
+    val runIdPairs = bp.alias
+        .select(riOrtRunId, riIdentifierId)
+        .withDistinct()
+        .alias("run_identifier_pairs")
+
+    val riOrtRunIdCol = runIdPairs[riOrtRunId]
+    val riIdentifierIdCol = runIdPairs[riIdentifierId]
+
+    val bpOrtRunId = riOrtRunIdCol.alias("run_bp_ort_run_id")
+    val bpIdentifierId = riIdentifierIdCol.alias("run_bp_identifier_id")
+    val basePurlMin = PackagesTable.purl.min().alias("run_base_purl")
+
+    val basePurl = AnalyzerJobsTable
+        .innerJoin(AnalyzerRunsTable)
+        .innerJoin(PackagesAnalyzerRunsTable)
+        .innerJoin(PackagesTable)
+        .join(runIdPairs, JoinType.INNER) {
+            (AnalyzerJobsTable.ortRunId eq riOrtRunIdCol) and
+                (PackagesTable.identifierId eq riIdentifierIdCol)
+        }
+        .select(bpOrtRunId, bpIdentifierId, basePurlMin)
+        .groupBy(bpOrtRunId, bpIdentifierId)
+        .alias("run_base_purl_by_run_identifier")
+
+    val curated = buildCuratedPurlByRunIdentifier(runIdPairs, riOrtRunIdCol, riIdentifierIdCol)
+
+    val purl = CustomFunction(
+        "COALESCE",
+        TextColumnType(),
+        curated.alias[curated.purl],
+        basePurl[basePurlMin],
+        stringLiteral("")
+    ).alias("run_purl")
+    val outOrtRunId = riOrtRunIdCol.alias("run_purl_ort_run_id")
+    val outIdentifierId = riIdentifierIdCol.alias("run_purl_identifier_id")
+
+    val query = runIdPairs
+        .join(basePurl, JoinType.LEFT) {
+            (riOrtRunIdCol eq basePurl[bpOrtRunId]) and
+                (riIdentifierIdCol eq basePurl[bpIdentifierId])
+        }
+        .join(curated.alias, JoinType.LEFT) {
+            (riOrtRunIdCol eq curated.alias[curated.ortRunId]) and
+                (riIdentifierIdCol eq curated.alias[curated.identifierId])
+        }
+        .select(outOrtRunId, outIdentifierId, purl)
+        .alias("run_purl_by_run_identifier")
+
+    return PurlResult(query, outOrtRunId, outIdentifierId, purl)
+}
+
+private fun buildOrtRunFinalQuery(
+    bp: OrtRunBasePairsResult,
+    ratingsByVulnerability: QueryAlias,
+    purls: PurlResult,
+    ratingAlias: ExpressionWithColumnTypeAlias<Int?>,
+    filters: VulnerabilityFilters
+): OrtRunVulnerabilityQueryContext {
+    val bpVulnId = bp.alias[bp.vulnerabilityId]
+    val bpIdentifierId = bp.alias[bp.identifierId]
+    val bpOrtRunId = bp.alias[bp.ortRunId]
+    val bpExternalId = bp.alias[bp.externalId]
+    val bpSummary = bp.alias[bp.summary]
+    val bpDescription = bp.alias[bp.description]
+    val bpAdvisorName = bp.alias[bp.advisorName]
+
+    val ratingsVulnId = ratingsByVulnerability[VulnerabilityReferencesTable.vulnerabilityId]
+    val scopedRating = ratingsByVulnerability[ratingAlias].alias("run_scoped_rating")
+
+    val purlOrtRunId = purls.alias[purls.ortRunId]
+    val purlIdentifierId = purls.alias[purls.identifierId]
+
+    val sqVulnId = bpVulnId.alias("run_sq_vulnerability_id")
+    val sqIdentifierId = bpIdentifierId.alias("run_sq_identifier_id")
+    val sqOrtRunId = bpOrtRunId.alias("run_sq_ort_run_id")
+    val sqExternalId = bpExternalId.alias("run_sq_external_id")
+    val sqSummary = bpSummary.alias("run_sq_summary")
+    val sqDescription = bpDescription.alias("run_sq_description")
+    val sqAdvisorName = bpAdvisorName.alias("run_sq_advisor_name")
+    val sqPurl = purls.alias[purls.purl].alias("run_sq_purl")
+
+    val subQuery = bp.alias
+        .join(ratingsByVulnerability, JoinType.LEFT) {
+            bpVulnId eq ratingsVulnId
+        }
+        .join(purls.alias, JoinType.INNER) {
+            (bpOrtRunId eq purlOrtRunId) and
+                (bpIdentifierId eq purlIdentifierId)
+        }
+        .select(
+            sqVulnId,
+            sqIdentifierId,
+            sqOrtRunId,
+            sqExternalId,
+            sqSummary,
+            sqDescription,
+            sqAdvisorName,
+            sqPurl,
+            scopedRating
+        )
+        .alias("run_subquery")
+
+    val vulnerabilityIdColumn: Expression<EntityID<Long>> = subQuery[sqVulnId]
+    val identifierIdColumn: Expression<EntityID<Long>> = subQuery[sqIdentifierId]
+    val ortRunIdColumn: Expression<EntityID<Long>> = subQuery[sqOrtRunId]
+    val externalIdColumn: Expression<String> = subQuery[sqExternalId]
+    val summaryColumn: Expression<String?> = subQuery[sqSummary]
+    val descriptionColumn: Expression<String?> = subQuery[sqDescription]
+    val advisorNameColumn: Expression<String> = subQuery[sqAdvisorName]
+    val purlColumn: Expression<String> = subQuery[sqPurl]
+    val ratingColumn: ExpressionWithColumnType<Int?> = subQuery[scopedRating]
+
+    val query = subQuery
+        .innerJoin(IdentifiersTable, { identifierIdColumn }, { IdentifiersTable.id })
+        .select(
+            vulnerabilityIdColumn,
+            externalIdColumn,
+            summaryColumn,
+            descriptionColumn,
+            identifierIdColumn,
+            advisorNameColumn,
+            purlColumn,
+            ratingColumn
+        )
+        .where {
+            var condition: Op<Boolean> = Op.TRUE
+
+            val resolutionExistsSubquery = ResolvedVulnerabilitiesTable
+                .select(ResolvedVulnerabilitiesTable.id)
+                .where {
+                    (ResolvedVulnerabilitiesTable.ortRunId eq ortRunIdColumn) and
+                        (ResolvedVulnerabilitiesTable.vulnerabilityId eq vulnerabilityIdColumn) and
+                        (ResolvedVulnerabilitiesTable.identifierId eq identifierIdColumn)
+                }
+
+            when (filters.resolved) {
+                true -> condition = condition and not(notExists(resolutionExistsSubquery))
+                false -> condition = condition and notExists(resolutionExistsSubquery)
+                null -> {}
+            }
+
+            filters.externalId?.let {
+                condition = condition and externalIdColumn.applyILike(it.value)
+            }
+
+            filters.identifier?.let {
+                val namespaceWithSlash = Case()
+                    .When(
+                        IdentifiersTable.namespace neq stringLiteral(""),
+                        concat(IdentifiersTable.namespace, stringLiteral("/"))
+                    )
+                    .Else(stringLiteral(":"))
+                val concatenatedIdentifier = concat(
+                    IdentifiersTable.type,
+                    stringLiteral(":"),
+                    namespaceWithSlash,
+                    IdentifiersTable.name,
+                    stringLiteral("@"),
+                    IdentifiersTable.version
+                )
+
+                condition = condition and concatenatedIdentifier.applyILike(it.value)
+            }
+
+            filters.rating?.let {
+                val ratingsAsInt = it.value.map { rating -> rating.ordinal }
+                condition = condition and when (it.operator) {
+                    ComparisonOperator.IN -> ratingColumn inList ratingsAsInt
+                    else -> ratingColumn notInList ratingsAsInt
+                }
+            }
+
+            filters.purl?.let {
+                condition = condition and purlColumn.applyILike(it.value)
+            }
+
+            condition
+        }
+
+    return OrtRunVulnerabilityQueryContext(
+        query = query,
+        purlColumn = purlColumn,
+        ratingColumn = ratingColumn,
+        vulnerabilityIdColumn = vulnerabilityIdColumn,
+        externalIdColumn = externalIdColumn,
+        summaryColumn = summaryColumn,
+        descriptionColumn = descriptionColumn,
+        identifierIdColumn = identifierIdColumn,
+        advisorNameColumn = advisorNameColumn
+    )
+}

--- a/services/ort-run/src/main/kotlin/OrtRunVulnerabilityQueryBuilder.kt
+++ b/services/ort-run/src/main/kotlin/OrtRunVulnerabilityQueryBuilder.kt
@@ -37,7 +37,6 @@ import org.eclipse.apoapsis.ortserver.dao.utils.applyILike
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityFilters
 import org.eclipse.apoapsis.ortserver.model.util.ComparisonOperator
 
-import org.jetbrains.exposed.v1.core.Case
 import org.jetbrains.exposed.v1.core.CustomFunction
 import org.jetbrains.exposed.v1.core.Expression
 import org.jetbrains.exposed.v1.core.ExpressionWithColumnType
@@ -54,7 +53,6 @@ import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.innerJoin
 import org.jetbrains.exposed.v1.core.min
-import org.jetbrains.exposed.v1.core.neq
 import org.jetbrains.exposed.v1.core.not
 import org.jetbrains.exposed.v1.core.notExists
 import org.jetbrains.exposed.v1.core.notInList
@@ -287,18 +285,13 @@ private fun buildOrtRunFinalQuery(
             }
 
             filters.identifier?.let {
-                val namespaceWithSlash = Case()
-                    .When(
-                        IdentifiersTable.namespace neq stringLiteral(""),
-                        concat(IdentifiersTable.namespace, stringLiteral("/"))
-                    )
-                    .Else(stringLiteral(":"))
                 val concatenatedIdentifier = concat(
                     IdentifiersTable.type,
                     stringLiteral(":"),
-                    namespaceWithSlash,
+                    IdentifiersTable.namespace,
+                    stringLiteral(":"),
                     IdentifiersTable.name,
-                    stringLiteral("@"),
+                    stringLiteral(":"),
                     IdentifiersTable.version
                 )
 

--- a/services/ort-run/src/main/kotlin/OrtRunsVulnerabilityQueryBuilder.kt
+++ b/services/ort-run/src/main/kotlin/OrtRunsVulnerabilityQueryBuilder.kt
@@ -42,7 +42,6 @@ import org.eclipse.apoapsis.ortserver.dao.utils.applyILike
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityForRunsFilters
 import org.eclipse.apoapsis.ortserver.model.util.ComparisonOperator
 
-import org.jetbrains.exposed.v1.core.Case
 import org.jetbrains.exposed.v1.core.CustomFunction
 import org.jetbrains.exposed.v1.core.Expression
 import org.jetbrains.exposed.v1.core.ExpressionWithColumnType
@@ -62,7 +61,6 @@ import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.innerJoin
 import org.jetbrains.exposed.v1.core.isNotNull
 import org.jetbrains.exposed.v1.core.min
-import org.jetbrains.exposed.v1.core.neq
 import org.jetbrains.exposed.v1.core.notInList
 import org.jetbrains.exposed.v1.core.plus
 import org.jetbrains.exposed.v1.core.stringLiteral
@@ -411,19 +409,13 @@ private fun buildFinalQuery(
             }
 
             filters.identifier?.let {
-                val namespaceWithSlash = Case()
-                    .When(
-                        IdentifiersTable.namespace neq stringLiteral(""),
-                        concat(IdentifiersTable.namespace, stringLiteral("/"))
-                    )
-                    .Else(stringLiteral(":"))
-
                 val concatenatedIdentifier = concat(
                     IdentifiersTable.type,
                     stringLiteral(":"),
-                    namespaceWithSlash,
+                    IdentifiersTable.namespace,
+                    stringLiteral(":"),
                     IdentifiersTable.name,
-                    stringLiteral("@"),
+                    stringLiteral(":"),
                     IdentifiersTable.version
                 )
 

--- a/services/ort-run/src/main/kotlin/OrtRunsVulnerabilityQueryBuilder.kt
+++ b/services/ort-run/src/main/kotlin/OrtRunsVulnerabilityQueryBuilder.kt
@@ -114,14 +114,14 @@ private class BasePairsResult(
     val description: ExpressionWithColumnTypeAlias<String?>
 )
 
-private class CuratedPurlResult(
+internal class CuratedPurlResult(
     val alias: QueryAlias,
     val ortRunId: ExpressionWithColumnTypeAlias<EntityID<Long>>,
     val identifierId: ExpressionWithColumnTypeAlias<EntityID<Long>>,
     val purl: ExpressionWithColumnTypeAlias<String?>
 )
 
-private class PurlResult(
+internal class PurlResult(
     val alias: QueryAlias,
     val ortRunId: ExpressionWithColumnTypeAlias<EntityID<Long>>,
     val identifierId: ExpressionWithColumnTypeAlias<EntityID<Long>>,
@@ -268,7 +268,7 @@ private fun buildPurlByRunIdentifier(bp: BasePairsResult): PurlResult {
  * As a side benefit, fewer subquery stages means fewer plan nodes for PostgreSQL's JIT
  * compiler to process, modestly reducing compilation overhead.
  */
-private fun buildCuratedPurlByRunIdentifier(
+internal fun buildCuratedPurlByRunIdentifier(
     runIdPairs: QueryAlias,
     riOrtRunIdCol: ExpressionWithColumnType<EntityID<Long>>,
     riIdentifierIdCol: ExpressionWithColumnType<EntityID<Long>>

--- a/services/ort-run/src/main/kotlin/VulnerabilityService.kt
+++ b/services/ort-run/src/main/kotlin/VulnerabilityService.kt
@@ -62,10 +62,10 @@ import org.eclipse.apoapsis.ortserver.shared.apimodel.VulnerabilityResolution
 import org.jetbrains.exposed.v1.core.Case
 import org.jetbrains.exposed.v1.core.Count
 import org.jetbrains.exposed.v1.core.Expression
+import org.jetbrains.exposed.v1.core.ExpressionWithColumnType
 import org.jetbrains.exposed.v1.core.ExpressionWithColumnTypeAlias
 import org.jetbrains.exposed.v1.core.GroupConcat
 import org.jetbrains.exposed.v1.core.IntegerColumnType
-import org.jetbrains.exposed.v1.core.JoinType
 import org.jetbrains.exposed.v1.core.LiteralOp
 import org.jetbrains.exposed.v1.core.Max
 import org.jetbrains.exposed.v1.core.ResultRow
@@ -79,13 +79,11 @@ import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.innerJoin
-import org.jetbrains.exposed.v1.core.not
 import org.jetbrains.exposed.v1.core.notExists
 import org.jetbrains.exposed.v1.core.or
 import org.jetbrains.exposed.v1.core.stringLiteral
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.Query
-import org.jetbrains.exposed.v1.jdbc.andWhere
 import org.jetbrains.exposed.v1.jdbc.select
 
 /**
@@ -106,10 +104,10 @@ class VulnerabilityService(
         )
 
         return db.blockingQuery {
-            val (query, ratingAlias) = buildListForOrtRunIdQuery(ortRunId, vulnerabilityFilters)
+            val context = buildOrtRunVulnerabilityQueryContext(ortRunId, vulnerabilityFilters)
 
-            val totalCount = query.count()
-            val pagedRows = fetchPagedVulnerabilityRows(query, ratingAlias, parameters)
+            val totalCount = context.query.count()
+            val pagedRows = fetchPagedVulnerabilityRows(context, parameters)
 
             if (pagedRows.isEmpty()) {
                 return@blockingQuery ListQueryResult(emptyList(), parameters, totalCount)
@@ -142,79 +140,27 @@ class VulnerabilityService(
                             source = it.source,
                             isDeleted = it.source == ResolutionSource.SERVER && it !in serverResolutions
                         )
-                    }
+                }
                 }
 
             val identifierRowsById = fetchIdentifierRowsById(identifierIds)
-            val purlByIdentifierId = getPurlByIdentifierIdForOrtRun(ortRunId, identifierIds)
             val vulnerabilities = assembleVulnerabilitiesWithDetails(
                 pagedRows,
                 vulnerabilityReferencesById,
                 appliedResolutionsByVulnerabilityAndIdentifier,
                 unappliedResolutions,
-                identifierRowsById,
-                purlByIdentifierId
+                identifierRowsById
             )
 
             ListQueryResult(data = vulnerabilities, params = parameters, totalCount = totalCount)
         }
     }
 
-    private fun buildListForOrtRunIdQuery(
-        ortRunId: Long,
-        vulnerabilityFilters: VulnerabilityFilters
-    ): Pair<Query, ExpressionWithColumnTypeAlias<Int?>> {
-        val ratingAlias = ratingAlias()
-
-        val baseJoin = VulnerabilitiesTable
-            .innerJoin(AdvisorResultsVulnerabilitiesTable)
-            .innerJoin(AdvisorResultsTable)
-            .innerJoin(AdvisorRunsIdentifiersTable)
-            .innerJoin(AdvisorRunsTable)
-            .innerJoin(AdvisorJobsTable)
-            .innerJoin(IdentifiersTable)
-            .join(
-                VulnerabilityReferencesTable,
-                JoinType.LEFT,
-                VulnerabilitiesTable.id,
-                VulnerabilityReferencesTable.vulnerabilityId
-            )
-
-        val query = baseJoin
-            .select(
-                VulnerabilitiesTable.id,
-                VulnerabilitiesTable.externalId,
-                VulnerabilitiesTable.summary,
-                VulnerabilitiesTable.description,
-                IdentifiersTable.id,
-                AdvisorResultsTable.advisorName,
-                ratingAlias
-            )
-            .where { AdvisorJobsTable.ortRunId eq ortRunId }
-            .groupBy(VulnerabilitiesTable.id, IdentifiersTable.id, AdvisorResultsTable.advisorName)
-
-        val resolutionExistsSubquery = ResolvedVulnerabilitiesTable
-            .select(ResolvedVulnerabilitiesTable.id)
-            .where {
-                (ResolvedVulnerabilitiesTable.ortRunId eq ortRunId) and
-                    (ResolvedVulnerabilitiesTable.vulnerabilityId eq VulnerabilitiesTable.id) and
-                    (ResolvedVulnerabilitiesTable.identifierId eq IdentifiersTable.id)
-            }
-
-        when (vulnerabilityFilters.resolved) {
-            true -> query.andWhere { not(notExists(resolutionExistsSubquery)) }
-            false -> query.andWhere { notExists(resolutionExistsSubquery) }
-            null -> {}
-        }
-
-        return query to ratingAlias
-    }
-
     private fun fetchPagedVulnerabilityRows(
-        query: Query,
-        ratingAlias: ExpressionWithColumnTypeAlias<Int?>,
+        context: OrtRunVulnerabilityQueryContext,
         parameters: ListQueryParameters
     ): List<PagedVulnerabilityRow> {
+        val query = context.query
         val sortFields = parameters.sortFields.ifEmpty {
             listOf(OrderField("externalId", OrderDirection.ASCENDING))
         }
@@ -223,26 +169,39 @@ class VulnerabilityService(
             val sortOrder = orderField.direction.toSortOrder()
 
             when (orderField.name) {
-                "externalId" -> query.orderBy(VulnerabilitiesTable.externalId to sortOrder)
+                "rating" -> query.orderBy(context.ratingColumn to sortOrder)
+
+                "externalId" -> query.orderBy(context.externalIdColumn to sortOrder)
+
+                "identifier" -> {
+                    query.orderBy(IdentifiersTable.type to sortOrder)
+                    query.orderBy(IdentifiersTable.namespace to sortOrder)
+                    query.orderBy(IdentifiersTable.name to sortOrder)
+                    query.orderBy(IdentifiersTable.version to sortOrder)
+                }
+
+                "purl" -> query.orderBy(context.purlColumn to sortOrder)
+
                 else -> throw QueryParametersException("Unsupported field for sorting: '${orderField.name}'.")
             }
         }
 
-        query.orderBy(VulnerabilitiesTable.id to SortOrder.ASC)
-        query.orderBy(IdentifiersTable.id to SortOrder.ASC)
-        query.orderBy(AdvisorResultsTable.advisorName to SortOrder.ASC)
+        query.orderBy(context.vulnerabilityIdColumn to SortOrder.ASC)
+        query.orderBy(context.identifierIdColumn to SortOrder.ASC)
+        query.orderBy(context.advisorNameColumn to SortOrder.ASC)
 
         query.limit(parameters.limit ?: ListQueryParameters.DEFAULT_LIMIT).offset(parameters.offset ?: 0L)
 
         return query.map { row ->
             PagedVulnerabilityRow(
-                vulnerabilityId = row[VulnerabilitiesTable.id].value,
-                externalId = row[VulnerabilitiesTable.externalId],
-                summary = row[VulnerabilitiesTable.summary],
-                description = row[VulnerabilitiesTable.description],
-                identifierId = row[IdentifiersTable.id].value,
-                advisorName = row[AdvisorResultsTable.advisorName],
-                ratingOrdinal = row.getOrNull(ratingAlias) ?: VulnerabilityRating.NONE.ordinal
+                vulnerabilityId = row[context.vulnerabilityIdColumn].value,
+                externalId = row[context.externalIdColumn],
+                summary = row[context.summaryColumn],
+                description = row[context.descriptionColumn],
+                identifierId = row[context.identifierIdColumn].value,
+                advisorName = row[context.advisorNameColumn],
+                ratingOrdinal = row.getOrNull(context.ratingColumn) ?: VulnerabilityRating.NONE.ordinal,
+                purl = row[context.purlColumn]
             )
         }
     }
@@ -351,8 +310,7 @@ class VulnerabilityService(
         vulnerabilityReferencesById: Map<Long, List<VulnerabilityReference>>,
         resolutionsByVulnerabilityAndIdentifier: Map<Pair<Long, Long>, List<AppliedVulnerabilityResolution>>,
         unappliedResolutions: List<VulnerabilityResolution>,
-        identifierRowsById: Map<Long, ResultRow>,
-        purlByIdentifierId: Map<Long, String>
+        identifierRowsById: Map<Long, ResultRow>
     ): List<VulnerabilityWithDetails> =
         pagedRows.map { pagedRow ->
             val identifierRow = requireNotNull(identifierRowsById[pagedRow.identifierId]) {
@@ -380,7 +338,7 @@ class VulnerabilityService(
                 ].orEmpty(),
                 unappliedResolutions = unappliedResolutions,
                 advisor = AdvisorDetails(name = pagedRow.advisorName),
-                purl = purlByIdentifierId[pagedRow.identifierId] ?: identifier.toFallbackPurl()
+                purl = pagedRow.purl.ifEmpty { identifier.toFallbackPurl() }
             )
         }
 
@@ -607,7 +565,20 @@ private data class PagedVulnerabilityRow(
     val description: String?,
     val identifierId: Long,
     val advisorName: String,
-    val ratingOrdinal: Int
+    val ratingOrdinal: Int,
+    val purl: String
+)
+
+internal data class OrtRunVulnerabilityQueryContext(
+    val query: Query,
+    val purlColumn: Expression<String>,
+    val ratingColumn: ExpressionWithColumnType<Int?>,
+    val vulnerabilityIdColumn: Expression<EntityID<Long>>,
+    val externalIdColumn: Expression<String>,
+    val summaryColumn: Expression<String?>,
+    val descriptionColumn: Expression<String?>,
+    val identifierIdColumn: Expression<EntityID<Long>>,
+    val advisorNameColumn: Expression<String>
 )
 
 /** Alias for determining an advisory overall rating of a vulnerability based on its individual references. */

--- a/services/ort-run/src/test/kotlin/VulnerabilityServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/VulnerabilityServiceTest.kt
@@ -462,7 +462,10 @@ class VulnerabilityServiceTest : WordSpec() {
                 val results = service.listForOrtRunId(
                     ortRun.id,
                     vulnerabilityFilters = VulnerabilityFilters(
-                        identifier = FilterOperatorAndValue(ComparisonOperator.ILIKE, "jackson-databind")
+                        identifier = FilterOperatorAndValue(
+                            ComparisonOperator.ILIKE,
+                            "maven:com.fasterxml.jackson.core:jackson-databind:2.9.6"
+                        )
                     )
                 )
 
@@ -1813,16 +1816,14 @@ class VulnerabilityServiceTest : WordSpec() {
                     VulnerabilityForRunsFilters(
                         identifier = FilterOperatorAndValue(
                             ComparisonOperator.ILIKE,
-                            "maven"
+                            "maven:com.example:example2:1.0"
                         )
                     )
                 )
 
-                results.totalCount shouldBe 3
+                results.totalCount shouldBe 1
 
-                results.data[0].identifier shouldBe pkg1.identifier.mapToApi()
-                results.data[1].identifier shouldBe pkg2.identifier.mapToApi()
-                results.data[2].identifier shouldBe pkg3.identifier.mapToApi()
+                results.data[0].identifier shouldBe pkg2.identifier.mapToApi()
             }
 
             "have a match when filtering by an identifier that doesn't have a namespace" {
@@ -1866,7 +1867,7 @@ class VulnerabilityServiceTest : WordSpec() {
                     VulnerabilityForRunsFilters(
                         identifier = FilterOperatorAndValue(
                             ComparisonOperator.ILIKE,
-                            "npm::example@1.0"
+                            "npm::example:1.0"
                         )
                     )
                 )

--- a/services/ort-run/src/test/kotlin/VulnerabilityServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/VulnerabilityServiceTest.kt
@@ -417,6 +417,218 @@ class VulnerabilityServiceTest : WordSpec() {
                 }
             }
 
+            "filter by externalId" {
+                val vulnerabilities = createVulnerabilities(
+                    Triple(
+                        Identifier("Maven", "com.fasterxml.jackson.core", "jackson-databind", "2.9.6"),
+                        listOf("CVE-2018-14721"),
+                        listOf(4.2)
+                    ),
+                    Triple(
+                        Identifier("Maven", "org.apache.logging.log4j", "log4j-core", "2.14.0"),
+                        listOf("CVE-2021-45046"),
+                        listOf(10.0)
+                    )
+                )
+                val ortRun = createVulnerabilityEntries(createAdvisorResults(vulnerabilities))
+
+                val results = service.listForOrtRunId(
+                    ortRun.id,
+                    vulnerabilityFilters = VulnerabilityFilters(
+                        externalId = FilterOperatorAndValue(ComparisonOperator.ILIKE, "CVE-2018")
+                    )
+                )
+
+                results.data.shouldBeSingleton {
+                    it.vulnerability.externalId shouldBe "CVE-2018-14721"
+                }
+            }
+
+            "filter by identifier" {
+                val vulnerabilities = createVulnerabilities(
+                    Triple(
+                        Identifier("Maven", "com.fasterxml.jackson.core", "jackson-databind", "2.9.6"),
+                        listOf("CVE-2018-14721"),
+                        listOf(4.2)
+                    ),
+                    Triple(
+                        Identifier("Maven", "org.apache.logging.log4j", "log4j-core", "2.14.0"),
+                        listOf("CVE-2021-45046"),
+                        listOf(10.0)
+                    )
+                )
+                val ortRun = createVulnerabilityEntries(createAdvisorResults(vulnerabilities))
+
+                val results = service.listForOrtRunId(
+                    ortRun.id,
+                    vulnerabilityFilters = VulnerabilityFilters(
+                        identifier = FilterOperatorAndValue(ComparisonOperator.ILIKE, "jackson-databind")
+                    )
+                )
+
+                results.data.shouldBeSingleton {
+                    it.identifier.name shouldBe "jackson-databind"
+                }
+            }
+
+            "filter by rating inclusion" {
+                val runId = fixtures.createOrtRun().id
+
+                val highVulnerability = Vulnerability(
+                    externalId = "CVE-2021-HIGH",
+                    summary = "A vulnerability",
+                    description = "A description",
+                    references = listOf(
+                        VulnerabilityReference(
+                            url = "https://example.com",
+                            scoringSystem = "CVSS",
+                            severity = "HIGH",
+                            score = 8.9f,
+                            vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                        )
+                    )
+                )
+                val lowVulnerability = Vulnerability(
+                    externalId = "CVE-2021-LOW",
+                    summary = "A vulnerability",
+                    description = "A description",
+                    references = listOf(
+                        VulnerabilityReference(
+                            url = "https://example.com",
+                            scoringSystem = "CVSS",
+                            severity = "LOW",
+                            score = 1.2f,
+                            vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L"
+                        )
+                    )
+                )
+
+                val advisorResults = createAdvisorResults(
+                    mapOf(
+                        Identifier("Maven", "com.example", "lib-a", "1.0") to listOf(highVulnerability),
+                        Identifier("Maven", "com.example", "lib-b", "1.0") to listOf(lowVulnerability)
+                    )
+                )
+                val advJobId = fixtures.createAdvisorJob(
+                    ortRunId = runId,
+                    configuration = AdvisorJobConfiguration(config = advisorConfig())
+                ).id
+                fixtures.createAdvisorRun(advJobId, advisorResults)
+
+                val results = service.listForOrtRunId(
+                    runId,
+                    vulnerabilityFilters = VulnerabilityFilters(
+                        rating = FilterOperatorAndValue(
+                            ComparisonOperator.IN,
+                            setOf(VulnerabilityRating.HIGH)
+                        )
+                    )
+                )
+
+                results.data.shouldBeSingleton {
+                    it.vulnerability.externalId shouldBe "CVE-2021-HIGH"
+                    it.rating shouldBe ApiVulnerabilityRating.HIGH
+                }
+            }
+
+            "filter by rating exclusion" {
+                val runId = fixtures.createOrtRun().id
+
+                val highVulnerability = Vulnerability(
+                    externalId = "CVE-2021-HIGH",
+                    summary = "A vulnerability",
+                    description = "A description",
+                    references = listOf(
+                        VulnerabilityReference(
+                            url = "https://example.com",
+                            scoringSystem = "CVSS",
+                            severity = "HIGH",
+                            score = 8.9f,
+                            vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                        )
+                    )
+                )
+                val lowVulnerability = Vulnerability(
+                    externalId = "CVE-2021-LOW",
+                    summary = "A vulnerability",
+                    description = "A description",
+                    references = listOf(
+                        VulnerabilityReference(
+                            url = "https://example.com",
+                            scoringSystem = "CVSS",
+                            severity = "LOW",
+                            score = 1.2f,
+                            vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:L/A:L"
+                        )
+                    )
+                )
+
+                val advisorResults = createAdvisorResults(
+                    mapOf(
+                        Identifier("Maven", "com.example", "lib-a", "1.0") to listOf(highVulnerability),
+                        Identifier("Maven", "com.example", "lib-b", "1.0") to listOf(lowVulnerability)
+                    )
+                )
+                val advJobId = fixtures.createAdvisorJob(
+                    ortRunId = runId,
+                    configuration = AdvisorJobConfiguration(config = advisorConfig())
+                ).id
+                fixtures.createAdvisorRun(advJobId, advisorResults)
+
+                val results = service.listForOrtRunId(
+                    runId,
+                    vulnerabilityFilters = VulnerabilityFilters(
+                        rating = FilterOperatorAndValue(
+                            ComparisonOperator.NOT_IN,
+                            setOf(VulnerabilityRating.HIGH)
+                        )
+                    )
+                )
+
+                results.data.shouldBeSingleton {
+                    it.vulnerability.externalId shouldBe "CVE-2021-LOW"
+                    it.rating shouldBe ApiVulnerabilityRating.LOW
+                }
+            }
+
+            "filter by purl" {
+                val repository = fixtures.createRepository()
+                val ortRun = fixtures.createOrtRun(repository.id)
+                val analyzerJob = fixtures.createAnalyzerJob(ortRun.id)
+
+                val pkg1 = fixtures.generatePackage(
+                    Identifier("Maven", "com.fasterxml.jackson.core", "jackson-databind", "2.9.6")
+                )
+                val pkg2 = fixtures.generatePackage(
+                    Identifier("Maven", "org.apache.logging.log4j", "log4j-core", "2.14.0")
+                )
+
+                fixtures.createAnalyzerRun(analyzerJobId = analyzerJob.id, packages = setOf(pkg1, pkg2))
+
+                val vulnerabilities = createVulnerabilities(
+                    Triple(pkg1.identifier, listOf("CVE-2018-14721"), listOf(4.2)),
+                    Triple(pkg2.identifier, listOf("CVE-2021-45046"), listOf(10.0))
+                )
+
+                val advisorJobId = fixtures.createAdvisorJob(
+                    ortRunId = ortRun.id,
+                    configuration = AdvisorJobConfiguration(config = advisorConfig())
+                ).id
+                fixtures.createAdvisorRun(advisorJobId, createAdvisorResults(vulnerabilities))
+
+                val results = service.listForOrtRunId(
+                    ortRun.id,
+                    vulnerabilityFilters = VulnerabilityFilters(
+                        purl = FilterOperatorAndValue(ComparisonOperator.ILIKE, "jackson")
+                    )
+                )
+
+                results.data.shouldBeSingleton {
+                    it.vulnerability.externalId shouldBe "CVE-2018-14721"
+                    it.purl shouldBe pkg1.purl
+                }
+            }
+
             "return multiple vulnerabilities and references for a package" {
                 val vulnerabilities = createVulnerabilities(
                     Triple(

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
@@ -17,21 +17,18 @@
  * License-Filename: LICENSE
  */
 
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import {
   createColumnHelper,
   ExpandedState,
   getCoreRowModel,
   getExpandedRowModel,
-  getFilteredRowModel,
-  getPaginationRowModel,
-  getSortedRowModel,
   Row,
   useReactTable,
 } from '@tanstack/react-table';
 import { ChevronDown, ChevronUp } from 'lucide-react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 import z from 'zod';
 
 import { VulnerabilityRating, VulnerabilityWithDetails } from '@/api';
@@ -80,15 +77,17 @@ import {
   getResolvedBackgroundColor,
   getVulnerabilityRatingBackgroundColor,
 } from '@/helpers/get-status-class';
-import { updateColumnSorting } from '@/helpers/handle-multisort';
+import {
+  convertToBackendSorting,
+  updateColumnSorting,
+} from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-conversion';
 import {
   getResolutionAccordionDefaultValue,
   getResolutionAccordionLabel,
   getResolvedStatus,
 } from '@/helpers/resolutions';
-import { compareVulnerabilityRating } from '@/helpers/sorting-functions';
-import { ACTION_COLUMN_SIZE, ALL_ITEMS } from '@/lib/constants';
+import { ACTION_COLUMN_SIZE } from '@/lib/constants';
 import { toastError } from '@/lib/toast';
 import {
   externalIdSearchParameterSchema,
@@ -104,6 +103,12 @@ import {
 import { useUserSettingsStore } from '@/store/user-settings.store';
 
 const defaultPageSize = 10;
+const supportedSortColumns = new Set([
+  'identifier',
+  'purl',
+  'externalId',
+  'rating',
+]);
 
 const columnHelper = createColumnHelper<VulnerabilityWithDetails>();
 
@@ -186,7 +191,18 @@ const VulnerabilitiesComponent = () => {
   const params = Route.useParams();
   const search = Route.useSearch();
   const navigate = Route.useNavigate();
+  const pageIndex = search.page ? search.page - 1 : 0;
+  const pageSize = search.pageSize ? search.pageSize : defaultPageSize;
+  const itemStatus = search.itemResolved;
+  const packageIdentifier = search.pkgId;
+  const rating = search.rating;
+  const externalId = search.externalId;
   const packageIdType = useUserSettingsStore((state) => state.packageIdType);
+  const resolved =
+    itemStatus?.length === 1 ? itemStatus[0] === 'Resolved' : undefined;
+  const sortBy = search.sortBy?.filter((sort) =>
+    supportedSortColumns.has(sort.id)
+  );
 
   const columns = [
     columnHelper.display({
@@ -264,9 +280,7 @@ const VulnerabilitiesComponent = () => {
       {
         id: 'itemStatus',
         header: 'Status',
-        filterFn: (row, _columnId, filterValue): boolean => {
-          return filterValue.includes(getResolvedStatus(row.original));
-        },
+        enableSorting: false,
         meta: {
           filter: {
             filterVariant: 'select',
@@ -288,16 +302,8 @@ const VulnerabilitiesComponent = () => {
       }
     ),
     columnHelper.accessor('rating', {
+      id: 'rating',
       header: 'Rating',
-      filterFn: (row, _columnId, filterValue): boolean => {
-        return filterValue.includes(row.original.rating);
-      },
-      sortingFn: (rowA, rowB) => {
-        return compareVulnerabilityRating(
-          rowA.getValue('rating'),
-          rowB.getValue('rating')
-        );
-      },
       meta: {
         filter: {
           filterVariant: 'select',
@@ -334,6 +340,7 @@ const VulnerabilitiesComponent = () => {
     columnHelper.accessor('advisor.name', {
       id: 'advisorName',
       header: 'Advisor',
+      enableSorting: false,
       enableColumnFilter: false,
     }),
     columnHelper.accessor(
@@ -349,61 +356,7 @@ const VulnerabilitiesComponent = () => {
     ),
   ];
 
-  // All of these need to be memoized to prevent unnecessary re-renders
-  // and (at least for Firefox) the browser freezing up.
-  const pageIndex = useMemo(
-    () => (search.page ? search.page - 1 : 0),
-    [search.page]
-  );
-
-  const pageSize = useMemo(
-    () => (search.pageSize ? search.pageSize : defaultPageSize),
-    [search.pageSize]
-  );
-
-  const itemStatus = useMemo(
-    () => (search.itemResolved ? search.itemResolved : undefined),
-    [search.itemResolved]
-  );
-
-  const packageIdentifier = useMemo(
-    () => (search.pkgId ? search.pkgId : undefined),
-    [search.pkgId]
-  );
-
-  const rating = useMemo(
-    () => (search.rating ? search.rating : undefined),
-    [search.rating]
-  );
-
-  const externalId = useMemo(
-    () => (search.externalId ? search.externalId : undefined),
-    [search.externalId]
-  );
-
   const columnId = packageIdType === 'ORT_ID' ? 'identifier' : 'purl';
-
-  const columnFilters = useMemo(() => {
-    const filters = [];
-    if (itemStatus) {
-      filters.push({ id: 'itemStatus', value: itemStatus });
-    }
-    if (packageIdentifier) {
-      filters.push({ id: columnId, value: packageIdentifier });
-    }
-    if (rating) {
-      filters.push({ id: 'rating', value: rating });
-    }
-    if (externalId) {
-      filters.push({ id: 'externalId', value: externalId });
-    }
-    return filters;
-  }, [itemStatus, packageIdentifier, columnId, rating, externalId]);
-
-  const sortBy = useMemo(
-    () => (search.sortBy ? search.sortBy : undefined),
-    [search.sortBy]
-  );
 
   const { data: ortRun } = useSuspenseQuery({
     ...getRepositoryRunOptions({
@@ -415,14 +368,36 @@ const VulnerabilitiesComponent = () => {
   });
 
   const {
+    data: totalVulnerabilities,
+    isPending: totalIsPending,
+    isError: totalIsError,
+    error: totalError,
+  } = useSuspenseQuery({
+    ...getRunVulnerabilitiesOptions({
+      path: { runId: ortRun.id },
+      query: { limit: 1 },
+    }),
+  });
+
+  const {
     data: vulnerabilities,
     isPending,
     isError,
     error,
-  } = useQuery({
+  } = useSuspenseQuery({
     ...getRunVulnerabilitiesOptions({
       path: { runId: ortRun.id },
-      query: { limit: ALL_ITEMS },
+      query: {
+        limit: pageSize,
+        offset: pageIndex * pageSize,
+        sort: convertToBackendSorting(sortBy),
+        resolved,
+        rating: rating?.join(','),
+        ...(packageIdType === 'ORT_ID'
+          ? { identifier: packageIdentifier }
+          : { purl: packageIdentifier }),
+        externalId,
+      },
     }),
   });
 
@@ -516,12 +491,20 @@ const VulnerabilitiesComponent = () => {
   const table = useReactTable({
     data: vulnerabilities?.data || [],
     columns,
+    pageCount: Math.ceil(
+      (vulnerabilities?.pagination.totalCount ?? 0) / pageSize
+    ),
     state: {
       pagination: {
         pageIndex,
         pageSize,
       },
-      columnFilters,
+      columnFilters: [
+        { id: 'itemStatus', value: itemStatus },
+        { id: columnId, value: packageIdentifier },
+        { id: 'rating', value: rating },
+        { id: 'externalId', value: externalId },
+      ].filter(({ value }) => value !== undefined),
       columnVisibility: {
         [columnId]: false,
         rating: false,
@@ -536,29 +519,28 @@ const VulnerabilitiesComponent = () => {
     onExpandedChange: setExpanded,
     getCoreRowModel: getCoreRowModel(),
     getExpandedRowModel: getExpandedRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
-    getSortedRowModel: getSortedRowModel(),
     getRowCanExpand: () => true,
-    enableMultiSort: false,
+    manualPagination: true,
   });
 
-  if (isPending) {
+  if (isPending || totalIsPending) {
     return <LoadingIndicator />;
   }
 
-  if (isError) {
-    toastError('Unable to load data', error);
+  if (isError || totalIsError) {
+    toastError('Unable to load data', error || totalError);
     return;
   }
-  const filtersInUse = table.getState().columnFilters.length > 0;
-  const matching = `, ${table.getPrePaginationRowModel().rows.length} matching filters`;
+  const filtersInUse =
+    totalVulnerabilities.pagination.totalCount !==
+    vulnerabilities.pagination.totalCount;
+  const matching = `, ${vulnerabilities.pagination.totalCount} matching filters`;
 
   return (
     <Card className='h-fit'>
       <CardHeader>
         <CardTitle>
-          Vulnerabilities ({vulnerabilities.pagination.totalCount} in total
+          Vulnerabilities ({totalVulnerabilities.pagination.totalCount} in total
           {filtersInUse && matching})
         </CardTitle>
         <CardDescription>


### PR DESCRIPTION
This is to be able to switch the corresponding UI table finally to use server-side data manipulation, as is the target for most of UI tables. The PR prepares to add filtering by advisors to all three vulnerabilities endpoints in the upcoming PRs.

Please see the commits for details.