### PR TITLE
fix: Ensure that component classes are on the classpath at runtime

### DIFF
--- a/buildSrc/src/main/kotlin/ort-server-kotlin-component-backend-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-kotlin-component-backend-conventions.gradle.kts
@@ -31,6 +31,12 @@ java {
     }
 }
 
+dependencies {
+    // Ensure that consumers of the routes feature have the main artifact on their runtime classpath, since the compiled
+    // routes classes reference types from the main source set at runtime.
+    "routesRuntimeOnly"(project)
+}
+
 kotlin.target.compilations.apply {
     getByName("routes").associateWith(getByName(KotlinCompilation.MAIN_COMPILATION_NAME))
     getByName("test").associateWith(getByName("routes"))


### PR DESCRIPTION
When depending only on the routes capability of a component, the classes from the main source set still need to be on the classpath. To ensure this, add a runtime only dependency from the routes source set to the main source set.