### PR TITLE
fix(scanner): Return issues from scan summaries

### DIFF
--- a/dao/src/main/kotlin/tables/ScanSummariesTable.kt
+++ b/dao/src/main/kotlin/tables/ScanSummariesTable.kt
@@ -49,34 +49,30 @@ class ScanSummaryDao(id: EntityID<Long>) : LongEntity(id) {
     val issues by ScanSummariesIssuesDao referrersOn ScanSummariesIssuesTable.scanSummaryId
 
     /**
-     * Map this DAO to a [ScanSummary] model object. If the [withRelations] flag is *true*, populate the collections
-     * for findings and issues. (Note that this may cause a larger number of SELECT statements issued to the database
-     * to load all these objects.) If the flag is *false*, only initialize the direct properties and leave the
-     * collections empty.
+     * Map this DAO to a [ScanSummary] model object. If the [withFindings] flag is *true*, populate the collections
+     * for findings. (Note that this may cause a larger number of SELECT statements issued to the database to load all
+     * these objects.) If the flag is *false*, only initialize the direct properties and the issues and leave the
+     * collections for findings empty.
      */
-    fun mapToModel(withRelations: Boolean = true) = ScanSummary(
+    fun mapToModel(withFindings: Boolean = true) = ScanSummary(
         startTime = startTime,
         endTime = endTime,
         hash = hash,
-        licenseFindings = if (withRelations) {
+        licenseFindings = if (withFindings) {
             licenseFindings.mapTo(mutableSetOf(), LicenseFindingDao::mapToModel)
         } else {
             emptySet()
         },
-        copyrightFindings = if (withRelations) {
+        copyrightFindings = if (withFindings) {
             copyrightFindings.mapTo(mutableSetOf(), CopyrightFindingDao::mapToModel)
         } else {
             emptySet()
         },
-        snippetFindings = if (withRelations) {
+        snippetFindings = if (withFindings) {
             snippetFindings.mapTo(mutableSetOf(), SnippetFindingDao::mapToModel)
         } else {
             emptySet()
         },
-        issues = if (withRelations) {
-            issues.map(ScanSummariesIssuesDao::mapToModel)
-        } else {
-            emptyList()
-        }
+        issues = issues.map(ScanSummariesIssuesDao::mapToModel)
     )
 }

--- a/workers/scanner/src/main/kotlin/OrtServerScanResultStorage.kt
+++ b/workers/scanner/src/main/kotlin/OrtServerScanResultStorage.kt
@@ -53,7 +53,6 @@ import org.jetbrains.exposed.v1.core.Expression
 import org.jetbrains.exposed.v1.core.Op
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.core.innerJoin
 import org.jetbrains.exposed.v1.core.stringLiteral
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SizedCollection
@@ -125,16 +124,17 @@ class OrtServerScanResultStorage(
                             version = it.scannerVersion,
                             configuration = it.scannerConfiguration
                         ),
-                        summary = it.scanSummary.mapToModel(withRelations = false).mapToOrt(),
+                        summary = it.scanSummary.mapToModel(withFindings = false).mapToOrt(),
                         additionalData = it.additionalScanResultData?.data.orEmpty()
                     )
                 }.filterValues { scannerMatcher?.matches(it.scanner) != false }
 
-                matchingScanResults.forEach { (dao, _) ->
+                matchingScanResults.forEach { (dao, result) ->
                     associateScanResultWithScannerRun(dao)
+                    storeIssues(provenance, result.summary)
                 }
 
-                matchingScanResults.values.toList()
+                dropScanSummaryIssues(matchingScanResults.values)
             }
         }
 
@@ -388,3 +388,12 @@ private fun <T> withLoggedTime(action: String, block: () -> T): T {
 
     return timedValue.value
 }
+
+/**
+ * Process the given collection of [scanResults] by removing all issues from their scan summaries. The issues are
+ * collected separately by [OrtServerScanResultStorage]; therefore, they must not be in [ScanResult] objects.
+ */
+private fun dropScanSummaryIssues(scanResults: Collection<ScanResult>): List<ScanResult> =
+    scanResults.map { scanResult ->
+        scanResult.copy(summary = scanResult.summary.copy(issues = emptyList()))
+    }

--- a/workers/scanner/src/test/kotlin/OrtServerScanResultStorageTest.kt
+++ b/workers/scanner/src/test/kotlin/OrtServerScanResultStorageTest.kt
@@ -319,6 +319,56 @@ class OrtServerScanResultStorageTest : WordSpec() {
 
                 loadScanSummaryIds() shouldHaveSize 2
             }
+
+            "link a new artifact-provenance scan result to the matching package provenance" {
+                val remoteArtifact = createRemoteArtifact()
+                val packageProvenance = createPackageProvenanceForArtifact(scannerRun, remoteArtifact)
+                val scanResult = createScanResult("ScanCode", createIssue("source"), createArtifactProvenance())
+
+                scanResultStorage.write(scanResult)
+
+                verifyJunctionRow(scanResult, packageProvenance)
+            }
+
+            "link a new VCS-provenance scan result to the matching package provenance" {
+                val vcsInfo = createVcsInfo()
+                val packageProvenance = createPackageProvenanceForVcs(scannerRun, vcsInfo)
+                val scanResult =
+                    createScanResult("ScanCode", createIssue("source"), createRepositoryProvenance(vcsInfo))
+
+                scanResultStorage.write(scanResult)
+
+                verifyJunctionRow(scanResult, packageProvenance)
+            }
+
+            "link a cached (reused) scan result to the new scanner run's package provenance" {
+                val remoteArtifact = createRemoteArtifact()
+                val scanResult = createScanResult("ScanCode", createIssue("source"), createArtifactProvenance())
+
+                // Write in run 1 (no package provenance yet — no junction row expected).
+                scanResultStorage.write(scanResult)
+
+                // Start run 2, add a package provenance, then read (cache hit path).
+                val scannerRun2 = dbExtension.fixtures.scannerRunRepository.create(dbExtension.fixtures.scannerJob.id)
+                val storage2 = OrtServerScanResultStorage(dbExtension.db, scannerRun2.id)
+                val packageProvenance = createPackageProvenanceForArtifact(scannerRun2, remoteArtifact)
+
+                storage2.write(scanResult)
+
+                verifyJunctionRow(scanResult, packageProvenance, scannerRun2)
+            }
+
+            "link a scan result to all package provenances sharing the same artifact URL" {
+                val remoteArtifact = createRemoteArtifact()
+                val provenance1 = createPackageProvenanceForArtifact(scannerRun, remoteArtifact, namespace = "com.a")
+                val provenance2 = createPackageProvenanceForArtifact(scannerRun, remoteArtifact, namespace = "com.b")
+                val scanResult = createScanResult("ScanCode", createIssue("source"), createArtifactProvenance())
+
+                scanResultStorage.write(scanResult)
+
+                verifyJunctionRow(scanResult, provenance1)
+                verifyJunctionRow(scanResult, provenance2)
+            }
         }
 
         "read" should {
@@ -404,58 +454,6 @@ class OrtServerScanResultStorageTest : WordSpec() {
                 val readResult = scanResultStorage.read(repositoryProvenance.mapToOrt(), scannerMatcher)
                 readResult shouldContain matchingScanResult.withoutRelations()
                 readResult shouldNotContain notMatchingScanResult
-            }
-        }
-
-        "write" should {
-            "link a new artifact-provenance scan result to the matching package provenance" {
-                val remoteArtifact = createRemoteArtifact()
-                val packageProvenance = createPackageProvenanceForArtifact(scannerRun, remoteArtifact)
-                val scanResult = createScanResult("ScanCode", createIssue("source"), createArtifactProvenance())
-
-                scanResultStorage.write(scanResult)
-
-                verifyJunctionRow(scanResult, packageProvenance)
-            }
-
-            "link a new VCS-provenance scan result to the matching package provenance" {
-                val vcsInfo = createVcsInfo()
-                val packageProvenance = createPackageProvenanceForVcs(scannerRun, vcsInfo)
-                val scanResult =
-                    createScanResult("ScanCode", createIssue("source"), createRepositoryProvenance(vcsInfo))
-
-                scanResultStorage.write(scanResult)
-
-                verifyJunctionRow(scanResult, packageProvenance)
-            }
-
-            "link a cached (reused) scan result to the new scanner run's package provenance" {
-                val remoteArtifact = createRemoteArtifact()
-                val scanResult = createScanResult("ScanCode", createIssue("source"), createArtifactProvenance())
-
-                // Write in run 1 (no package provenance yet — no junction row expected).
-                scanResultStorage.write(scanResult)
-
-                // Start run 2, add a package provenance, then read (cache hit path).
-                val scannerRun2 = dbExtension.fixtures.scannerRunRepository.create(dbExtension.fixtures.scannerJob.id)
-                val storage2 = OrtServerScanResultStorage(dbExtension.db, scannerRun2.id)
-                val packageProvenance = createPackageProvenanceForArtifact(scannerRun2, remoteArtifact)
-
-                storage2.write(scanResult)
-
-                verifyJunctionRow(scanResult, packageProvenance, scannerRun2)
-            }
-
-            "link a scan result to all package provenances sharing the same artifact URL" {
-                val remoteArtifact = createRemoteArtifact()
-                val provenance1 = createPackageProvenanceForArtifact(scannerRun, remoteArtifact, namespace = "com.a")
-                val provenance2 = createPackageProvenanceForArtifact(scannerRun, remoteArtifact, namespace = "com.b")
-                val scanResult = createScanResult("ScanCode", createIssue("source"), createArtifactProvenance())
-
-                scanResultStorage.write(scanResult)
-
-                verifyJunctionRow(scanResult, provenance1)
-                verifyJunctionRow(scanResult, provenance2)
             }
         }
 

