### PR TITLE
ui: Refactor Analyzer / environment configurations

### DIFF
--- a/api/v1/model/src/commonMain/kotlin/EnvironmentConfig.kt
+++ b/api/v1/model/src/commonMain/kotlin/EnvironmentConfig.kt
@@ -42,7 +42,7 @@ typealias EnvironmentDefinitions = Map<String, List<Options>>
 @Serializable
 data class EnvironmentConfig(
     /** The list of infrastructure services declared for this repository. */
-    val infrastructureServices: List<InfrastructureService>,
+    val infrastructureServices: List<InfrastructureService> = emptyList(),
 
     /** A map with environment definitions of different types. */
     val environmentDefinitions: EnvironmentDefinitions = emptyMap(),

--- a/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
@@ -778,6 +778,51 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
             }
         }
 
+        "create a new ORT run with default infrastructure services in the environment config" {
+            integrationTestApplication {
+                val createdRepository = createRepository()
+                val environmentDefinitions = mapOf(
+                    "maven" to listOf(mapOf("id" to "repositoryServer"))
+                )
+                val environmentVariables = listOf(
+                    ApiEnvironmentVariableDeclaration("MY_ENV_VAR", "mySecret")
+                )
+
+                val envConfig = EnvironmentConfig(
+                    environmentDefinitions = environmentDefinitions,
+                    environmentVariables = environmentVariables
+                )
+                val createRun = PostRepositoryRun(
+                    revision = "main",
+                    jobConfigs = ApiJobConfigurations(
+                        analyzer = AnalyzerJobConfiguration(environmentConfig = envConfig)
+                    )
+                )
+
+                val response = superuserClient.post("/api/v1/repositories/${createdRepository.id}/runs") {
+                    setBody(createRun)
+                }
+
+                response shouldHaveStatus HttpStatusCode.Created
+                val runResponse = response.body<OrtRun>()
+                runResponse.jobConfigs.analyzer.environmentConfig shouldNotBeNull {
+                    infrastructureServices.shouldBeEmpty()
+                    this.environmentDefinitions shouldBe environmentDefinitions
+                    this.environmentVariables shouldContainExactly environmentVariables
+                }
+
+                val run = ortRunRepository.listForRepository(createdRepository.id).data.single()
+
+                run.jobConfigs.analyzer.environmentConfig shouldNotBeNull {
+                    infrastructureServices.shouldBeEmpty()
+                    this.environmentDefinitions shouldBe environmentDefinitions
+                    this.environmentVariables shouldContainExactly listOf(
+                        EnvironmentVariableDeclaration("MY_ENV_VAR", "mySecret")
+                    )
+                }
+            }
+        }
+
         "resolve provided plugin secrets from the user secrets" {
             integrationTestApplication {
                 val createdRepository = createRepository()

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
@@ -196,7 +196,7 @@ export const AnalyzerFields = ({
           />
           <div className='flex flex-col gap-2'>
             <h3>Environment variables</h3>
-            <div className='mb-2 text-sm text-gray-500'>
+            <div className='text-sm text-gray-500'>
               A list of environment variable names and their values, either
               literal ones, or retrieved from named secrets. Use this to specify
               environment variables that are required by the build process. In

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/environment-definitions.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/environment-definitions.tsx
@@ -17,17 +17,12 @@
  * License-Filename: LICENSE
  */
 
-import * as AccordionPrimitive from '@radix-ui/react-accordion';
-import { ChevronDownIcon } from 'lucide-react';
-import { ReactNode, useRef } from 'react';
+import { PlusIcon, TrashIcon } from 'lucide-react';
+import { ReactNode } from 'react';
 import { FieldPath, UseFormReturn } from 'react-hook-form';
 
-import { Accordion, AccordionContent } from '@/components/ui/accordion';
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from '@/components/ui/collapsible';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   FormControl,
   FormDescription,
@@ -49,13 +44,18 @@ import { capitalize } from '@/helpers/capitalize';
 import { InfrastructureServiceWithHierarchy } from '@/hooks/use-infrastructure-services';
 import {
   ENVIRONMENT_DEFINITION_SCHEMAS,
+  EnvironmentDefinitionSchema,
   FieldEntry,
 } from '@/lib/environment-definition-fields';
-import { EnvironmentDefinitionEntry } from '@/lib/types';
+import {
+  EnvironmentDefinitionEntry,
+  EnvironmentDefinitions,
+} from '@/lib/types';
 import { CreateRunFormValues } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components';
 
 type PackageManagerFieldProps = {
   pmKey: string;
+  index: number;
   entry: FieldEntry;
   form: UseFormReturn<CreateRunFormValues>;
   infrastructureServices: InfrastructureServiceWithHierarchy[];
@@ -63,12 +63,13 @@ type PackageManagerFieldProps = {
 
 function PackageManagerField({
   pmKey,
+  index,
   entry,
   form,
   infrastructureServices,
 }: PackageManagerFieldProps): ReactNode {
   const name =
-    `jobConfigs.analyzer.environmentDefinitions.${pmKey}.0.${entry.key}` as FieldPath<CreateRunFormValues>;
+    `jobConfigs.analyzer.environmentDefinitions.${pmKey}.${index}.${entry.key}` as FieldPath<CreateRunFormValues>;
   const { def } = entry;
 
   if (def.type === 'service') {
@@ -84,7 +85,16 @@ function PackageManagerField({
           return (
             <FormItem>
               <FormLabel>Service</FormLabel>
-              <Select value={value} onValueChange={(v) => field.onChange(v)}>
+              <Select
+                value={value}
+                onValueChange={(v) => {
+                  form.setValue(name, v, {
+                    shouldDirty: true,
+                    shouldTouch: true,
+                    shouldValidate: true,
+                  });
+                }}
+              >
                 <FormControl>
                   <SelectTrigger className='w-full'>
                     <SelectValue placeholder='Select an infrastructure service' />
@@ -150,7 +160,11 @@ function PackageManagerField({
               <Switch
                 checked={((field.value as string) ?? 'true') === 'true'}
                 onCheckedChange={(checked) =>
-                  field.onChange(checked ? 'true' : 'false')
+                  form.setValue(name, checked ? 'true' : 'false', {
+                    shouldDirty: true,
+                    shouldTouch: true,
+                    shouldValidate: true,
+                  })
                 }
               />
             </FormControl>
@@ -172,7 +186,16 @@ function PackageManagerField({
         return (
           <FormItem>
             <FormLabel>{def.label}</FormLabel>
-            <Select value={value} onValueChange={(v) => field.onChange(v)}>
+            <Select
+              value={value}
+              onValueChange={(v) => {
+                form.setValue(name, v, {
+                  shouldDirty: true,
+                  shouldTouch: true,
+                  shouldValidate: true,
+                });
+              }}
+            >
               <FormControl>
                 <SelectTrigger className='w-full'>
                   <SelectValue placeholder={def.placeholder} />
@@ -200,123 +223,184 @@ type EnvironmentDefinitionsFieldsProps = {
   infrastructureServices: InfrastructureServiceWithHierarchy[];
 };
 
-function cloneEntries(
-  entries: EnvironmentDefinitionEntry[] | undefined
-): EnvironmentDefinitionEntry[] | undefined {
-  return entries?.map((entry) => ({ ...entry }));
+type EnvironmentDefinitionCard = {
+  schema: EnvironmentDefinitionSchema;
+  index: number;
+};
+
+const firstSchema = ENVIRONMENT_DEFINITION_SCHEMAS[0];
+
+function cloneDefaultEntry(schema: EnvironmentDefinitionSchema) {
+  const defaultEntry = schema.defaultEntries[0];
+  return defaultEntry ? { ...defaultEntry } : undefined;
+}
+
+function definitionsAsRecord(
+  definitions: EnvironmentDefinitions | undefined
+): Record<string, EnvironmentDefinitionEntry[]> {
+  return (definitions ?? {}) as Record<string, EnvironmentDefinitionEntry[]>;
 }
 
 export const EnvironmentDefinitionsFields = ({
   form,
   infrastructureServices,
 }: EnvironmentDefinitionsFieldsProps) => {
-  const definitionBackups = useRef<
-    Record<string, EnvironmentDefinitionEntry[]>
-  >({});
+  const environmentDefinitions = definitionsAsRecord(
+    form.watch('jobConfigs.analyzer.environmentDefinitions')
+  );
 
-  const enabledDefinitions =
-    form.watch('jobConfigs.analyzer.environmentDefinitionsEnabled') ?? {};
+  const cards = ENVIRONMENT_DEFINITION_SCHEMAS.flatMap((schema) =>
+    (environmentDefinitions[schema.key] ?? []).map((_, index) => ({
+      schema,
+      index,
+    }))
+  );
 
-  function setEnabled(packageManager: string, value: boolean) {
-    form.setValue(
-      'jobConfigs.analyzer.environmentDefinitionsEnabled',
-      { ...enabledDefinitions, [packageManager]: value },
-      { shouldDirty: true }
-    );
-  }
-
-  function setEntries(
-    packageManager: string,
-    entries: EnvironmentDefinitionEntry[] | undefined
+  function setEnvironmentDefinitions(
+    definitions: Record<string, EnvironmentDefinitionEntry[]>
   ) {
-    const current =
-      form.getValues('jobConfigs.analyzer.environmentDefinitions') ?? {};
-    const updated = entries
-      ? { ...current, [packageManager]: entries }
-      : Object.fromEntries(
-          Object.entries(current).filter(([k]) => k !== packageManager)
-        );
+    const nonEmptyDefinitions = Object.fromEntries(
+      Object.entries(definitions).filter(([, entries]) => entries.length > 0)
+    );
+
     form.setValue(
       'jobConfigs.analyzer.environmentDefinitions',
-      Object.keys(updated).length > 0 ? updated : undefined,
-      { shouldDirty: true }
+      Object.keys(nonEmptyDefinitions).length > 0
+        ? (nonEmptyDefinitions as EnvironmentDefinitions)
+        : undefined,
+      { shouldDirty: true, shouldValidate: true }
     );
   }
 
-  function onToggle(
-    packageManager: string,
-    checked: boolean,
-    defaultEntries: EnvironmentDefinitionEntry[]
+  function addEnvironmentDefinition() {
+    if (!firstSchema) return;
+
+    const defaultEntry = cloneDefaultEntry(firstSchema);
+    if (!defaultEntry) return;
+
+    const current = definitionsAsRecord(
+      form.getValues('jobConfigs.analyzer.environmentDefinitions')
+    );
+    setEnvironmentDefinitions({
+      ...current,
+      [firstSchema.key]: [...(current[firstSchema.key] ?? []), defaultEntry],
+    });
+  }
+
+  function removeEnvironmentDefinition(schemaKey: string, index: number) {
+    const current = definitionsAsRecord(
+      form.getValues('jobConfigs.analyzer.environmentDefinitions')
+    );
+    const entries = [...(current[schemaKey] ?? [])];
+    entries.splice(index, 1);
+
+    setEnvironmentDefinitions({
+      ...current,
+      [schemaKey]: entries,
+    });
+  }
+
+  function changeEnvironmentDefinitionSchema(
+    card: EnvironmentDefinitionCard,
+    schemaKey: string
   ) {
-    setEnabled(packageManager, checked);
-    if (checked) {
-      setEntries(
-        packageManager,
-        cloneEntries(definitionBackups.current[packageManager]) ??
-          cloneEntries(defaultEntries)
-      );
-    } else {
-      definitionBackups.current[packageManager] =
-        cloneEntries(
-          form.getValues('jobConfigs.analyzer.environmentDefinitions')?.[
-            packageManager
-          ]
-        ) ?? [];
-      setEntries(packageManager, undefined);
-    }
+    if (schemaKey === card.schema.key) return;
+
+    const schema = ENVIRONMENT_DEFINITION_SCHEMAS.find(
+      (schema) => schema.key === schemaKey
+    );
+    if (!schema) return;
+
+    const defaultEntry = cloneDefaultEntry(schema);
+    if (!defaultEntry) return;
+
+    const current = definitionsAsRecord(
+      form.getValues('jobConfigs.analyzer.environmentDefinitions')
+    );
+    const sourceEntries = [...(current[card.schema.key] ?? [])];
+    sourceEntries.splice(card.index, 1);
+
+    setEnvironmentDefinitions({
+      ...current,
+      [card.schema.key]: sourceEntries,
+      [schema.key]: [...(current[schema.key] ?? []), defaultEntry],
+    });
   }
 
   return (
-    <Collapsible className='flex flex-col gap-2'>
-      <CollapsibleTrigger className='flex w-full items-start justify-between gap-4 text-left [&[data-state=open]>svg]:rotate-180'>
-        <div>
-          <h3>Environment configuration</h3>
-          <p className='mt-1 text-sm text-gray-500'>
-            Configure the credentials for different package managers to access
-            private artifact repositories.
-          </p>
-        </div>
-        <ChevronDownIcon className='text-muted-foreground mt-1 size-4 shrink-0 transition-transform duration-200' />
-      </CollapsibleTrigger>
-      <CollapsibleContent>
-        <Accordion type='multiple' className='ml-4 flex flex-col gap-2'>
-          {ENVIRONMENT_DEFINITION_SCHEMAS.map((schema) => (
-            <AccordionPrimitive.Item
-              key={schema.key}
-              value={schema.key}
-              className='rounded-lg border'
-            >
-              <AccordionPrimitive.Header className='flex flex-row items-center'>
-                <AccordionPrimitive.Trigger className='focus-visible:border-ring focus-visible:ring-ring/50 flex flex-1 items-center gap-2 px-4 py-4 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:ring-[3px] [&[data-state=open]>svg]:rotate-180'>
-                  {schema.label}
-                  <ChevronDownIcon className='text-muted-foreground size-4 shrink-0 translate-y-0.5 transition-transform duration-200' />
-                </AccordionPrimitive.Trigger>
-                <div className='pr-4'>
-                  <Switch
-                    checked={enabledDefinitions[schema.key] ?? false}
-                    onCheckedChange={(checked) =>
-                      onToggle(schema.key, checked, schema.defaultEntries)
-                    }
-                  />
-                </div>
-              </AccordionPrimitive.Header>
-              <AccordionContent>
-                <div className='flex flex-col gap-4 px-4 pb-4'>
-                  {schema.fields.map((entry) => (
-                    <PackageManagerField
-                      key={entry.key}
-                      pmKey={schema.key}
-                      entry={entry}
-                      form={form}
-                      infrastructureServices={infrastructureServices}
-                    />
-                  ))}
-                </div>
-              </AccordionContent>
-            </AccordionPrimitive.Item>
-          ))}
-        </Accordion>
-      </CollapsibleContent>
-    </Collapsible>
+    <div className='flex flex-col gap-2'>
+      <div>
+        <h3>Environment configuration</h3>
+        <p className='mt-1 text-sm text-gray-500'>
+          Configure the credentials for different package managers to access
+          private artifact repositories.
+        </p>
+      </div>
+      <div className='mt-2 flex flex-col gap-4'>
+        {cards.map((card) => (
+          <Card key={`${card.schema.key}-${card.index}`}>
+            <CardHeader className='flex flex-row items-center justify-between gap-4'>
+              <CardTitle>
+                {card.schema.label} #{card.index + 1}
+              </CardTitle>
+              <Button
+                type='button'
+                variant='outline'
+                size='sm'
+                onClick={() => {
+                  removeEnvironmentDefinition(card.schema.key, card.index);
+                }}
+              >
+                <TrashIcon className='h-4 w-4' />
+              </Button>
+            </CardHeader>
+            <CardContent className='flex flex-col gap-4'>
+              <FormItem>
+                <FormLabel>Package manager</FormLabel>
+                <Select
+                  value={card.schema.key}
+                  onValueChange={(value) => {
+                    changeEnvironmentDefinitionSchema(card, value);
+                  }}
+                >
+                  <FormControl>
+                    <SelectTrigger className='w-full'>
+                      <SelectValue placeholder='Select a package manager' />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {ENVIRONMENT_DEFINITION_SCHEMAS.map((schema) => (
+                      <SelectItem key={schema.key} value={schema.key}>
+                        {schema.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </FormItem>
+              {card.schema.fields.map((entry) => (
+                <PackageManagerField
+                  key={entry.key}
+                  pmKey={card.schema.key}
+                  index={card.index}
+                  entry={entry}
+                  form={form}
+                  infrastructureServices={infrastructureServices}
+                />
+              ))}
+            </CardContent>
+          </Card>
+        ))}
+        <Button
+          size='sm'
+          className='w-min'
+          variant='outline'
+          type='button'
+          onClick={addEnvironmentDefinition}
+        >
+          Add environment configuration
+          <PlusIcon className='ml-1 h-4 w-4' />
+        </Button>
+      </div>
+    </div>
   );
 };

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/environment-definitions.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/environment-definitions.tsx
@@ -263,6 +263,7 @@ export const EnvironmentDefinitionsFields = ({
       Object.entries(definitions).filter(([, entries]) => entries.length > 0)
     );
 
+    form.clearErrors('jobConfigs.analyzer.environmentDefinitions');
     form.setValue(
       'jobConfigs.analyzer.environmentDefinitions',
       Object.keys(nonEmptyDefinitions).length > 0

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/default-values.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/default-values.ts
@@ -103,7 +103,6 @@ export function defaultValues(
         allowDynamicVersions: true,
         skipExcluded: true,
         keepAliveWorker: false,
-        environmentDefinitionsEnabled: {},
         environmentDefinitions: undefined,
         infrastructureServices: [],
         packageManagers: {
@@ -214,11 +213,6 @@ export function defaultValues(
             // defaultPackageManagerOptions gets the options from the previous run already in the
             // baseDefaults object, so those values can be used here.
             packageManagers: baseDefaults.jobConfigs.analyzer.packageManagers,
-            environmentDefinitionsEnabled: Object.fromEntries(
-              Object.entries(parsedEnvironmentDefinitions ?? {}).map(
-                ([key, entries]) => [key, (entries?.length ?? 0) > 0]
-              )
-            ),
             environmentDefinitions: hasEnvironmentDefinitions
               ? parsedEnvironmentDefinitions
               : undefined,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/default-values.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/default-values.ts
@@ -317,6 +317,41 @@ export function defaultValues(
 if (import.meta.vitest) {
   const { expect, it } = import.meta.vitest;
 
+  it('preserves multiple environment definitions from reruns', () => {
+    const ortRun = {
+      revision: 'main',
+      path: '',
+      jobConfigs: {
+        analyzer: {
+          environmentConfig: {
+            infrastructureServices: [],
+            environmentDefinitions: {
+              maven: [
+                {
+                  service: 'service-a',
+                  id: 'repository-a',
+                  mirrorOf: '',
+                },
+                {
+                  service: 'service-b',
+                  id: 'repository-b',
+                  mirrorOf: 'central',
+                },
+              ],
+            },
+          },
+        },
+      },
+      labels: {},
+    } as unknown as OrtRun;
+
+    const defaults = defaultValues(ortRun, [], [], false);
+
+    expect(defaults.jobConfigs.analyzer.environmentDefinitions).toEqual(
+      ortRun.jobConfigs.analyzer?.environmentConfig?.environmentDefinitions
+    );
+  });
+
   it('uses scanner plugin default values for fresh runs', () => {
     const defaults = defaultValues(
       null,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/payload.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/payload.ts
@@ -22,6 +22,7 @@ import {
   PostRepositoryRun,
   ReporterJobConfiguration,
 } from '@/api';
+import { defaultValues } from './default-values';
 import { convertArrayToMap } from './form-primitives';
 import { createPluginPayload } from './plugin-utils';
 import type { CreateRunFormValues } from './run-schema';
@@ -330,4 +331,88 @@ export function formValuesToPayload(
     jobConfigContext: values.jobConfigContext,
     environmentConfigPath: values.environmentConfigPath,
   };
+}
+
+if (import.meta.vitest) {
+  const { describe, expect, it } = import.meta.vitest;
+
+  function createFormValues(): CreateRunFormValues {
+    return {
+      ...defaultValues(null, [], [], false),
+      revision: 'main',
+      path: '',
+    };
+  }
+
+  describe('formValuesToPayload', () => {
+    it('omits the environment config when no environment settings are configured', () => {
+      const values = createFormValues();
+      values.jobConfigs.analyzer.infrastructureServices = [
+        {
+          credentialsTypes: ['NETRC_FILE'],
+          name: 'inherited-service',
+          passwordSecretRef: 'password',
+          url: 'https://example.org/repository',
+          usernameSecretRef: 'username',
+        },
+      ];
+
+      const payload = formValuesToPayload(values);
+
+      expect(payload.jobConfigs.analyzer?.environmentConfig).toBeUndefined();
+    });
+
+    it('preserves multiple environment definitions for the same ecosystem', () => {
+      const values = createFormValues();
+      values.jobConfigs.analyzer.environmentDefinitions = {
+        maven: [
+          {
+            service: 'service-a',
+            id: 'repository-a',
+            mirrorOf: '',
+          },
+          {
+            service: 'service-b',
+            id: 'repository-b',
+            mirrorOf: 'central',
+          },
+        ],
+      };
+
+      const payload = formValuesToPayload(values);
+
+      expect(
+        payload.jobConfigs.analyzer?.environmentConfig?.environmentDefinitions
+      ).toEqual(values.jobConfigs.analyzer.environmentDefinitions);
+    });
+
+    it('omits infrastructure services from environment configs', () => {
+      const values = createFormValues();
+      values.jobConfigs.analyzer.environmentDefinitions = {
+        conan: [
+          {
+            service: 'service-a',
+            name: 'private-conan',
+            url: '',
+            verifySsl: 'true',
+          },
+        ],
+      };
+      values.jobConfigs.analyzer.infrastructureServices = [
+        {
+          credentialsTypes: ['NETRC_FILE'],
+          name: 'inherited-service',
+          passwordSecretRef: 'password',
+          url: 'https://example.org/repository',
+          usernameSecretRef: 'username',
+        },
+      ];
+
+      const payload = formValuesToPayload(values);
+
+      expect(payload.jobConfigs.analyzer?.environmentConfig).not.toHaveProperty(
+        'infrastructureServices'
+      );
+    });
+  });
 }

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/payload.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/payload.ts
@@ -103,13 +103,11 @@ export function formValuesToPayload(
   // as the configuration for that job in the request body, in effect leaving
   // it empty, and thus disabling the job.
   const allDefinitions = values.jobConfigs.analyzer.environmentDefinitions;
-  const enabledDefinitions =
-    values.jobConfigs.analyzer.environmentDefinitionsEnabled;
   const filteredDefinitions: NonNullable<typeof allDefinitions> = {};
   for (const [packageManager, entries] of Object.entries(
     allDefinitions ?? {}
   )) {
-    if (enabledDefinitions[packageManager] && entries.length > 0) {
+    if (entries.length > 0) {
       filteredDefinitions[packageManager] = entries;
     }
   }

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/payload.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/payload.ts
@@ -19,7 +19,6 @@
 
 import {
   AnalyzerJobConfiguration,
-  InfrastructureService,
   PostRepositoryRun,
   ReporterJobConfiguration,
 } from '@/api';
@@ -122,28 +121,20 @@ export function formValuesToPayload(
       ? values.jobConfigs.analyzer.environmentVariables
       : undefined;
 
-  const infrastructureServices: InfrastructureService[] =
-    values.jobConfigs.analyzer.infrastructureServices?.map((service) => ({
-      credentialsTypes: service.credentialsTypes,
-      description: service.description,
-      name: service.name,
-      passwordSecretRef: service.passwordSecretRef,
-      url: service.url,
-      usernameSecretRef: service.usernameSecretRef,
-    })) || [];
-
-  const environmentConfig = {
-    infrastructureServices,
-    ...(environmentDefinitions ? { environmentDefinitions } : {}),
-    ...(environmentVariables ? { environmentVariables } : {}),
-  };
+  const environmentConfig =
+    environmentDefinitions || environmentVariables
+      ? {
+          ...(environmentDefinitions ? { environmentDefinitions } : {}),
+          ...(environmentVariables ? { environmentVariables } : {}),
+        }
+      : undefined;
 
   const analyzerConfig: AnalyzerJobConfiguration = {
     allowDynamicVersions: values.jobConfigs.analyzer.allowDynamicVersions,
     repositoryConfigPath:
       values.jobConfigs.analyzer.repositoryConfigPath || undefined,
     skipExcluded: values.jobConfigs.analyzer.skipExcluded,
-    environmentConfig,
+    ...(environmentConfig ? { environmentConfig } : {}),
     // Determine the enabled package managers by filtering the packageManagers object
     // and finding those for which 'enabled' is true.
     enabledPackageManagers: [

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/run-schema.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/run-schema.ts
@@ -57,7 +57,6 @@ export const createRunFormSchema = (
         repositoryConfigPath: z.string().optional(),
         allowDynamicVersions: z.boolean(),
         skipExcluded: z.boolean(),
-        environmentDefinitionsEnabled: z.record(z.string(), z.boolean()),
         environmentDefinitions: environmentDefinitionsSchema.optional(),
         environmentVariables: z.array(environmentVariableSchema).optional(),
         infrastructureServices: z.array(zInfrastructureService).optional(),


### PR DESCRIPTION
<img width="1090" height="817" alt="Screenshot from 2026-06-09 08-19-48" src="https://github.com/user-attachments/assets/7e709f22-c660-4d49-856f-5d0d403ba82c" />

Align handling of the environment configurations in the run form with environment variables/secrets. This makes it possible to specify multiple configurations per ecosystem. Because of this, the specified configurations are given a "running title" to assist the user, eg. `Gradle #1`, `Gradle #2`, `Maven #1`. The configurations can be edited inline and deleted, and are carried out to the new run, when using the rerun feature.

This PR also removes infrastructure services completely from the run payload, as they are anyway inherited from the repository hierarchy by the back-end.

Please see the commits for details.