### PR TITLE
Advisor endpoints

### DIFF
--- a/core/src/main/kotlin/api/OrganizationsRoute.kt
+++ b/core/src/main/kotlin/api/OrganizationsRoute.kt
@@ -58,6 +58,7 @@ import org.eclipse.apoapsis.ortserver.core.apiDocs.getOrganizationProducts
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getOrganizationRunStatistics
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getOrganizationUsers
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getOrganizationVulnerabilities
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getOrganizationVulnerabilityAdvisors
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getOrganizations
 import org.eclipse.apoapsis.ortserver.core.apiDocs.patchOrganization
 import org.eclipse.apoapsis.ortserver.core.apiDocs.postOrganization
@@ -267,6 +268,18 @@ fun Route.organizations() = route("organizations") {
                     .toSearchResponse(filters)
 
                 call.respond(HttpStatusCode.OK, pagedSearchResponse)
+            }
+
+            route("advisors") {
+                get(getOrganizationVulnerabilityAdvisors, requirePermission(OrganizationPermission.READ)) {
+                    val organizationId = call.requireIdParameter("organizationId")
+                    val repositoryIds = organizationService.getRepositoryIdsForOrganization(organizationId)
+                    val ortRunIds = repositoryIds.mapNotNull { repositoryId ->
+                        repositoryService.getLatestOrtRunIdWithSuccessfulAdvisorJob(repositoryId)
+                    }
+                    val advisors = vulnerabilityService.getAdvisorsForOrtRunIds(ortRunIds)
+                    call.respond(HttpStatusCode.OK, advisors.toList())
+                }
             }
         }
 

--- a/core/src/main/kotlin/api/ProductsRoute.kt
+++ b/core/src/main/kotlin/api/ProductsRoute.kt
@@ -56,6 +56,7 @@ import org.eclipse.apoapsis.ortserver.core.apiDocs.getProductRepositories
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getProductRunStatistics
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getProductUsers
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getProductVulnerabilities
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getProductVulnerabilityAdvisors
 import org.eclipse.apoapsis.ortserver.core.apiDocs.patchProduct
 import org.eclipse.apoapsis.ortserver.core.apiDocs.postProductRuns
 import org.eclipse.apoapsis.ortserver.core.apiDocs.postRepository
@@ -231,6 +232,18 @@ fun Route.products() = route("products/{productId}") {
                 .toSearchResponse(filters)
 
             call.respond(HttpStatusCode.OK, pagedSearchResponse)
+        }
+
+        route("advisors") {
+            get(getProductVulnerabilityAdvisors, requirePermission(ProductPermission.READ)) {
+                val productId = call.requireIdParameter("productId")
+                val repositoryIds = productService.getRepositoryIdsForProduct(productId)
+                val ortRunIds = repositoryIds.mapNotNull { repositoryId ->
+                    repositoryService.getLatestOrtRunIdWithSuccessfulAdvisorJob(repositoryId)
+                }
+                val advisors = vulnerabilityService.getAdvisorsForOrtRunIds(ortRunIds)
+                call.respond(HttpStatusCode.OK, advisors.toList())
+            }
         }
     }
 

--- a/core/src/main/kotlin/api/RunsRoute.kt
+++ b/core/src/main/kotlin/api/RunsRoute.kt
@@ -69,6 +69,7 @@ import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunReport
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunRuleViolations
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunStatistics
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunVulnerabilities
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunVulnerabilityAdvisors
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getRuns
 import org.eclipse.apoapsis.ortserver.core.utils.findByName
 import org.eclipse.apoapsis.ortserver.logaccess.LogFileService
@@ -238,6 +239,13 @@ fun Route.runs() = route("runs") {
                 val pagedResponse = vulnerabilitiesForOrtRun.mapToApi { it }
 
                 call.respond(HttpStatusCode.OK, pagedResponse)
+            }
+
+            route("advisors") {
+                get(getRunVulnerabilityAdvisors, requireRunPermission()) {
+                    val advisors = vulnerabilityService.getAdvisorsForOrtRunId(call.ortRun.id)
+                    call.respond(HttpStatusCode.OK, advisors.toList())
+                }
             }
         }
 

--- a/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
@@ -398,6 +398,31 @@ val getOrganizationVulnerabilities: RouteConfig.() -> Unit = {
     }
 }
 
