### PR TITLE
deps(docker): Add provenant to the scanner Docker image

### DIFF
--- a/workers/scanner/docker/Scanner.Dockerfile
+++ b/workers/scanner/docker/Scanner.Dockerfile
@@ -68,7 +68,7 @@ RUN curl -LOs https://github.com/amzn/askalono/releases/download/$ASKALONO_VERSI
     unzip askalono-Linux.zip -d /opt/askalono && \
     rm askalono-Linux.zip
 
-ENV PATH=$PATH:/opt/askalono
+ENV PATH=/opt/askalono:$PATH
 
 # Use rbenv to install Licensee.
 ENV RBENV_ROOT=/opt/rbenv
@@ -104,4 +104,4 @@ RUN curl -Os https://raw.githubusercontent.com/nexB/scancode-toolkit/v$SCANCODE_
     /opt/scancode/bin/pip install --constraint requirements.txt scancode-toolkit==$SCANCODE_VERSION && \
     rm requirements.txt
 
-ENV PATH="/opt/scancode/bin:${PATH}"
+ENV PATH=/opt/scancode/bin:$PATH

--- a/workers/scanner/docker/Scanner.Dockerfile
+++ b/workers/scanner/docker/Scanner.Dockerfile
@@ -58,6 +58,7 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 
 ARG ASKALONO_VERSION=0.5.0
 ARG LICENSEE_VERSION=9.18.0
+ARG PROVENANT_VERSION=0.1.1
 ARG RUBY_VERSION=3.4.4
 ARG SCANCODE_VERSION=32.5.0
 
@@ -85,6 +86,17 @@ RUN rbenv install $RUBY_VERSION -v \
     && gem install licensee:$LICENSEE_VERSION
 
 WORKDIR $HOME
+
+# Install the Provenant binary from GitHub releases.
+RUN mkdir -p /opt/provenant && \
+    if [ "$(arch)" = "aarch64" ]; then \
+        PROVENANT_ARCHIVE="provenant-linux-aarch64.tar.gz"; \
+    else \
+        PROVENANT_ARCHIVE="provenant-linux-x86_64.tar.gz"; \
+    fi \
+    && curl -LSs "https://github.com/mstykow/provenant/releases/download/v$PROVENANT_VERSION/$PROVENANT_ARCHIVE" | tar -xz -C /opt/provenant
+
+ENV PATH=/opt/provenant:$PATH
 
 # Use pip to install ScanCode
 RUN curl -Os https://raw.githubusercontent.com/nexB/scancode-toolkit/v$SCANCODE_VERSION/requirements.txt && \

--- a/workers/scanner/docker/Scanner.Dockerfile
+++ b/workers/scanner/docker/Scanner.Dockerfile
@@ -62,7 +62,7 @@ ARG PROVENANT_VERSION=0.1.1
 ARG RUBY_VERSION=3.4.4
 ARG SCANCODE_VERSION=32.5.0
 
-# Install Askalono
+# Install Askalono.
 RUN curl -LOs https://github.com/amzn/askalono/releases/download/$ASKALONO_VERSION/askalono-Linux.zip && \
     mkdir /opt/askalono && \
     unzip askalono-Linux.zip -d /opt/askalono && \
@@ -70,7 +70,7 @@ RUN curl -LOs https://github.com/amzn/askalono/releases/download/$ASKALONO_VERSI
 
 ENV PATH=$PATH:/opt/askalono
 
-# Use rbenv to install Licensee
+# Use rbenv to install Licensee.
 ENV RBENV_ROOT=/opt/rbenv
 ENV PATH=$RBENV_ROOT/bin:$RBENV_ROOT/shims/:$RBENV_ROOT/plugins/ruby-build/bin:$PATH
 
@@ -98,7 +98,7 @@ RUN mkdir -p /opt/provenant && \
 
 ENV PATH=/opt/provenant:$PATH
 
-# Use pip to install ScanCode
+# Use pip to install ScanCode.
 RUN curl -Os https://raw.githubusercontent.com/nexB/scancode-toolkit/v$SCANCODE_VERSION/requirements.txt && \
     python3 -m venv /opt/scancode && \
     /opt/scancode/bin/pip install --constraint requirements.txt scancode-toolkit==$SCANCODE_VERSION && \


### PR DESCRIPTION
A provenant scanner plugin was already added to ORT, so it is selectable via the UI, and thus the scanner binary should be added as well.