### PR TITLE
Filter vulnerabilities with advisors

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
@@ -858,7 +858,8 @@ fun ApiVulnerabilityFilters.mapToModel(): VulnerabilityFilters = VulnerabilityFi
     },
     identifier = identifier?.mapToModel { it },
     purl = purl?.mapToModel { it },
-    externalId = externalId?.mapToModel { it }
+    externalId = externalId?.mapToModel { it },
+    advisors = advisors?.mapToModel { it }
 )
 
 fun Project.mapToApi() = ApiProject(
@@ -894,5 +895,6 @@ fun ApiVulnerabilityForRunsFilters.mapToModel() = VulnerabilityForRunsFilters(
     },
     identifier = identifier?.mapToModel { it },
     purl = purl?.mapToModel { it },
-    externalId = externalId?.mapToModel { it }
+    externalId = externalId?.mapToModel { it },
+    advisors = advisors?.mapToModel { it }
 )

--- a/api/v1/model/src/commonMain/kotlin/Vulnerability.kt
+++ b/api/v1/model/src/commonMain/kotlin/Vulnerability.kt
@@ -50,5 +50,8 @@ data class VulnerabilityFilters(
     val purl: FilterOperatorAndValue<String>? = null,
 
     /** Substring filter for external ID. */
-    val externalId: FilterOperatorAndValue<String>? = null
+    val externalId: FilterOperatorAndValue<String>? = null,
+
+    /** Filter by advisor name. */
+    val advisors: FilterOperatorAndValue<Set<String>>? = null
 )

--- a/api/v1/model/src/commonMain/kotlin/VulnerabilityForRunsFilters.kt
+++ b/api/v1/model/src/commonMain/kotlin/VulnerabilityForRunsFilters.kt
@@ -36,5 +36,8 @@ data class VulnerabilityForRunsFilters(
     val purl: FilterOperatorAndValue<String>? = null,
 
     /** Substring filter for external ID. */
-    val externalId: FilterOperatorAndValue<String>? = null
+    val externalId: FilterOperatorAndValue<String>? = null,
+
+    /** Filter by advisor name. */
+    val advisors: FilterOperatorAndValue<Set<String>>? = null
 )

--- a/core/src/main/kotlin/api/RunsRoute.kt
+++ b/core/src/main/kotlin/api/RunsRoute.kt
@@ -566,7 +566,14 @@ private fun ApplicationCall.vulnerabilityFilters() =
         },
         identifier = parameters["identifier"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) },
         purl = parameters["purl"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) },
