### PR TITLE
Enable project health plugin again

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -132,6 +132,20 @@ jobs:
       working-directory: website
       run: pnpm format:check
 
+  project-health:
+    runs-on: ubuntu-24.04
+    env:
+      GRADLE_OPTS: -Dorg.gradle.daemon=false
+    steps:
+    - name: Checkout Repository
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
+
+    - name: Check Project Health
+      run: ./gradlew --stacktrace projectHealth
+
   renovate-validation:
     runs-on: ubuntu-24.04
     steps:

--- a/api/v1/client/build.gradle.kts
+++ b/api/v1/client/build.gradle.kts
@@ -37,7 +37,8 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(projects.api.v1.apiV1Model)
+                api(projects.api.v1.apiV1Model)
+
                 implementation(projects.utils.system)
 
                 implementation(ktorLibs.client.auth)

--- a/api/v1/client/build.gradle.kts
+++ b/api/v1/client/build.gradle.kts
@@ -43,7 +43,6 @@ kotlin {
                 implementation(ktorLibs.client.auth)
                 implementation(ktorLibs.client.contentNegotiation)
                 implementation(ktorLibs.serialization.kotlinx.json)
-                implementation(libs.okio)
             }
         }
 
@@ -63,6 +62,7 @@ kotlin {
         linuxMain {
             dependencies {
                 implementation(ktorLibs.client.curl)
+                implementation(libs.okio)
             }
         }
 

--- a/api/v1/model/build.gradle.kts
+++ b/api/v1/model/build.gradle.kts
@@ -37,13 +37,11 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                api(projects.components.infrastructureServices.infrastructureServicesApiModel)
                 api(projects.shared.apiModel)
 
                 api(libs.konform)
 
                 implementation(ktorLibs.http)
-                implementation(libs.kotlinxSerializationJson)
             }
         }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencyAnalysis {
                 exclude(projects.utils.test)
             }
             onUsedTransitiveDependencies { severity("ignore") }
-            onIncorrectConfiguration { severity("ignore") }
+            onIncorrectConfiguration { severity("fail") }
             onCompileOnly { severity("ignore") }
             onRuntimeOnly { severity("ignore") }
             onUnusedAnnotationProcessors { severity("ignore") }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,31 @@ plugins {
 }
 
 dependencyAnalysis {
+    issues {
+        all {
+            onUnusedDependencies {
+                severity("fail")
+
+                // Exclude modules which are automatically added by the "ort-server-kotlin-jvm-conventions".
+                exclude(projects.utils.logging)
+                exclude(projects.utils.test)
+            }
+            onUsedTransitiveDependencies { severity("ignore") }
+            onIncorrectConfiguration { severity("ignore") }
+            onCompileOnly { severity("ignore") }
+            onRuntimeOnly { severity("ignore") }
+            onUnusedAnnotationProcessors { severity("ignore") }
+            onRedundantPlugins { severity("ignore") }
+        }
+
+        project(projects.api.v1.apiV1Client) {
+            onUnusedDependencies {
+                // The dependency is wrongly reported as unused.
+                exclude(libs.okio)
+            }
+        }
+    }
+
     useTypesafeProjectAccessors(true)
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,10 +40,10 @@ dependencyAnalysis {
             }
             onUsedTransitiveDependencies { severity("ignore") }
             onIncorrectConfiguration { severity("fail") }
-            onCompileOnly { severity("ignore") }
+            onCompileOnly { severity("fail") }
             onRuntimeOnly { severity("ignore") }
-            onUnusedAnnotationProcessors { severity("ignore") }
-            onRedundantPlugins { severity("ignore") }
+            onUnusedAnnotationProcessors { severity("fail") }
+            onRedundantPlugins { severity("fail") }
         }
 
         project(projects.api.v1.apiV1Client) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,10 @@ plugins {
     alias(libs.plugins.gitSemver)
 }
 
+dependencyAnalysis {
+    useTypesafeProjectAccessors(true)
+}
+
 semver {
     // Do not create an empty release commit when running the "releaseVersion" task.
     createReleaseCommit = false

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,7 +38,10 @@ dependencyAnalysis {
                 exclude(projects.utils.logging)
                 exclude(projects.utils.test)
             }
-            onUsedTransitiveDependencies { severity("ignore") }
+            onUsedTransitiveDependencies {
+                // Ignore this rule for now as it creates a massive amount of findings.
+                severity("ignore")
+            }
             onIncorrectConfiguration { severity("fail") }
             onCompileOnly { severity("fail") }
             onRuntimeOnly { severity("ignore") }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -31,7 +31,6 @@ repositories {
 
 dependencies {
     implementation(libs.kotlinxSerializationJson)
-    implementation(libs.plugin.dependencyAnalysis)
     implementation(libs.plugin.detekt)
     implementation(libs.plugin.kotlin)
     implementation(libs.plugin.mavenPublish)

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -34,6 +34,7 @@ dependencies {
     implementation(libs.plugin.detekt)
     implementation(libs.plugin.kotlin)
     implementation(libs.plugin.mavenPublish)
+    implementation(libs.plugin.tinyJib)
 }
 
 gradlePlugin {

--- a/buildSrc/src/main/kotlin/ort-server-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-kotlin-conventions.gradle.kts
@@ -22,6 +22,7 @@ import dev.detekt.gradle.Detekt
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 private val catalogs = extensions.getByType<VersionCatalogsExtension>()
+private val detektVersion = catalogs.named("libs").findVersion("detektPlugin").get().requiredVersion
 private val detektRulesVersion = catalogs.named("ortLibs").findLibrary("detektRules").get().get().version
 
 plugins {
@@ -33,7 +34,7 @@ plugins {
 }
 
 dependencies {
-    detektPlugins("dev.detekt:detekt-rules-ktlint-wrapper:${libs.versions.detektPlugin.get()}")
+    detektPlugins("dev.detekt:detekt-rules-ktlint-wrapper:$detektVersion")
     detektPlugins("org.ossreviewtoolkit:detekt-rules:$detektRulesVersion")
 }
 

--- a/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-application-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-application-conventions.gradle.kts
@@ -17,16 +17,18 @@
  * License-Filename: LICENSE
  */
 
+private val libsCatalog = extensions.getByType<VersionCatalogsExtension>().named("libs")
+
 plugins {
     // Apply precompiled plugins.
     id("ort-server-kotlin-jvm-conventions")
 
     // Apply third-party plugins.
-    alias(libs.plugins.tinyJib)
+    id("tel.schich.tinyjib")
 }
 
 dependencies {
-    implementation(enforcedPlatform(libs.kotlinBom))
+    implementation(enforcedPlatform(libsCatalog.findLibrary("kotlinBom").get()))
 }
 
 tinyJib {

--- a/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-conventions.gradle.kts
@@ -29,7 +29,6 @@ plugins {
     id("ort-server-kotlin-conventions")
 
     // Apply third-party plugins.
-    id("com.autonomousapps.dependency-analysis")
     id("org.jetbrains.kotlin.jvm")
 }
 

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -57,18 +57,20 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(projects.api.v1.apiV1Client)
-                implementation(projects.api.v1.apiV1Model)
+                api(projects.api.v1.apiV1Client)
+                api(projects.api.v1.apiV1Model)
+
+                api(libs.clikt)
+                api(libs.okio)
+
                 implementation(projects.utils.system)
 
                 implementation(ktorLibs.client.auth)
                 implementation(ktorLibs.client.core)
-                implementation(libs.clikt)
                 implementation(libs.kaml)
                 implementation(libs.kotlinxCoroutines)
                 implementation(libs.kotlinxSerializationJson)
                 implementation(libs.mordantCoroutines)
-                implementation(libs.okio)
             }
         }
 

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -63,7 +63,6 @@ kotlin {
 
                 implementation(ktorLibs.client.auth)
                 implementation(ktorLibs.client.core)
-                implementation(ktorLibs.utils)
                 implementation(libs.clikt)
                 implementation(libs.kaml)
                 implementation(libs.kotlinxCoroutines)

--- a/clients/keycloak/build.gradle.kts
+++ b/clients/keycloak/build.gradle.kts
@@ -32,13 +32,14 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.clients"
 
 dependencies {
+    api(ktorLibs.client.core)
+    api(libs.kotlinxSerializationJson)
+
     implementation(projects.shared.ktorClientUtils)
     implementation(ktorLibs.client.auth)
     implementation(ktorLibs.client.contentNegotiation)
-    implementation(ktorLibs.client.core)
     implementation(ktorLibs.client.okhttp)
     implementation(ktorLibs.serialization.kotlinx.json)
-    implementation(libs.kotlinxSerializationJson)
 
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestRunnerJunit5)

--- a/clients/keycloak/build.gradle.kts
+++ b/clients/keycloak/build.gradle.kts
@@ -41,7 +41,6 @@ dependencies {
     implementation(libs.kotlinxSerializationJson)
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.wiremock)
 

--- a/components/admin-config/api-model/build.gradle.kts
+++ b/components/admin-config/api-model/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(libs.kotlinxSerializationJson)
+                implementation(libs.kotlinxSerializationCore)
             }
         }
     }

--- a/components/admin-config/api-model/build.gradle.kts
+++ b/components/admin-config/api-model/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(libs.kotlinxSerializationCore)
+                api(libs.kotlinxSerializationCore)
             }
         }
     }

