### PR TITLE
fix(docker): Upgrade the base image to Java 25

### DIFF
--- a/docker/Base.Dockerfile
+++ b/docker/Base.Dockerfile
@@ -22,7 +22,7 @@
 # setting file permissions for the user, setting up certificates, etc. And, it defines the temurin base image.
 
 ARG CREDENTIAL_HELPER_VERSION=0.2.0
-ARG TEMURIN_VERSION=21.0.11_10-jdk-noble
+ARG TEMURIN_VERSION=25.0.3_9-jdk-noble@sha256:02aba7518e48cfed96403ac9634e357a40329d6ec9418feb0b32636e43b245a1
 
 FROM alpine:3.24 AS credential-helper
 

--- a/renovate.json
+++ b/renovate.json
@@ -26,7 +26,7 @@
     },
     {
       "matchPackageNames": ["eclipse-temurin"],
-      "allowedVersions": "< 22"
+      "allowedVersions": "< 26"
     },
     {
       "matchPackageNames": ["docusaurus-plugin-openapi-docs", "docusaurus-theme-openapi-docs"],


### PR DESCRIPTION
Also pin the Temurin base image to a specific digest as Renovate does not do this automatically.

This is a fixup for 2a75662.