### PR TITLE
chore: Add AI-related directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ http-client.private.env.json
 *.db
 .beads-credential-key
 .bv/
+.agents/
 .claude/
 .codex/
 .dolt/


### PR DESCRIPTION
Yet another directory to add. This is maybe the most common one yet, and the different agents are slowly adapting to using it, so it could be that some other agent-related ignored folders could be removed from `.gitignore` in the future.