### PR TITLE
Render plugin descriptions in Markdown

### DIFF
--- a/ui/src/components/form/multi-select-field.tsx
+++ b/ui/src/components/form/multi-select-field.tsx
@@ -25,6 +25,7 @@ import {
   UseFormReturn,
 } from 'react-hook-form';
 
+import { MarkdownRenderer } from '@/components/markdown-renderer';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
   FormControl,
@@ -129,9 +130,10 @@ export const MultiSelectField = <
               <div className='flex flex-col'>
                 <FormLabel className='font-normal'>{option.label}</FormLabel>
                 {option.description != null && (
-                  <div className='text-sm text-gray-500'>
-                    {option.description}
-                  </div>
+                  <MarkdownRenderer
+                    markdown={option.description}
+                    className='text-muted-foreground max-w-none [&_p]:my-0'
+                  />
                 )}
               </div>
             </FormItem>

--- a/ui/src/components/form/plugin-multi-select-field.tsx
+++ b/ui/src/components/form/plugin-multi-select-field.tsx
@@ -29,6 +29,7 @@ import {
 
 import { PreconfiguredPluginDescriptor, Secret } from '@/api';
 import { OptionalInput } from '@/components/form/optional-input.tsx';
+import { MarkdownRenderer } from '@/components/markdown-renderer';
 import { Badge } from '@/components/ui/badge.tsx';
 import { Checkbox } from '@/components/ui/checkbox';
 import {
@@ -227,9 +228,10 @@ export const PluginMultiSelectField = <
                   {plugin.displayName}
                 </FormLabel>
                 {plugin.description != null && (
-                  <FormDescription className='pb-4'>
-                    {plugin.description}
-                  </FormDescription>
+                  <MarkdownRenderer
+                    markdown={plugin.description}
+                    className='text-muted-foreground max-w-none pb-4 [&_p]:my-0'
+                  />
                 )}
                 {scannerScopeName && field.value?.includes(plugin.id) && (
                   <FormField


### PR DESCRIPTION
This aligns the rendering with `admin/plugins` section in the UI.

<img width="1080" height="567" alt="Screenshot from 2026-05-28 12-41-49" src="https://github.com/user-attachments/assets/1df53023-bfdf-4dad-99fd-40e2649fa27f" />