### PR TITLE
feat: Add an option to enable JSON logging

### DIFF
--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -18,12 +18,31 @@
   -->
 
 <configuration>
-    <conversionRule conversionWord="customMdc" class="org.eclipse.apoapsis.ortserver.utils.logging.MdcConverter" />
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>time=%d{YYYY-MM-dd'T'HH:mm:ss.SSS} thread=%thread %customMdc level=%-5level logger=%logger{36} message="%replace(%msg){'\"','\\\"'}"%n</pattern>
-        </encoder>
-    </appender>
+    <variable name="LOG_FORMAT" value="${LOG_FORMAT:-text}" />
+
+    <condition class="ch.qos.logback.core.boolex.PropertyEqualityCondition">
+        <key>LOG_FORMAT</key>
+        <value>json</value>
+    </condition>
+    <if>
+        <then>
+            <sequenceNumberGenerator class="ch.qos.logback.core.spi.BasicSequenceNumberGenerator" />
+            <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder class="ch.qos.logback.classic.encoder.JsonEncoder">
+                    <withContext>false</withContext>
+                </encoder>
+            </appender>
+        </then>
+        <else>
+            <conversionRule conversionWord="customMdc" class="org.eclipse.apoapsis.ortserver.utils.logging.MdcConverter" />
+            <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder>
+                    <pattern>time=%d{YYYY-MM-dd'T'HH:mm:ss.SSS} thread=%thread %customMdc level=%-5level logger=%logger{36} message="%replace(%msg){'\"','\\\"'}"%n</pattern>
+                </encoder>
+            </appender>
+        </else>
+    </if>
+
     <root level="trace">
         <appender-ref ref="STDOUT"/>
     </root>
@@ -34,5 +53,4 @@
     <logger name="org.flywaydb.core.internal.license.VersionPrinter" level="WARN"/>
     <logger name="io.ktor" level="INFO"/>
     <logger name="io.ktor.server.plugins.cors.CORS" level="TRACE"/>
-
 </configuration>

--- a/orchestrator/src/main/resources/logback.xml
+++ b/orchestrator/src/main/resources/logback.xml
@@ -18,12 +18,31 @@
   -->
 
 <configuration>
-    <conversionRule conversionWord="customMdc" class="org.eclipse.apoapsis.ortserver.utils.logging.MdcConverter" />
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>time=%d{YYYY-MM-dd'T'HH:mm:ss.SSS} thread=%thread %customMdc level=%-5level logger=%logger{36} message="%replace(%msg){'\"','\\\"'}"%n</pattern>
-        </encoder>
-    </appender>
+    <variable name="LOG_FORMAT" value="${LOG_FORMAT:-text}" />
+
+    <condition class="ch.qos.logback.core.boolex.PropertyEqualityCondition">
+        <key>LOG_FORMAT</key>
+        <value>json</value>
+    </condition>
+    <if>
+        <then>
+            <sequenceNumberGenerator class="ch.qos.logback.core.spi.BasicSequenceNumberGenerator" />
+            <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder class="ch.qos.logback.classic.encoder.JsonEncoder">
+                    <withContext>false</withContext>
+                </encoder>
+            </appender>
+        </then>
+        <else>
+            <conversionRule conversionWord="customMdc" class="org.eclipse.apoapsis.ortserver.utils.logging.MdcConverter" />
+            <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder>
+                    <pattern>time=%d{YYYY-MM-dd'T'HH:mm:ss.SSS} thread=%thread %customMdc level=%-5level logger=%logger{36} message="%replace(%msg){'\"','\\\"'}"%n</pattern>
+                </encoder>
+            </appender>
+        </else>
+    </if>
+
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>

--- a/tasks/src/main/resources/logback.xml
+++ b/tasks/src/main/resources/logback.xml
@@ -18,12 +18,31 @@
   -->
 
 <configuration>
-    <conversionRule conversionWord="customMdc" class="org.eclipse.apoapsis.ortserver.utils.logging.MdcConverter" />
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>time=%d{YYYY-MM-dd'T'HH:mm:ss.SSS} thread=%thread %customMdc level=%-5level logger=%logger{36} message="%replace(%msg){'\"','\\\"'}"%n</pattern>
-        </encoder>
-    </appender>
+    <variable name="LOG_FORMAT" value="${LOG_FORMAT:-text}" />
+
+    <condition class="ch.qos.logback.core.boolex.PropertyEqualityCondition">
+        <key>LOG_FORMAT</key>
+        <value>json</value>
+    </condition>
+    <if>
+        <then>
+            <sequenceNumberGenerator class="ch.qos.logback.core.spi.BasicSequenceNumberGenerator" />
+            <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder class="ch.qos.logback.classic.encoder.JsonEncoder">
+                    <withContext>false</withContext>
+                </encoder>
+            </appender>
+        </then>
+        <else>
+            <conversionRule conversionWord="customMdc" class="org.eclipse.apoapsis.ortserver.utils.logging.MdcConverter" />
+            <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder>
+                    <pattern>time=%d{YYYY-MM-dd'T'HH:mm:ss.SSS} thread=%thread %customMdc level=%-5level logger=%logger{36} message="%replace(%msg){'\"','\\\"'}"%n</pattern>
+                </encoder>
+            </appender>
+        </else>
+    </if>
+
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>

--- a/utils/test/src/commonMain/resources/logback.xml
+++ b/utils/test/src/commonMain/resources/logback.xml
@@ -18,17 +18,34 @@
   -->
 
 <configuration>
