### PR TITLE
ui: Better indications for empty vulnerabilities and rule violations tables

### DIFF
--- a/ui/src/components/data-table-cards/data-table-cards.tsx
+++ b/ui/src/components/data-table-cards/data-table-cards.tsx
@@ -33,6 +33,7 @@ interface DataTableCardsProps<
 > extends React.HTMLAttributes<HTMLDivElement> {
   table: TanstackTable<TData>;
   renderSubComponent?: (props: { row: Row<TData> }) => React.ReactElement;
+  noResultsContent?: React.ReactNode;
   setCurrentPageOptions: (page: number) => LinkOptions;
   setPageSizeOptions: (pageSize: number) => LinkOptions;
   setSortingOptions?: (sorting: {
@@ -44,6 +45,7 @@ interface DataTableCardsProps<
 export function DataTableCards<TData>({
   table,
   renderSubComponent,
+  noResultsContent,
   className,
   setCurrentPageOptions,
   setPageSizeOptions,
@@ -69,6 +71,7 @@ export function DataTableCards<TData>({
           rows={table.getRowModel().rows}
           renderSubComponent={renderSubComponent}
           columnSizing={columnSizing}
+          noResultsContent={noResultsContent}
           columnCount={table.getVisibleLeafColumns().length}
         />
       </Table>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
@@ -529,6 +529,13 @@ const RuleViolationsComponent = () => {
   });
   const filtersInUse = table.getState().columnFilters.length > 0;
   const matching = `, ${table.getPrePaginationRowModel().rows.length} matching filters`;
+  const evaluatorWasIncludedInRun = ortRun.jobs.evaluator != null;
+  const noResultsContent = !evaluatorWasIncludedInRun ? (
+    <div className='text-muted-foreground text-sm'>
+      No rule violations are available because the evaluator job was not enabled
+      for this run.
+    </div>
+  ) : undefined;
 
   return (
     <Card className='h-fit'>
@@ -545,6 +552,7 @@ const RuleViolationsComponent = () => {
       <CardContent>
         <DataTableCards
           table={table}
+          noResultsContent={noResultsContent}
           renderSubComponent={renderSubComponent}
           setCurrentPageOptions={(currentPage) => {
             return {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
@@ -569,6 +569,13 @@ const VulnerabilitiesComponent = () => {
     totalVulnerabilities.pagination.totalCount !==
     vulnerabilities.pagination.totalCount;
   const matching = `, ${vulnerabilities.pagination.totalCount} matching filters`;
+  const advisorWasIncludedInRun = ortRun.jobs.advisor != null;
+  const noResultsContent = !advisorWasIncludedInRun ? (
+    <div className='text-muted-foreground text-sm'>
+      No vulnerabilities are available because the advisor job was not enabled
+      for this run.
+    </div>
+  ) : undefined;
 
   return (
     <Card className='h-fit'>
@@ -588,6 +595,7 @@ const VulnerabilitiesComponent = () => {
       <CardContent>
         <DataTableCards
           table={table}
+          noResultsContent={noResultsContent}
           renderSubComponent={renderSubComponent}
           setCurrentPageOptions={(currentPage) => {
             return {


### PR DESCRIPTION
### This is already implemented

<img width="1179" height="283" alt="Screenshot from 2026-06-10 06-33-22" src="https://github.com/user-attachments/assets/d4cb161c-8c2d-485a-b51e-d4f0464c0e1c" />

### Implement the same for vulnerabilities and rule violations tables

<img width="1179" height="310" alt="Screenshot from 2026-06-10 06-34-36" src="https://github.com/user-attachments/assets/50551321-7268-4571-9073-eeded36cd027" />

<img width="1179" height="297" alt="Screenshot from 2026-06-10 06-34-15" src="https://github.com/user-attachments/assets/e23f976c-447d-47ce-89e8-6db349773ad5" />

Please see the commits for details.

NOTE: I did not touch product and organization vulnerability tables yet, because they aggregate the results of several runs, and it is probably a rare use case that none of runs in a product/organization include advisor jobs. If needed, I can align those tables as well.