+val getOrganizationVulnerabilityAdvisors: RouteConfig.() -> Unit = {
+    operationId = "getOrganizationVulnerabilityAdvisors"
+    summary = "Get the advisors used for vulnerability checks in an organization"
+    description = "Get the distinct advisor names from the latest successful advisor runs across the repositories " +
+            "in an organization."
+    tags = listOf("Organizations")
+
+    request {
+        pathParameter<Long>("organizationId") {
+            description = "The organization's ID."
+        }
+    }
+
+    response {
+        HttpStatusCode.OK to {
+            description = "Success. The advisors are sorted by name."
+            jsonBody<List<String>> {
+                example("Get vulnerability advisors for an organization") {
+                    value = listOf("NexusIQ", "OSV", "VulnerableCode")
+                }
+            }
+        }
+    }
+}
+
 val getOrganizationRunStatistics: RouteConfig.() -> Unit = {
     operationId = "getOrganizationRunStatistics"
     summary = "Get statistics about ORT runs across the repositories of an organization"

--- a/core/src/main/kotlin/apiDocs/ProductsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/ProductsDocs.kt
@@ -369,6 +369,31 @@ val getProductVulnerabilities: RouteConfig.() -> Unit = {
     }
 }
 
+val getProductVulnerabilityAdvisors: RouteConfig.() -> Unit = {
+    operationId = "getProductVulnerabilityAdvisors"
+    summary = "Get the advisors used for vulnerability checks in a product"
+    description = "Get the distinct advisor names from the latest successful advisor runs across the repositories " +
+            "in a product."
+    tags = listOf("Products")
+
+    request {
+        pathParameter<Long>("productId") {
+            description = "The product's ID."
+        }
+    }
+
+    response {
+        HttpStatusCode.OK to {
+            description = "Success. The advisors are sorted by name."
+            jsonBody<List<String>> {
+                example("Get vulnerability advisors for a product") {
+                    value = listOf("NexusIQ", "OSV", "VulnerableCode")
+                }
+            }
+        }
+    }
+}
+
 val getProductRunStatistics: RouteConfig.() -> Unit = {
     operationId = "getProductRunStatistics"
     summary = "Get statistics about ORT runs across the repositories of a product"

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -381,6 +381,33 @@ val getRunVulnerabilities: RouteConfig.() -> Unit = {
     }
 }
 
+val getRunVulnerabilityAdvisors: RouteConfig.() -> Unit = {
+    operationId = "getRunVulnerabilityAdvisors"
+    summary = "Get the advisors used for vulnerability checks in an ORT run"
+    tags = listOf("Runs")
+
+    request {
+        pathParameter<Long>("runId") {
+            description = "The ID of the ORT run."
+        }
+    }
+
+    response {
+        HttpStatusCode.OK to {
+            description = "Success. The advisors are sorted by name."
+            jsonBody<List<String>> {
+                example("Get vulnerability advisors for an ORT run") {
+                    value = listOf("NexusIQ", "OSV", "VulnerableCode")
+                }
+            }
+        }
+
+        HttpStatusCode.NotFound to {
+            description = "The ORT run does not exist."
+        }
+    }
+}
+
 val getRunRuleViolations: RouteConfig.() -> Unit = {
     operationId = "getRunRuleViolations"
     summary = "Get the rule violations found in an ORT run"

--- a/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
@@ -24,6 +24,7 @@ import io.kotest.data.forAll
 import io.kotest.data.row
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
@@ -74,6 +75,7 @@ import org.eclipse.apoapsis.ortserver.components.authorization.service.Authoriza
 import org.eclipse.apoapsis.ortserver.components.authorization.service.DbAuthorizationService
 import org.eclipse.apoapsis.ortserver.core.SUPERUSER
 import org.eclipse.apoapsis.ortserver.core.TEST_USER
+import org.eclipse.apoapsis.ortserver.model.AdvisorJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.CompoundHierarchyId
 import org.eclipse.apoapsis.ortserver.model.JobStatus
 import org.eclipse.apoapsis.ortserver.model.OrganizationId
@@ -1527,6 +1529,66 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
             val createdOrganization = createOrganization()
             requestShouldRequireRole(OrganizationRole.READER, createdOrganization.hierarchyId) {
                 get("/api/v1/organizations/${createdOrganization.id}/vulnerabilities")
+            }
+        }
+    }
+
+    "GET /organizations/{organizationId}/vulnerabilities/advisors" should {
+        "return distinct advisors from latest successful advisor runs across repositories" {
+            integrationTestApplication {
+                val orgId = createOrganization().id
+
+                val prod1Id = dbExtension.fixtures.createProduct(organizationId = orgId).id
+                val prod2Id = dbExtension.fixtures.createProduct("Prod2", organizationId = orgId).id
+
+                val repo1Id = dbExtension.fixtures.createRepository(productId = prod1Id).id
+                val repo2Id = dbExtension.fixtures.createRepository(
+                    url = "https://example.com/repo2.git",
+                    productId = prod2Id
+                ).id
+
+                val run1Id = dbExtension.fixtures.createOrtRun(repo1Id).id
+                val advisorJob1Id = dbExtension.fixtures.createAdvisorJob(
+                    ortRunId = run1Id,
+                    configuration = AdvisorJobConfiguration(advisors = listOf("OSV", "VulnerableCode"))
+                ).id
+                dbExtension.fixtures.advisorJobRepository.update(
+                    advisorJob1Id,
+                    status = JobStatus.FINISHED.asPresent2()
+                )
+
+                val run2Id = dbExtension.fixtures.createOrtRun(repo2Id).id
+                val advisorJob2Id = dbExtension.fixtures.createAdvisorJob(
+                    ortRunId = run2Id,
+                    configuration = AdvisorJobConfiguration(advisors = listOf("NexusIQ", "VulnerableCode"))
+                ).id
+                dbExtension.fixtures.advisorJobRepository.update(
+                    advisorJob2Id,
+                    status = JobStatus.FINISHED.asPresent2()
+                )
+
+                val response = superuserClient.get("/api/v1/organizations/$orgId/vulnerabilities/advisors")
+
+                response shouldHaveStatus HttpStatusCode.OK
+                response.body<List<String>>() should containExactly("NexusIQ", "OSV", "VulnerableCode")
+            }
+        }
+
+        "return an empty list when no successful advisor jobs exist in the organization" {
+            integrationTestApplication {
+                val orgId = createOrganization().id
+
+                val response = superuserClient.get("/api/v1/organizations/$orgId/vulnerabilities/advisors")
+
+                response shouldHaveStatus HttpStatusCode.OK
+                response.body<List<String>>() should beEmpty()
+            }
+        }
+
+        "require OrganizationPermission.READ" {
+            val createdOrganization = createOrganization()
+            requestShouldRequireRole(OrganizationRole.READER, createdOrganization.hierarchyId) {
+                get("/api/v1/organizations/${createdOrganization.id}/vulnerabilities/advisors")
             }
         }
     }