--- a/components/admin-config/backend/build.gradle.kts
+++ b/components/admin-config/backend/build.gradle.kts
@@ -37,11 +37,12 @@ repositories {
 }
 
 dependencies {
-    implementation(projects.components.adminConfig.adminConfigApiModel)
+    api(projects.components.adminConfig.adminConfigApiModel)
+
+    api(libs.exposedCore)
 
     implementation(projects.dao)
 
-    implementation(libs.exposedCore)
     implementation(libs.exposedJdbc)
     implementation(libs.exposedKotlinDatetime)
 

--- a/components/admin-config/backend/build.gradle.kts
+++ b/components/admin-config/backend/build.gradle.kts
@@ -49,21 +49,15 @@ dependencies {
     routesImplementation(projects.shared.apiModel)
     routesImplementation(projects.shared.ktorUtils)
 
-    routesImplementation(ktorLibs.server.auth)
     routesImplementation(ktorLibs.server.core)
     routesImplementation(libs.ktorOpenApi)
 
-    testImplementation(testFixtures(projects.clients.keycloak))
     testImplementation(testFixtures(projects.dao))
     testImplementation(testFixtures(projects.shared.ktorUtils))
 
     testImplementation(ktorLibs.serialization.kotlinx.json)
-    testImplementation(ktorLibs.server.auth)
-    testImplementation(ktorLibs.server.contentNegotiation)
-    testImplementation(ktorLibs.server.statusPages)
     testImplementation(ktorLibs.server.testHost)
     testImplementation(libs.kotestAssertionsKtor)
     testImplementation(libs.kotestRunnerJunit5)
-    testImplementation(libs.kotlinxSerializationJson)
     testImplementation(libs.mockk)
 }

--- a/components/authorization-keycloak/backend/build.gradle.kts
+++ b/components/authorization-keycloak/backend/build.gradle.kts
@@ -29,21 +29,13 @@ dependencies {
     api(projects.components.authorization.authorizationBackend)
     api(projects.model)
 
-    api(ktorLibs.server.auth)
-    api(ktorLibs.server.auth.jwt)
     api(ktorLibs.server.core)
 
     implementation(projects.dao)
-    implementation(projects.shared.ktorUtils)
 
-    implementation(libs.aedile)
-
-    testImplementation(testFixtures(projects.clients.keycloak))
     testImplementation(testFixtures(projects.dao))
 
-    testImplementation(ktorLibs.server.testHost)
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestAssertionsKtor)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
 }

--- a/components/authorization/api-model/build.gradle.kts
+++ b/components/authorization/api-model/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(libs.kotlinxSerializationJson)
+                implementation(libs.kotlinxSerializationCore)
             }
         }
     }

--- a/components/authorization/api-model/build.gradle.kts
+++ b/components/authorization/api-model/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(libs.kotlinxSerializationCore)
+                api(libs.kotlinxSerializationCore)
             }
         }
     }

--- a/components/authorization/backend/build.gradle.kts
+++ b/components/authorization/backend/build.gradle.kts
@@ -45,7 +45,6 @@ dependencies {
     testImplementation(testFixtures(projects.dao))
     testImplementation(testFixtures(projects.shared.ktorUtils))
 
-    testImplementation(ktorLibs.client.contentNegotiation)
     testImplementation(ktorLibs.client.core)
     testImplementation(ktorLibs.server.statusPages)
     testImplementation(ktorLibs.server.testHost)

--- a/components/authorization/backend/build.gradle.kts
+++ b/components/authorization/backend/build.gradle.kts
@@ -32,13 +32,12 @@ dependencies {
     api(ktorLibs.server.auth)
     api(ktorLibs.server.auth.jwt)
     api(ktorLibs.server.core)
+    api(libs.exposedCore)
+    api(libs.exposedJdbc)
     api(libs.ktorOpenApi)
 
     implementation(projects.dao)
     implementation(projects.shared.ktorUtils)
-
-    implementation(libs.exposedCore)
-    implementation(libs.exposedJdbc)
 
     routesImplementation(libs.ktorOpenApi)
 

--- a/components/dependency-graph/api-model/build.gradle.kts
+++ b/components/dependency-graph/api-model/build.gradle.kts
@@ -38,7 +38,7 @@ kotlin {
             dependencies {
                 api(projects.api.v1.apiV1Model)
 
-                implementation(libs.kotlinxSerializationCore)
+                api(libs.kotlinxSerializationCore)
             }
         }
     }

--- a/components/dependency-graph/api-model/build.gradle.kts
+++ b/components/dependency-graph/api-model/build.gradle.kts
@@ -37,9 +37,8 @@ kotlin {
         commonMain {
             dependencies {
                 api(projects.api.v1.apiV1Model)
-                api(projects.shared.apiModel)
 
-                implementation(libs.kotlinxSerializationJson)
+                implementation(libs.kotlinxSerializationCore)
             }
         }
     }

--- a/components/dependency-graph/backend/build.gradle.kts
+++ b/components/dependency-graph/backend/build.gradle.kts
@@ -26,13 +26,14 @@ group = "org.eclipse.apoapsis.ortserver.components.dependencygraph"
 
 dependencies {
     api(projects.components.dependencyGraph.dependencyGraphApiModel)
+    api(projects.model)
+
+    api(libs.exposedJdbc)
 
     implementation(projects.dao)
-    implementation(projects.model)
 
-    implementation(libs.exposedJdbc)
+    routesApi(projects.components.authorization.authorizationBackend)
 
-    routesImplementation(projects.components.authorization.authorizationBackend)
     routesImplementation(projects.components.dependencyGraph.dependencyGraphApiModel)
     routesImplementation(projects.shared.apiMappings)
     routesImplementation(projects.shared.apiModel)

--- a/components/dependency-graph/backend/build.gradle.kts
+++ b/components/dependency-graph/backend/build.gradle.kts
@@ -45,12 +45,8 @@ dependencies {
     testImplementation(testFixtures(projects.shared.ktorUtils))
 
     testImplementation(ktorLibs.serialization.kotlinx.json)
-    testImplementation(ktorLibs.server.auth)
-    testImplementation(ktorLibs.server.contentNegotiation)
-    testImplementation(ktorLibs.server.statusPages)
     testImplementation(ktorLibs.server.testHost)
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestAssertionsKtor)
     testImplementation(libs.kotestRunnerJunit5)
-    testImplementation(libs.kotlinxSerializationJson)
 }

--- a/components/infrastructure-services/api-model/build.gradle.kts
+++ b/components/infrastructure-services/api-model/build.gradle.kts
@@ -40,7 +40,7 @@ kotlin {
 
                 api(libs.konform)
 
-                 implementation(libs.kotlinxSerializationJson)
+                 implementation(libs.kotlinxSerializationCore)
             }
         }
     }

--- a/components/infrastructure-services/api-model/build.gradle.kts
+++ b/components/infrastructure-services/api-model/build.gradle.kts
@@ -39,8 +39,7 @@ kotlin {
                 api(projects.shared.apiModel)
 
                 api(libs.konform)
-
-                 implementation(libs.kotlinxSerializationCore)
+                api(libs.kotlinxSerializationCore)
             }
         }
     }

--- a/components/infrastructure-services/backend/build.gradle.kts
+++ b/components/infrastructure-services/backend/build.gradle.kts
@@ -53,24 +53,19 @@ dependencies {
     routesImplementation(projects.shared.apiMappings)
     routesImplementation(projects.shared.ktorUtils)
 
-    routesImplementation(ktorLibs.server.auth)
     routesImplementation(ktorLibs.server.core)
     routesImplementation(libs.ktorOpenApi)
 
-    testImplementation(testFixtures(projects.clients.keycloak))
     testImplementation(testFixtures(projects.dao))
     testImplementation(testFixtures(projects.secrets.secretsSpi))
     testImplementation(testFixtures(projects.shared.ktorUtils))
 
     testImplementation(ktorLibs.serialization.kotlinx.json)
-    testImplementation(ktorLibs.server.auth)
-    testImplementation(ktorLibs.server.contentNegotiation)
     testImplementation(ktorLibs.server.statusPages)
     testImplementation(ktorLibs.server.testHost)
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestAssertionsKtor)
     testImplementation(libs.kotestRunnerJunit5)
