### PR TITLE
UI Docker improvements

### DIFF
--- a/ui/docker/entrypoint.sh
+++ b/ui/docker/entrypoint.sh
@@ -39,6 +39,10 @@ find /usr/share/nginx/html/assets -name '*.js' -exec sed -i "s#UI_BASEPATH_PLACE
 find /usr/share/nginx/html/assets -name '*.js' -exec sed -i "s#UI_CLIENT_ID_PLACEHOLDER#$UI_CLIENT_ID#g" {} +
 find /usr/share/nginx/html/assets -name '*.js' -exec sed -i "s#UI_URL_PLACEHOLDER#$UI_URL#g" {} +
 
+# Pre-compress CSS and JS assets after all placeholder substitutions have been applied.
+# nginx will serve these .gz files directly via gzip_static, avoiding per-request compression.
+find /usr/share/nginx/html/assets \( -name '*.css' -o -name '*.js' \) | xargs gzip -k -f
+
 # Replace placeholders with actual environment variables in the nginx configuration.
 export UI_BASEPATH
 envsubst '${UI_BASEPATH}' < /etc/nginx/default.conf.template > /etc/nginx/conf.d/default.conf

--- a/ui/docker/nginx.conf.template
+++ b/ui/docker/nginx.conf.template
@@ -20,6 +20,12 @@ server {
 
   root /usr/share/nginx/html/;
 
+  # Serve pre-compressed .gz files when the client supports gzip.
+  gzip_static on;
+
+  # Add Vary: Accept-Encoding so CDNs and proxies cache compressed and uncompressed responses separately.
+  gzip_vary on;
+
   location $UI_BASEPATH {
     try_files $uri /index.html;
     alias /usr/share/nginx/html/;

--- a/ui/docker/nginx.conf.template
+++ b/ui/docker/nginx.conf.template
@@ -30,4 +30,11 @@ server {
     try_files $uri /index.html;
     alias /usr/share/nginx/html/;
   }
+
+  # Vite generates content-hashed filenames for JS and CSS assets, so they can be cached indefinitely.
+  location ~* \.(?:js|css)$ {
+    root /usr/share/nginx/html/;
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+  }
 }

--- a/ui/docker/nginx.conf.template
+++ b/ui/docker/nginx.conf.template
@@ -37,4 +37,10 @@ server {
     expires 1y;
     add_header Cache-Control "public, immutable";
   }
+
+  # index.html is not content-hashed, so always revalidate to prevent a stale app shell after deployments.
+  location = /index.html {
+    root /usr/share/nginx/html/;
+    add_header Cache-Control "no-cache";
+  }
 }


### PR DESCRIPTION
Enable compression for static assets and configure caching. See the commit messages for details.

Effect of enabling compression for static assets:
* index.js: 2.74MB -> 692kB
* index.css: 94kB -> 17kB

I have tested all changes in the local Docker Compose environment.