-        externalId = parameters["externalId"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) }
+        externalId = parameters["externalId"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) },
+        advisors = parameters["advisors"]?.let { advisors ->
+            val (operators, names) = advisors.split(',').partition { it == "-" }
+            FilterOperatorAndValue(
+                if (operators.isEmpty()) ComparisonOperator.IN else ComparisonOperator.NOT_IN,
+                names.toSet()
+            )
+        }
     )
 
 /**

--- a/core/src/main/kotlin/api/RunsRoute.kt
+++ b/core/src/main/kotlin/api/RunsRoute.kt
@@ -48,7 +48,6 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatus
 import org.eclipse.apoapsis.ortserver.api.v1.model.PackageFilters
 import org.eclipse.apoapsis.ortserver.api.v1.model.RuleViolationFilters
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityFilters
-import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityRating
 import org.eclipse.apoapsis.ortserver.components.authorization.rights.EffectiveRole
 import org.eclipse.apoapsis.ortserver.components.authorization.rights.HierarchyPermissions
 import org.eclipse.apoapsis.ortserver.components.authorization.rights.RepositoryPermission
@@ -72,6 +71,11 @@ import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunVulnerabilities
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunVulnerabilityAdvisors
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getRuns
 import org.eclipse.apoapsis.ortserver.core.utils.findByName
+import org.eclipse.apoapsis.ortserver.core.utils.vulnerabilityAdvisorFilter
+import org.eclipse.apoapsis.ortserver.core.utils.vulnerabilityExternalIdFilter
+import org.eclipse.apoapsis.ortserver.core.utils.vulnerabilityIdentifierFilter
+import org.eclipse.apoapsis.ortserver.core.utils.vulnerabilityPurlFilter
+import org.eclipse.apoapsis.ortserver.core.utils.vulnerabilityRatingFilter
 import org.eclipse.apoapsis.ortserver.logaccess.LogFileService
 import org.eclipse.apoapsis.ortserver.model.JobStatus
 import org.eclipse.apoapsis.ortserver.model.LogLevel
@@ -559,21 +563,11 @@ private fun ApplicationCall.issueFilters() =
 private fun ApplicationCall.vulnerabilityFilters() =
     VulnerabilityFilters(
         resolved = parameters["resolved"]?.lowercase()?.toBooleanStrictOrNull(),
-        rating = parameters["rating"]?.let { rating ->
-            val (operators, ratings) = rating.split(',').partition { it == "-" }
-            val enums = ratings.mapTo(mutableSetOf()) { findByName<VulnerabilityRating>(it) }
-            FilterOperatorAndValue(if (operators.isEmpty()) ComparisonOperator.IN else ComparisonOperator.NOT_IN, enums)
-        },
-        identifier = parameters["identifier"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) },
-        purl = parameters["purl"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) },
-        externalId = parameters["externalId"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) },
-        advisors = parameters["advisors"]?.let { advisors ->
-            val (operators, names) = advisors.split(',').partition { it == "-" }
-            FilterOperatorAndValue(
-                if (operators.isEmpty()) ComparisonOperator.IN else ComparisonOperator.NOT_IN,
-                names.toSet()
-            )
-        }
+        rating = vulnerabilityRatingFilter(),
+        identifier = vulnerabilityIdentifierFilter(),
+        purl = vulnerabilityPurlFilter(),
+        externalId = vulnerabilityExternalIdFilter(),
+        advisors = vulnerabilityAdvisorFilter()
     )
 
 /**

--- a/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
@@ -349,6 +349,11 @@ val getOrganizationVulnerabilities: RouteConfig.() -> Unit = {
         queryParameter<String>("externalId") {
             description = "Defines an external ID to filter the results by. Uses a case-insensitive substring match."
         }
+        queryParameter<String>("advisors") {
+            description = "Defines the advisors to filter the results by. This is a comma-separated string of " +
+                    "advisor names (e.g. 'OSV,VulnerableCode'). Add a minus as the first item to exclude " +
+                    "vulnerabilities from the specified advisors, e.g. '-,OSV'."
+        }
     }
 
     response {

--- a/core/src/main/kotlin/apiDocs/ProductsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/ProductsDocs.kt
@@ -320,6 +320,11 @@ val getProductVulnerabilities: RouteConfig.() -> Unit = {
         queryParameter<String>("externalId") {
             description = "Defines an external ID to filter the results by. Uses a case-insensitive substring match."
         }
+        queryParameter<String>("advisors") {
+            description = "Defines the advisors to filter the results by. This is a comma-separated string of " +
+                    "advisor names (e.g. 'OSV,VulnerableCode'). Add a minus as the first item to exclude " +
+                    "vulnerabilities from the specified advisors, e.g. '-,OSV'."
+        }
     }
 
     response {

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -317,6 +317,11 @@ val getRunVulnerabilities: RouteConfig.() -> Unit = {
             description = "Defines an external ID to filter the results by. Uses a case-insensitive " +
                     "substring match."
         }
+        queryParameter<String>("advisors") {
+            description = "Defines the advisors to filter the results by. This is a comma-separated string of " +
+                    "advisor names (e.g. 'OSV,VulnerableCode'). Add a minus as the first item to exclude " +
+                    "vulnerabilities from the specified advisors, e.g. '-,OSV'."
+        }
     }
 
     response {

--- a/core/src/main/kotlin/utils/Extensions.kt
+++ b/core/src/main/kotlin/utils/Extensions.kt
@@ -176,5 +176,12 @@ fun ApplicationCall.vulnerabilityForRunsFilters(): VulnerabilityForRunsFilters =
     },
     identifier = parameters["identifier"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) },
     purl = parameters["purl"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) },
-    externalId = parameters["externalId"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) }
+    externalId = parameters["externalId"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) },
+    advisors = parameters["advisors"]?.let { advisors ->
+        val (operators, names) = advisors.split(',').partition { it == "-" }
+        FilterOperatorAndValue(
+            if (operators.isEmpty()) ComparisonOperator.IN else ComparisonOperator.NOT_IN,
+            names.toSet()
+        )
+    }
 )

--- a/core/src/main/kotlin/utils/Extensions.kt
+++ b/core/src/main/kotlin/utils/Extensions.kt
@@ -157,31 +157,43 @@ inline fun <reified E : Enum<E>> findByName(name: String): E =
                 enumEntries<E>().joinToString { "'$it'" }
     )
 
+/** Extract the vulnerability rating filter from the [ApplicationCall]. */
+internal fun ApplicationCall.vulnerabilityRatingFilter(): FilterOperatorAndValue<Set<VulnerabilityRating>>? =
+    parameters["rating"]?.let { rating ->
+        val ratings = rating.split(',')
+        val operator = if (ratings.first() == "-") ComparisonOperator.NOT_IN else ComparisonOperator.IN
+        val values = if (operator == ComparisonOperator.NOT_IN) ratings.drop(1) else ratings
+
+        FilterOperatorAndValue(operator, values.mapTo(mutableSetOf()) { findByName<VulnerabilityRating>(it) })
+    }
+
+/** Extract the vulnerability identifier filter from the [ApplicationCall]. */
+internal fun ApplicationCall.vulnerabilityIdentifierFilter(): FilterOperatorAndValue<String>? =
+    parameters["identifier"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) }
+
+/** Extract the vulnerability purl filter from the [ApplicationCall]. */
+internal fun ApplicationCall.vulnerabilityPurlFilter(): FilterOperatorAndValue<String>? =
+    parameters["purl"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) }
+
+/** Extract the vulnerability external ID filter from the [ApplicationCall]. */
+internal fun ApplicationCall.vulnerabilityExternalIdFilter(): FilterOperatorAndValue<String>? =
+    parameters["externalId"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) }
+
+/** Extract the vulnerability advisor filter from the [ApplicationCall]. */
+internal fun ApplicationCall.vulnerabilityAdvisorFilter(): FilterOperatorAndValue<Set<String>>? =
+    parameters["advisors"]?.let { advisors ->
+        val names = advisors.split(',')
+        val operator = if (names.first() == "-") ComparisonOperator.NOT_IN else ComparisonOperator.IN
+        val values = if (operator == ComparisonOperator.NOT_IN) names.drop(1) else names
+
+        FilterOperatorAndValue(operator, values.toSet())
+    }
+
 /** Extract [VulnerabilityForRunsFilters] from the [ApplicationCall] */
 fun ApplicationCall.vulnerabilityForRunsFilters(): VulnerabilityForRunsFilters = VulnerabilityForRunsFilters(
-    rating = parameters["rating"]?.let {
-        val parts = parameters["rating"]?.split(',').orEmpty()
-
-        val ratingOperator = if (parts.first() == ("-")) ComparisonOperator.NOT_IN else ComparisonOperator.IN
-
-        val ratings = parts
-            .filter { part -> part != "-" }
-            .map { rating -> findByName<VulnerabilityRating>(rating) }
-            .toSet()
-
-        FilterOperatorAndValue(
-            ratingOperator,
-            ratings
-        )
-    },
-    identifier = parameters["identifier"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) },
-    purl = parameters["purl"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) },
-    externalId = parameters["externalId"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) },
-    advisors = parameters["advisors"]?.let { advisors ->
-        val (operators, names) = advisors.split(',').partition { it == "-" }
-        FilterOperatorAndValue(
-            if (operators.isEmpty()) ComparisonOperator.IN else ComparisonOperator.NOT_IN,
-            names.toSet()
-        )
-    }
+    rating = vulnerabilityRatingFilter(),
+    identifier = vulnerabilityIdentifierFilter(),
+    purl = vulnerabilityPurlFilter(),
+    externalId = vulnerabilityExternalIdFilter(),
+    advisors = vulnerabilityAdvisorFilter()
 )

--- a/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
@@ -1525,6 +1525,75 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
             }
         }
 
