### PR TITLE
chore(core): Avoid unnecessary `toList()` conversions

### DIFF
--- a/core/src/main/kotlin/api/OrganizationsRoute.kt
+++ b/core/src/main/kotlin/api/OrganizationsRoute.kt
@@ -278,7 +278,7 @@ fun Route.organizations() = route("organizations") {
                         repositoryService.getLatestOrtRunIdWithSuccessfulAdvisorJob(repositoryId)
                     }
                     val advisors = vulnerabilityService.getAdvisorsForOrtRunIds(ortRunIds)
-                    call.respond(HttpStatusCode.OK, advisors.toList())
+                    call.respond(HttpStatusCode.OK, advisors)
                 }
             }
         }

--- a/core/src/main/kotlin/api/ProductsRoute.kt
+++ b/core/src/main/kotlin/api/ProductsRoute.kt
@@ -242,7 +242,7 @@ fun Route.products() = route("products/{productId}") {
                     repositoryService.getLatestOrtRunIdWithSuccessfulAdvisorJob(repositoryId)
                 }
                 val advisors = vulnerabilityService.getAdvisorsForOrtRunIds(ortRunIds)
-                call.respond(HttpStatusCode.OK, advisors.toList())
+                call.respond(HttpStatusCode.OK, advisors)
             }
         }
     }

--- a/core/src/main/kotlin/api/RunsRoute.kt
+++ b/core/src/main/kotlin/api/RunsRoute.kt
@@ -244,7 +244,7 @@ fun Route.runs() = route("runs") {
             route("advisors") {
                 get(getRunVulnerabilityAdvisors, requireRunPermission()) {
                     val advisors = vulnerabilityService.getAdvisorsForOrtRunId(call.ortRun.id)
-                    call.respond(HttpStatusCode.OK, advisors.toList())
+                    call.respond(HttpStatusCode.OK, advisors)
                 }
             }
         }

--- a/services/ort-run/src/main/kotlin/VulnerabilityService.kt
+++ b/services/ort-run/src/main/kotlin/VulnerabilityService.kt
@@ -21,8 +21,6 @@ package org.eclipse.apoapsis.ortserver.services.ortrun
 
 import com.github.michaelbull.result.getOr
 
-import java.util.SortedSet
-
 import org.eclipse.apoapsis.ortserver.api.v1.model.AdvisorDetails
 import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
 import org.eclipse.apoapsis.ortserver.api.v1.model.Vulnerability
@@ -548,11 +546,11 @@ class VulnerabilityService(
         }
 
     /** Get the distinct advisors used for vulnerability checks in the provided ORT run, sorted by name. */
-    suspend fun getAdvisorsForOrtRunId(runId: Long): SortedSet<String> =
+    suspend fun getAdvisorsForOrtRunId(runId: Long): Set<String> =
         getAdvisorsForOrtRunIds(listOf(runId))
 
     /** Get the distinct advisors used for vulnerability checks in the provided ORT runs, sorted by name. */
-    suspend fun getAdvisorsForOrtRunIds(runIds: List<Long>): SortedSet<String> = db.dbQuery {
+    suspend fun getAdvisorsForOrtRunIds(runIds: List<Long>): Set<String> = db.dbQuery {
         if (runIds.isEmpty()) return@dbQuery sortedSetOf()
         AdvisorJobsTable
             .select(AdvisorJobsTable.configuration)


### PR DESCRIPTION
Generalize the `SortedSet` return types for advisor endpoints to `Set`. This way no custom serializer is required for the response. The documentation still makes clear that entries are sorted.