--- a/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
@@ -24,6 +24,7 @@ import io.kotest.data.forAll
 import io.kotest.data.row
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
@@ -91,6 +92,7 @@ import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginService
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
 import org.eclipse.apoapsis.ortserver.core.SUPERUSER
 import org.eclipse.apoapsis.ortserver.core.TEST_USER
+import org.eclipse.apoapsis.ortserver.model.AdvisorJobConfiguration as ModelAdvisorJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.CompoundHierarchyId
 import org.eclipse.apoapsis.ortserver.model.JobStatus
 import org.eclipse.apoapsis.ortserver.model.OrganizationId
@@ -1301,6 +1303,62 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
             val createdProduct = createProduct()
             requestShouldRequireRole(ProductRole.READER, createdProduct.hierarchyId()) {
                 get("/api/v1/products/${createdProduct.id}/vulnerabilities")
+            }
+        }
+    }
+
+    "GET /products/{productId}/vulnerabilities/advisors" should {
+        "return distinct advisors from latest successful advisor runs across repositories" {
+            integrationTestApplication {
+                val productId = createProduct().id
+                val repo1Id = dbExtension.fixtures.createRepository(productId = productId).id
+                val repo2Id = dbExtension.fixtures.createRepository(
+                    url = "https://example.com/repo2.git",
+                    productId = productId
+                ).id
+
+                val run1Id = dbExtension.fixtures.createOrtRun(repo1Id).id
+                val advisorJob1Id = dbExtension.fixtures.createAdvisorJob(
+                    ortRunId = run1Id,
+                    configuration = ModelAdvisorJobConfiguration(advisors = listOf("OSV", "VulnerableCode"))
+                ).id
+                dbExtension.fixtures.advisorJobRepository.update(
+                    advisorJob1Id,
+                    status = JobStatus.FINISHED.asPresent2()
+                )
+
+                val run2Id = dbExtension.fixtures.createOrtRun(repo2Id).id
+                val advisorJob2Id = dbExtension.fixtures.createAdvisorJob(
+                    ortRunId = run2Id,
+                    configuration = ModelAdvisorJobConfiguration(advisors = listOf("NexusIQ", "VulnerableCode"))
+                ).id
+                dbExtension.fixtures.advisorJobRepository.update(
+                    advisorJob2Id,
+                    status = JobStatus.FINISHED.asPresent2()
+                )
+
+                val response = superuserClient.get("/api/v1/products/$productId/vulnerabilities/advisors")
+
+                response shouldHaveStatus HttpStatusCode.OK
+                response.body<List<String>>() should containExactly("NexusIQ", "OSV", "VulnerableCode")
+            }
+        }
+
+        "return an empty list when no successful advisor jobs exist in the product" {
+            integrationTestApplication {
+                val productId = createProduct().id
+
+                val response = superuserClient.get("/api/v1/products/$productId/vulnerabilities/advisors")
+
+                response shouldHaveStatus HttpStatusCode.OK
+                response.body<List<String>>() should beEmpty()
+            }
+        }
+
+        "require ProductPermission.READ" {
+            val createdProduct = createProduct()
+            requestShouldRequireRole(ProductRole.READER, createdProduct.hierarchyId()) {
+                get("/api/v1/products/${createdProduct.id}/vulnerabilities/advisors")
             }
         }
     }

