### PR TITLE
Handle provenance resolution issues

### DIFF
--- a/dao/src/main/kotlin/repositories/scannerrun/DaoScannerRunRepository.kt
+++ b/dao/src/main/kotlin/repositories/scannerrun/DaoScannerRunRepository.kt
@@ -26,7 +26,6 @@ import org.eclipse.apoapsis.ortserver.dao.blockingQuery
 import org.eclipse.apoapsis.ortserver.dao.entityQuery
 import org.eclipse.apoapsis.ortserver.dao.mapAndDeduplicate
 import org.eclipse.apoapsis.ortserver.dao.queries.ortrun.GetIssuesForOrtRunQuery
-import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerConfigurationsSecretsTable.scannerConfigurationSecretId
 import org.eclipse.apoapsis.ortserver.dao.tables.PackageProvenanceDao
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.EnvironmentDao
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.OrtRunIssueDao
@@ -96,19 +95,10 @@ class DaoScannerRunRepository(private val db: Database) : ScannerRunRepository {
             scanners.getOrPut(dao.identifier.mapToModel()) { mutableSetOf() }.add(dao.scannerName)
         }
 
-        val ortRunId = scannerRunDao.scannerJob.ortRun.id.value
-        val scannerIssues = GetIssuesForOrtRunQuery(ortRunId, ScannerRunDao.ISSUE_WORKER_TYPE).execute()
-        val issuesById = mutableMapOf<Identifier, MutableSet<Issue>>()
-        scannerIssues.forEach { issue ->
-            issue.identifier?.also { identifier ->
-                issuesById.getOrPut(identifier) { mutableSetOf() } += issue
-            }
-        }
-
         scannerRunDao.mapToModel().copy(
             provenances = provenanceResolutionResults,
             scanResults = scanResults,
-            issues = issuesById,
+            issues = getScannerRunIssues(scannerRunDao, provenanceResolutionResults),
             scanners = scanners
         )
     }
@@ -179,6 +169,32 @@ class DaoScannerRunRepository(private val db: Database) : ScannerRunRepository {
 
             add(result)
         }
+    }
+
+    /**
+     * Get the [Issue]s for the provided [scannerRunDao] and group them by their [Identifier]. Remove duplicate issues
+     * that are related to the given [provenanceResolutionResults]. Note that resolution issues are created dynamically
+     * and therefore have a different timestamp. So, the matching is done based on the message.
+     */
+    private fun getScannerRunIssues(
+        scannerRunDao: ScannerRunDao,
+        provenanceResolutionResults: Set<ProvenanceResolutionResult>
+    ): MutableMap<Identifier, MutableSet<Issue>> {
+        val ortRunId = scannerRunDao.scannerJob.ortRun.id.value
+        val scannerIssues = GetIssuesForOrtRunQuery(ortRunId, ScannerRunDao.ISSUE_WORKER_TYPE).execute()
+        val resolutionIssues = provenanceResolutionResults.flatMapTo(mutableSetOf()) { result ->
+            listOfNotNull(result.packageProvenanceResolutionIssue, result.nestedProvenanceResolutionIssue)
+                .map(Issue::message)
+        }
+
+        val issuesById = mutableMapOf<Identifier, MutableSet<Issue>>()
+        scannerIssues.filterNot { it.message in resolutionIssues }.forEach { issue ->
+            issue.identifier?.also { identifier ->
+                issuesById.getOrPut(identifier) { mutableSetOf() } += issue
+            }
+        }
+
+        return issuesById
     }
 }
 

--- a/dao/src/test/kotlin/repositories/scannerrun/DaoScannerRunRepositoryTest.kt
+++ b/dao/src/test/kotlin/repositories/scannerrun/DaoScannerRunRepositoryTest.kt
@@ -30,6 +30,7 @@ import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.contain
 
 import kotlin.time.Clock
+import kotlin.time.Instant
 
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.DaoAnalyzerRunRepository
 import org.eclipse.apoapsis.ortserver.dao.tables.NestedProvenanceDao