--- a/workers/scanner/src/test/kotlin/OrtServerScanResultStorageTest.kt
+++ b/workers/scanner/src/test/kotlin/OrtServerScanResultStorageTest.kt
@@ -26,6 +26,7 @@ import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.maps.shouldHaveSize
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
@@ -454,6 +455,33 @@ class OrtServerScanResultStorageTest : WordSpec() {
                 val readResult = scanResultStorage.read(repositoryProvenance.mapToOrt(), scannerMatcher)
                 readResult shouldContain matchingScanResult.withoutRelations()
                 readResult shouldNotContain notMatchingScanResult
+            }
+
+            "collect the issues from the read results" {
+                val issues1 = listOf(createIssue("source1", "some error"))
+                val issues2 = listOf(createIssue("source2", "some other error"), createIssue("source3", "some timeout"))
+                val issues3 = listOf(createIssue("source4", "a failure"), createIssue("source5", "a mistake"))
+                val artifactProvenance = createArtifactProvenance()
+                val repositoryProvenance = createRepositoryProvenance()
+
+                val scanResult1 = createScanResult("ScanCode", issues1, artifactProvenance)
+                val scanResult2 = createScanResult("FossID", issues2, artifactProvenance)
+                val scanResult3 = createScanResult("FossID", issues3, repositoryProvenance)
+
+                scanResultStorage.write(scanResult1)
+                scanResultStorage.write(scanResult2)
+                scanResultStorage.write(scanResult3)
+
+                val scanResultStorage2 = OrtServerScanResultStorage(dbExtension.db, scannerRun.id)
+                scanResultStorage2.read(artifactProvenance.mapToOrt(), scannerMatcher)
+                scanResultStorage2.read(repositoryProvenance.mapToOrt(), scannerMatcher)
+
+                val expectedArtifactIssues = (issues1 + issues2).map { it.mapToOrt() }
+                val expectedRepositoryIssues = issues3.map { it.mapToOrt() }
+                val allIssues = scanResultStorage2.getAllIssues()
+                allIssues shouldHaveSize 2
+                allIssues[artifactProvenance.mapToOrt()] shouldContainExactlyInAnyOrder expectedArtifactIssues
+                allIssues[repositoryProvenance.mapToOrt()] shouldContainExactlyInAnyOrder expectedRepositoryIssues
             }
         }
 

