### PR TITLE
fix(ui): Treat `STRING_LIST` values as strings in plugin template forms

### DIFF
--- a/ui/src/routes/admin/plugins/$pluginType/$pluginId/create-template/index.tsx
+++ b/ui/src/routes/admin/plugins/$pluginType/$pluginId/create-template/index.tsx
@@ -74,7 +74,7 @@ function optionTypeToZodType(type: PluginOptionType): ZodType {
     case 'STRING':
       return z.string();
     case 'STRING_LIST':
-      return z.array(z.string());
+      return z.string();
     default:
       throw new Error(`Unsupported option type: ${type}`);
   }

--- a/ui/src/routes/admin/plugins/$pluginType/$pluginId/edit-template/$templateName/index.tsx
+++ b/ui/src/routes/admin/plugins/$pluginType/$pluginId/edit-template/$templateName/index.tsx
@@ -78,7 +78,7 @@ function optionTypeToZodType(type: PluginOptionType): ZodType {
     case 'STRING':
       return z.string();
     case 'STRING_LIST':
-      return z.array(z.string());
+      return z.string();
     default:
       throw new Error(`Unsupported option type: ${type}`);
   }
@@ -114,7 +114,7 @@ function parseStoredValue(
     case 'LONG':
       return value;
     case 'STRING_LIST':
-      return value.split(',');
+      return value;
     default:
       return value;
   }


### PR DESCRIPTION
The `STRING_LIST` type was mapped to `z.array(z.string())` in both the create and edit template forms, but the plain text input always produces a string value. This caused Zod validation to fail, even when the field was marked as undefined.

Fix this by using `z.string()` instead which is consistent with the API which also expects a comma-separated string, because as long as a plain text input is used for `STRING_LIST` options, there is no value in converting the value to an array in the form schema.