-    testImplementation(libs.kotlinxSerializationJson)
 }
 
 tasks.withType<KotlinCompile> {

--- a/components/infrastructure-services/backend/build.gradle.kts
+++ b/components/infrastructure-services/backend/build.gradle.kts
@@ -41,8 +41,6 @@ repositories {
 }
 
 dependencies {
-    api(projects.components.infrastructureServices.infrastructureServicesApiModel)
-    api(projects.components.secrets.secretsBackend)
     api(projects.model)
 
     implementation(projects.dao)
@@ -50,12 +48,14 @@ dependencies {
     implementation(libs.exposedCore)
 
     routesImplementation(projects.components.authorization.authorizationBackend)
+    routesImplementation(projects.components.infrastructureServices.infrastructureServicesApiModel)
     routesImplementation(projects.shared.apiMappings)
     routesImplementation(projects.shared.ktorUtils)
 
     routesImplementation(ktorLibs.server.core)
     routesImplementation(libs.ktorOpenApi)
 
+    testImplementation(projects.components.secrets.secretsBackend)
     testImplementation(testFixtures(projects.dao))
     testImplementation(testFixtures(projects.secrets.secretsSpi))
     testImplementation(testFixtures(projects.shared.ktorUtils))

--- a/components/license-findings/api-model/build.gradle.kts
+++ b/components/license-findings/api-model/build.gradle.kts
@@ -38,7 +38,7 @@ kotlin {
             dependencies {
                 api(projects.api.v1.apiV1Model)
 
-                implementation(libs.kotlinxSerializationCore)
+                api(libs.kotlinxSerializationCore)
             }
         }
     }

--- a/components/license-findings/api-model/build.gradle.kts
+++ b/components/license-findings/api-model/build.gradle.kts
@@ -37,9 +37,8 @@ kotlin {
         commonMain {
             dependencies {
                 api(projects.api.v1.apiV1Model)
-                api(projects.shared.apiModel)
 
-                implementation(libs.kotlinxSerializationJson)
+                implementation(libs.kotlinxSerializationCore)
             }
         }
     }

--- a/components/license-findings/backend/build.gradle.kts
+++ b/components/license-findings/backend/build.gradle.kts
@@ -26,15 +26,17 @@ group = "org.eclipse.apoapsis.ortserver.components.licensefindings"
 
 dependencies {
     api(projects.components.licenseFindings.licenseFindingsApiModel)
+    api(projects.model)
+
     api(libs.exposedJdbc)
 
     implementation(projects.dao)
-    implementation(projects.model)
-    implementation(projects.shared.apiMappings)
 
     implementation(libs.exposedCore)
 
-    routesImplementation(projects.components.authorization.authorizationBackend)
+    routesApi(projects.components.authorization.authorizationBackend)
+
+    routesImplementation(projects.shared.apiMappings)
     routesImplementation(projects.shared.ktorUtils)
 
     routesImplementation(ktorLibs.server.core)

--- a/components/plugin-manager/api-model/build.gradle.kts
+++ b/components/plugin-manager/api-model/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(libs.kotlinxSerializationJson)
+                implementation(libs.kotlinxSerializationCore)
             }
         }
     }

--- a/components/plugin-manager/api-model/build.gradle.kts
+++ b/components/plugin-manager/api-model/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(libs.kotlinxSerializationCore)
+                api(libs.kotlinxSerializationCore)
             }
         }
     }

--- a/components/plugin-manager/backend/build.gradle.kts
+++ b/components/plugin-manager/backend/build.gradle.kts
@@ -59,18 +59,13 @@ dependencies {
     routesImplementation(projects.components.authorization.authorizationBackend)
     routesImplementation(projects.shared.ktorUtils)
 
-    routesImplementation(ktorLibs.server.auth)
     routesImplementation(ktorLibs.server.core)
     routesImplementation(libs.ktorOpenApi)
 
-    testImplementation(testFixtures(projects.clients.keycloak))
     testImplementation(testFixtures(projects.dao))
     testImplementation(testFixtures(projects.shared.ktorUtils))
 
     testImplementation(ktorLibs.serialization.kotlinx.json)
-    testImplementation(ktorLibs.server.auth)
-    testImplementation(ktorLibs.server.contentNegotiation)
-    testImplementation(ktorLibs.server.statusPages)
     testImplementation(ktorLibs.server.testHost)
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestAssertionsKtor)

--- a/components/resolutions/api-model/build.gradle.kts
+++ b/components/resolutions/api-model/build.gradle.kts
@@ -38,7 +38,7 @@ kotlin {
             dependencies {
                 api(projects.shared.apiModel)
 
-                implementation(libs.kotlinxSerializationJson)
+                implementation(libs.kotlinxSerializationCore)
             }
         }
     }

--- a/components/resolutions/api-model/build.gradle.kts
+++ b/components/resolutions/api-model/build.gradle.kts
@@ -38,7 +38,7 @@ kotlin {
             dependencies {
                 api(projects.shared.apiModel)
 
-                implementation(libs.kotlinxSerializationCore)
+                api(libs.kotlinxSerializationCore)
             }
         }
     }

--- a/components/resolutions/backend/build.gradle.kts
+++ b/components/resolutions/backend/build.gradle.kts
@@ -54,8 +54,6 @@ dependencies {
     testImplementation(projects.components.authorization.authorizationBackend)
 
     testImplementation(ktorLibs.serialization.kotlinx.json)
-    testImplementation(ktorLibs.server.auth)
-    testImplementation(ktorLibs.server.contentNegotiation)
     testImplementation(ktorLibs.server.testHost)
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestAssertionsKtor)

--- a/components/resolutions/backend/build.gradle.kts
+++ b/components/resolutions/backend/build.gradle.kts
@@ -28,14 +28,13 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.components.resolutions"
 
 dependencies {
-    api(projects.components.resolutions.resolutionsApiModel)
+    api(projects.model)
+    api(projects.services.hierarchyService)
 
     api(libs.exposedJdbc)
     api(libs.kotlinResult)
 
     implementation(projects.dao)
-    implementation(projects.model)
-    implementation(projects.services.hierarchyService)
     implementation(projects.utils.logging)
 
     implementation(libs.exposedCore)
@@ -43,6 +42,7 @@ dependencies {
     implementation(libs.kotlinxSerializationJson)
 
     routesImplementation(projects.components.authorization.authorizationBackend)
+    routesImplementation(projects.components.resolutions.resolutionsApiModel)
     routesImplementation(projects.shared.apiMappings)
     routesImplementation(projects.shared.ktorUtils)
 

--- a/components/search/api-model/build.gradle.kts
+++ b/components/search/api-model/build.gradle.kts
@@ -38,7 +38,7 @@ kotlin {
             dependencies {
                 api(projects.api.v1.apiV1Model)
 
-                implementation(libs.kotlinxSerializationJson)
+                implementation(libs.kotlinxSerializationCore)
             }
         }
     }

--- a/components/search/api-model/build.gradle.kts
+++ b/components/search/api-model/build.gradle.kts
@@ -38,7 +38,7 @@ kotlin {
             dependencies {
                 api(projects.api.v1.apiV1Model)
 
-                implementation(libs.kotlinxSerializationCore)
+                api(libs.kotlinxSerializationCore)
             }
         }
     }

--- a/components/search/backend/build.gradle.kts
+++ b/components/search/backend/build.gradle.kts
@@ -36,15 +36,15 @@ repositories {
 }
 
 dependencies {
-    api(libs.exposedCore)
+    api(projects.components.authorization.authorizationBackend)
+    api(projects.components.search.searchApiModel)
+    api(projects.model)
 
-    implementation(projects.components.authorization.authorizationBackend)
-    implementation(projects.components.search.searchApiModel)
     implementation(projects.dao)
-    implementation(projects.model)
 
-    routesImplementation(projects.components.authorization.authorizationBackend)
-    routesImplementation(projects.shared.apiModel)
+    implementation(libs.exposedCore)
+
+    routesApi(projects.components.authorization.authorizationBackend)
     routesImplementation(projects.shared.ktorUtils)
 
     routesImplementation(ktorLibs.server.auth)
@@ -52,6 +52,7 @@ dependencies {
     routesImplementation(libs.ktorOpenApi)
 
     testImplementation(testFixtures(projects.dao))
+    testImplementation(projects.shared.apiModel)
     testImplementation(testFixtures(projects.shared.ktorUtils))
 
     testImplementation(ktorLibs.serialization.kotlinx.json)

--- a/components/secrets/api-model/build.gradle.kts
+++ b/components/secrets/api-model/build.gradle.kts
@@ -40,7 +40,7 @@ kotlin {
 
                 api(libs.konform)
 
-                implementation(libs.kotlinxSerializationJson)
+                implementation(libs.kotlinxSerializationCore)
             }
         }
     }

