### PR TITLE
build(gradle): Use the same dependency substitutions as in ORT

### DIFF
--- a/buildSrc/src/main/kotlin/ort-server-base-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-base-conventions.gradle.kts
@@ -70,6 +70,22 @@ repositories {
     }
 }
 
+configurations.all {
+    resolutionStrategy {
+        dependencySubstitution {
+            substitute(module("org.lz4:lz4-java"))
+                .using(module("at.yawk.lz4:lz4-java:1.11.0"))
+                .because("lz4-java is unmaintained and vulnerable to CVE‐2025‐12183")
+        }
+
+        dependencySubstitution {
+            substitute(module("org.slf4j:slf4j-api"))
+                .using(module("org.slf4j:slf4j-api:2.0.18"))
+                .because("https://github.com/gradle/gradle/issues/37947")
+        }
+    }
+}
+
 tasks.withType<AbstractArchiveTask>().configureEach {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
     isPreserveFileTimestamps = false


### PR DESCRIPTION
These are not inherited by using ORT as a dependency, so redeclare them.