-    <conversionRule conversionWord="customMdc" class="org.eclipse.apoapsis.ortserver.utils.logging.MdcConverter" />
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>time=%d{YYYY-MM-dd'T'HH:mm:ss.SSS} thread=%thread %customMdc level=%-5level logger=%logger{36} message="%replace(%msg){'\"','\\\"'}"%n</pattern>
-        </encoder>
-    </appender>
+    <variable name="LOG_FORMAT" value="${LOG_FORMAT:-text}" />
+
+    <condition class="ch.qos.logback.core.boolex.PropertyEqualityCondition">
+        <key>LOG_FORMAT</key>
+        <value>json</value>
+    </condition>
+    <if>
+        <then>
+            <sequenceNumberGenerator class="ch.qos.logback.core.spi.BasicSequenceNumberGenerator" />
+            <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder class="ch.qos.logback.classic.encoder.JsonEncoder">
+                    <withContext>false</withContext>
+                </encoder>
+            </appender>
+        </then>
+        <else>
+            <conversionRule conversionWord="customMdc" class="org.eclipse.apoapsis.ortserver.utils.logging.MdcConverter" />
+            <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder>
+                    <pattern>time=%d{YYYY-MM-dd'T'HH:mm:ss.SSS} thread=%thread %customMdc level=%-5level logger=%logger{36} message="%replace(%msg){'\"','\\\"'}"%n</pattern>
+                </encoder>
+            </appender>
+        </else>
+    </if>
 
     <root level="DEBUG">
         <appender-ref ref="STDOUT"/>
     </root>
-
     <logger name="org.apache.http.headers" level="ERROR"/>
     <logger name="org.apache.http.wire" level="ERROR"/>
     <logger name="org.eclipse.jgit.internal.storage.file.FileSnapshot" level="ERROR"/>

--- a/workers/common/src/main/resources/logback.xml
+++ b/workers/common/src/main/resources/logback.xml
@@ -18,12 +18,31 @@
   -->
 
 <configuration>
-    <conversionRule conversionWord="customMdc" class="org.eclipse.apoapsis.ortserver.utils.logging.MdcConverter" />
-    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-        <encoder>
-            <pattern>time=%d{YYYY-MM-dd'T'HH:mm:ss.SSS} thread=%thread %customMdc level=%-5level logger=%logger{36} message="%replace(%msg){'\"','\\\"'}"%n</pattern>
-        </encoder>
-    </appender>
+    <variable name="LOG_FORMAT" value="${LOG_FORMAT:-text}" />
+
+    <condition class="ch.qos.logback.core.boolex.PropertyEqualityCondition">
+        <key>LOG_FORMAT</key>
+        <value>json</value>
+    </condition>
+    <if>
+        <then>
+            <sequenceNumberGenerator class="ch.qos.logback.core.spi.BasicSequenceNumberGenerator" />
+            <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder class="ch.qos.logback.classic.encoder.JsonEncoder">
+                    <withContext>false</withContext>
+                </encoder>
+            </appender>
+        </then>
+        <else>
+            <conversionRule conversionWord="customMdc" class="org.eclipse.apoapsis.ortserver.utils.logging.MdcConverter" />
+            <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder>
+                    <pattern>time=%d{YYYY-MM-dd'T'HH:mm:ss.SSS} thread=%thread %customMdc level=%-5level logger=%logger{36} message="%replace(%msg){'\"','\\\"'}"%n</pattern>
+                </encoder>
+            </appender>
+        </else>
+    </if>
+
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>


### PR DESCRIPTION
Configure Logback to optionally enable JSON logging by setting the environment variable `LOG_FORMAT` to `json`. This will later be used for the Elasticsearch logaccess provider where it is a lot easier to ingest JSON logs.

The built-in `JsonEncoder` [1] is used instead of alternatives like [2] or [3] because it does not require any additional depdencies.

The appender configuration enables a sequence number generator which to ensure the correct sorting of logs in case of identical timestamps. It also disables the `context` section because it currently does not contain relevant information.

Relates to #571.

[1]: https://logback.qos.ch/manual/encoders.html#JsonEncoder
[2]: https://github.com/logfellow/logstash-logback-encoder
[3]: https://github.com/pgomulka/java-ecs-logging/tree/master/logback-ecs-encoder

As an example, JSON logs look like this with the current config:

```
{"sequenceNumber":1,"timestamp":1780665436218,"nanoseconds":218159415,"level":"INFO","threadName":"main","loggerName":"Application","mdc": {},"message":"Autoreload is disabled because the development mode is off.","throwable":null}
{"sequenceNumber":2,"timestamp":1780665436324,"nanoseconds":324426116,"level":"INFO","threadName":"main","loggerName":"org.eclipse.apoapsis.ortserver.config.secret.file.ConfigSecretFileProviderFactory","mdc": {"component":"core"},"message":"Creating ConfigSecretFileProvider, reading secrets from these files: {}.","arguments": ["[\/mnt\/secrets.properties]"],"throwable":null}
{"sequenceNumber":3,"timestamp":1780665436670,"nanoseconds":670555903,"level":"INFO","threadName":"main","loggerName":"org.flywaydb.core.FlywayExecutor","mdc": {"component":"core"},"message":"Database: jdbc:postgresql:\/\/postgres:5432\/ort_server (PostgreSQL 18.4)","throwable":null}
{"sequenceNumber":4,"timestamp":1780665436828,"nanoseconds":828786928,"level":"INFO","threadName":"main","loggerName":"org.flywaydb.core.internal.command.DbValidate","mdc": {"component":"core"},"message":"Successfully validated 149 migrations (execution time 00:00.096s)","throwable":null}
```