### PR TITLE
fix(ui): Generalize the Conan entry to not only refer to 1.x

### DIFF
--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -233,7 +233,7 @@ export const packageManagers = [
   },
   {
     id: 'Conan',
-    label: 'Conan 1.x (C / C++)',
+    label: 'Conan (C / C++)',
   },
   {
     id: 'Gleam',


### PR DESCRIPTION
Conan 2.x is supported as well if the `useConan2` plugin option is set to `true`. This will become clearer once the options are auto-populated to the UI.