### PR TITLE
fix(ui): Show the plugin summary instead of description

### DIFF
--- a/ui/src/components/form/plugin-multi-select-field.tsx
+++ b/ui/src/components/form/plugin-multi-select-field.tsx
@@ -227,9 +227,9 @@ export const PluginMultiSelectField = <
                 <FormLabel className='font-normal'>
                   {plugin.displayName}
                 </FormLabel>
-                {plugin.description != null && (
+                {plugin.summary != null && (
                   <MarkdownRenderer
-                    markdown={plugin.description}
+                    markdown={plugin.summary}
                     className='text-muted-foreground max-w-none pb-4 [&_p]:my-0'
                   />
                 )}


### PR DESCRIPTION
This is a fixup for 4a93436. As part of the ORT upgrade the plugin `description` was renamed to `summary`.