### PR TITLE
docs(kubernetes): Add mountPvcs and mountEmptyDirs documentation

### DIFF
--- a/website/docs/admin-guide/infrastructure/transport/kubernetes.md
+++ b/website/docs/admin-guide/infrastructure/transport/kubernetes.md
@@ -26,6 +26,8 @@ endpoint {
         commands = "/bin/sh"
         args = "-c java my.pkg.MyClass"
         mountSecrets = "server-secrets->/mnt/secrets server-certificates->/mnt/certificates"
+        mountPvcs = "my-pvc->/mnt/data,W"
+        mountEmptyDirs = "shared->/mnt/shared"
         labels = "label1=value1,label2=value2"
         annotationVariables = "ANNOTATION_VAR1, ANNOTATION_VAR2"
         serviceAccount = "my_service_account"
@@ -108,6 +110,24 @@ Each mount declaration has the form `secret→mountPath`, where `secret` is the 
 On this path, for each key of the secret a file is created whose content is the value of the key.
 To achieve this, the Kubernetes Transport implementation generates corresponding `volume` and `volumeMount` declarations in the pod configuration.
 This mechanism is useful not only for secrets but also for other kinds of external data that should be accessible from a pod, for instance, custom certificates.
+
+### `mountPvcs`
+
+**Default: `empty`**
+
+With this property, it is possible to mount [PersistentVolumeClaims](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) into the resulting pod.
+The string is interpreted as a sequence of mount declarations separated by whitespace.
+Each mount declaration has the form `pvcName->mountPath,access`, where `pvcName` is the name of the persistent volume claim, `mountPath` is the path in the container where the volume should be mounted, and `access` is either `R` (read-only) or `W` (writable).
+To achieve this, the Kubernetes Transport implementation generates corresponding `volume` and `volumeMount` declarations in the pod configuration.
+
+### `mountEmptyDirs`
+
+**Default: `empty`**
+
+With this property, it is possible to mount [emptyDir](https://kubernetes.io/docs/concepts/storage/volumes/#emptydir) volumes into the resulting pod.
+The string is interpreted as a sequence of mount declarations separated by whitespace.
+Each mount declaration has the form `name->mountPath`, where `name` is the name of the empty dir volume and `mountPath` is the path in the container where the volume should be mounted.
+To achieve this, the Kubernetes Transport implementation generates corresponding `volume` and `volumeMount` declarations in the pod configuration.
 
 ### `labels`
 


### PR DESCRIPTION
Document the `mountPvcs` and `mountEmptyDirs` configuration properties that were added in 5020d0d.