### PR TITLE
build(gradle): Remove the global `ExperimentalSerializationApi` opt-in

### DIFF
--- a/buildSrc/src/main/kotlin/ort-server-kotlin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-kotlin-conventions.gradle.kts
@@ -55,18 +55,9 @@ detekt {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-    val serializationOptIn = libraries.elements.map { files ->
-        buildList {
-            if (files.any { it.asFile.name.startsWith("kotlinx-serialization-core") }) {
-                add("kotlinx.serialization.ExperimentalSerializationApi")
-            }
-        }
-    }
-
     compilerOptions {
         allWarningsAsErrors = true
         freeCompilerArgs.addAll("-Xconsistent-data-class-copy-visibility", "-Xcontext-parameters")
-        optIn = serializationOptIn
     }
 }
 

--- a/secrets/scaleway/src/main/kotlin/ScalewaySecretsModel.kt
+++ b/secrets/scaleway/src/main/kotlin/ScalewaySecretsModel.kt
@@ -19,11 +19,13 @@
 
 package org.eclipse.apoapsis.ortserver.secrets.scaleway
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonNamingStrategy
 
+@OptIn(ExperimentalSerializationApi::class)
 internal val json = Json {
     ignoreUnknownKeys = true
     namingStrategy = JsonNamingStrategy.SnakeCase

--- a/workers/common/src/main/kotlin/env/EnvironmentForkHelper.kt
+++ b/workers/common/src/main/kotlin/env/EnvironmentForkHelper.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.workers.common.env
 import java.io.InputStream
 import java.io.OutputStream
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
@@ -52,6 +53,7 @@ import org.slf4j.MDC
  * read this information and set up its environment accordingly. The inter-process communication is done via the
  * `stdin` stream of the forked process.
  */
+@OptIn(ExperimentalSerializationApi::class)
 object EnvironmentForkHelper {
     private val logger = LoggerFactory.getLogger(EnvironmentForkHelper.javaClass)
 


### PR DESCRIPTION
The implementation introduced in 8355756 causes issues when importing the project in IntelliJ, because the `optIn` property is read before dependencies are resolved:

    Failed to query the value of property 'optIn'.
    Querying the mapped value of provider(java.util.Set) before task
    ':api:v1:api-v1-model:jvmJar' has completed is not supported

IntelliJ still succeeded to import the project, but having these error messages on each project import is annoying and might also have other side-effects.

Instead of implementing a more complicated solution to this problem, simply remove the global opt-in in favor of local opt-ins, as the experimental serialization API is only used in two places. This also aligns with how opt-ins for other experimental APIs are done.