### PR TITLE
test(keycloak): Share a single Keycloak test container to speed up tests

### DIFF
--- a/clients/keycloak/src/testFixtures/kotlin/KeycloakTestExtension.kt
+++ b/clients/keycloak/src/testFixtures/kotlin/KeycloakTestExtension.kt
@@ -25,19 +25,18 @@ import io.kotest.core.extensions.MountableExtension
 import io.kotest.core.listeners.AfterEachListener
 import io.kotest.core.listeners.AfterSpecListener
 import io.kotest.core.listeners.BeforeEachListener
+import io.kotest.core.listeners.BeforeSpecListener
 import io.kotest.core.spec.Spec
 import io.kotest.core.test.TestCase
 import io.kotest.engine.test.TestResult
-
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 import org.keycloak.admin.client.Keycloak
 import org.keycloak.representations.idm.RealmRepresentation
 
 /**
  * A test extension for integration tests that need access to Keycloak. The extension sets up a
- * [Keycloak test container][KeycloakContainer] with the provided [realm] which defaults to [testRealm].
+ * [shared Keycloak test container][SharedKeycloakTestContainer] with the provided [realm] which defaults to
+ * [testRealm].
  *
  * By default, the extension creates the realm once per spec. If [createRealmPerTest] is set to `true` the realm is
  * created once per test. This provides better isolation of tests but also extends the duration of each test case by
@@ -57,27 +56,32 @@ import org.keycloak.representations.idm.RealmRepresentation
  * }
  * ```
  *
- * The container is started on installation of the extension and stopped when the [Spec] is completed.
+ * The underlying Keycloak container is shared across all specs within the same JVM process and is stopped at JVM exit.
+ * This means that no two test classes using this extension may run in parallel.
  */
 class KeycloakTestExtension(
     private val realm: RealmRepresentation = testRealm,
     private val createRealmPerTest: Boolean = false
-) : MountableExtension<Keycloak, KeycloakContainer>, AfterSpecListener, BeforeEachListener, AfterEachListener {
-    private val keycloak = KeycloakContainer("quay.io/keycloak/keycloak:26.6.0")
+) : MountableExtension<Keycloak, KeycloakContainer>,
+    BeforeSpecListener,
+    AfterSpecListener,
+    BeforeEachListener,
+    AfterEachListener {
+    private val keycloak get() = SharedKeycloakTestContainer.container
 
     private lateinit var configureRealm: Keycloak.() -> Unit
 
     override fun mount(configure: Keycloak.() -> Unit): KeycloakContainer {
         configureRealm = configure
-        keycloak.start()
-        if (!createRealmPerTest) createRealm()
         return keycloak
     }
 
+    override suspend fun beforeSpec(spec: Spec) {
+        if (!createRealmPerTest) createRealm()
+    }
+
     override suspend fun afterSpec(spec: Spec) {
-        if (keycloak.isRunning) {
-            withContext(Dispatchers.IO) { keycloak.stop() }
-        }
+        if (!createRealmPerTest) removeRealm()
     }
 
     override suspend fun beforeEach(testCase: TestCase) {

--- a/clients/keycloak/src/testFixtures/kotlin/SharedKeycloakTestContainer.kt
+++ b/clients/keycloak/src/testFixtures/kotlin/SharedKeycloakTestContainer.kt
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.clients.keycloak.test
+
+import dasniko.testcontainers.keycloak.KeycloakContainer
+
+/**
+ * A singleton that manages a shared [KeycloakContainer] across all test specs within a JVM process. The container is
+ * started lazily on the first access to [container] and stopped via a JVM shutdown hook when the process exits.
+ *
+ * Using this shared container avoids the overhead of starting a new Keycloak instance for every test spec. Realm
+ * isolation between specs is still ensured by [KeycloakTestExtension], which creates and removes the test realm around
+ * each spec (or each test when [KeycloakTestExtension.createRealmPerTest] is `true`).
+ */
+internal object SharedKeycloakTestContainer {
+    private val containerLazy: Lazy<KeycloakContainer> = lazy {
+        KeycloakContainer("quay.io/keycloak/keycloak:26.6.0").also { it.start() }
+    }
+
+    val container: KeycloakContainer by containerLazy
+
+    init {
+        Runtime.getRuntime().addShutdownHook(
+            Thread {
+                if (containerLazy.isInitialized() && container.isRunning) {
+                    container.stop()
+                }
+            }
+        )
+    }
+}


### PR DESCRIPTION
Creating a new instance of the Keycloak test container for every test class that uses the `KeycloakTestExtension` takes a lot of time and slows down running the tests on CI significantly. As the extension is managing the creation and deletion of the test realm and tests are not executed in parallel, reuse the same container across all tests.