@@ -281,6 +282,69 @@ class DaoScannerRunRepositoryTest : WordSpec({
                     scanResultPkg3.mapToModel()
                         .copy(provenance = RepositoryProvenance(pkg3.vcsProcessed, pkg3.vcsProcessed.revision))
                 )
+            }
+        }
+
+        "remove duplicate issues for provenance resolution results" {
+            val scanResult = createScanResult(artifact = pkg.sourceArtifact)
+            val scanners = mapOf(pkg.identifier to setOf(SCANNER_NAME))
+
+            val resolutionIssue = Issue(
+                timestamp = Instant.parse("2026-05-27T05:42:02Z"),
+                source = "scanner",
+                message = "Could not resolve provenance for package " +
+                        "'Identifier(type=type, namespace=namespace, name=package, version=version)':\n" +
+                        "Could not resolve provenance.",
+                severity = Severity.ERROR,
+                identifier = pkg.identifier,
+                worker = "scanner"
+            )
+            val nestedResolutionIssue = Issue(
+                timestamp = Instant.parse("2026-05-27T05:43:27Z"),
+                source = "scanner",
+                message = "Could not resolve provenance for package " +
+                        "'Identifier(type=type, namespace=namespace, name=package, version=version)':\n" +
+                        "Could not resolve provenance.",
+                severity = Severity.ERROR,
+                identifier = pkg.identifier,
+                worker = "scanner"
+            )
+            val scannerIssue = Issue(
+                timestamp = Instant.parse("2026-05-27T05:44:11Z"),
+                source = "scanner",
+                message = "Some trouble with the scanner.",
+                severity = Severity.ERROR,
+                identifier = pkg.identifier,
+                worker = "scanner"
+            )
+            val issues = mapOf(pkg.identifier to setOf(resolutionIssue, nestedResolutionIssue, scannerIssue))
+
+            analyzerRunRepository.create(fixtures.analyzerJob.id, analyzerRun.copy(packages = setOf(pkg)))
+            val createdScannerRun = scannerRunRepository.create(
+                scannerJobId,
+                scannerRun.copy(scanners = scanners, issues = issues)
+            )
+            associateScannerRunWithScanResult(createdScannerRun, scanResult)
+
+            val newOrtRun = fixtures.createOrtRun()
+            val newAnalyzerJobId = fixtures.createAnalyzerJob(newOrtRun.id).id
+            analyzerRunRepository.create(newAnalyzerJobId, analyzerRun.copy(packages = setOf(pkg)))
+
+            transaction {
+                val provenanceDao = PackageProvenanceDao.new {
+                    identifier = IdentifierDao.getOrPut(pkg.identifier)
+                    artifact = RemoteArtifactDao.getOrPut(pkg.sourceArtifact)
+                    errorMessage = "Could not resolve provenance."
+                }
+                associateScannerRunWithPackageProvenance(createdScannerRun, provenanceDao)
+            }
+
+            val scannerRun = scannerRunRepository.get(scannerJobId)
+
+            scannerRun.shouldNotBeNull()
+
+            scannerRun.issues[pkg.identifier].orEmpty().shouldBeSingleton { issue ->
+                issue shouldBe scannerIssue
             }
         }
     }

--- a/workers/scanner/src/main/kotlin/OrtServerScanResultStorage.kt
+++ b/workers/scanner/src/main/kotlin/OrtServerScanResultStorage.kt
@@ -165,7 +165,9 @@ class OrtServerScanResultStorage(
     }
 
     /**
-     * Return a [Map] with all issues that
+     * Return a [Map] with all issues that are related to all scan results encountered for the current run. This
+     * includes issues from scan results read from the storage and issues from results written to the storage.
+     * Such issues need to be associated with the run.
      */
     fun getAllIssues(): Map<Provenance, Set<Issue>> = issuesMap
 

--- a/workers/scanner/src/main/kotlin/ScannerWorker.kt
+++ b/workers/scanner/src/main/kotlin/ScannerWorker.kt
@@ -38,7 +38,9 @@ import org.eclipse.apoapsis.ortserver.workers.common.validateForProcessing
 
 import org.jetbrains.exposed.v1.jdbc.Database
 