+        "allow filtering by advisor" {
+            integrationTestApplication {
+                val orgId = createOrganization().id
+                val prodId = dbExtension.fixtures.createProduct(organizationId = orgId).id
+                val repoId = dbExtension.fixtures.createRepository(productId = prodId).id
+                val runId = dbExtension.fixtures.createOrtRun(repoId).id
+                val advisorJobId = dbExtension.fixtures.createAdvisorJob(runId).id
+                dbExtension.fixtures.advisorJobRepository.update(
+                    advisorJobId,
+                    status = JobStatus.FINISHED.asPresent2()
+                )
+                dbExtension.fixtures.createAdvisorRun(
+                    advisorJobId,
+                    mapOf(
+                        Identifier("Maven", "com.example", "lib-a", "1.0") to listOf(
+                            generateAdvisorResult(
+                                listOf(
+                                    Vulnerability(
+                                        externalId = "CVE-2021-11111",
+                                        summary = "A vulnerability",
+                                        description = "A description",
+                                        references = listOf(
+                                            VulnerabilityReference(
+                                                url = "https://example.com",
+                                                scoringSystem = "CVSS",
+                                                severity = "MEDIUM",
+                                                score = 4.2f,
+                                                vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                                            )
+                                        )
+                                    )
+                                )
+                            ).copy(advisorName = "OSV")
+                        ),
+                        Identifier("Maven", "com.example", "lib-b", "1.0") to listOf(
+                            generateAdvisorResult(
+                                listOf(
+                                    Vulnerability(
+                                        externalId = "CVE-2021-22222",
+                                        summary = "A vulnerability",
+                                        description = "A description",
+                                        references = listOf(
+                                            VulnerabilityReference(
+                                                url = "https://example.com",
+                                                scoringSystem = "CVSS",
+                                                severity = "LOW",
+                                                score = 1.2f,
+                                                vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                                            )
+                                        )
+                                    )
+                                )
+                            ).copy(advisorName = "VulnerableCode")
+                        )
+                    )
+                )
+
+                val response = superuserClient.get(
+                    "/api/v1/organizations/$orgId/vulnerabilities?advisors=OSV"
+                )
+
+                response shouldHaveStatus HttpStatusCode.OK
+                val vulns = response.body<PagedSearchResponse<VulnerabilityWithStats, VulnerabilityForRunsFilters>>()
+
+                vulns.data shouldHaveSize 1
+                vulns.data.single().vulnerability.externalId shouldBe "CVE-2021-11111"
+            }
+        }
+
         "require OrganizationPermission.READ" {
             val createdOrganization = createOrganization()
             requestShouldRequireRole(OrganizationRole.READER, createdOrganization.hierarchyId) {

--- a/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
@@ -1299,6 +1299,74 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
             }
         }
 
+        "allow filtering by advisor" {
+            integrationTestApplication {
+                val prodId = createProduct().id
+                val repoId = dbExtension.fixtures.createRepository(productId = prodId).id
+                val runId = dbExtension.fixtures.createOrtRun(repoId).id
+                val advisorJobId = dbExtension.fixtures.createAdvisorJob(runId).id
+                dbExtension.fixtures.advisorJobRepository.update(
+                    advisorJobId,
+                    status = JobStatus.FINISHED.asPresent2()
+                )
+                dbExtension.fixtures.createAdvisorRun(
+                    advisorJobId,
+                    mapOf(
+                        Identifier("Maven", "com.example", "lib-a", "1.0") to listOf(
+                            generateAdvisorResult(
+                                listOf(
+                                    Vulnerability(
+                                        externalId = "CVE-2021-11111",
+                                        summary = "A vulnerability",
+                                        description = "A description",
+                                        references = listOf(
+                                            VulnerabilityReference(
+                                                url = "https://example.com",
+                                                scoringSystem = "CVSS",
+                                                severity = "MEDIUM",
+                                                score = 4.2f,
+                                                vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                                            )
+                                        )
+                                    )
+                                )
+                            ).copy(advisorName = "OSV")
+                        ),
+                        Identifier("Maven", "com.example", "lib-b", "1.0") to listOf(
+                            generateAdvisorResult(
+                                listOf(
+                                    Vulnerability(
+                                        externalId = "CVE-2021-22222",
+                                        summary = "A vulnerability",
+                                        description = "A description",
+                                        references = listOf(
+                                            VulnerabilityReference(
+                                                url = "https://example.com",
+                                                scoringSystem = "CVSS",
+                                                severity = "LOW",
+                                                score = 1.2f,
+                                                vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                                            )
+                                        )
+                                    )
+                                )
+                            ).copy(advisorName = "VulnerableCode")
+                        )
+                    )
+                )
+
+                val response = superuserClient.get(
+                    "/api/v1/products/$prodId/vulnerabilities?advisors=OSV"
+                )
+
+                response shouldHaveStatus HttpStatusCode.OK
+                val vulns = response.body<PagedSearchResponse<VulnerabilityWithStats, VulnerabilityForRunsFilters>>()
+
+                vulns.data shouldHaveSize 1
+                vulns.data.single().vulnerability.externalId shouldBe "CVE-2021-11111"
+            }
+        }
+
         "require ProductPermission.READ" {
             val createdProduct = createProduct()
             requestShouldRequireRole(ProductRole.READER, createdProduct.hierarchyId()) {

--- a/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
@@ -1194,6 +1194,85 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
             }
         }
 
