### PR TITLE
fix(nuget): Quote API key attribute in NuGet.Config

### DIFF
--- a/workers/common/src/main/kotlin/env/NuGetGenerator.kt
+++ b/workers/common/src/main/kotlin/env/NuGetGenerator.kt
@@ -108,6 +108,6 @@ class NuGetGenerator : EnvironmentConfigGenerator<NuGetDefinition> {
     private fun generateApiKeyBlock(
         definition: NuGetDefinition,
         builder: ConfigFileBuilder
-    ) = "<add key=${definition.sourcePath} value=\"${builder.secretRef(definition.service.passwordSecret)}\" />"
+    ) = "<add key=\"${definition.sourcePath}\" value=\"${builder.secretRef(definition.service.passwordSecret)}\" />"
         .prependIndent(INDENT_4_SPACES)
 }

--- a/workers/common/src/test/kotlin/env/NuGetGeneratorTest.kt
+++ b/workers/common/src/test/kotlin/env/NuGetGeneratorTest.kt
@@ -78,7 +78,7 @@ class NuGetGeneratorTest : WordSpec({
                   </packageSourceCredentials>
 
                   <apikeys>
-                    <add key=https://api.nuget.org/v3/index.json value="${MockConfigFileBuilder.testSecretRef(passwordSecret)}" />
+                    <add key="https://api.nuget.org/v3/index.json" value="${MockConfigFileBuilder.testSecretRef(passwordSecret)}" />
                   </apikeys>
                 </configuration>
             """.trimIndent().lines()
@@ -152,8 +152,8 @@ class NuGetGeneratorTest : WordSpec({
                   </packageSourceCredentials>
 
                   <apikeys>
-                    <add key=https://api.nuget.org/v3/index.json value="${MockConfigFileBuilder.testSecretRef(passwordSecret1)}" />
-                    <add key=https://api.nuget.org/v3/index.json3 value="${MockConfigFileBuilder.testSecretRef(passwordSecret4)}" />
+                    <add key="https://api.nuget.org/v3/index.json" value="${MockConfigFileBuilder.testSecretRef(passwordSecret1)}" />
+                    <add key="https://api.nuget.org/v3/index.json3" value="${MockConfigFileBuilder.testSecretRef(passwordSecret4)}" />
                   </apikeys>
                 </configuration>
             """.trimIndent().lines()


### PR DESCRIPTION
The `key` attribute value in the `<apikeys>` section was missing quotes, generating invalid XML. This caused nuget-inspector to fail with a `NuGetConfigurationException` when parsing the config file.