--- a/components/secrets/api-model/build.gradle.kts
+++ b/components/secrets/api-model/build.gradle.kts
@@ -39,8 +39,7 @@ kotlin {
                 api(projects.shared.apiModel)
 
                 api(libs.konform)
-
-                implementation(libs.kotlinxSerializationCore)
+                api(libs.kotlinxSerializationCore)
             }
         }
     }

--- a/components/secrets/backend/build.gradle.kts
+++ b/components/secrets/backend/build.gradle.kts
@@ -28,8 +28,6 @@ dependencies {
     api(projects.model)
     api(projects.secrets.secretsSpi)
 
-    api(libs.exposedCore)
-
     implementation(projects.dao)
 
     routesApi(projects.components.secrets.secretsApiModel)

--- a/components/secrets/backend/build.gradle.kts
+++ b/components/secrets/backend/build.gradle.kts
@@ -30,14 +30,14 @@ dependencies {
 
     implementation(projects.dao)
 
-    routesApi(projects.components.secrets.secretsApiModel)
+    routesApi(projects.services.hierarchyService)
 
     routesApi(ktorLibs.server.core)
     routesApi(ktorLibs.server.requestValidation)
 
     routesImplementation(projects.components.authorization.authorizationBackend)
+    routesImplementation(projects.components.secrets.secretsApiModel)
     routesImplementation(projects.model)
-    routesImplementation(projects.services.hierarchyService)
     routesImplementation(projects.shared.apiMappings)
     routesImplementation(projects.shared.apiModel)
     routesImplementation(projects.shared.ktorUtils)

--- a/compositions/secrets-routes/build.gradle.kts
+++ b/compositions/secrets-routes/build.gradle.kts
@@ -26,18 +26,19 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.compositions"
 
 dependencies {
+    api(projects.components.infrastructureServices.infrastructureServicesBackend)
     api(projects.components.secrets.secretsBackend)
 
     api(ktorLibs.server.core)
 
     implementation(projects.components.authorization.authorizationBackend)
-    implementation(projects.components.infrastructureServices.infrastructureServicesBackend)
-    implementation(projects.components.secrets.secretsBackend) {
-        capabilities { requireCapability("$group:routes") }
-    }
     implementation(projects.shared.ktorUtils)
 
     implementation(libs.ktorOpenApi)
+
+    testImplementation(projects.components.secrets.secretsBackend) {
+        capabilities { requireCapability("$group:routes") }
+    }
 
     testImplementation(testFixtures(projects.secrets.secretsSpi))
     testImplementation(testFixtures(projects.shared.ktorUtils))

--- a/compositions/secrets-routes/build.gradle.kts
+++ b/compositions/secrets-routes/build.gradle.kts
@@ -32,7 +32,6 @@ dependencies {
 
     implementation(projects.components.authorization.authorizationBackend)
     implementation(projects.components.infrastructureServices.infrastructureServicesBackend)
-    implementation(projects.components.secrets.secretsApiModel)
     implementation(projects.components.secrets.secretsBackend) {
         capabilities { requireCapability("$group:routes") }
     }

--- a/config/git/build.gradle.kts
+++ b/config/git/build.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     implementation(libs.slf4j)
     implementation(ortLibs.downloader)
     implementation(ortLibs.ortPlugins.versionControlSystems.git)
-    implementation(ortLibs.utils.common)
     implementation(projects.config.configSpi)
     implementation(projects.utils.config)
 

--- a/config/git/build.gradle.kts
+++ b/config/git/build.gradle.kts
@@ -26,12 +26,13 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.config"
 
 dependencies {
+    api(projects.config.configSpi)
+
     api(libs.typesafeConfig)
 
     implementation(libs.slf4j)
     implementation(ortLibs.downloader)
     implementation(ortLibs.ortPlugins.versionControlSystems.git)
-    implementation(projects.config.configSpi)
     implementation(projects.utils.config)
 
     testImplementation(testFixtures(projects.config.configSpi))

--- a/config/github/build.gradle.kts
+++ b/config/github/build.gradle.kts
@@ -26,14 +26,15 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.config"
 
 dependencies {
+    api(projects.config.configSpi)
+
+    api(ktorLibs.io)
     api(libs.typesafeConfig)
 
-    implementation(projects.config.configSpi)
     implementation(projects.shared.ktorClientUtils)
     implementation(projects.utils.config)
     implementation(projects.utils.logging)
 
-    implementation(ktorLibs.io)
     implementation(ktorLibs.serialization.kotlinx.json)
 
     testImplementation(testFixtures(projects.config.configSpi))

--- a/config/local/build.gradle.kts
+++ b/config/local/build.gradle.kts
@@ -29,7 +29,6 @@ dependencies {
     api(libs.typesafeConfig)
 
     implementation(projects.config.configSpi)
-    implementation(projects.utils.config)
 
     testImplementation(testFixtures(projects.config.configSpi))
 

--- a/config/local/build.gradle.kts
+++ b/config/local/build.gradle.kts
@@ -26,9 +26,9 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.config"
 
 dependencies {
-    api(libs.typesafeConfig)
+    api(projects.config.configSpi)
 
-    implementation(projects.config.configSpi)
+    api(libs.typesafeConfig)
 
     testImplementation(testFixtures(projects.config.configSpi))
 

--- a/config/secret-file/build.gradle.kts
+++ b/config/secret-file/build.gradle.kts
@@ -27,7 +27,6 @@ group = "org.eclipse.apoapsis.ortserver.config"
 
 dependencies {
     implementation(projects.config.configSpi)
-    implementation(projects.utils.config)
 
     implementation(libs.slf4j)
 

--- a/config/secret-file/build.gradle.kts
+++ b/config/secret-file/build.gradle.kts
@@ -26,7 +26,7 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.config"
 
 dependencies {
-    implementation(projects.config.configSpi)
+    api(projects.config.configSpi)
 
     implementation(libs.slf4j)
 

--- a/config/spi/build.gradle.kts
+++ b/config/spi/build.gradle.kts
@@ -34,7 +34,6 @@ dependencies {
     implementation(projects.utils.config)
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
 

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -57,7 +57,6 @@ repositories {
 dependencies {
     implementation(projects.api.v1.apiV1Mapping)
     implementation(projects.clients.keycloak)
-    implementation(projects.components.adminConfig.adminConfigBackend)
     implementation(projects.components.adminConfig.adminConfigBackend) {
         capabilities {
             requireCapability("$group:routes:$version")
@@ -185,7 +184,6 @@ dependencies {
     testImplementation(libs.kotestAssertionsTable)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
-    testImplementation(ortLibs.utils.common)
 }
 
 tinyJib {

--- a/dao/build.gradle.kts
+++ b/dao/build.gradle.kts
@@ -34,21 +34,22 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver"
 
 dependencies {
-    implementation(projects.config.configSpi)
-    implementation(projects.model)
+    api(projects.config.configSpi)
+    api(projects.model)
+
     implementation(projects.utils.config)
     implementation(projects.utils.system)
 
+    api(libs.exposedCore)
     api(libs.exposedDao)
     api(libs.exposedJdbc)
     api(libs.koinCore)
+    api(libs.kotlinxSerializationJson)
 
     implementation(libs.bundles.flyway)
-    implementation(libs.exposedCore)
     implementation(libs.exposedJson)
     implementation(libs.exposedKotlinDatetime)
     implementation(libs.hikari)
-    implementation(libs.kotlinxSerializationJson)
     implementation(libs.postgres)
     implementation(libs.typesafeConfig)
 

--- a/dao/build.gradle.kts
+++ b/dao/build.gradle.kts
@@ -58,7 +58,6 @@ dependencies {
     testImplementation(testFixtures(projects.config.configSpi))
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestAssertionsKtor)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,6 @@
 [versions]
 # Gradle plugins
 buildConfigPlugin = "6.0.9"
-dependencyAnalysisPlugin = "3.12.0"
 detektPlugin = "2.0.0-alpha.3"
 gitSemverPlugin = "0.19.0"
 tinyJibPlugin = "0.3.4"
@@ -76,7 +75,6 @@ tinyJib = { id = "tel.schich.tinyjib", version.ref = "tinyJibPlugin" }
 
 [libraries]
 # These are Maven coordinates for Gradle plugins, which is necessary to use them in precompiled plugin scripts.
-plugin-dependencyAnalysis = { module = "com.autonomousapps:dependency-analysis-gradle-plugin", version.ref = "dependencyAnalysisPlugin" }
 plugin-detekt = { module = "dev.detekt:detekt-gradle-plugin", version.ref = "detektPlugin" }
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinPlugin" }
 plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublishPlugin" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -111,6 +111,7 @@ kotlinBom = { module = "org.jetbrains.kotlin:kotlin-bom", version.ref = "kotlinP
 kotlinResult = { module = "com.michael-bull.kotlin-result:kotlin-result", version.ref = "kotlinResult" }
 kotlinxCoroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "kotlinxCoroutines" }
 kotlinxCoroutinesSlf4j = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-slf4j", version.ref = "kotlinxCoroutines" }
+kotlinxSerializationCore = { module = "org.jetbrains.kotlinx:kotlinx-serialization-core", version.ref = "kotlinxSerialization" }
 kotlinxSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }
 ktorOpenApi = { module = "io.github.smiley4:ktor-openapi", version.ref = "ktorOpenApi" }
 ktorSwaggerUi = { module = "io.github.smiley4:ktor-swagger-ui", version.ref = "ktorOpenApi" }
@@ -129,7 +130,6 @@ qpidJmsClient = { module = "org.apache.qpid:qpid-jms-client", version.ref = "qpi
 rabbitMqAmqpClient = { module = "com.rabbitmq:amqp-client", version.ref = "rabbitMq" }
 s3 = { module = "aws.sdk.kotlin:s3", version.ref = "awsSdk" }
 schemaKeneratorCore = { module = "io.github.smiley4:schema-kenerator-core", version.ref = "schemaKenerator" }
-schemaKeneratorJsonschema = { module = "io.github.smiley4:schema-kenerator-jsonschema", version.ref = "schemaKenerator" }
 schemaKeneratorReflection = { module = "io.github.smiley4:schema-kenerator-reflection", version.ref = "schemaKenerator" }
 schemaKeneratorSwagger = { module = "io.github.smiley4:schema-kenerator-swagger", version.ref = "schemaKenerator" }
 slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
@@ -145,4 +145,4 @@ wiremock = { module = "org.wiremock:wiremock", version.ref = "wiremock" }
 
 [bundles]
 flyway = ["flywayCore", "flywayPostgresql"]
-schemaKenerator = ["schemaKeneratorCore", "schemaKeneratorJsonschema", "schemaKeneratorReflection", "schemaKeneratorSwagger"]
+schemaKenerator = ["schemaKeneratorCore", "schemaKeneratorReflection", "schemaKeneratorSwagger"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -78,6 +78,7 @@ tinyJib = { id = "tel.schich.tinyjib", version.ref = "tinyJibPlugin" }
 plugin-detekt = { module = "dev.detekt:detekt-gradle-plugin", version.ref = "detektPlugin" }
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinPlugin" }
 plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublishPlugin" }
+plugin-tinyJib = { module = "tel.schich.tinyjib:tel.schich.tinyjib.gradle.plugin", version.ref = "tinyJibPlugin" }
 
 aedile = { module = "com.sksamuel.aedile:aedile-core", version.ref = "aedile" }
 azureIdentity = { module = "com.azure:azure-identity", version.ref = "azureIdentity" }

--- a/logaccess/elasticsearch/build.gradle.kts
+++ b/logaccess/elasticsearch/build.gradle.kts
@@ -27,9 +27,10 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.logaccess"
 
 dependencies {
-    implementation(projects.config.configSpi)
-    implementation(projects.logaccess.logaccessSpi)
-    implementation(projects.model)
+    api(projects.config.configSpi)
+    api(projects.logaccess.logaccessSpi)
+    api(projects.model)
+
     implementation(projects.shared.ktorClientUtils)
     implementation(projects.utils.config)
 

--- a/logaccess/loki/build.gradle.kts
+++ b/logaccess/loki/build.gradle.kts
@@ -29,10 +29,9 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.logaccess"
 
 dependencies {
-    api(libs.typesafeConfig)
+    api(projects.logaccess.logaccessSpi)
+    api(projects.model)
 
-    implementation(projects.logaccess.logaccessSpi)
-    implementation(projects.model)
     implementation(projects.shared.ktorClientUtils)
     implementation(projects.utils.config)
 
@@ -41,6 +40,7 @@ dependencies {
     implementation(ktorLibs.client.core)
     implementation(ktorLibs.client.okhttp)
     implementation(ktorLibs.serialization.kotlinx.json)
+    implementation(libs.typesafeConfig)
 
     testImplementation(testFixtures(projects.logaccess.logaccessSpi))
 

--- a/logaccess/spi/build.gradle.kts
+++ b/logaccess/spi/build.gradle.kts
@@ -40,10 +40,8 @@ dependencies {
     implementation(ortLibs.utils.common)
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
 
     testFixturesImplementation(projects.model)
-    testFixturesImplementation(projects.utils.config)
 }

--- a/logaccess/spi/build.gradle.kts
+++ b/logaccess/spi/build.gradle.kts
@@ -32,7 +32,6 @@ dependencies {
     api(projects.config.configSpi)
     api(projects.model)
 
-    implementation(projects.model)
     implementation(projects.utils.config)
 
     implementation(libs.kotlinxCoroutines)
@@ -43,5 +42,5 @@ dependencies {
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
 
-    testFixturesImplementation(projects.model)
+    testFixturesApi(projects.model)
 }

--- a/orchestrator/build.gradle.kts
+++ b/orchestrator/build.gradle.kts
@@ -30,10 +30,11 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver"
 
 dependencies {
+    api(projects.model)
+    api(projects.transport.transportSpi)
+
     implementation(projects.config.configSpi)
     implementation(projects.dao)
-    implementation(projects.model)
-    implementation(projects.transport.transportSpi)
     implementation(projects.utils.logging)
 
     runtimeOnly(projects.config.secretFile)

--- a/secrets/azure-keyvault/build.gradle.kts
+++ b/secrets/azure-keyvault/build.gradle.kts
@@ -30,7 +30,6 @@ group = "org.eclipse.apoapsis.ortserver.secrets"
 
 dependencies {
     implementation(projects.secrets.secretsSpi)
-    implementation(projects.utils.config)
     implementation(projects.utils.logging)
 
     implementation(ktorLibs.serialization.kotlinx.json)
@@ -39,6 +38,5 @@ dependencies {
 
     testImplementation(testFixtures(projects.config.configSpi))
 
-    testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestRunnerJunit5)
 }

--- a/secrets/azure-keyvault/build.gradle.kts
+++ b/secrets/azure-keyvault/build.gradle.kts
@@ -29,12 +29,14 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.secrets"
 
 dependencies {
-    implementation(projects.secrets.secretsSpi)
+    api(projects.secrets.secretsSpi)
+
+    api(libs.azureSecurityKeyvaultSecrets)
+
     implementation(projects.utils.logging)
 
     implementation(ktorLibs.serialization.kotlinx.json)
     implementation(libs.azureIdentity)
-    implementation(libs.azureSecurityKeyvaultSecrets)
 
     testImplementation(testFixtures(projects.config.configSpi))
 

--- a/secrets/database/build.gradle.kts
+++ b/secrets/database/build.gradle.kts
@@ -25,8 +25,9 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.secrets"
 
 dependencies {
-    implementation(projects.config.configSpi)
-    implementation(projects.secrets.secretsSpi)
+    api(projects.config.configSpi)
+    api(projects.secrets.secretsSpi)
+
     implementation(projects.utils.config)
 
     implementation(libs.exposedCore)

--- a/secrets/database/build.gradle.kts
+++ b/secrets/database/build.gradle.kts
@@ -38,6 +38,5 @@ dependencies {
     testImplementation(testFixtures(projects.dao))
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
 }

--- a/secrets/file/build.gradle.kts
+++ b/secrets/file/build.gradle.kts
@@ -29,7 +29,8 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.secrets"
 
 dependencies {
-    implementation(projects.secrets.secretsSpi)
+    api(projects.secrets.secretsSpi)
+
     implementation(projects.utils.config)
 
     implementation(ktorLibs.serialization.kotlinx.json)

--- a/secrets/scaleway/build.gradle.kts
+++ b/secrets/scaleway/build.gradle.kts
@@ -29,7 +29,8 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.secrets"
 
 dependencies {
-    implementation(projects.secrets.secretsSpi)
+    api(projects.secrets.secretsSpi)
+
     implementation(projects.shared.ktorClientUtils)
     implementation(projects.utils.config)
     implementation(projects.utils.logging)

--- a/secrets/spi/build.gradle.kts
+++ b/secrets/spi/build.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
     api(projects.model)
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
 

--- a/secrets/vault/build.gradle.kts
+++ b/secrets/vault/build.gradle.kts
@@ -29,7 +29,8 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.secrets"
 
 dependencies {
-    implementation(projects.secrets.secretsSpi)
+    api(projects.secrets.secretsSpi)
+
     implementation(projects.shared.ktorClientUtils)
     implementation(projects.utils.config)
     implementation(projects.utils.logging)

--- a/services/content-management/build.gradle.kts
+++ b/services/content-management/build.gradle.kts
@@ -28,13 +28,9 @@ group = "org.eclipse.apoapsis.ortserver.services"
 dependencies {
     api(projects.model)
 
-    api(libs.exposedCore)
-
     implementation(projects.dao)
 
     runtimeOnly(libs.logback)
-
-    testImplementation(testFixtures(projects.dao))
 
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)

--- a/services/hierarchy/build.gradle.kts
+++ b/services/hierarchy/build.gradle.kts
@@ -26,11 +26,11 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.services"
 
 dependencies {
+    api(projects.components.authorization.authorizationBackend)
     api(projects.model)
 
     api(libs.exposedCore)
 
-    implementation(projects.components.authorization.authorizationBackend)
     implementation(projects.dao)
     implementation(projects.utils.logging)
 

--- a/services/hierarchy/build.gradle.kts
+++ b/services/hierarchy/build.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
     implementation(projects.components.authorization.authorizationBackend)
     implementation(projects.dao)
     implementation(projects.utils.logging)
-    implementation(projects.services.reportStorageService)
 
     runtimeOnly(libs.logback)
 

--- a/services/ort-run/build.gradle.kts
+++ b/services/ort-run/build.gradle.kts
@@ -26,19 +26,19 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.services"
 
 dependencies {
-    api(projects.api.v1.apiV1Mapping)
     api(projects.api.v1.apiV1Model)
     api(projects.components.resolutions.resolutionsBackend)
-    api(projects.dao)
     api(projects.model)
-    api(projects.services.hierarchyService)
     api(projects.services.reportStorageService)
-    api(projects.shared.apiMappings)
-    api(projects.shared.apiModel)
 
     api(ortLibs.model)
     api(ortLibs.scanner)
 
+    implementation(projects.api.v1.apiV1Mapping)
+    implementation(projects.dao)
+    implementation(projects.services.hierarchyService)
+    implementation(projects.shared.apiMappings)
+    implementation(projects.shared.apiModel)
     implementation(projects.utils.logging)
 
     testImplementation(testFixtures(projects.dao))

--- a/services/report-storage/build.gradle.kts
+++ b/services/report-storage/build.gradle.kts
@@ -27,10 +27,9 @@ group = "org.eclipse.apoapsis.ortserver.services"
 
 dependencies {
     api(projects.storage.storageSpi)
+    api(projects.model)
 
-    implementation(projects.model)
-
-    implementation(ktorLibs.http)
+    api(ktorLibs.http)
 
     runtimeOnly(libs.logback)
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -132,7 +132,11 @@ rootProject.children.single { it.name == "components" }.children.forEach { compo
 
 plugins {
     // Gradle cannot access the version catalog from here, so hard-code the dependency.
+    id("com.autonomousapps.build-health").version("3.12.0")
     id("org.gradle.toolchains.foojay-resolver-convention").version("1.0.0")
+
+    // Required for the build-health plugin. Keep the version in sync with the one from the version catalog.
+    id("org.jetbrains.kotlin.jvm").version("2.3.21").apply(false)
 }
 
 dependencyResolutionManagement {

--- a/shared/api-model/build.gradle.kts
+++ b/shared/api-model/build.gradle.kts
@@ -37,7 +37,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(libs.kotlinxSerializationJson)
+                implementation(libs.kotlinxSerializationCore)
             }
         }
     }

--- a/shared/api-model/build.gradle.kts
+++ b/shared/api-model/build.gradle.kts
@@ -37,7 +37,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                implementation(libs.kotlinxSerializationCore)
+                api(libs.kotlinxSerializationCore)
             }
         }
     }

--- a/shared/ktor-utils/build.gradle.kts
+++ b/shared/ktor-utils/build.gradle.kts
@@ -43,11 +43,12 @@ dependencies {
     testImplementation(libs.kotestAssertionsKtor)
 
     testFixturesApi(projects.components.authorization.authorizationBackend)
-    testFixturesApi(projects.utils.test)
     testFixturesApi(testFixtures(projects.dao))
     testFixturesApi(libs.kotestAssertionsCore)
 
-    testFixturesImplementation(testFixtures(projects.clients.keycloak))
+    testFixturesApi(testFixtures(projects.clients.keycloak))
+
+    testFixturesImplementation(projects.utils.test)
 
     testFixturesImplementation(ktorLibs.client.contentNegotiation)
     testFixturesImplementation(ktorLibs.serialization.kotlinx.json)

--- a/shared/ktor-utils/build.gradle.kts
+++ b/shared/ktor-utils/build.gradle.kts
@@ -52,7 +52,6 @@ dependencies {
     testFixturesImplementation(ktorLibs.client.contentNegotiation)
     testFixturesImplementation(ktorLibs.serialization.kotlinx.json)
     testFixturesImplementation(ktorLibs.server.auth)
-    testFixturesImplementation(ktorLibs.server.auth.jwt)
     testFixturesImplementation(ktorLibs.server.contentNegotiation)
     testFixturesImplementation(ktorLibs.server.core)
     testFixturesImplementation(ktorLibs.server.statusPages)

--- a/shared/ort-test-data/build.gradle.kts
+++ b/shared/ort-test-data/build.gradle.kts
@@ -27,5 +27,6 @@ group = "org.eclipse.apoapsis.ortserver.shared"
 
 dependencies {
     api(ortLibs.model)
-    api(ortLibs.ortPlugins.api)
+
+    implementation(ortLibs.ortPlugins.api)
 }

--- a/storage/azure-blob/build.gradle.kts
+++ b/storage/azure-blob/build.gradle.kts
@@ -31,11 +31,12 @@ group = "org.eclipse.apoapsis.ortserver.storage"
 dependencies {
     api(projects.storage.storageSpi)
 
+    api(libs.azureStorageBlob)
+
     implementation(projects.utils.config)
     implementation(projects.utils.logging)
 
     implementation(libs.azureIdentity)
-    implementation(libs.azureStorageBlob)
 
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestExtensionsTestcontainers)

--- a/storage/database/build.gradle.kts
+++ b/storage/database/build.gradle.kts
@@ -26,9 +26,10 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.storage"
 
 dependencies {
-    implementation(projects.storage.storageSpi)
+    api(projects.storage.storageSpi)
 
-    implementation(libs.exposedDao)
+    api(libs.exposedDao)
+
     implementation(libs.exposedJdbc)
     implementation(libs.exposedKotlinDatetime)
     implementation(libs.postgres)

--- a/storage/database/build.gradle.kts
+++ b/storage/database/build.gradle.kts
@@ -26,17 +26,16 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.storage"
 
 dependencies {
-    implementation(projects.dao)
     implementation(projects.storage.storageSpi)
 
     implementation(libs.exposedDao)
+    implementation(libs.exposedJdbc)
     implementation(libs.exposedKotlinDatetime)
     implementation(libs.postgres)
 
     testImplementation(testFixtures(projects.dao))
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
 }

--- a/storage/s3/build.gradle.kts
+++ b/storage/s3/build.gradle.kts
@@ -31,10 +31,11 @@ group = "org.eclipse.apoapsis.ortserver.storage"
 dependencies {
     api(projects.storage.storageSpi)
 
+    api(libs.s3)
+
     implementation(projects.utils.config)
     implementation(projects.utils.logging)
 
-    implementation(libs.s3)
     implementation(ortLibs.utils.common)
 
     testImplementation(libs.kotestAssertionsCore)

--- a/storage/s3/build.gradle.kts
+++ b/storage/s3/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     implementation(projects.utils.logging)
 
     implementation(libs.s3)
-    implementation(ortLibs.utils.ort)
+    implementation(ortLibs.utils.common)
 
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestExtensionsTestcontainers)

--- a/storage/spi/build.gradle.kts
+++ b/storage/spi/build.gradle.kts
@@ -33,12 +33,8 @@ dependencies {
 
     implementation(projects.utils.config)
     implementation(libs.kotlinxCoroutines)
-    implementation(libs.kotlinxCoroutinesSlf4j)
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
-
-    testFixturesImplementation(projects.utils.config)
 }

--- a/tasks/build.gradle.kts
+++ b/tasks/build.gradle.kts
@@ -33,7 +33,6 @@ dependencies {
     implementation(projects.config.configSpi)
     implementation(projects.dao)
     implementation(projects.utils.logging)
-    implementation(projects.services.hierarchyService)
     implementation(projects.services.ortRunService)
     implementation(projects.services.reportStorageService)
     implementation(projects.storage.storageSpi)

--- a/tasks/build.gradle.kts
+++ b/tasks/build.gradle.kts
@@ -30,10 +30,11 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver"
 
 dependencies {
-    implementation(projects.config.configSpi)
+    api(projects.config.configSpi)
+    api(projects.services.ortRunService)
+
     implementation(projects.dao)
     implementation(projects.utils.logging)
-    implementation(projects.services.ortRunService)
     implementation(projects.services.reportStorageService)
     implementation(projects.storage.storageSpi)
     implementation(projects.transport.transportSpi)

--- a/transport/activemqartemis/build.gradle.kts
+++ b/transport/activemqartemis/build.gradle.kts
@@ -32,7 +32,6 @@ dependencies {
     implementation(projects.transport.transportSpi)
     implementation(projects.utils.logging)
 
-    implementation(libs.kotlinxSerializationJson)
     implementation(libs.qpidJmsClient)
 
     runtimeOnly(libs.logback)

--- a/transport/activemqartemis/build.gradle.kts
+++ b/transport/activemqartemis/build.gradle.kts
@@ -29,7 +29,8 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.transport"
 
 dependencies {
-    implementation(projects.transport.transportSpi)
+    api(projects.transport.transportSpi)
+
     implementation(projects.utils.logging)
 
     implementation(libs.qpidJmsClient)

--- a/transport/azure-servicebus/build.gradle.kts
+++ b/transport/azure-servicebus/build.gradle.kts
@@ -26,12 +26,14 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.transport"
 
 dependencies {
-    implementation(projects.transport.transportSpi)
+    api(projects.transport.transportSpi)
+
+    api(libs.azureMessagingServicebus)
+
     implementation(projects.utils.logging)
 
     implementation(libs.kotlinxCoroutines)
     implementation(libs.azureIdentity)
-    implementation(libs.azureMessagingServicebus)
 
     runtimeOnly(libs.logback)
 

--- a/transport/azure-servicebus/build.gradle.kts
+++ b/transport/azure-servicebus/build.gradle.kts
@@ -35,7 +35,6 @@ dependencies {
 
     runtimeOnly(libs.logback)
 
-    testImplementation(projects.model)
     testImplementation(testFixtures(projects.config.configSpi))
     testImplementation(testFixtures(projects.transport.transportSpi))
 

--- a/transport/kubernetes/build.gradle.kts
+++ b/transport/kubernetes/build.gradle.kts
@@ -26,7 +26,8 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.transport"
 
 dependencies {
-    implementation(projects.transport.transportSpi)
+    api(projects.transport.transportSpi)
+
     implementation(projects.utils.config)
     implementation(projects.utils.logging)
 

--- a/transport/rabbitmq/build.gradle.kts
+++ b/transport/rabbitmq/build.gradle.kts
@@ -26,11 +26,13 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.transport"
 
 dependencies {
-    implementation(projects.transport.transportSpi)
+    api(projects.transport.transportSpi)
+
+    api(libs.rabbitMqAmqpClient)
+
     implementation(projects.utils.logging)
 
     implementation(libs.kotlinxCoroutines)
-    implementation(libs.rabbitMqAmqpClient)
 
     runtimeOnly(libs.logback)
 

--- a/transport/rabbitmq/build.gradle.kts
+++ b/transport/rabbitmq/build.gradle.kts
@@ -30,7 +30,6 @@ dependencies {
     implementation(projects.utils.logging)
 
     implementation(libs.kotlinxCoroutines)
-    implementation(libs.kotlinxCoroutinesSlf4j)
     implementation(libs.rabbitMqAmqpClient)
 
     runtimeOnly(libs.logback)

--- a/transport/spi/build.gradle.kts
+++ b/transport/spi/build.gradle.kts
@@ -42,7 +42,6 @@ dependencies {
     api(libs.koinCore)
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
 

--- a/transport/spi/build.gradle.kts
+++ b/transport/spi/build.gradle.kts
@@ -32,7 +32,8 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.transport"
 
 dependencies {
-    implementation(projects.model)
+    api(projects.model)
+
     implementation(projects.utils.system)
 
     implementation(ktorLibs.serialization.kotlinx.json)
@@ -45,7 +46,7 @@ dependencies {
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
 
-    testFixturesImplementation(projects.model)
+    testFixturesApi(projects.model)
 
     testFixturesImplementation(libs.kotestAssertionsCore)
     testFixturesImplementation(libs.kotlinxCoroutines)

--- a/transport/sqs/build.gradle.kts
+++ b/transport/sqs/build.gradle.kts
@@ -29,11 +29,13 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.transport"
 
 dependencies {
-    implementation(projects.transport.transportSpi)
+    api(projects.transport.transportSpi)
+
+    api(libs.sqs)
+
     implementation(projects.utils.logging)
 
     implementation(libs.slf4j)
-    implementation(libs.sqs)
 
     runtimeOnly(libs.logback)
 

--- a/transport/sqs/build.gradle.kts
+++ b/transport/sqs/build.gradle.kts
@@ -30,10 +30,8 @@ group = "org.eclipse.apoapsis.ortserver.transport"
 
 dependencies {
     implementation(projects.transport.transportSpi)
-    implementation(projects.utils.config)
     implementation(projects.utils.logging)
 
-    implementation(libs.kotlinxSerializationJson)
     implementation(libs.slf4j)
     implementation(libs.sqs)
 

--- a/utils/config/build.gradle.kts
+++ b/utils/config/build.gradle.kts
@@ -30,6 +30,5 @@ dependencies {
     implementation(ortLibs.utils.common)
 
     testImplementation(libs.kotestAssertionsCore)
-    testImplementation(libs.kotestExtensionsTestcontainers)
     testImplementation(libs.kotestRunnerJunit5)
 }

--- a/utils/config/build.gradle.kts
+++ b/utils/config/build.gradle.kts
@@ -26,7 +26,8 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.utils"
 
 dependencies {
-    implementation(libs.typesafeConfig)
+    api(libs.typesafeConfig)
+
     implementation(ortLibs.utils.common)
 
     testImplementation(libs.kotestAssertionsCore)

--- a/utils/logging/build.gradle.kts
+++ b/utils/logging/build.gradle.kts
@@ -32,9 +32,9 @@ group = "org.eclipse.apoapsis.ortserver.utils"
 dependencies {
     api(libs.kotlinxCoroutines)
     api(libs.kotlinxSerializationJson)
+    api(libs.logback)
 
     implementation(libs.kotlinxCoroutinesSlf4j)
-    implementation(libs.logback)
     implementation(libs.slf4j)
 
     testImplementation(libs.kotestAssertionsCore)

--- a/utils/test/build.gradle.kts
+++ b/utils/test/build.gradle.kts
@@ -35,8 +35,6 @@ kotlin {
 
         jvmMain {
             dependencies {
-                api(libs.kotestExtensions)
-
                 // Transitively export this to consumers so they do not have to declare a logger implementation.
                 api(libs.logback)
             }

--- a/workers/advisor/build.gradle.kts
+++ b/workers/advisor/build.gradle.kts
@@ -39,7 +39,6 @@ dependencies {
     implementation(projects.model)
     implementation(projects.services.adminConfigService)
     implementation(projects.transport.transportSpi)
-    implementation(projects.utils.config)
     implementation(projects.utils.logging)
     implementation(projects.workers.common)
 

--- a/workers/advisor/build.gradle.kts
+++ b/workers/advisor/build.gradle.kts
@@ -34,10 +34,13 @@ group = "org.eclipse.apoapsis.ortserver.workers"
 
 dependencies {
     implementation(projects.components.authorization.authorizationBackend)
+    implementation(projects.components.resolutions.resolutionsBackend)
     implementation(projects.config.configSpi)
     implementation(projects.dao)
     implementation(projects.model)
     implementation(projects.services.adminConfigService)
+    implementation(projects.services.hierarchyService)
+    implementation(projects.services.ortRunService)
     implementation(projects.transport.transportSpi)
     implementation(projects.utils.logging)
     implementation(projects.workers.common)

--- a/workers/analyzer/build.gradle.kts
+++ b/workers/analyzer/build.gradle.kts
@@ -48,7 +48,6 @@ repositories {
 }
 
 dependencies {
-    implementation(projects.api.v1.apiV1Model)
     implementation(projects.components.authorization.authorizationBackend)
     implementation(projects.dao)
     implementation(projects.model)
@@ -59,9 +58,6 @@ dependencies {
     implementation(projects.utils.logging)
     implementation(projects.workers.common)
 
-    implementation(ktorLibs.client.auth)
-    implementation(ktorLibs.client.contentNegotiation)
-    implementation(ktorLibs.client.core)
     implementation(ktorLibs.client.okhttp)
     implementation(ktorLibs.serialization.kotlinx.json)
     implementation(ortLibs.analyzer)
@@ -79,7 +75,6 @@ dependencies {
     runtimeOnly(libs.logback)
 
     testImplementation(projects.components.infrastructureServices.infrastructureServicesBackend)
-    testImplementation(projects.services.adminConfigService)
     testImplementation(projects.shared.ortTestData)
 
     testImplementation(testFixtures(projects.config.configSpi))

--- a/workers/analyzer/build.gradle.kts
+++ b/workers/analyzer/build.gradle.kts
@@ -49,9 +49,12 @@ repositories {
 
 dependencies {
     implementation(projects.components.authorization.authorizationBackend)
+    implementation(projects.components.resolutions.resolutionsBackend)
     implementation(projects.dao)
     implementation(projects.model)
     implementation(projects.services.adminConfigService)
+    implementation(projects.services.hierarchyService)
+    implementation(projects.services.ortRunService)
     implementation(projects.shared.packageCurationProviders)
     implementation(projects.transport.transportSpi)
     implementation(projects.utils.config)
@@ -75,6 +78,7 @@ dependencies {
     runtimeOnly(libs.logback)
 
     testImplementation(projects.components.infrastructureServices.infrastructureServicesBackend)
+    testImplementation(projects.components.secrets.secretsBackend)
     testImplementation(projects.shared.ortTestData)
 
     testImplementation(testFixtures(projects.config.configSpi))

--- a/workers/common/build.gradle.kts
+++ b/workers/common/build.gradle.kts
@@ -59,11 +59,8 @@ dependencies {
     api(libs.koinCore)
     api(ortLibs.downloader)
     api(ortLibs.model)
-    api(ortLibs.ortPlugins.api)
     api(ortLibs.scanner)
     api(libs.typesafeConfig)
-
-    testImplementation(projects.shared.ortTestData)
 
     testImplementation(testFixtures(projects.config.configSpi))
     testImplementation(testFixtures(projects.dao))

--- a/workers/common/build.gradle.kts
+++ b/workers/common/build.gradle.kts
@@ -36,31 +36,30 @@ repositories {
 }
 
 dependencies {
+    api(libs.koinCore)
+
     implementation(projects.components.infrastructureServices.infrastructureServicesBackend)
+    implementation(projects.components.resolutions.resolutionsBackend)
+    implementation(projects.components.secrets.secretsBackend)
+    implementation(projects.config.configSpi)
     implementation(projects.dao)
     implementation(projects.model)
     implementation(projects.secrets.secretsSpi)
-    implementation(projects.utils.config)
     implementation(projects.services.adminConfigService)
+    implementation(projects.services.ortRunService)
+    implementation(projects.storage.storageSpi)
     implementation(projects.transport.transportSpi)
+    implementation(projects.utils.config)
     implementation(projects.utils.logging)
 
     implementation(libs.commonsText)
     implementation(libs.kaml)
     implementation(libs.kotlinxCoroutines)
     implementation(libs.kotlinxSerializationJson)
-
-    api(projects.components.resolutions.resolutionsBackend)
-    api(projects.components.secrets.secretsBackend)
-    api(projects.config.configSpi)
-    api(projects.services.ortRunService)
-    api(projects.storage.storageSpi)
-
-    api(libs.koinCore)
-    api(ortLibs.downloader)
-    api(ortLibs.model)
-    api(ortLibs.scanner)
-    api(libs.typesafeConfig)
+    implementation(libs.typesafeConfig)
+    implementation(ortLibs.downloader)
+    implementation(ortLibs.model)
+    implementation(ortLibs.scanner)
 
     testImplementation(testFixtures(projects.config.configSpi))
     testImplementation(testFixtures(projects.dao))

--- a/workers/config/build.gradle.kts
+++ b/workers/config/build.gradle.kts
@@ -67,7 +67,6 @@ dependencies {
     runtimeOnly(libs.logback)
     runtimeOnly(platform(ortLibs.ortPlugins.packageManagers))
 
-    testImplementation(projects.components.pluginManager.pluginManagerBackend)
     testImplementation(testFixtures(projects.config.configSpi))
     testImplementation(testFixtures(projects.dao))
     testImplementation(testFixtures(projects.secrets.secretsSpi))

--- a/workers/config/build.gradle.kts
+++ b/workers/config/build.gradle.kts
@@ -56,7 +56,9 @@ dependencies {
 
     implementation("org.jetbrains.kotlin:kotlin-scripting-common")
     implementation("org.jetbrains.kotlin:kotlin-scripting-jvm-host")
+    implementation(libs.kotlinResult)
     implementation(libs.typesafeConfig)
+    implementation(ortLibs.model)
     implementation(ortLibs.utils.scripting)
 
     runtimeOnly(platform(projects.config))

--- a/workers/evaluator/build.gradle.kts
+++ b/workers/evaluator/build.gradle.kts
@@ -34,10 +34,14 @@ group = "org.eclipse.apoapsis.ortserver.workers"
 
 dependencies {
     implementation(projects.components.authorization.authorizationBackend)
+    implementation(projects.components.resolutions.resolutionsBackend)
     implementation(projects.config.configSpi)
     implementation(projects.dao)
     implementation(projects.model)
     implementation(projects.services.adminConfigService)
+    implementation(projects.services.hierarchyService)
+    implementation(projects.services.ortRunService)
+    implementation(projects.storage.storageSpi)
     implementation(projects.transport.transportSpi)
     implementation(projects.utils.logging)
     implementation(projects.workers.common)

--- a/workers/notifier/build.gradle.kts
+++ b/workers/notifier/build.gradle.kts
@@ -37,6 +37,7 @@ dependencies {
     implementation(projects.dao)
     implementation(projects.model)
     implementation(projects.services.adminConfigService)
+    implementation(projects.services.ortRunService)
     implementation(projects.transport.transportSpi)
     implementation(projects.utils.logging)
     implementation(projects.workers.common)

--- a/workers/reporter/build.gradle.kts
+++ b/workers/reporter/build.gradle.kts
@@ -34,10 +34,13 @@ group = "org.eclipse.apoapsis.ortserver.workers"
 
 dependencies {
     implementation(projects.components.authorization.authorizationBackend)
+    implementation(projects.components.resolutions.resolutionsBackend)
     implementation(projects.config.configSpi)
     implementation(projects.dao)
     implementation(projects.model)
     implementation(projects.services.adminConfigService)
+    implementation(projects.services.hierarchyService)
+    implementation(projects.services.ortRunService)
     implementation(projects.shared.reporters)
     implementation(projects.storage.storageSpi)
     implementation(projects.transport.transportSpi)

--- a/workers/reporter/build.gradle.kts
+++ b/workers/reporter/build.gradle.kts
@@ -45,7 +45,6 @@ dependencies {
     implementation(projects.workers.common)
 
     implementation(libs.typesafeConfig)
-    implementation(ortLibs.downloader)
     implementation(ortLibs.reporter)
     implementation(ortLibs.utils.config)
     implementation(platform(ortLibs.ortPlugins.licenseFactProviders))

--- a/workers/scanner/build.gradle.kts
+++ b/workers/scanner/build.gradle.kts
@@ -38,6 +38,8 @@ dependencies {
     implementation(projects.dao)
     implementation(projects.model)
     implementation(projects.services.adminConfigService)
+    implementation(projects.services.hierarchyService)
+    implementation(projects.services.ortRunService)
     implementation(projects.storage.storageSpi)
     implementation(projects.transport.transportSpi)
     implementation(projects.utils.logging)


### PR DESCRIPTION
Enable the project health plugin again which was disabled in #4121. ~The errors are currently not reproducible, after merge I will create a release to check if there are still issues with the release workflow if the plugin is applied.~

Also enable most rules and address the findings, and add a CI job to verify project health. Findings of the `onRuntimeOnly` rule are still ignored, because investigating them takes more time and will be done in a follow-up.

Update: The error occurred again when build scans were enabled. I fixed this by not using the `libs` extension in convention plugins which to me is an acceptable inconvenience if it allows to run `projectHealth` in CI now.