### PR TITLE
build(gradle): Prefer `buildHealth` over `projectHealth`

### DIFF
--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -132,7 +132,7 @@ jobs:
       working-directory: website
       run: pnpm format:check
 
-  project-health:
+  build-health:
     runs-on: ubuntu-24.04
     env:
       GRADLE_OPTS: -Dorg.gradle.daemon=false
@@ -143,8 +143,8 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0
 
-    - name: Check Project Health
-      run: ./gradlew --stacktrace projectHealth
+    - name: Check Build Health
+      run: ./gradlew --stacktrace buildHealth
 
   renovate-validation:
     runs-on: ubuntu-24.04

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,10 @@ dependencyAnalysis {
         }
     }
 
+    reporting {
+        printBuildHealth(true)
+    }
+
     useTypesafeProjectAccessors(true)
 }
 


### PR DESCRIPTION
Do not stop at the first issue found, but report all of them for the whole build.