+        "filter vulnerabilities by advisor" {
+            integrationTestApplication {
+                val ortRun = dbExtension.fixtures.createOrtRun(
+                    repositoryId = repositoryId,
+                    revision = "revision",
+                    jobConfigurations = JobConfigurations()
+                )
+                val advisorJob = dbExtension.fixtures.createAdvisorJob(ortRunId = ortRun.id)
+                dbExtension.fixtures.advisorRunRepository.create(
+                    advisorJobId = advisorJob.id,
+                    startTime = Clock.System.now().toDatabasePrecision(),
+                    endTime = Clock.System.now().toDatabasePrecision(),
+                    environment = generateAdvisorEnvironment(),
+                    config = generateAdvisorConfiguration(),
+                    providerIssues = emptySet(),
+                    results = mapOf(
+                        Identifier("Maven", "com.example", "lib-a", "1.0") to listOf(
+                            AdvisorResult(
+                                advisorName = "OSV",
+                                startTime = Clock.System.now().toDatabasePrecision(),
+                                endTime = Clock.System.now().toDatabasePrecision(),
+                                issues = emptyList(),
+                                vulnerabilities = listOf(
+                                    Vulnerability(
+                                        externalId = "CVE-2021-11111",
+                                        summary = "A vulnerability",
+                                        description = "A description",
+                                        references = listOf(
+                                            VulnerabilityReference(
+                                                url = "https://example.com",
+                                                scoringSystem = "CVSS",
+                                                severity = "MEDIUM",
+                                                score = 4.2f,
+                                                vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        ),
+                        Identifier("Maven", "com.example", "lib-b", "1.0") to listOf(
+                            AdvisorResult(
+                                advisorName = "VulnerableCode",
+                                startTime = Clock.System.now().toDatabasePrecision(),
+                                endTime = Clock.System.now().toDatabasePrecision(),
+                                issues = emptyList(),
+                                vulnerabilities = listOf(
+                                    Vulnerability(
+                                        externalId = "CVE-2021-22222",
+                                        summary = "A vulnerability",
+                                        description = "A description",
+                                        references = listOf(
+                                            VulnerabilityReference(
+                                                url = "https://example.com",
+                                                scoringSystem = "CVSS",
+                                                severity = "LOW",
+                                                score = 1.2f,
+                                                vector = "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+                                            )
+                                        )
+                                    )
+                                )
+                            )
+                        )
+                    )
+                )
+
+                val response = superuserClient.get(
+                    "/api/v1/runs/${ortRun.id}/vulnerabilities?advisors=OSV"
+                )
+
+                response shouldHaveStatus HttpStatusCode.OK
+                val vulnerabilities = response.body<PagedResponse<VulnerabilityWithDetails>>()
+
+                vulnerabilities.data shouldHaveSize 1
+                vulnerabilities.data.single().vulnerability.externalId shouldBe "CVE-2021-11111"
+            }
+        }
+
         "sort vulnerabilities by purl" {
             integrationTestApplication {
                 val ortRun = dbExtension.fixtures.createOrtRun(

--- a/model/src/commonMain/kotlin/VulnerabilityFilters.kt
+++ b/model/src/commonMain/kotlin/VulnerabilityFilters.kt
@@ -41,5 +41,8 @@ data class VulnerabilityFilters(
     val purl: FilterOperatorAndValue<String>? = null,
 
     /** Substring filter for external ID. */
-    val externalId: FilterOperatorAndValue<String>? = null
+    val externalId: FilterOperatorAndValue<String>? = null,
+
+    /** Filter by advisor name. */
+    val advisors: FilterOperatorAndValue<Set<String>>? = null
 )

--- a/model/src/commonMain/kotlin/VulnerabilityForRunsFilters.kt
+++ b/model/src/commonMain/kotlin/VulnerabilityForRunsFilters.kt
@@ -32,5 +32,8 @@ data class VulnerabilityForRunsFilters(
     val purl: FilterOperatorAndValue<String>? = null,
 
     /** Substring filter for external ID. */
-    val externalId: FilterOperatorAndValue<String>? = null
+    val externalId: FilterOperatorAndValue<String>? = null,
+
+    /** Filter by advisor name. */
+    val advisors: FilterOperatorAndValue<Set<String>>? = null
 )

--- a/services/ort-run/src/main/kotlin/OrtRunVulnerabilityQueryBuilder.kt
+++ b/services/ort-run/src/main/kotlin/OrtRunVulnerabilityQueryBuilder.kt
@@ -36,6 +36,7 @@ import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
 import org.eclipse.apoapsis.ortserver.dao.utils.applyILike
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityFilters
 import org.eclipse.apoapsis.ortserver.model.util.ComparisonOperator
+import org.eclipse.apoapsis.ortserver.model.util.FilterOperatorAndValue
 
 import org.jetbrains.exposed.v1.core.CustomFunction
 import org.jetbrains.exposed.v1.core.Expression
@@ -57,6 +58,7 @@ import org.jetbrains.exposed.v1.core.not
 import org.jetbrains.exposed.v1.core.notExists
 import org.jetbrains.exposed.v1.core.notInList
 import org.jetbrains.exposed.v1.core.stringLiteral
+import org.jetbrains.exposed.v1.jdbc.andWhere
 import org.jetbrains.exposed.v1.jdbc.select
 
 internal fun buildOrtRunVulnerabilityQueryContext(
@@ -65,7 +67,7 @@ internal fun buildOrtRunVulnerabilityQueryContext(
 ): OrtRunVulnerabilityQueryContext {
     val ratingAlias = ratingAlias()
 
-    val bp = buildOrtRunBasePairs(ortRunId)
+    val bp = buildOrtRunBasePairs(ortRunId, filters.advisors)
     val ratings = buildOrtRunRatingsByVulnerability(bp, ratingAlias)
     val purls = buildOrtRunPurlByRunIdentifier(bp)
 
@@ -83,7 +85,10 @@ private class OrtRunBasePairsResult(
     val advisorName: ExpressionWithColumnTypeAlias<String>
 )
 
-private fun buildOrtRunBasePairs(ortRunId: Long): OrtRunBasePairsResult {
+private fun buildOrtRunBasePairs(
+    ortRunId: Long,
+    advisors: FilterOperatorAndValue<Set<String>>?
+): OrtRunBasePairsResult {
     val vulnerabilityId = VulnerabilitiesTable.id.alias("run_vulnerability_id")
     val identifierId = IdentifiersTable.id.alias("run_identifier_id")
     val runId = OrtRunsTable.id.alias("run_ort_run_id")
@@ -102,11 +107,22 @@ private fun buildOrtRunBasePairs(ortRunId: Long): OrtRunBasePairsResult {
         .innerJoin(IdentifiersTable)
         .select(vulnerabilityId, identifierId, runId, externalId, summary, description, advisorName)
         .where { OrtRunsTable.id eq ortRunId }
+
+    if (advisors != null) {
+        query.andWhere {
+            when (advisors.operator) {
+                ComparisonOperator.IN -> AdvisorResultsTable.advisorName inList advisors.value.toList()
+                else -> AdvisorResultsTable.advisorName notInList advisors.value.toList()
+            }
+        }
+    }
+
+    val basePairs = query
         .groupBy(VulnerabilitiesTable.id, IdentifiersTable.id, OrtRunsTable.id, AdvisorResultsTable.advisorName)
         .alias("run_base_pairs")
 
     return OrtRunBasePairsResult(
-        query,
+        basePairs,
         vulnerabilityId,
         identifierId,
         runId,

--- a/services/ort-run/src/main/kotlin/OrtRunsVulnerabilityQueryBuilder.kt
+++ b/services/ort-run/src/main/kotlin/OrtRunsVulnerabilityQueryBuilder.kt
@@ -41,6 +41,7 @@ import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
 import org.eclipse.apoapsis.ortserver.dao.utils.applyILike
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityForRunsFilters
 import org.eclipse.apoapsis.ortserver.model.util.ComparisonOperator
+import org.eclipse.apoapsis.ortserver.model.util.FilterOperatorAndValue
 
 import org.jetbrains.exposed.v1.core.CustomFunction
 import org.jetbrains.exposed.v1.core.Expression
@@ -65,6 +66,7 @@ import org.jetbrains.exposed.v1.core.notInList
 import org.jetbrains.exposed.v1.core.plus
 import org.jetbrains.exposed.v1.core.stringLiteral
 import org.jetbrains.exposed.v1.core.times
+import org.jetbrains.exposed.v1.jdbc.andWhere
 import org.jetbrains.exposed.v1.jdbc.select
 
 /**
@@ -91,7 +93,7 @@ internal fun buildOrtRunsQueryContext(
     val repositoriesCountAlias = repositoriesCountAlias()
     val ratingAlias = ratingAlias()
 
-    val bp = buildBasePairs(ortRunIds)
+    val bp = buildBasePairs(ortRunIds, filters.advisors)
     val ratings = buildRatingsByVulnerability(bp, ratingAlias)
     val purls = buildPurlByRunIdentifier(bp)
 
@@ -132,7 +134,10 @@ internal class PurlResult(
  * Build distinct (vulnerability_id, identifier_id, ort_run_id) tuples from the advisor join chain,
  * carrying vulnerability metadata columns needed downstream.
  */
-private fun buildBasePairs(ortRunIds: List<Long>): BasePairsResult {
+private fun buildBasePairs(
+    ortRunIds: List<Long>,
+    advisors: FilterOperatorAndValue<Set<String>>?
+): BasePairsResult {
     val vulnerabilityId = VulnerabilitiesTable.id.alias("vulnerability_id")
     val identifierId = IdentifiersTable.id.alias("identifier_id")
     val ortRunId = OrtRunsTable.id.alias("ort_run_id")
@@ -150,10 +155,21 @@ private fun buildBasePairs(ortRunIds: List<Long>): BasePairsResult {
         .innerJoin(IdentifiersTable)
         .select(vulnerabilityId, identifierId, ortRunId, externalId, summary, description)
         .where { OrtRunsTable.id inList ortRunIds }
+
+    if (advisors != null) {
+        query.andWhere {
+            when (advisors.operator) {
+                ComparisonOperator.IN -> AdvisorResultsTable.advisorName inList advisors.value.toList()
+                else -> AdvisorResultsTable.advisorName notInList advisors.value.toList()
+            }
+        }
+    }
+
+    val basePairs = query
         .groupBy(VulnerabilitiesTable.id, IdentifiersTable.id, OrtRunsTable.id)
         .alias("base_pairs")
 
-    return BasePairsResult(query, vulnerabilityId, identifierId, ortRunId, externalId, summary, description)
+    return BasePairsResult(basePairs, vulnerabilityId, identifierId, ortRunId, externalId, summary, description)
 }
 
 // -- Step 2: Ratings ----------------------------------------------------------------------------------

--- a/services/ort-run/src/test/kotlin/VulnerabilityServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/VulnerabilityServiceTest.kt
@@ -632,6 +632,41 @@ class VulnerabilityServiceTest : WordSpec() {
                 }
             }
 
+            "filter by advisor" {
+                val id1 = Identifier("Maven", "com.example", "lib-a", "1.0")
+                val id2 = Identifier("Maven", "com.example", "lib-b", "1.0")
+
+                val vulns1 = createVulnerabilities(Triple(id1, listOf("CVE-2021-11111"), listOf(4.2)))
+                val vulns2 = createVulnerabilities(Triple(id2, listOf("CVE-2021-22222"), listOf(8.9)))
+
+                val ortRun = createVulnerabilityEntries(
+                    createAdvisorResults(vulns1, advisorName = "OSV") +
+                        createAdvisorResults(vulns2, advisorName = "VulnerableCode")
+                )
+
+                // Inclusion filter - only OSV vulnerabilities.
+                val osvResults = service.listForOrtRunId(
+                    ortRun.id,
+                    vulnerabilityFilters = VulnerabilityFilters(
+                        advisors = FilterOperatorAndValue(ComparisonOperator.IN, setOf("OSV"))
+                    )
+                )
+                osvResults.data.shouldBeSingleton {
+                    it.vulnerability.externalId shouldBe "CVE-2021-11111"
+                }
+
+                // Exclusion filter - all except OSV.
+                val nonOsvResults = service.listForOrtRunId(
+                    ortRun.id,
+                    vulnerabilityFilters = VulnerabilityFilters(
+                        advisors = FilterOperatorAndValue(ComparisonOperator.NOT_IN, setOf("OSV"))
+                    )
+                )
+                nonOsvResults.data.shouldBeSingleton {
+                    it.vulnerability.externalId shouldBe "CVE-2021-22222"
+                }
+            }
+
             "return multiple vulnerabilities and references for a package" {
                 val vulnerabilities = createVulnerabilities(
                     Triple(
@@ -1991,6 +2026,48 @@ class VulnerabilityServiceTest : WordSpec() {
 
                 results.data[0].vulnerability.externalId shouldBe "CVE-2024-32562"
                 results.data[1].vulnerability.externalId shouldBe "CVE-2024-35326"
+            }
+
+            "allow filtering by advisor" {
+                val runId = fixtures.createOrtRun().id
+
+                val pkg1 = fixtures.generatePackage(Identifier("Maven", "com.example", "lib-a", "1.0"))
+                val pkg2 = fixtures.generatePackage(Identifier("Maven", "com.example", "lib-b", "1.0"))
+
+                val vulns1 = createVulnerabilities(Triple(pkg1.identifier, listOf("CVE-2021-11111"), listOf(4.2)))
+                val vulns2 = createVulnerabilities(Triple(pkg2.identifier, listOf("CVE-2021-22222"), listOf(8.9)))
+
+                val analyzerJobId = fixtures.createAnalyzerJob(runId).id
+                fixtures.createAnalyzerRun(analyzerJobId, packages = setOf(pkg1, pkg2))
+
+                val advisorJobId = fixtures.createAdvisorJob(runId).id
+                fixtures.createAdvisorRun(
+                    advisorJobId,
+                    createAdvisorResults(vulns1, advisorName = "OSV") +
+                        createAdvisorResults(vulns2, advisorName = "VulnerableCode")
+                )
+
+                // Inclusion filter - only OSV vulnerabilities.
+                val osvResults = service.listForOrtRuns(
+                    listOf(runId),
+                    filters = VulnerabilityForRunsFilters(
+                        advisors = FilterOperatorAndValue(ComparisonOperator.IN, setOf("OSV"))
+                    )
+                )
+                osvResults.data.shouldBeSingleton {
+                    it.vulnerability.externalId shouldBe "CVE-2021-11111"
+                }
+
+                // Exclusion filter - all except OSV.
+                val nonOsvResults = service.listForOrtRuns(
+                    listOf(runId),
+                    filters = VulnerabilityForRunsFilters(
+                        advisors = FilterOperatorAndValue(ComparisonOperator.NOT_IN, setOf("OSV"))
+                    )
+                )
+                nonOsvResults.data.shouldBeSingleton {
+                    it.vulnerability.externalId shouldBe "CVE-2021-22222"
+                }
             }
         }
 

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
@@ -35,6 +35,7 @@ import { VulnerabilityRating, VulnerabilityWithDetails } from '@/api';
 import {
   getRepositoryRunOptions,
   getRunVulnerabilitiesOptions,
+  getRunVulnerabilityAdvisorsOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { zVulnerabilityRating } from '@/api/zod.gen';
 import { BreakableString } from '@/components/breakable-string';
@@ -90,6 +91,7 @@ import {
 import { ACTION_COLUMN_SIZE } from '@/lib/constants';
 import { toastError } from '@/lib/toast';
 import {
+  advisorSearchParameterSchema,
   externalIdSearchParameterSchema,
   ItemResolved,
   itemResolvedSchema,
@@ -197,12 +199,33 @@ const VulnerabilitiesComponent = () => {
   const packageIdentifier = search.pkgId;
   const rating = search.rating;
   const externalId = search.externalId;
+  const advisor = search.advisor;
   const packageIdType = useUserSettingsStore((state) => state.packageIdType);
   const resolved =
     itemStatus?.length === 1 ? itemStatus[0] === 'Resolved' : undefined;
   const sortBy = search.sortBy?.filter((sort) =>
     supportedSortColumns.has(sort.id)
   );
+
+  const { data: ortRun } = useSuspenseQuery({
+    ...getRepositoryRunOptions({
+      path: {
+        repositoryId: Number.parseInt(params.repoId),
+        ortRunIndex: Number.parseInt(params.runIndex),
+      },
+    }),
+  });
+
+  const {
+    data: advisors,
+    isPending: advisorsIsPending,
+    isError: advisorsIsError,
+    error: advisorsError,
+  } = useSuspenseQuery({
+    ...getRunVulnerabilityAdvisorsOptions({
+      path: { runId: ortRun.id },
+    }),
+  });
 
   const columns = [
     columnHelper.display({
@@ -341,7 +364,25 @@ const VulnerabilitiesComponent = () => {
       id: 'advisorName',
       header: 'Advisor',
       enableSorting: false,
-      enableColumnFilter: false,
+      enableColumnFilter: advisors.length > 1,
+      meta: {
+        filter: {
+          filterVariant: 'select',
+          selectOptions: advisors.map((advisor) => ({
+            label: advisor,
+            value: advisor,
+          })),
+          setSelected: (advisors: string[]) => {
+            navigate({
+              search: {
+                ...search,
+                page: 1,
+                advisor: advisors.length === 0 ? undefined : advisors,
+              },
+            });
+          },
+        },
+      },
     }),
     columnHelper.accessor(
       (row) => {
@@ -357,15 +398,6 @@ const VulnerabilitiesComponent = () => {
   ];
 
   const columnId = packageIdType === 'ORT_ID' ? 'identifier' : 'purl';
-
-  const { data: ortRun } = useSuspenseQuery({
-    ...getRepositoryRunOptions({
-      path: {
-        repositoryId: Number.parseInt(params.repoId),
-        ortRunIndex: Number.parseInt(params.runIndex),
-      },
-    }),
-  });
 
   const {
     data: totalVulnerabilities,
@@ -393,6 +425,7 @@ const VulnerabilitiesComponent = () => {
         sort: convertToBackendSorting(sortBy),
         resolved,
         rating: rating?.join(','),
+        advisors: advisor?.join(','),
         ...(packageIdType === 'ORT_ID'
           ? { identifier: packageIdentifier }
           : { purl: packageIdentifier }),
@@ -503,6 +536,7 @@ const VulnerabilitiesComponent = () => {
         { id: 'itemStatus', value: itemStatus },
         { id: columnId, value: packageIdentifier },
         { id: 'rating', value: rating },
+        { id: 'advisorName', value: advisor },
         { id: 'externalId', value: externalId },
       ].filter(({ value }) => value !== undefined),
       columnVisibility: {
@@ -523,12 +557,12 @@ const VulnerabilitiesComponent = () => {
     manualPagination: true,
   });
 
-  if (isPending || totalIsPending) {
+  if (isPending || totalIsPending || advisorsIsPending) {
     return <LoadingIndicator />;
   }
 
-  if (isError || totalIsError) {
-    toastError('Unable to load data', error || totalError);
+  if (isError || totalIsError || advisorsIsError) {
+    toastError('Unable to load data', error || totalError || advisorsError);
     return;
   }
   const filtersInUse =
@@ -591,6 +625,7 @@ export const Route = createFileRoute(
     ...itemStatusSearchParameterSchema.shape,
     ...packageIdentifierSearchParameterSchema.shape,
     ...vulnerabilityRatingSearchParameterSchema.shape,
+    ...advisorSearchParameterSchema.shape,
     ...externalIdSearchParameterSchema.shape,
     ...markedSearchParameterSchema.shape,
   }),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
@@ -296,6 +296,42 @@ const VulnerabilitiesComponent = () => {
         },
       }
     ),
+    columnHelper.accessor('vulnerability.externalId', {
+      id: 'externalId',
+      header: 'External ID',
+      meta: {
+        filter: {
+          filterVariant: 'text',
+          setFilterValue: (value: string | undefined) => {
+            navigate({
+              search: { ...search, page: 1, externalId: value },
+            });
+          },
+        },
+      },
+    }),
+    columnHelper.accessor('rating', {
+      id: 'rating',
+      header: 'Rating',
+      meta: {
+        filter: {
+          filterVariant: 'select',
+          selectOptions: zVulnerabilityRating.options.map((rating) => ({
+            label: rating,
+            value: rating,
+          })),
+          setSelected: (ratings: VulnerabilityRating[]) => {
+            navigate({
+              search: {
+                ...search,
+                page: 1,
+                rating: ratings.length === 0 ? undefined : ratings,
+              },
+            });
+          },
+        },
+      },
+    }),
     columnHelper.accessor(
       (vuln) => {
         return getResolvedStatus(vuln);
@@ -324,42 +360,6 @@ const VulnerabilitiesComponent = () => {
         },
       }
     ),
-    columnHelper.accessor('rating', {
-      id: 'rating',
-      header: 'Rating',
-      meta: {
-        filter: {
-          filterVariant: 'select',
-          selectOptions: zVulnerabilityRating.options.map((rating) => ({
-            label: rating,
-            value: rating,
-          })),
-          setSelected: (ratings: VulnerabilityRating[]) => {
-            navigate({
-              search: {
-                ...search,
-                page: 1,
-                rating: ratings.length === 0 ? undefined : ratings,
-              },
-            });
-          },
-        },
-      },
-    }),
-    columnHelper.accessor('vulnerability.externalId', {
-      id: 'externalId',
-      header: 'External ID',
-      meta: {
-        filter: {
-          filterVariant: 'text',
-          setFilterValue: (value: string | undefined) => {
-            navigate({
-              search: { ...search, page: 1, externalId: value },
-            });
-          },
-        },
-      },
-    }),
     columnHelper.accessor('advisor.name', {
       id: 'advisorName',
       header: 'Advisor',

--- a/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
@@ -313,6 +313,20 @@ const ProductVulnerabilitiesComponent = () => {
           },
         }
       ),
+      columnHelper.accessor('vulnerability.externalId', {
+        id: 'externalId',
+        header: 'External ID',
+        meta: {
+          filter: {
+            filterVariant: 'text',
+            setFilterValue: (value: string | undefined) => {
+              navigate({
+                search: { ...search, page: 1, externalId: value },
+              });
+            },
+          },
+        },
+      }),
       columnHelper.accessor('rating', {
         id: 'rating',
         header: 'Rating',
@@ -359,20 +373,6 @@ const ProductVulnerabilitiesComponent = () => {
                   page: 1,
                   advisor: advisors.length === 0 ? undefined : advisors,
                 },
-              });
-            },
-          },
-        },
-      }),
-      columnHelper.accessor('vulnerability.externalId', {
-        id: 'externalId',
-        header: 'External ID',
-        meta: {
-          filter: {
-            filterVariant: 'text',
-            setFilterValue: (value: string | undefined) => {
-              navigate({
-                search: { ...search, page: 1, externalId: value },
               });
             },
           },

--- a/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
@@ -35,6 +35,7 @@ import { VulnerabilityRating, VulnerabilityWithStats } from '@/api';
 import {
   getProductOptions,
   getProductVulnerabilitiesOptions,
+  getProductVulnerabilityAdvisorsOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { zVulnerabilityRating } from '@/api/zod.gen';
 import { BreakableString } from '@/components/breakable-string';
@@ -75,6 +76,7 @@ import { identifierToString } from '@/helpers/identifier-conversion';
 import { ACTION_COLUMN_SIZE } from '@/lib/constants';
 import { toastError } from '@/lib/toast';
 import {
+  advisorSearchParameterSchema,
   externalIdSearchParameterSchema,
   markedSearchParameterSchema,
   packageIdentifierSearchParameterSchema,
@@ -220,6 +222,17 @@ const ProductVulnerabilitiesComponent = () => {
   const navigate = Route.useNavigate();
   const packageIdType = useUserSettingsStore((state) => state.packageIdType);
 
+  const {
+    data: advisors,
+    isPending: advisorsIsPending,
+    isError: advisorsIsError,
+    error: advisorsError,
+  } = useQuery({
+    ...getProductVulnerabilityAdvisorsOptions({
+      path: { productId: Number.parseInt(params.productId) },
+    }),
+  });
+
   // Prevent infinite rerenders by providing a stable reference to columns via memoization.
   // https://tanstack.com/table/latest/docs/faq#solution-1-stable-references-with-usememo-or-usestate
   const columns = useMemo(
@@ -327,6 +340,30 @@ const ProductVulnerabilitiesComponent = () => {
         header: 'Repositories',
         enableColumnFilter: false,
       }),
+      columnHelper.accessor(() => '', {
+        id: 'advisor',
+        header: 'Advisor',
+        enableSorting: false,
+        enableColumnFilter: (advisors?.length ?? 0) > 1,
+        meta: {
+          filter: {
+            filterVariant: 'select',
+            selectOptions: (advisors ?? []).map((advisor) => ({
+              label: advisor,
+              value: advisor,
+            })),
+            setSelected: (advisors: string[]) => {
+              navigate({
+                search: {
+                  ...search,
+                  page: 1,
+                  advisor: advisors.length === 0 ? undefined : advisors,
+                },
+              });
+            },
+          },
+        },
+      }),
       columnHelper.accessor('vulnerability.externalId', {
         id: 'externalId',
         header: 'External ID',
@@ -348,7 +385,7 @@ const ProductVulnerabilitiesComponent = () => {
         enableColumnFilter: false,
       }),
     ],
-    [navigate, packageIdType, params.orgId, params.productId, search]
+    [advisors, navigate, packageIdType, params.orgId, params.productId, search]
   );
 
   const pageIndex = useMemo(
@@ -376,6 +413,11 @@ const ProductVulnerabilitiesComponent = () => {
     [search.externalId]
   );
 
+  const advisor = useMemo(
+    () => (search.advisor ? search.advisor : undefined),
+    [search.advisor]
+  );
+
   const columnFilters = useMemo(() => {
     const filters = [];
     if (packageIdentifier) {
@@ -390,8 +432,11 @@ const ProductVulnerabilitiesComponent = () => {
     if (externalId) {
       filters.push({ id: 'externalId', value: externalId });
     }
+    if (advisor) {
+      filters.push({ id: 'advisor', value: advisor });
+    }
     return filters;
-  }, [packageIdentifier, rating, packageIdType, externalId]);
+  }, [packageIdentifier, rating, packageIdType, externalId, advisor]);
 
   const sortBy = useMemo(
     () => (search.sortBy ? search.sortBy : undefined),
@@ -423,6 +468,7 @@ const ProductVulnerabilitiesComponent = () => {
         offset: pageIndex * pageSize,
         sort: convertToBackendSorting(sortBy),
         rating: rating?.join(','),
+        advisors: advisor?.join(','),
         ...(packageIdType === 'ORT_ID'
           ? { identifier: packageIdentifier }
           : { purl: packageIdentifier }),
@@ -453,6 +499,7 @@ const ProductVulnerabilitiesComponent = () => {
         [columnId]: false,
         rating: false,
         repositoriesCount: false,
+        advisor: false,
         externalId: false,
         summary: false,
       },
@@ -466,12 +513,12 @@ const ProductVulnerabilitiesComponent = () => {
     manualPagination: true,
   });
 
-  if (isPending || totIsPending) {
+  if (isPending || totIsPending || advisorsIsPending) {
     return <LoadingIndicator />;
   }
 
-  if (isError || totIsError) {
-    toastError('Unable to load data', error || totError);
+  if (isError || totIsError || advisorsIsError) {
+    toastError('Unable to load data', error || totError || advisorsError);
     return;
   }
   const filtersInUse =
@@ -533,6 +580,7 @@ export const Route = createFileRoute(
     ...sortingSearchParameterSchema.shape,
     ...packageIdentifierSearchParameterSchema.shape,
     ...vulnerabilityRatingSearchParameterSchema.shape,
+    ...advisorSearchParameterSchema.shape,
     ...externalIdSearchParameterSchema.shape,
     ...markedSearchParameterSchema.shape,
   }),

--- a/ui/src/routes/organizations/$orgId/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/vulnerabilities/index.tsx
@@ -35,6 +35,7 @@ import { VulnerabilityRating, VulnerabilityWithStats } from '@/api';
 import {
   getOrganizationOptions,
   getOrganizationVulnerabilitiesOptions,
+  getOrganizationVulnerabilityAdvisorsOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { zVulnerabilityRating } from '@/api/zod.gen';
 import { BreakableString } from '@/components/breakable-string';
@@ -75,6 +76,7 @@ import { identifierToString } from '@/helpers/identifier-conversion';
 import { ACTION_COLUMN_SIZE } from '@/lib/constants';
 import { toastError } from '@/lib/toast';
 import {
+  advisorSearchParameterSchema,
   externalIdSearchParameterSchema,
   markedSearchParameterSchema,
   packageIdentifierSearchParameterSchema,
@@ -240,6 +242,11 @@ const OrganizationVulnerabilitiesComponent = () => {
     [search.externalId]
   );
 
+  const advisor = useMemo(
+    () => (search.advisor ? search.advisor : undefined),
+    [search.advisor]
+  );
+
   const columnFilters = useMemo(() => {
     const filters = [];
     if (rating) {
@@ -257,8 +264,22 @@ const OrganizationVulnerabilitiesComponent = () => {
     if (externalId) {
       filters.push({ id: 'externalId', value: externalId });
     }
+    if (advisor) {
+      filters.push({ id: 'advisor', value: advisor });
+    }
     return filters;
-  }, [rating, packageIdentifier, packageIdType, externalId]);
+  }, [rating, packageIdentifier, packageIdType, externalId, advisor]);
+
+  const {
+    data: advisors,
+    error: advisorsError,
+    isPending: advisorsPending,
+    isError: advisorsIsError,
+  } = useQuery({
+    ...getOrganizationVulnerabilityAdvisorsOptions({
+      path: { organizationId: Number.parseInt(params.orgId) },
+    }),
+  });
 
   const {
     data: totalVulnerabilities,
@@ -287,6 +308,7 @@ const OrganizationVulnerabilitiesComponent = () => {
         offset: pageIndex * pageSize,
         sort: convertToBackendSorting(search.sortBy),
         rating: rating?.join(','),
+        advisors: advisor?.join(','),
         ...(packageIdType === 'ORT_ID'
           ? { identifier: packageIdentifier }
           : { purl: packageIdentifier }),
@@ -401,6 +423,30 @@ const OrganizationVulnerabilitiesComponent = () => {
         header: 'Repositories',
         enableColumnFilter: false,
       }),
+      columnHelper.accessor(() => '', {
+        id: 'advisor',
+        header: 'Advisor',
+        enableSorting: false,
+        enableColumnFilter: (advisors?.length ?? 0) > 1,
+        meta: {
+          filter: {
+            filterVariant: 'select',
+            selectOptions: (advisors ?? []).map((advisor) => ({
+              label: advisor,
+              value: advisor,
+            })),
+            setSelected: (advisors: string[]) => {
+              navigate({
+                search: {
+                  ...search,
+                  page: 1,
+                  advisor: advisors.length === 0 ? undefined : advisors,
+                },
+              });
+            },
+          },
+        },
+      }),
       columnHelper.accessor('vulnerability.externalId', {
         id: 'externalId',
         header: 'External ID',
@@ -422,7 +468,7 @@ const OrganizationVulnerabilitiesComponent = () => {
         enableColumnFilter: false,
       }),
     ],
-    [packageIdType, search, navigate, params.orgId]
+    [advisors, packageIdType, search, navigate, params.orgId]
   );
 
   const [expanded, setExpanded] = useState<ExpandedState>(
@@ -447,6 +493,7 @@ const OrganizationVulnerabilitiesComponent = () => {
         [columnId]: false,
         rating: false,
         repositoriesCount: false,
+        advisor: false,
         externalId: false,
         summary: false,
       },
@@ -460,12 +507,12 @@ const OrganizationVulnerabilitiesComponent = () => {
     manualPagination: true,
   });
 
-  if (isPending || totPending) {
+  if (isPending || totPending || advisorsPending) {
     return <LoadingIndicator />;
   }
 
-  if (isError || totIsError) {
-    toastError('Unable to load data', error || totError);
+  if (isError || totIsError || advisorsIsError) {
+    toastError('Unable to load data', error || totError || advisorsError);
     return;
   }
 
@@ -525,6 +572,7 @@ export const Route = createFileRoute('/organizations/$orgId/vulnerabilities/')({
     ...paginationSearchParameterSchema.shape,
     ...sortingSearchParameterSchema.shape,
     ...vulnerabilityRatingSearchParameterSchema.shape,
+    ...advisorSearchParameterSchema.shape,
     ...packageIdentifierSearchParameterSchema.shape,
     ...externalIdSearchParameterSchema.shape,
     ...markedSearchParameterSchema.shape,

--- a/ui/src/routes/organizations/$orgId/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/vulnerabilities/index.tsx
@@ -396,6 +396,20 @@ const OrganizationVulnerabilitiesComponent = () => {
           },
         }
       ),
+      columnHelper.accessor('vulnerability.externalId', {
+        id: 'externalId',
+        header: 'External ID',
+        meta: {
+          filter: {
+            filterVariant: 'text',
+            setFilterValue: (value: string | undefined) => {
+              navigate({
+                search: { ...search, page: 1, externalId: value },
+              });
+            },
+          },
+        },
+      }),
       columnHelper.accessor('rating', {
         id: 'rating',
         header: 'Rating',
@@ -442,20 +456,6 @@ const OrganizationVulnerabilitiesComponent = () => {
                   page: 1,
                   advisor: advisors.length === 0 ? undefined : advisors,
                 },
-              });
-            },
-          },
-        },
-      }),
-      columnHelper.accessor('vulnerability.externalId', {
-        id: 'externalId',
-        header: 'External ID',
-        meta: {
-          filter: {
-            filterVariant: 'text',
-            setFilterValue: (value: string | undefined) => {
-              navigate({
-                search: { ...search, page: 1, externalId: value },
               });
             },
           },

--- a/ui/src/schemas/index.ts
+++ b/ui/src/schemas/index.ts
@@ -184,6 +184,14 @@ export const vulnerabilityRatingSearchParameterSchema = z.object({
   rating: z.array(zVulnerabilityRating).optional(),
 });
 
+// Refine validates that the advisor names are unique.
+export const advisorSearchParameterSchema = z.object({
+  advisor: z
+    .array(z.string())
+    .refine((items) => new Set(items).size === items.length)
+    .optional(),
+});
+
 export const externalIdSearchParameterSchema = z.object({
   externalId: z.string().optional(),
 });


### PR DESCRIPTION
#### More than one vulnerability advisor chosen:

<img width="1174" height="546" alt="Screenshot from 2026-05-18 14-14-24" src="https://github.com/user-attachments/assets/bb2a6d43-53a5-4733-9ec7-8ad1406a3116" />

#### When only one vulnerability advisor is chosen to the run, no sense in rendering the advisor filter:

<img width="1172" height="447" alt="Screenshot from 2026-05-18 14-14-44" src="https://github.com/user-attachments/assets/0cc5393e-8b4d-4b6b-ad56-6d38e3ba5eb0" />

Please see the commits for details.