+import org.ossreviewtoolkit.model.Issue as OrtIssue
 import org.ossreviewtoolkit.model.Provenance
+import org.ossreviewtoolkit.model.ProvenanceResolutionResult
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.utils.ort.ORT_VERSION
 
@@ -159,6 +161,8 @@ class ScannerWorker(
  * Extract all [Issue]s from this [OrtScannerResult] and convert it to the ORT Server model.
  */
 private fun OrtScannerResult.extractIssues(): Set<Issue> {
+    val result = mutableSetOf<Issue>()
+
     val idsByProvenance = mutableMapOf<Provenance, Identifier>()
     scannerRun.getAllScanResults().forEach { (id, results) ->
         results.forEach { result ->
@@ -166,9 +170,29 @@ private fun OrtScannerResult.extractIssues(): Set<Issue> {
         }
     }
 
-    return issues.flatMapTo(mutableSetOf()) { (provenance, issues) ->
-        issues.map { issue ->
-            issue.mapToModel(identifier = idsByProvenance[provenance], worker = "scanner")
+    issues.forEach { (provenance, provenanceIssues) ->
+        provenanceIssues.forEach { issue ->
+            result += issue.mapToModel(identifier = idsByProvenance[provenance], worker = "scanner")
         }
+    }
+
+    scannerRun.provenances.extractIssues(result, ProvenanceResolutionResult::packageProvenanceResolutionIssue)
+    scannerRun.provenances.extractIssues(result, ProvenanceResolutionResult::nestedProvenanceResolutionIssue)
+
+    return result
+}
+
+/**
+ * Extract a certain kind of issues from the [ProvenanceResolutionResult]s in this [Set] as determined by the given
+ * [extract] function to the provided [issues].
+ */
+private fun Set<ProvenanceResolutionResult>.extractIssues(
+    issues: MutableSet<Issue>,
+    extract: (ProvenanceResolutionResult) -> OrtIssue?
+) {
+    mapNotNull { resolutionResult ->
+        extract(resolutionResult)?.let { resolutionResult.id to it }
+    }.forEach { (id, issue) ->
+        issues += issue.mapToModel(identifier = id.mapToModel(), worker = "scanner")
     }
 }

--- a/workers/scanner/src/test/kotlin/ScannerWorkerTest.kt
+++ b/workers/scanner/src/test/kotlin/ScannerWorkerTest.kt
@@ -62,6 +62,8 @@ import org.eclipse.apoapsis.ortserver.services.ortrun.mapToModel
 import org.eclipse.apoapsis.ortserver.services.ortrun.mapToOrt
 import org.eclipse.apoapsis.ortserver.shared.orttestdata.OrtTestData
 import org.eclipse.apoapsis.ortserver.shared.orttestdata.OrtTestData.issue
+import org.eclipse.apoapsis.ortserver.shared.orttestdata.OrtTestData.pkgIdentifier
+import org.eclipse.apoapsis.ortserver.shared.orttestdata.OrtTestData.providerIssue
 import org.eclipse.apoapsis.ortserver.workers.common.RunResult
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContextFactory
@@ -250,6 +252,7 @@ class ScannerWorkerTest : StringSpec({
         val provenance3 = mockk<RepositoryProvenance>(relaxed = true)
         val ortIdentifier1 = Identifier("type", "namespace", "name", "version")
         val ortIdentifier2 = Identifier("type2", "namespace2", "name2", "version2")
+        val ortIdentifier3 = Identifier("type3", "namespace3", "name3", "version3")
         val ortIssue1 = OrtIssue(
             timestamp = Instant.now(),
             source = "TestScanner",
@@ -277,6 +280,18 @@ class ScannerWorkerTest : StringSpec({
             message = "Test message 4",
             severity = Severity.HINT,
             affectedPath = "test/path2"
+        )
+        val provenanceResolutionIssue = OrtIssue(
+            timestamp = Instant.now(),
+            source = "Scanner",
+            message = "Could not resolve provenance.",
+            severity = Severity.ERROR
+        )
+        val nestedResolutionIssue = OrtIssue(
+            timestamp = Instant.now(),
+            source = "Scanner",
+            message = "Could not resolve nested provenance.",
+            severity = Severity.ERROR
         )
         val scanResult1 = ScanResult(
             provenance = provenance1,
@@ -315,15 +330,30 @@ class ScannerWorkerTest : StringSpec({
                 ortIdentifier1 to listOf(scanResult1),
                 ortIdentifier2 to listOf(scanResult2, scanResult3)
             )
+            every { provenances } returns setOf(
+                ProvenanceResolutionResult(
+                    id = ortIdentifier1,
+                    packageProvenance = provenance1
+                ),
+                ProvenanceResolutionResult(
+                    id = ortIdentifier2,
+                    packageProvenanceResolutionIssue = provenanceResolutionIssue
+                ),
+                ProvenanceResolutionResult(
+                    id = ortIdentifier3,
+                    packageProvenance = provenance2,
+                    nestedProvenanceResolutionIssue = nestedResolutionIssue
+                )
+            )
         }
-        val issuesMap = mapOf<Provenance, Set<OrtIssue>>(
+        val scannerIssuesMap = mapOf<Provenance, Set<OrtIssue>>(
             provenance1 to setOf(ortIssue1, ortIssue2),
             provenance2 to setOf(ortIssue2, ortIssue3),
             provenance3 to setOf(ortIssue4, ortIssue2)
         )
 
         val runner = mockk<ScannerRunner> {
-            coEvery { run(context, any(), any(), any()) } returns OrtScannerResult(ortScannerRun, issuesMap)
+            coEvery { run(context, any(), any(), any()) } returns OrtScannerResult(ortScannerRun, scannerIssuesMap)
         }
 
         val environmentService = mockk<EnvironmentService> {
@@ -357,8 +387,26 @@ class ScannerWorkerTest : StringSpec({
 
             val identifier1 = ortIdentifier1.mapToModel()
             val identifier2 = ortIdentifier2.mapToModel()
-            val expectedIssues = listOf(ortIssue1, ortIssue2, ortIssue2, ortIssue3, ortIssue4)
-                .zip(listOf(identifier1, identifier1, identifier2, identifier2, identifier2))
+            val expectedIssues = listOf(
+                ortIssue1,
+                ortIssue2,
+                ortIssue2,
+                ortIssue3,
+                ortIssue4,
+                provenanceResolutionIssue,
+                nestedResolutionIssue
+            )
+                .zip(
+                    listOf(
+                        identifier1,
+                        identifier1,
+                        identifier2,
+                        identifier2,
+                        identifier2,
+                        identifier2,
+                        ortIdentifier3.mapToModel()
+                    )
+                )
                 .map { (issue, identifier) ->
                     Issue(
                         timestamp = issue.timestamp.toKotlinInstant(),
@@ -515,9 +563,15 @@ class ScannerWorkerTest : StringSpec({
         val provenance: Provenance =
             OrtTestData.scannerRun.provenances.firstNotNullOf(ProvenanceResolutionResult::packageProvenance)
 
-        val issuesMap = mapOf(provenance to setOf(issue))
+        val scannerIssuesMap = mapOf(provenance to setOf(issue))
+        val run = OrtTestData.scannerRun.copy(
+            provenances = OrtTestData.scannerRun.provenances + ProvenanceResolutionResult(
+                id = pkgIdentifier.copy(version = "version2"),
+                packageProvenanceResolutionIssue = providerIssue
+            )
+        )
         val runner = mockk<ScannerRunner> {
-            coEvery { run(context, any(), any(), any()) } returns OrtScannerResult(OrtTestData.scannerRun, issuesMap)
+            coEvery { run(context, any(), any(), any()) } returns OrtScannerResult(run, scannerIssuesMap)
         }
 
         val environmentService = mockk<EnvironmentService> {


### PR DESCRIPTION
This PR makes sure that issues created by the scanner when provenance resolution fails are returned by the REST API and shown by the UI. Previously, such issues were only shown by the WebApp report.