--- a/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
@@ -27,6 +27,7 @@ import io.kotest.assertions.ktor.client.shouldHaveStatus
 import io.kotest.engine.spec.tempdir
 import io.kotest.inspectors.forAll
 import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.shouldBeSingleton
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
@@ -2908,6 +2909,55 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
 
             requestShouldRequireRole(RepositoryRole.READER, hierarchyId) {
                 get("/api/v1/runs/$ortRunId/packages/licenses")
+            }
+        }
+    }
+
+    "GET /runs/{runId}/vulnerabilities/advisors" should {
+        "return the advisors used in a run" {
+            integrationTestApplication {
+                val ortRun = dbExtension.fixtures.createOrtRun(
+                    repositoryId = repositoryId,
+                    revision = "revision",
+                    jobConfigurations = JobConfigurations()
+                )
+
+                dbExtension.fixtures.createAdvisorJob(
+                    ortRunId = ortRun.id,
+                    configuration = AdvisorJobConfiguration(advisors = listOf("OSV", "VulnerableCode"))
+                )
+
+                val response = superuserClient.get("/api/v1/runs/${ortRun.id}/vulnerabilities/advisors")
+
+                response shouldHaveStatus HttpStatusCode.OK
+                response.body<List<String>>() should containExactly("OSV", "VulnerableCode")
+            }
+        }
+
+        "return an empty list when no advisor job exists for the run" {
+            integrationTestApplication {
+                val ortRun = dbExtension.fixtures.createOrtRun(
+                    repositoryId = repositoryId,
+                    revision = "revision",
+                    jobConfigurations = JobConfigurations()
+                )
+
+                val response = superuserClient.get("/api/v1/runs/${ortRun.id}/vulnerabilities/advisors")
+
+                response shouldHaveStatus HttpStatusCode.OK
+                response.body<List<String>>() should beEmpty()
+            }
+        }
+
+        "require RepositoryPermission.READ_ORT_RUNS" {
+            val ortRunId = dbExtension.fixtures.createOrtRun(
+                repositoryId = repositoryId,
+                revision = "revision",
+                jobConfigurations = JobConfigurations()
+            ).id
+
+            requestShouldRequireRole(RepositoryRole.READER, hierarchyId) {
+                get("/api/v1/runs/$ortRunId/vulnerabilities/advisors")
             }
         }
     }

--- a/services/ort-run/src/main/kotlin/VulnerabilityService.kt
+++ b/services/ort-run/src/main/kotlin/VulnerabilityService.kt
@@ -21,6 +21,8 @@ package org.eclipse.apoapsis.ortserver.services.ortrun
 
 import com.github.michaelbull.result.getOr
 
+import java.util.SortedSet
+
 import org.eclipse.apoapsis.ortserver.api.v1.model.AdvisorDetails
 import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
 import org.eclipse.apoapsis.ortserver.api.v1.model.Vulnerability
@@ -544,6 +546,21 @@ class VulnerabilityService(
 
             CountByCategory(ratingToCountMap)
         }
