### PR TITLE
fix(ui): Add missing OrtProjectFile package manager to UI

### DIFF
--- a/ui/src/helpers/get-status-class.ts
+++ b/ui/src/helpers/get-status-class.ts
@@ -202,6 +202,8 @@ export function getEcosystemBackgroundColor(
       return 'bg-teal-400';
     case 'NuGet':
       return 'bg-violet-500';
+    case 'OrtProjectFile':
+      return 'bg-orange-500';
     case 'PIP':
       return 'bg-lime-400';
     case 'Pipenv':

--- a/ui/src/lib/types.ts
+++ b/ui/src/lib/types.ts
@@ -264,6 +264,10 @@ export const packageManagers = [
     label: 'NuGet (C# and DotNet in general)',
   },
   {
+    id: 'OrtProjectFile',
+    label: 'ORT Project File',
+  },
+  {
     id: 'PIP',
     label: 'PIP (Python)',
   },

--- a/ui/src/routes/admin/colors/index.tsx
+++ b/ui/src/routes/admin/colors/index.tsx
@@ -237,6 +237,18 @@ const ColorsComponent = () => {
                 </TableCell>
               </TableRow>
               <TableRow>
+                <TableCell>ORT</TableCell>
+                <TableCell className='flex gap-2'>
+                  {['OrtProjectFile'].map((p) => (
+                    <Badge
+                      className={`border ${getEcosystemBackgroundColor(p)}`}
+                    >
+                      {p}
+                    </Badge>
+                  ))}
+                </TableCell>
+              </TableRow>
+              <TableRow>
                 <TableCell>Objective-C</TableCell>
                 <TableCell className='flex gap-2'>
                   {['Carthage', 'CocoaPods'].map((p) => (

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/default-values.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/default-values.ts
@@ -122,6 +122,7 @@ export function defaultValues(
           Maven: defaultPackageManagerOptions('Maven'),
           NPM: defaultPackageManagerOptions('NPM'),
           NuGet: defaultPackageManagerOptions('NuGet'),
+          OrtProjectFile: defaultPackageManagerOptions('OrtProjectFile'),
           PIP: defaultPackageManagerOptions('PIP'),
           Pipenv: defaultPackageManagerOptions('Pipenv'),
           PNPM: defaultPackageManagerOptions('PNPM'),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/run-schema.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/run-schema.ts
@@ -79,6 +79,7 @@ export const createRunFormSchema = (
             Maven: packageManagerOptionsSchema,
             NPM: packageManagerOptionsSchema,
             NuGet: packageManagerOptionsSchema,
+            OrtProjectFile: packageManagerOptionsSchema,
             PIP: packageManagerOptionsSchema,
             Pipenv: packageManagerOptionsSchema,
             PNPM: packageManagerOptionsSchema,


### PR DESCRIPTION
Add OrtProjectFile to the list of selectable package managers in the create-run form, as it is already supported by ORT Server but was missing from the UI.