### PR TITLE
fix(dao): Correctly match issues when storing resolutions

### DIFF
--- a/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
@@ -2410,6 +2410,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     jobConfigurations = JobConfigurations()
                 )
 
+                val identifier = Identifier("NPM", "com.example", "example2", "1.0")
                 val now = Clock.System.now()
 
                 // Define issues, vulnerabilities, and rule violations to be used in the test
@@ -2427,7 +2428,8 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     source = "Advisor",
                     message = "Issue 1",
                     severity = Severity.ERROR,
-                    affectedPath = "path"
+                    affectedPath = "path",
+                    identifier = identifier
                 )
 
                 val advisorIssue2 = Issue(
@@ -2632,7 +2634,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     ),
                     providerIssues = emptySet(),
                     results = mapOf(
-                        Identifier("NPM", "com.example", "example2", "1.0") to listOf(
+                        identifier to listOf(
                             AdvisorResult(
                                 advisorName = "Advisor",
                                 startTime = now.toDatabasePrecision(),

--- a/dao/src/main/kotlin/repositories/resolvedconfiguration/DaoResolvedConfigurationRepository.kt
+++ b/dao/src/main/kotlin/repositories/resolvedconfiguration/DaoResolvedConfigurationRepository.kt
@@ -49,6 +49,7 @@ import org.eclipse.apoapsis.ortserver.dao.tables.shared.IssuesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.OrtRunsIssuesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.ResolvedIssuesTable
 import org.eclipse.apoapsis.ortserver.dao.utils.DigestFunction
+import org.eclipse.apoapsis.ortserver.dao.utils.toDatabasePrecision
 import org.eclipse.apoapsis.ortserver.model.repositories.ResolvedConfigurationRepository
 import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.AppliedPackageCurationRef
 import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.ResolvedConfiguration
@@ -60,7 +61,6 @@ import org.eclipse.apoapsis.ortserver.model.runs.RuleViolation
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.Vulnerability
 import org.eclipse.apoapsis.ortserver.model.runs.repository.PackageConfiguration
 
-import org.jetbrains.exposed.v1.core.Op
 import org.jetbrains.exposed.v1.core.QueryParameter
 import org.jetbrains.exposed.v1.core.TextColumnType
 import org.jetbrains.exposed.v1.core.and
@@ -303,7 +303,8 @@ class DaoResolvedConfigurationRepository(private val db: Database) : ResolvedCon
                         ) and
                     (IssuesTable.severity eq issue.severity) and
                     (IssuesTable.affectedPath eq issue.affectedPath) and
-                        (identifierId?.let { OrtRunsIssuesTable.identifierId eq it } ?: Op.TRUE)
+                    (OrtRunsIssuesTable.timestamp eq issue.timestamp.toDatabasePrecision()) and
+                        (OrtRunsIssuesTable.identifierId eq identifierId)
             }
             .firstOrNull()?.get(OrtRunsIssuesTable.id)?.value
     }

--- a/dao/src/test/kotlin/repositories/resolvedconfiguration/DaoResolvedConfigurationRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/resolvedconfiguration/DaoResolvedConfigurationRepositoryTest.kt
@@ -36,6 +36,7 @@ import io.kotest.matchers.string.shouldContain
 import java.nio.charset.StandardCharsets
 
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.minutes
 
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
 import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.ResolvedVulnerabilitiesTable
@@ -770,6 +771,110 @@ class DaoResolvedConfigurationRepositoryTest : WordSpec({
                     .toList()
             }
             storedResolvedIssues shouldHaveSize 2
+        }
+
+        "match resolutions for issues that differ only in the timestamp correctly" {
+            val issue1 = Issue(
+                timestamp = Clock.System.now(),
+                source = "Analyzer",
+                message = "Some test issue",
+                severity = Severity.WARNING,
+                affectedPath = "/some/path"
+            )
+            val issue2 = Issue(
+                timestamp = Clock.System.now() - 10.minutes,
+                source = "Analyzer",
+                message = "Some test issue",
+                severity = Severity.WARNING,
+                affectedPath = "/some/path"
+            )
+            fixtures.createAnalyzerRun(
+                analyzerJobId = fixtures.analyzerJob.id,
+                issues = listOf(issue1, issue2)
+            )
+
+            // Use the same resolution for both issues (simulating a regex pattern match)
+            val sharedResolution = IssueResolution(
+                message = ".*test issue.*",
+                reason = IssueResolutionReason.CANT_FIX_ISSUE,
+                comment = "Matches multiple issues",
+                source = ResolutionSource.REPOSITORY_FILE
+            )
+
+            val resolvedItems = ResolvedItemsResult(
+                issues = mapOf(
+                    issue1 to listOf(sharedResolution),
+                    issue2 to listOf(sharedResolution)
+                ),
+                ruleViolations = emptyMap(),
+                vulnerabilities = emptyMap()
+            )
+
+            resolvedConfigurationRepository.addResolutions(ortRunId, resolvedItems)
+
+            // Verify mappings were stored for both issues
+            val storedResolvedIssues = dbExtension.db.dbQuery {
+                ResolvedIssuesTable.selectAll()
+                    .where { ResolvedIssuesTable.ortRunId eq ortRunId }
+                    .toList()
+            }
+            storedResolvedIssues shouldHaveSize 2
+        }
+
+        "match resolutions for issues without identifiers correctly" {
+            val issue1 = Issue(
+                timestamp = Clock.System.now(),
+                source = "Analyzer",
+                message = "Some test issue",
+                severity = Severity.WARNING,
+                affectedPath = "/some/path",
+                identifier = identifier1
+            )
+            val issue2 = Issue(
+                timestamp = issue1.timestamp,
+                source = "Analyzer",
+                message = "Some test issue",
+                severity = Severity.WARNING,
+                affectedPath = "/some/path",
+                identifier = identifier2
+            )
+            val issue3 = Issue(
+                timestamp = issue2.timestamp,
+                source = "Analyzer",
+                message = "Some test issue",
+                severity = Severity.WARNING,
+                affectedPath = "/some/path"
+            )
+            fixtures.createAnalyzerRun(
+                analyzerJobId = fixtures.analyzerJob.id,
+                issues = listOf(issue1, issue2, issue3)
+            )
+
+            val sharedResolution = IssueResolution(
+                message = ".*test issue.*",
+                reason = IssueResolutionReason.CANT_FIX_ISSUE,
+                comment = "Matches multiple issues",
+                source = ResolutionSource.REPOSITORY_FILE
+            )
+
+            val resolvedItems = ResolvedItemsResult(
+                issues = mapOf(
+                    issue1 to listOf(sharedResolution),
+                    issue2 to listOf(sharedResolution),
+                    issue3 to listOf(sharedResolution)
+                ),
+                ruleViolations = emptyMap(),
+                vulnerabilities = emptyMap()
+            )
+
+            resolvedConfigurationRepository.addResolutions(ortRunId, resolvedItems)
+
+            val storedResolvedIssues = dbExtension.db.dbQuery {
+                ResolvedIssuesTable.selectAll()
+                    .where { ResolvedIssuesTable.ortRunId eq ortRunId }
+                    .toList()
+            }
+            storedResolvedIssues shouldHaveSize 3
         }
 
         "persist long server issue resolutions without index row size errors" {


### PR DESCRIPTION
When storing resolutions for issues make sure that also the timestamp and the identifier are matched correctly. Otherwise, resolutions may be missed.