+
+    /** Get the distinct advisors used for vulnerability checks in the provided ORT run, sorted by name. */
+    suspend fun getAdvisorsForOrtRunId(runId: Long): SortedSet<String> =
+        getAdvisorsForOrtRunIds(listOf(runId))
+
+    /** Get the distinct advisors used for vulnerability checks in the provided ORT runs, sorted by name. */
+    suspend fun getAdvisorsForOrtRunIds(runIds: List<Long>): SortedSet<String> = db.dbQuery {
+        if (runIds.isEmpty()) return@dbQuery sortedSetOf()
+        AdvisorJobsTable
+            .select(AdvisorJobsTable.configuration)
+            .where { AdvisorJobsTable.ortRunId inList runIds }
+            .flatMapTo(sortedSetOf()) { row ->
+                row[AdvisorJobsTable.configuration].advisors
+            }
+    }
 }
 
 internal data class OrtRunsQueryContext(

--- a/services/ort-run/src/test/kotlin/VulnerabilityServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/VulnerabilityServiceTest.kt
@@ -2571,6 +2571,89 @@ class VulnerabilityServiceTest : WordSpec() {
                 ratingsToCounts.map.values.sum() shouldBe unresolvedCount
             }
         }
+
+        "getAdvisorsForOrtRunId" should {
+            "return advisor names from the advisors list" {
+                val repo = fixtures.createRepository()
+                val ortRun = fixtures.createOrtRun(repositoryId = repo.id)
+                fixtures.createAdvisorJob(
+                    ortRunId = ortRun.id,
+                    configuration = AdvisorJobConfiguration(advisors = listOf("OSV", "VulnerableCode"))
+                )
+
+                service.getAdvisorsForOrtRunId(ortRun.id) should containExactly("OSV", "VulnerableCode")
+            }
+
+            "ignore advisor names that are only present in config keys" {
+                val repo = fixtures.createRepository()
+                val ortRun = fixtures.createOrtRun(repositoryId = repo.id)
+                fixtures.createAdvisorJob(
+                    ortRunId = ortRun.id,
+                    configuration = AdvisorJobConfiguration(
+                        advisors = listOf("OSV"),
+                        config = mapOf(
+                            "VulnerableCode" to ResolvablePluginConfig(
+                                options = emptyMap(),
+                                secrets = emptyMap()
+                            )
+                        )
+                    )
+                )
+
+                service.getAdvisorsForOrtRunId(ortRun.id) should containExactly("OSV")
+            }
+
+            "return distinct advisor names" {
+                val repo = fixtures.createRepository()
+                val ortRun = fixtures.createOrtRun(repositoryId = repo.id)
+                fixtures.createAdvisorJob(
+                    ortRunId = ortRun.id,
+                    configuration = AdvisorJobConfiguration(
+                        advisors = listOf("OSV", "VulnerableCode", "OSV", "NexusIQ"),
+                        config = mapOf(
+                            "GitHubDefects" to ResolvablePluginConfig(
+                                options = emptyMap(),
+                                secrets = emptyMap()
+                            )
+                        )
+                    )
+                )
+
+                service.getAdvisorsForOrtRunId(ortRun.id) should containExactly(
+                    "NexusIQ",
+                    "OSV",
+                    "VulnerableCode"
+                )
+            }
+        }
+
+        "getAdvisorsForOrtRunIds" should {
+            "return empty list when run ids list is empty" {
+                service.getAdvisorsForOrtRunIds(emptyList()) should beEmpty()
+            }
+
+            "return distinct advisors across multiple runs" {
+                val repo1 = fixtures.createRepository()
+                val repo2 = fixtures.createRepository(url = "https://example.com/repo2.git")
+                val ortRun1 = fixtures.createOrtRun(repositoryId = repo1.id)
+                val ortRun2 = fixtures.createOrtRun(repositoryId = repo2.id)
+
+                fixtures.createAdvisorJob(
+                    ortRunId = ortRun1.id,
+                    configuration = AdvisorJobConfiguration(advisors = listOf("OSV", "VulnerableCode"))
+                )
+                fixtures.createAdvisorJob(
+                    ortRunId = ortRun2.id,
+                    configuration = AdvisorJobConfiguration(advisors = listOf("NexusIQ", "VulnerableCode"))
+                )
+
+                service.getAdvisorsForOrtRunIds(listOf(ortRun1.id, ortRun2.id)) should containExactly(
+                    "NexusIQ",
+                    "OSV",
+                    "VulnerableCode"
+                )
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This PR adds three new endpoints:
- get a list of advisors used for vulnerabilities in an ORT run
- get a list of advisors used for product vulnerabilities (from the latest runs of all product repositories)
- get a list of advisors used for organization vulnerabilities (from the latest runs of all repositories belonging to products in the organization)

This collection of endpoints enables possible tunings to this "latest run" logic later, if needed.

Please see the commits for details.