--- a/workers/scanner/src/test/kotlin/ScanResultFixtures.kt
+++ b/workers/scanner/src/test/kotlin/ScanResultFixtures.kt
@@ -82,12 +82,12 @@ internal object ScanResultFixtures {
 
     fun createArtifactProvenance() = ArtifactProvenance(createRemoteArtifact())
 
-    fun createIssue(source: String) =
-        Issue(Instant.fromEpochSeconds(TIME_STAMP_SECONDS), source, "message", Severity.ERROR)
+    fun createIssue(source: String, message: String = "message") =
+        Issue(Instant.fromEpochSeconds(TIME_STAMP_SECONDS), source, message, Severity.ERROR)
 
     fun createServerScanResult(
         scannerName: String,
-        issue: Issue,
+        issues: List<Issue>,
         provenance: KnownProvenance,
         scannerVersion: String = SCANNER_VERSION,
         scannerConfig: String = "config",
@@ -135,10 +135,27 @@ internal object ScanResultFixtures {
                     )
                 )
             ),
-            listOf(issue)
+            issues
         ),
         additionalData
     )
+
+    fun createScanResult(
+        scannerName: String,
+        issues: List<Issue>,
+        provenance: KnownProvenance,
+        scannerVersion: String = SCANNER_VERSION,
+        scannerConfig: String = "config",
+        additionalData: Map<String, String> = mapOf("additional1" to "data1", "additional2" to "data2")
+    ): OrtScanResult =
+        createServerScanResult(
+            scannerName,
+            issues,
+            provenance,
+            scannerVersion,
+            scannerConfig,
+            additionalData
+        ).mapToOrt()
 
     fun createScanResult(
         scannerName: String,
@@ -148,7 +165,14 @@ internal object ScanResultFixtures {
         scannerConfig: String = "config",
         additionalData: Map<String, String> = mapOf("additional1" to "data1", "additional2" to "data2")
     ): OrtScanResult =
-        createServerScanResult(scannerName, issue, provenance, scannerVersion, scannerConfig, additionalData).mapToOrt()
+        createScanResult(
+            scannerName,
+            listOf(issue),
+            provenance,
+            scannerVersion,
+            scannerConfig,
+            additionalData
+        )
 
     /**
      * Return a copy of this [OrtScanResult] that does not contain any objects from related tables.


### PR DESCRIPTION
When scan results were loaded from `OrtServerScanResultStorage` issues
from the scan summary were dropped. Fix this by loading these issues and
adding them to the internal `issuesMap` which is then queried by the
scanner runner. That way, issues from newly executed scans and those
loaded from the database can be treated in the same way.