### PR TITLE
Improve declared licenses filtering

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
@@ -843,7 +843,7 @@ fun ApiPackageFilters.mapToModel(): PackageFilters =
     PackageFilters(
         identifier = identifier?.mapToModel { it },
         purl = purl?.mapToModel { it },
-        processedDeclaredLicense = processedDeclaredLicense?.mapToModel { it },
+        declaredLicense = declaredLicense?.mapToModel { it },
         isDirectDependency = isDirectDependency
     )
 

--- a/api/v1/model/src/commonMain/kotlin/Licenses.kt
+++ b/api/v1/model/src/commonMain/kotlin/Licenses.kt
@@ -27,5 +27,8 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class Licenses(
     /** The distinct processed declared license expressions. */
-    val processedDeclaredLicenses: List<String>
+    val processedDeclaredLicenses: List<String>,
+
+    /** The distinct unmapped declared license strings. */
+    val unmappedDeclaredLicenses: List<String> = emptyList()
 )

--- a/api/v1/model/src/commonMain/kotlin/Package.kt
+++ b/api/v1/model/src/commonMain/kotlin/Package.kt
@@ -54,8 +54,8 @@ data class PackageFilters(
     /** Substring filter for purl. Null if not set. */
     val purl: FilterOperatorAndValue<String>? = null,
 
-    /** Set of SPDX license expressions to filter with. Null if not set. */
-    val processedDeclaredLicense: FilterOperatorAndValue<Set<String>>? = null,
+    /** Set of declared licenses to filter with. Null if not set. */
+    val declaredLicense: FilterOperatorAndValue<Set<String>>? = null,
 
     /** Filter by dependency type. True = direct, false = transitive, null = all. */
     val isDirectDependency: Boolean? = null

--- a/core/src/main/kotlin/api/RunsRoute.kt
+++ b/core/src/main/kotlin/api/RunsRoute.kt
@@ -292,7 +292,8 @@ fun Route.runs() = route("runs") {
             route("licenses") {
                 get(getRunPackageLicenses, requireRunPermission()) {
                     val licenses = Licenses(
-                        packageService.getProcessedDeclaredLicenses(call.ortRun.id)
+                        processedDeclaredLicenses = packageService.getProcessedDeclaredLicenses(call.ortRun.id),
+                        unmappedDeclaredLicenses = packageService.getUnmappedDeclaredLicenses(call.ortRun.id)
                     )
 
                     call.respond(HttpStatusCode.OK, licenses)

--- a/core/src/main/kotlin/api/RunsRoute.kt
+++ b/core/src/main/kotlin/api/RunsRoute.kt
@@ -517,15 +517,17 @@ private fun ApplicationCall.filters(): OrtRunFilters =
     )
 
 /**
- * Extract the filter for the processed declared license from this [ApplicationCall]. If this filter is missing or
- * empty, return null. Otherwise, it is interpreted as a comma-delimited list of license expression strings to filter
- * the result by. If the first item on the list is a minus, the provided licenses will be excluded from the result.
+ * Extract the filter for declared licenses from this [ApplicationCall]. If this filter is missing or empty, return
+ * null. Otherwise, it is interpreted as a comma-delimited list of license strings to filter the result by. If the
+ * first item on the list is a minus, the provided licenses will be excluded from the result.
  */
-private fun ApplicationCall.processedDeclaredLicense(): FilterOperatorAndValue<Set<String>>? {
-    val parts = parameters["processedDeclaredLicense"]?.split(',')?.toMutableSet() ?: return null
+private fun ApplicationCall.declaredLicense(): FilterOperatorAndValue<Set<String>>? = licenseFilter("declaredLicense")
 
-    return if (parts.removeIf { it == "-" }) {
-        FilterOperatorAndValue(ComparisonOperator.NOT_IN, parts)
+private fun ApplicationCall.licenseFilter(parameterName: String): FilterOperatorAndValue<Set<String>>? {
+    val parts = parameters[parameterName]?.split(',')?.toSet() ?: return null
+
+    return if ("-" in parts) {
+        FilterOperatorAndValue(ComparisonOperator.NOT_IN, parts - "-")
     } else {
         FilterOperatorAndValue(ComparisonOperator.IN, parts)
     }
@@ -538,7 +540,7 @@ private fun ApplicationCall.packageFilters(): PackageFilters =
     PackageFilters(
         identifier = parameters["identifier"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) },
         purl = parameters["purl"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) },
-        processedDeclaredLicense = processedDeclaredLicense(),
+        declaredLicense = declaredLicense(),
         isDirectDependency = parameters["isDirectDependency"]?.lowercase()?.toBooleanStrictOrNull()
     )
 

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -845,7 +845,9 @@ val getRunStatistics: RouteConfig.() -> Unit = {
 
 val getRunPackageLicenses: RouteConfig.() -> Unit = {
     operationId = "getRunPackageLicenses"
-    summary = "Get the licenses for packages found in an ORT run"
+    summary = "Get the declared licenses for packages found in an ORT run"
+    description = "The response contains independently deduplicated and alphabetically sorted processed and " +
+            "unmapped declared licenses."
     tags = listOf("Runs")
 
     request {
@@ -856,10 +858,14 @@ val getRunPackageLicenses: RouteConfig.() -> Unit = {
 
     response {
         HttpStatusCode.OK to {
+            description = "Success"
             jsonBody<Licenses> {
                 example("Get licenses for packages") {
                     value = Licenses(
-                        processedDeclaredLicenses = listOf("Apache-2.0", "MIT")
+                        processedDeclaredLicenses = listOf("Apache-2.0", "MIT"),
+                        unmappedDeclaredLicenses = listOf(
+                            "https://www.nuget.org/packages/CommandLineParser/2.9.1/license"
+                        )
                     )
                 }
             }

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -538,10 +538,11 @@ val getRunPackages: RouteConfig.() -> Unit = {
                     "substring match."
         }
 
-        queryParameter<String>("processedDeclaredLicense") {
-            description = "Defines the processed declared licenses for which packages are to be retrieved. This is a " +
+        queryParameter<String>("declaredLicense") {
+            description = "Defines the displayed declared license values for which packages are to be retrieved, " +
+                    "including processed declared licenses and unmapped declared license strings. This is a " +
                     "comma-separated string. Add a minus as the first item to exclude packages with the specified " +
-                    "license expressions, e.g. '-,MIT'."
+                    "licenses, e.g. '-,MIT'."
         }
 
         queryParameter<Boolean>("isDirectDependency") {
@@ -629,7 +630,7 @@ val getRunPackages: RouteConfig.() -> Unit = {
                                 operator = ComparisonOperator.ILIKE,
                                 value = "pkg:maven/org.example/name@1.0"
                             ),
-                            processedDeclaredLicense = FilterOperatorAndValue(
+                            declaredLicense = FilterOperatorAndValue(
                                 operator = ComparisonOperator.IN,
                                 value = setOf("Apache-2.0")
                             ),

--- a/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
@@ -1750,8 +1750,9 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
             }
         }
 
-        "allow filtering by processed declared license and identifier" {
+        "allow filtering by declared license" {
             integrationTestApplication {
+                val licenseUrl = "https://www.nuget.org/packages/CommandLineParser/2.9.1/license"
                 val ortRunId = dbExtension.fixtures.createOrtRun(
                     repositoryId = repositoryId,
                     revision = "revision",
@@ -1763,10 +1764,9 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     configuration = AnalyzerJobConfiguration()
                 ).id
 
-                val identifier1 = Identifier("Maven", "com.example", "example", "1.0")
-                val identifier2 = Identifier("Maven", "com.example", "example2", "1.0")
-                val identifier3 = Identifier("Maven", "com.example", "example3", "1.0")
-                val identifier4 = Identifier("NPM", "com.example", "example4", "1.0")
+                val identifier1 = Identifier("Maven", "com.example", "processed", "1.0")
+                val identifier2 = Identifier("Maven", "com.example", "unmapped", "1.0")
+                val identifier3 = Identifier("Maven", "com.example", "other", "1.0")
 
                 dbExtension.fixtures.createAnalyzerRun(
                     analyzerJobId,
@@ -1784,21 +1784,13 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                             processedDeclaredLicense = ProcessedDeclaredLicense(
                                 "Apache-2.0",
                                 emptyMap(),
-                                emptySet()
+                                setOf(licenseUrl)
                             )
                         ),
                         dbExtension.fixtures.generatePackage(
                             identifier3,
                             processedDeclaredLicense = ProcessedDeclaredLicense(
-                                "Apache-2.0",
-                                emptyMap(),
-                                emptySet()
-                            )
-                        ),
-                        dbExtension.fixtures.generatePackage(
-                            identifier4,
-                            processedDeclaredLicense = ProcessedDeclaredLicense(
-                                "MIT",
+                                "BSD-2-Clause",
                                 emptyMap(),
                                 emptySet()
                             )
@@ -1808,24 +1800,22 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
 
                 val response = superuserClient.get("/api/v1/runs/$ortRunId/packages") {
                     url {
-                        parameters.append("processedDeclaredLicense", "-,Apache-2.0 OR LGPL-2.1-or-later,MIT")
-                        parameters.append("identifier", "example3")
+                        parameters.append("declaredLicense", "Apache-2.0 OR LGPL-2.1-or-later,$licenseUrl")
                     }
                 }
 
                 response shouldHaveStatus HttpStatusCode.OK
                 val packages = response.body<PagedSearchResponse<ApiPackage, PackageFilters>>()
 
-                packages.data shouldHaveSize 1
-                packages.data.first().processedDeclaredLicense.spdxExpression shouldBe "Apache-2.0"
-                packages.data.first().identifier shouldBe identifier3.mapToApi()
-
+                packages.data.map { it.identifier } should containExactly(
+                    identifier1.mapToApi(),
+                    identifier2.mapToApi()
+                )
                 packages.filters shouldBe PackageFilters(
-                    processedDeclaredLicense = FilterOperatorAndValue(
-                        ComparisonOperator.NOT_IN,
-                        setOf("Apache-2.0 OR LGPL-2.1-or-later", "MIT")
-                    ),
-                    identifier = FilterOperatorAndValue(ComparisonOperator.ILIKE, "example3")
+                    declaredLicense = FilterOperatorAndValue(
+                        ComparisonOperator.IN,
+                        setOf("Apache-2.0 OR LGPL-2.1-or-later", licenseUrl)
+                    )
                 )
             }
         }

--- a/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
@@ -2925,8 +2925,9 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
     }
 
     "GET /runs/{runId}/packages/licenses" should {
-        "return the processed declared licenses found in packages" {
+        "return the processed and unmapped declared licenses found in packages" {
             integrationTestApplication {
+                val licenseUrl = "https://www.nuget.org/packages/CommandLineParser/2.9.1/license"
                 val ortRunId = dbExtension.fixtures.createOrtRun(
                     repositoryId = repositoryId,
                     revision = "revision",
@@ -2941,25 +2942,25 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                         dbExtension.fixtures.generatePackage(
                             Identifier("Maven", "com.example", "example", "1.0"),
                             processedDeclaredLicense = ProcessedDeclaredLicense(
-                                "LGPL-2.1-or-later",
-                                emptyMap(),
-                                emptySet()
+                                spdxExpression = "LGPL-2.1-or-later",
+                                mappedLicenses = emptyMap(),
+                                unmappedLicenses = setOf("custom-license", licenseUrl)
                             )
                         ),
                         dbExtension.fixtures.generatePackage(
                             Identifier("Maven", "com.example", "example2", "1.0"),
                             processedDeclaredLicense = ProcessedDeclaredLicense(
-                                "Apache-2.0 OR LGPL-2.1-or-later",
-                                emptyMap(),
-                                emptySet()
+                                spdxExpression = "Apache-2.0 OR LGPL-2.1-or-later",
+                                mappedLicenses = emptyMap(),
+                                unmappedLicenses = setOf(licenseUrl)
                             )
                         ),
                         dbExtension.fixtures.generatePackage(
                             Identifier("NPM", "", "example", "1.0"),
                             processedDeclaredLicense = ProcessedDeclaredLicense(
-                                "MIT",
-                                emptyMap(),
-                                emptySet()
+                                spdxExpression = "MIT",
+                                mappedLicenses = emptyMap(),
+                                unmappedLicenses = setOf("unknown-license")
                             )
                         )
                     )
@@ -2976,6 +2977,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     "LGPL-2.1-or-later",
                     "MIT"
                 )
+                licenses.unmappedDeclaredLicenses shouldBe listOf("custom-license", licenseUrl, "unknown-license")
             }
         }
 

--- a/model/src/commonMain/kotlin/runs/Package.kt
+++ b/model/src/commonMain/kotlin/runs/Package.kt
@@ -51,8 +51,8 @@ data class PackageFilters(
     /** Substring filter for purl. Null if not set. */
     val purl: FilterOperatorAndValue<String>? = null,
 
-    /** Set of SPDX license expressions to filter with. Null if not set. */
-    val processedDeclaredLicense: FilterOperatorAndValue<Set<String>>? = null,
+    /** Set of declared license values to filter with. Null if not set. */
+    val declaredLicense: FilterOperatorAndValue<Set<String>>? = null,
 
     /** Filter by dependency type. True = direct, false = transitive, null = all. */
     val isDirectDependency: Boolean? = null

--- a/services/ort-run/src/main/kotlin/PackageService.kt
+++ b/services/ort-run/src/main/kotlin/PackageService.kt
@@ -53,7 +53,7 @@ import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.inSubQuery
 import org.jetbrains.exposed.v1.core.not
-import org.jetbrains.exposed.v1.core.notInList
+import org.jetbrains.exposed.v1.core.or
 import org.jetbrains.exposed.v1.core.stringLiteral
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.andWhere
@@ -107,18 +107,27 @@ class PackageService(private val db: Database, private val ortRunService: OrtRun
                 query.andWhere { PackagesTable.purl.applyILike(filter.value) }
             }
 
-            filters.processedDeclaredLicense?.let { filter ->
+            filters.declaredLicense?.let { filter ->
                 require(filter.operator == ComparisonOperator.IN || filter.operator == ComparisonOperator.NOT_IN) {
-                    "Unsupported operator for identifier filter: ${filter.operator}"
+                    "Unsupported operator for declared license filter: ${filter.operator}"
                 }
 
+                val packageIdsSubquery = PackagesTable.joinAnalyzerTables()
+                    .innerJoin(ProcessedDeclaredLicensesTable)
+                    .leftJoin(ProcessedDeclaredLicensesUnmappedDeclaredLicensesTable)
+                    .leftJoin(UnmappedDeclaredLicensesTable)
+                    .select(PackagesTable.id)
+                    .where {
+                        (AnalyzerJobsTable.ortRunId eq ortRunId) and
+                            (
+                                (ProcessedDeclaredLicensesTable.spdxExpression inList filter.value) or
+                                    (UnmappedDeclaredLicensesTable.unmappedLicense inList filter.value)
+                            )
+                    }
+
                 when (filter.operator) {
-                    ComparisonOperator.IN ->
-                        query.andWhere { ProcessedDeclaredLicensesTable.spdxExpression inList filter.value }
-
-                    ComparisonOperator.NOT_IN ->
-                        query.andWhere { ProcessedDeclaredLicensesTable.spdxExpression notInList filter.value }
-
+                    ComparisonOperator.IN -> query.andWhere { PackagesTable.id inSubQuery packageIdsSubquery }
+                    ComparisonOperator.NOT_IN -> query.andWhere { not(PackagesTable.id inSubQuery packageIdsSubquery) }
                     else -> {}
                 }
             }

--- a/services/ort-run/src/main/kotlin/PackageService.kt
+++ b/services/ort-run/src/main/kotlin/PackageService.kt
@@ -35,6 +35,7 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ProcessedDecl
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ShortestDependencyPathsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.UnmappedDeclaredLicensesTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.resolvedconfiguration.CuratedPackagesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifierDao
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
 import org.eclipse.apoapsis.ortserver.dao.utils.applyILike
 import org.eclipse.apoapsis.ortserver.model.EcosystemStats
@@ -53,6 +54,7 @@ import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.inSubQuery
 import org.jetbrains.exposed.v1.core.not
+import org.jetbrains.exposed.v1.core.notInList
 import org.jetbrains.exposed.v1.core.or
 import org.jetbrains.exposed.v1.core.stringLiteral
 import org.jetbrains.exposed.v1.jdbc.Database
@@ -65,6 +67,7 @@ import org.ossreviewtoolkit.model.CuratedPackage as OrtCuratedPackage
  * A service to interact with packages.
  */
 class PackageService(private val db: Database, private val ortRunService: OrtRunService) {
+    @Suppress("LongMethod")
     fun listForOrtRunId(
         ortRunId: Long,
         parameters: ListQueryParameters = ListQueryParameters.DEFAULT,
@@ -78,6 +81,8 @@ class PackageService(private val db: Database, private val ortRunService: OrtRun
                 .innerJoin(ProcessedDeclaredLicensesTable)
                 .select(PackagesTable.id)
                 .where { AnalyzerJobsTable.ortRunId eq ortRunId }
+
+            val curationsMap by lazy { CuratedPackagesTable.getForOrtRunId(ortRunId) }
 
             filters.identifier?.let { filter ->
                 require(filter.operator == ComparisonOperator.ILIKE) {
@@ -112,6 +117,8 @@ class PackageService(private val db: Database, private val ortRunService: OrtRun
                     "Unsupported operator for declared license filter: ${filter.operator}"
                 }
 
+                // The SQL query uses the declared license values stored by the analyzer.
+                // This is sufficient for packages whose declared license is not changed by curations.
                 val packageIdsSubquery = PackagesTable.joinAnalyzerTables()
                     .innerJoin(ProcessedDeclaredLicensesTable)
                     .leftJoin(ProcessedDeclaredLicensesUnmappedDeclaredLicensesTable)
@@ -125,10 +132,73 @@ class PackageService(private val db: Database, private val ortRunService: OrtRun
                             )
                     }
 
-                when (filter.operator) {
-                    ComparisonOperator.IN -> query.andWhere { PackagesTable.id inSubQuery packageIdsSubquery }
-                    ComparisonOperator.NOT_IN -> query.andWhere { not(PackagesTable.id inSubQuery packageIdsSubquery) }
-                    else -> {}
+                // Only curations with a declared license mapping can change the processed declared license.
+                val affectedIdentifierIds = curationsMap
+                    .filterValues { list ->
+                        list.any { (_, curation) ->
+                            curation.data.declaredLicenseMapping.isNotEmpty()
+                        }
+                    }
+                    .keys
+                    .mapNotNull { IdentifierDao.findByIdentifier(it)?.id }
+
+                // For packages with such curations, apply the curations and use the resulting declared license.
+                val curatedDeclaredLicenses = if (affectedIdentifierIds.isEmpty()) {
+                    emptyList()
+                } else {
+                    val affectedPackageIds = PackagesTable.joinAnalyzerTables()
+                        .select(PackagesTable.id)
+                        .where {
+                            (AnalyzerJobsTable.ortRunId eq ortRunId) and
+                                (PackagesTable.identifierId inList affectedIdentifierIds)
+                        }
+                        .map { it[PackagesTable.id] }
+
+                    if (affectedPackageIds.isEmpty()) {
+                        emptyList()
+                    } else {
+                        PackageDao.find { PackagesTable.id inList affectedPackageIds }.map { dao ->
+                            val modelPackage = dao.mapToModel()
+                            val packageCurations = curationsMap[modelPackage.identifier].orEmpty()
+                            val curatedOrtPackage = packageCurations.fold(
+                                OrtCuratedPackage(modelPackage.mapToOrt())
+                            ) { acc, (_, curation) ->
+                                curation.mapToOrt().apply(acc)
+                            }
+
+                            dao.id to curatedOrtPackage.metadata.mapToModel().processedDeclaredLicense
+                        }
+                    }
+                }
+
+                val packageIdsWithDeclaredLicenseCurations = curatedDeclaredLicenses.map { it.first }
+                val curatedPackageIdsMatchingFilter = curatedDeclaredLicenses.filter { (_, curatedDeclared) ->
+                    val matches = curatedDeclared.spdxExpression in filter.value ||
+                            curatedDeclared.unmappedLicenses.any { it in filter.value }
+                    if (filter.operator == ComparisonOperator.IN) matches else !matches
+                }.map { it.first }
+
+                // Combine the SQL result for packages without declared license curations with the curated values
+                // calculated above. This prevents matching a package by an analyzer value that was changed by a
+                // curation.
+                query.andWhere {
+                    val sqlFilter = if (filter.operator == ComparisonOperator.IN) {
+                        PackagesTable.id inSubQuery packageIdsSubquery
+                    } else {
+                        not(PackagesTable.id inSubQuery packageIdsSubquery)
+                    }
+
+                    val unaffected = if (packageIdsWithDeclaredLicenseCurations.isEmpty()) {
+                        sqlFilter
+                    } else {
+                        (PackagesTable.id notInList packageIdsWithDeclaredLicenseCurations) and sqlFilter
+                    }
+
+                    if (curatedPackageIdsMatchingFilter.isEmpty()) {
+                        unaffected
+                    } else {
+                        unaffected or (PackagesTable.id inList curatedPackageIdsMatchingFilter)
+                    }
                 }
             }
 
@@ -191,7 +261,6 @@ class PackageService(private val db: Database, private val ortRunService: OrtRun
                 .associateBy { it.id }
             val packages = packageIds.map { packagesById.getValue(it) }
 
-            val curationsMap = CuratedPackagesTable.getForOrtRunId(ortRunId)
             val shortestPathsByPackage = ShortestDependencyPathsTable.getForOrtRunId(ortRunId)
 
             val finalResult = packages.map { packageDao ->
@@ -250,27 +319,123 @@ class PackageService(private val db: Database, private val ortRunService: OrtRun
     /** Return distinct processed declared SPDX license expressions for the ORT run. */
     suspend fun getProcessedDeclaredLicenses(ortRunId: Long): List<String> =
         db.dbQuery {
-            PackagesTable.joinAnalyzerTables()
+            val curationsMap = CuratedPackagesTable.getForOrtRunId(ortRunId)
+            val affectedIdentifierIds = curationsMap
+                .filterValues { list ->
+                    list.any { (_, curation) ->
+                        curation.data.declaredLicenseMapping.isNotEmpty()
+                    }
+                }
+                .keys
+                .mapNotNull { IdentifierDao.findByIdentifier(it)?.id }
+
+            val curatedDeclaredLicenses = if (affectedIdentifierIds.isEmpty()) {
+                emptyList()
+            } else {
+                val affectedPackageIds = PackagesTable.joinAnalyzerTables()
+                    .select(PackagesTable.id)
+                    .where {
+                        (AnalyzerJobsTable.ortRunId eq ortRunId) and
+                            (PackagesTable.identifierId inList affectedIdentifierIds)
+                    }
+                    .map { it[PackagesTable.id] }
+
+                if (affectedPackageIds.isEmpty()) {
+                    emptyList()
+                } else {
+                    PackageDao.find { PackagesTable.id inList affectedPackageIds }.map { dao ->
+                        val modelPackage = dao.mapToModel()
+                        val curations = curationsMap[modelPackage.identifier].orEmpty()
+                        val curatedOrtPackage = curations.fold(
+                            OrtCuratedPackage(modelPackage.mapToOrt())
+                        ) { acc, (_, curation) ->
+                            curation.mapToOrt().apply(acc)
+                        }
+
+                        dao.id to curatedOrtPackage.metadata.mapToModel().processedDeclaredLicense
+                    }
+                }
+            }
+            val packageIdsWithDeclaredLicenseCurations = curatedDeclaredLicenses.map { it.first }
+
+            val rawQuery = PackagesTable.joinAnalyzerTables()
                 .innerJoin(ProcessedDeclaredLicensesTable)
                 .select(ProcessedDeclaredLicensesTable.spdxExpression)
                 .withDistinct()
                 .where { AnalyzerJobsTable.ortRunId eq ortRunId }
-                .orderBy(ProcessedDeclaredLicensesTable.spdxExpression)
-                .mapNotNull { it[ProcessedDeclaredLicensesTable.spdxExpression] }
+
+            if (packageIdsWithDeclaredLicenseCurations.isNotEmpty()) {
+                rawQuery.andWhere { PackagesTable.id notInList packageIdsWithDeclaredLicenseCurations }
+            }
+
+            val licenses = rawQuery.mapNotNullTo(mutableSetOf()) {
+                it[ProcessedDeclaredLicensesTable.spdxExpression]
+            }
+
+            curatedDeclaredLicenses.mapNotNullTo(licenses) { it.second.spdxExpression }
+
+            licenses.sortedWith(String.CASE_INSENSITIVE_ORDER)
         }
 
     /** Return distinct unmapped declared license strings for the ORT run. */
     suspend fun getUnmappedDeclaredLicenses(ortRunId: Long): List<String> =
         db.dbQuery {
-            PackagesTable.joinAnalyzerTables()
+            val curationsMap = CuratedPackagesTable.getForOrtRunId(ortRunId)
+            val affectedIdentifierIds = curationsMap
+                .filterValues { list ->
+                    list.any { (_, curation) ->
+                        curation.data.declaredLicenseMapping.isNotEmpty()
+                    }
+                }
+                .keys
+                .mapNotNull { IdentifierDao.findByIdentifier(it)?.id }
+
+            val curatedDeclaredLicenses = if (affectedIdentifierIds.isEmpty()) {
+                emptyList()
+            } else {
+                val affectedPackageIds = PackagesTable.joinAnalyzerTables()
+                    .select(PackagesTable.id)
+                    .where {
+                        (AnalyzerJobsTable.ortRunId eq ortRunId) and
+                            (PackagesTable.identifierId inList affectedIdentifierIds)
+                    }
+                    .map { it[PackagesTable.id] }
+
+                if (affectedPackageIds.isEmpty()) {
+                    emptyList()
+                } else {
+                    PackageDao.find { PackagesTable.id inList affectedPackageIds }.map { dao ->
+                        val modelPackage = dao.mapToModel()
+                        val curations = curationsMap[modelPackage.identifier].orEmpty()
+                        val curatedOrtPackage = curations.fold(
+                            OrtCuratedPackage(modelPackage.mapToOrt())
+                        ) { acc, (_, curation) ->
+                            curation.mapToOrt().apply(acc)
+                        }
+
+                        dao.id to curatedOrtPackage.metadata.mapToModel().processedDeclaredLicense
+                    }
+                }
+            }
+            val packageIdsWithDeclaredLicenseCurations = curatedDeclaredLicenses.map { it.first }
+
+            val rawQuery = PackagesTable.joinAnalyzerTables()
                 .innerJoin(ProcessedDeclaredLicensesTable)
                 .innerJoin(ProcessedDeclaredLicensesUnmappedDeclaredLicensesTable)
                 .innerJoin(UnmappedDeclaredLicensesTable)
                 .select(UnmappedDeclaredLicensesTable.unmappedLicense)
                 .withDistinct()
                 .where { AnalyzerJobsTable.ortRunId eq ortRunId }
-                .orderBy(UnmappedDeclaredLicensesTable.unmappedLicense)
-                .map { it[UnmappedDeclaredLicensesTable.unmappedLicense] }
+
+            if (packageIdsWithDeclaredLicenseCurations.isNotEmpty()) {
+                rawQuery.andWhere { PackagesTable.id notInList packageIdsWithDeclaredLicenseCurations }
+            }
+
+            val licenses = rawQuery.mapTo(mutableSetOf()) { it[UnmappedDeclaredLicensesTable.unmappedLicense] }
+
+            curatedDeclaredLicenses.flatMapTo(licenses) { it.second.unmappedLicenses }
+
+            licenses.sortedWith(String.CASE_INSENSITIVE_ORDER)
         }
 }
 

--- a/services/ort-run/src/main/kotlin/PackageService.kt
+++ b/services/ort-run/src/main/kotlin/PackageService.kt
@@ -39,7 +39,10 @@ import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifierDao
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
 import org.eclipse.apoapsis.ortserver.dao.utils.applyILike
 import org.eclipse.apoapsis.ortserver.model.EcosystemStats
+import org.eclipse.apoapsis.ortserver.model.runs.Identifier
+import org.eclipse.apoapsis.ortserver.model.runs.Package as ModelPackage
 import org.eclipse.apoapsis.ortserver.model.runs.PackageFilters
+import org.eclipse.apoapsis.ortserver.model.runs.repository.PackageCuration
 import org.eclipse.apoapsis.ortserver.model.util.ComparisonOperator
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
@@ -159,14 +162,9 @@ class PackageService(private val db: Database, private val ortRunService: OrtRun
                     } else {
                         PackageDao.find { PackagesTable.id inList affectedPackageIds }.map { dao ->
                             val modelPackage = dao.mapToModel()
-                            val packageCurations = curationsMap[modelPackage.identifier].orEmpty()
-                            val curatedOrtPackage = packageCurations.fold(
-                                OrtCuratedPackage(modelPackage.mapToOrt())
-                            ) { acc, (_, curation) ->
-                                curation.mapToOrt().apply(acc)
-                            }
+                            val curatedModelPackage = modelPackage.applyCurations(curationsMap).metadata.mapToModel()
 
-                            dao.id to curatedOrtPackage.metadata.mapToModel().processedDeclaredLicense
+                            dao.id to curatedModelPackage.processedDeclaredLicense
                         }
                     }
                 }
@@ -268,12 +266,7 @@ class PackageService(private val db: Database, private val ortRunService: OrtRun
                 val shortestDependencyPaths = shortestPathsByPackage[modelPackage.identifier].orEmpty()
 
                 val packageCurations = curationsMap[modelPackage.identifier].orEmpty()
-
-                val ortPackage = modelPackage.mapToOrt()
-                val curatedOrtPackage = packageCurations.fold(OrtCuratedPackage(ortPackage)) { acc, (_, curation) ->
-                    curation.mapToOrt().apply(acc)
-                }
-                val curatedModelPackage = curatedOrtPackage.metadata.mapToModel()
+                val curatedModelPackage = modelPackage.applyCurations(curationsMap).metadata.mapToModel()
 
                 val apiCurations = packageCurations.map { (providerName, curation) ->
                     ApiPackageCuration(providerName, curation.data.mapToApi())
@@ -345,14 +338,9 @@ class PackageService(private val db: Database, private val ortRunService: OrtRun
                 } else {
                     PackageDao.find { PackagesTable.id inList affectedPackageIds }.map { dao ->
                         val modelPackage = dao.mapToModel()
-                        val curations = curationsMap[modelPackage.identifier].orEmpty()
-                        val curatedOrtPackage = curations.fold(
-                            OrtCuratedPackage(modelPackage.mapToOrt())
-                        ) { acc, (_, curation) ->
-                            curation.mapToOrt().apply(acc)
-                        }
+                        val curatedModelPackage = modelPackage.applyCurations(curationsMap).metadata.mapToModel()
 
-                        dao.id to curatedOrtPackage.metadata.mapToModel().processedDeclaredLicense
+                        dao.id to curatedModelPackage.processedDeclaredLicense
                     }
                 }
             }
@@ -406,14 +394,9 @@ class PackageService(private val db: Database, private val ortRunService: OrtRun
                 } else {
                     PackageDao.find { PackagesTable.id inList affectedPackageIds }.map { dao ->
                         val modelPackage = dao.mapToModel()
-                        val curations = curationsMap[modelPackage.identifier].orEmpty()
-                        val curatedOrtPackage = curations.fold(
-                            OrtCuratedPackage(modelPackage.mapToOrt())
-                        ) { acc, (_, curation) ->
-                            curation.mapToOrt().apply(acc)
-                        }
+                        val curatedModelPackage = modelPackage.applyCurations(curationsMap).metadata.mapToModel()
 
-                        dao.id to curatedOrtPackage.metadata.mapToModel().processedDeclaredLicense
+                        dao.id to curatedModelPackage.processedDeclaredLicense
                     }
                 }
             }
@@ -438,6 +421,13 @@ class PackageService(private val db: Database, private val ortRunService: OrtRun
             licenses.sortedWith(String.CASE_INSENSITIVE_ORDER)
         }
 }
+
+private fun ModelPackage.applyCurations(
+    curationsByIdentifier: Map<Identifier, List<Pair<String, PackageCuration>>>
+): OrtCuratedPackage =
+    curationsByIdentifier[identifier].orEmpty().fold(OrtCuratedPackage(mapToOrt())) { curatedPackage, (_, curation) ->
+        curation.mapToOrt().apply(curatedPackage)
+    }
 
 private fun PackagesTable.joinAnalyzerTables() =
     innerJoin(PackagesAnalyzerRunsTable)

--- a/services/ort-run/src/main/kotlin/PackageService.kt
+++ b/services/ort-run/src/main/kotlin/PackageService.kt
@@ -42,6 +42,7 @@ import org.eclipse.apoapsis.ortserver.model.EcosystemStats
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.Package as ModelPackage
 import org.eclipse.apoapsis.ortserver.model.runs.PackageFilters
+import org.eclipse.apoapsis.ortserver.model.runs.ProcessedDeclaredLicense
 import org.eclipse.apoapsis.ortserver.model.runs.repository.PackageCuration
 import org.eclipse.apoapsis.ortserver.model.util.ComparisonOperator
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
@@ -53,6 +54,7 @@ import org.jetbrains.exposed.v1.core.CustomFunction
 import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.TextColumnType
 import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.inSubQuery
@@ -135,40 +137,7 @@ class PackageService(private val db: Database, private val ortRunService: OrtRun
                             )
                     }
 
-                // Only curations with a declared license mapping can change the processed declared license.
-                val affectedIdentifierIds = curationsMap
-                    .filterValues { list ->
-                        list.any { (_, curation) ->
-                            curation.data.declaredLicenseMapping.isNotEmpty()
-                        }
-                    }
-                    .keys
-                    .mapNotNull { IdentifierDao.findByIdentifier(it)?.id }
-
-                // For packages with such curations, apply the curations and use the resulting declared license.
-                val curatedDeclaredLicenses = if (affectedIdentifierIds.isEmpty()) {
-                    emptyList()
-                } else {
-                    val affectedPackageIds = PackagesTable.joinAnalyzerTables()
-                        .select(PackagesTable.id)
-                        .where {
-                            (AnalyzerJobsTable.ortRunId eq ortRunId) and
-                                (PackagesTable.identifierId inList affectedIdentifierIds)
-                        }
-                        .map { it[PackagesTable.id] }
-
-                    if (affectedPackageIds.isEmpty()) {
-                        emptyList()
-                    } else {
-                        PackageDao.find { PackagesTable.id inList affectedPackageIds }.map { dao ->
-                            val modelPackage = dao.mapToModel()
-                            val curatedModelPackage = modelPackage.applyCurations(curationsMap).metadata.mapToModel()
-
-                            dao.id to curatedModelPackage.processedDeclaredLicense
-                        }
-                    }
-                }
-
+                val curatedDeclaredLicenses = getCuratedDeclaredLicenses(ortRunId, curationsMap)
                 val packageIdsWithDeclaredLicenseCurations = curatedDeclaredLicenses.map { it.first }
                 val curatedPackageIdsMatchingFilter = curatedDeclaredLicenses.filter { (_, curatedDeclared) ->
                     val matches = curatedDeclared.spdxExpression in filter.value ||
@@ -313,37 +282,7 @@ class PackageService(private val db: Database, private val ortRunService: OrtRun
     suspend fun getProcessedDeclaredLicenses(ortRunId: Long): List<String> =
         db.dbQuery {
             val curationsMap = CuratedPackagesTable.getForOrtRunId(ortRunId)
-            val affectedIdentifierIds = curationsMap
-                .filterValues { list ->
-                    list.any { (_, curation) ->
-                        curation.data.declaredLicenseMapping.isNotEmpty()
-                    }
-                }
-                .keys
-                .mapNotNull { IdentifierDao.findByIdentifier(it)?.id }
-
-            val curatedDeclaredLicenses = if (affectedIdentifierIds.isEmpty()) {
-                emptyList()
-            } else {
-                val affectedPackageIds = PackagesTable.joinAnalyzerTables()
-                    .select(PackagesTable.id)
-                    .where {
-                        (AnalyzerJobsTable.ortRunId eq ortRunId) and
-                            (PackagesTable.identifierId inList affectedIdentifierIds)
-                    }
-                    .map { it[PackagesTable.id] }
-
-                if (affectedPackageIds.isEmpty()) {
-                    emptyList()
-                } else {
-                    PackageDao.find { PackagesTable.id inList affectedPackageIds }.map { dao ->
-                        val modelPackage = dao.mapToModel()
-                        val curatedModelPackage = modelPackage.applyCurations(curationsMap).metadata.mapToModel()
-
-                        dao.id to curatedModelPackage.processedDeclaredLicense
-                    }
-                }
-            }
+            val curatedDeclaredLicenses = getCuratedDeclaredLicenses(ortRunId, curationsMap)
             val packageIdsWithDeclaredLicenseCurations = curatedDeclaredLicenses.map { it.first }
 
             val rawQuery = PackagesTable.joinAnalyzerTables()
@@ -369,37 +308,7 @@ class PackageService(private val db: Database, private val ortRunService: OrtRun
     suspend fun getUnmappedDeclaredLicenses(ortRunId: Long): List<String> =
         db.dbQuery {
             val curationsMap = CuratedPackagesTable.getForOrtRunId(ortRunId)
-            val affectedIdentifierIds = curationsMap
-                .filterValues { list ->
-                    list.any { (_, curation) ->
-                        curation.data.declaredLicenseMapping.isNotEmpty()
-                    }
-                }
-                .keys
-                .mapNotNull { IdentifierDao.findByIdentifier(it)?.id }
-
-            val curatedDeclaredLicenses = if (affectedIdentifierIds.isEmpty()) {
-                emptyList()
-            } else {
-                val affectedPackageIds = PackagesTable.joinAnalyzerTables()
-                    .select(PackagesTable.id)
-                    .where {
-                        (AnalyzerJobsTable.ortRunId eq ortRunId) and
-                            (PackagesTable.identifierId inList affectedIdentifierIds)
-                    }
-                    .map { it[PackagesTable.id] }
-
-                if (affectedPackageIds.isEmpty()) {
-                    emptyList()
-                } else {
-                    PackageDao.find { PackagesTable.id inList affectedPackageIds }.map { dao ->
-                        val modelPackage = dao.mapToModel()
-                        val curatedModelPackage = modelPackage.applyCurations(curationsMap).metadata.mapToModel()
-
-                        dao.id to curatedModelPackage.processedDeclaredLicense
-                    }
-                }
-            }
+            val curatedDeclaredLicenses = getCuratedDeclaredLicenses(ortRunId, curationsMap)
             val packageIdsWithDeclaredLicenseCurations = curatedDeclaredLicenses.map { it.first }
 
             val rawQuery = PackagesTable.joinAnalyzerTables()
@@ -420,6 +329,40 @@ class PackageService(private val db: Database, private val ortRunService: OrtRun
 
             licenses.sortedWith(String.CASE_INSENSITIVE_ORDER)
         }
+}
+
+private fun getCuratedDeclaredLicenses(
+    ortRunId: Long,
+    curationsByIdentifier: Map<Identifier, List<Pair<String, PackageCuration>>>
+): List<Pair<EntityID<Long>, ProcessedDeclaredLicense>> {
+    // Only curations with a declared license mapping can change the processed declared license.
+    val identifierIds = curationsByIdentifier
+        .filterValues { curations ->
+            curations.any { (_, curation) ->
+                curation.data.declaredLicenseMapping.isNotEmpty()
+            }
+        }
+        .keys
+        .mapNotNull { IdentifierDao.findByIdentifier(it)?.id }
+
+    if (identifierIds.isEmpty()) return emptyList()
+
+    // Apply curations only to packages from this ORT run that can be affected by these curations.
+    val packageIds = PackagesTable.joinAnalyzerTables()
+        .select(PackagesTable.id)
+        .where {
+            (AnalyzerJobsTable.ortRunId eq ortRunId) and (PackagesTable.identifierId inList identifierIds)
+        }
+        .map { it[PackagesTable.id] }
+
+    if (packageIds.isEmpty()) return emptyList()
+
+    return PackageDao.find { PackagesTable.id inList packageIds }.map { dao ->
+        val modelPackage = dao.mapToModel()
+        val curatedModelPackage = modelPackage.applyCurations(curationsByIdentifier).metadata.mapToModel()
+
+        dao.id to curatedModelPackage.processedDeclaredLicense
+    }
 }
 
 private fun ModelPackage.applyCurations(

--- a/services/ort-run/src/main/kotlin/PackageService.kt
+++ b/services/ort-run/src/main/kotlin/PackageService.kt
@@ -31,7 +31,9 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackageDao
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesAnalyzerRunsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ProcessedDeclaredLicensesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ProcessedDeclaredLicensesUnmappedDeclaredLicensesTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.ShortestDependencyPathsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.UnmappedDeclaredLicensesTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.resolvedconfiguration.CuratedPackagesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
 import org.eclipse.apoapsis.ortserver.dao.utils.applyILike
@@ -236,7 +238,7 @@ class PackageService(private val db: Database, private val ortRunService: OrtRun
                 }
         }
 
-    /** Get all distinct processed declared license expressions found in packages in an ORT run. */
+    /** Return distinct processed declared SPDX license expressions for the ORT run. */
     suspend fun getProcessedDeclaredLicenses(ortRunId: Long): List<String> =
         db.dbQuery {
             PackagesTable.joinAnalyzerTables()
@@ -246,6 +248,20 @@ class PackageService(private val db: Database, private val ortRunService: OrtRun
                 .where { AnalyzerJobsTable.ortRunId eq ortRunId }
                 .orderBy(ProcessedDeclaredLicensesTable.spdxExpression)
                 .mapNotNull { it[ProcessedDeclaredLicensesTable.spdxExpression] }
+        }
+
+    /** Return distinct unmapped declared license strings for the ORT run. */
+    suspend fun getUnmappedDeclaredLicenses(ortRunId: Long): List<String> =
+        db.dbQuery {
+            PackagesTable.joinAnalyzerTables()
+                .innerJoin(ProcessedDeclaredLicensesTable)
+                .innerJoin(ProcessedDeclaredLicensesUnmappedDeclaredLicensesTable)
+                .innerJoin(UnmappedDeclaredLicensesTable)
+                .select(UnmappedDeclaredLicensesTable.unmappedLicense)
+                .withDistinct()
+                .where { AnalyzerJobsTable.ortRunId eq ortRunId }
+                .orderBy(UnmappedDeclaredLicensesTable.unmappedLicense)
+                .map { it[UnmappedDeclaredLicensesTable.unmappedLicense] }
         }
 }
 

--- a/services/ort-run/src/test/kotlin/PackageServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/PackageServiceTest.kt
@@ -457,7 +457,8 @@ class PackageServiceTest : WordSpec() {
                 }
             }
 
-            "allow filtering by processed declared license" {
+            "allow filtering by declared license" {
+                val licenseUrl = "https://www.nuget.org/packages/CommandLineParser/2.9.1/license"
                 val ortRunId = createAnalyzerRunWithPackages(
                     setOf(
                         fixtures.generatePackage(
@@ -465,7 +466,7 @@ class PackageServiceTest : WordSpec() {
                             processedDeclaredLicense = ProcessedDeclaredLicense(
                                 "Apache-2.0 OR LGPL-2.1-or-later",
                                 emptyMap(),
-                                emptySet()
+                                setOf(licenseUrl)
                             )
                         ),
                         fixtures.generatePackage(
@@ -491,9 +492,9 @@ class PackageServiceTest : WordSpec() {
                     ortRunId,
                     ListQueryParameters(listOf(OrderField("processedDeclaredLicense", OrderDirection.ASCENDING))),
                     PackageFilters(
-                        processedDeclaredLicense = FilterOperatorAndValue(
+                        declaredLicense = FilterOperatorAndValue(
                             ComparisonOperator.IN,
-                            setOf("MIT", "Apache-2.0 OR LGPL-2.1-or-later")
+                            setOf("MIT", licenseUrl)
                         )
                     )
                 )
@@ -510,6 +511,54 @@ class PackageServiceTest : WordSpec() {
                     identifier shouldBe Identifier("NPM", "com.example", "example2", "1.0").mapToApi()
                     processedDeclaredLicense.spdxExpression shouldBe "MIT"
                 }
+            }
+
+            "allow excluding by declared license" {
+                val licenseUrl = "https://www.nuget.org/packages/CommandLineParser/2.9.1/license"
+                val ortRunId = createAnalyzerRunWithPackages(
+                    setOf(
+                        fixtures.generatePackage(
+                            Identifier("Maven", "com.example", "processed", "1.0"),
+                            processedDeclaredLicense = ProcessedDeclaredLicense(
+                                spdxExpression = "Apache-2.0",
+                                mappedLicenses = emptyMap(),
+                                unmappedLicenses = emptySet()
+                            )
+                        ),
+                        fixtures.generatePackage(
+                            Identifier("Maven", "com.example", "unmapped", "1.0"),
+                            processedDeclaredLicense = ProcessedDeclaredLicense(
+                                spdxExpression = "MIT",
+                                mappedLicenses = emptyMap(),
+                                unmappedLicenses = setOf(licenseUrl)
+                            )
+                        ),
+                        fixtures.generatePackage(
+                            Identifier("Maven", "com.example", "other", "1.0"),
+                            processedDeclaredLicense = ProcessedDeclaredLicense(
+                                spdxExpression = "BSD-2-Clause",
+                                mappedLicenses = emptyMap(),
+                                unmappedLicenses = emptySet()
+                            )
+                        )
+                    )
+                ).id
+
+                val results = service.listForOrtRunId(
+                    ortRunId,
+                    ListQueryParameters(listOf(OrderField("identifier", OrderDirection.ASCENDING))),
+                    PackageFilters(
+                        declaredLicense = FilterOperatorAndValue(
+                            ComparisonOperator.NOT_IN,
+                            setOf("Apache-2.0", licenseUrl)
+                        )
+                    )
+                )
+
+                results.data.shouldBeSingleton {
+                    it.identifier.name shouldBe "other"
+                }
+                results.totalCount shouldBe 1
             }
 
             "allow filtering by direct dependencies" {

--- a/services/ort-run/src/test/kotlin/PackageServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/PackageServiceTest.kt
@@ -784,7 +784,7 @@ class PackageServiceTest : WordSpec() {
                             processedDeclaredLicense = ProcessedDeclaredLicense(
                                 "MIT",
                                 emptyMap(),
-                                emptySet()
+                                setOf("unknown-license")
                             )
                         ),
                         fixtures.generatePackage(
@@ -800,8 +800,45 @@ class PackageServiceTest : WordSpec() {
 
                 val licenses = service.getProcessedDeclaredLicenses(ortRunId)
 
-                licenses shouldHaveSize 3
                 licenses shouldBe listOf("Apache-2.0", "Apache-2.0 OR LGPL-2.1-or-later", "MIT")
+            }
+        }
+
+        "getUnmappedDeclaredLicenses" should {
+            "return the distinct unmapped declared licenses found in packages in the ORT run" {
+                val licenseUrl = "https://www.nuget.org/packages/CommandLineParser/2.9.1/license"
+                val ortRunId = createAnalyzerRunWithPackages(
+                    setOf(
+                        fixtures.generatePackage(
+                            Identifier("Maven", "com.example", "example", "1.0"),
+                            processedDeclaredLicense = ProcessedDeclaredLicense(
+                                spdxExpression = "Apache-2.0",
+                                mappedLicenses = emptyMap(),
+                                unmappedLicenses = setOf(licenseUrl, "custom-license")
+                            )
+                        ),
+                        fixtures.generatePackage(
+                            Identifier("Maven", "com.example", "example2", "1.0"),
+                            processedDeclaredLicense = ProcessedDeclaredLicense(
+                                spdxExpression = "MIT",
+                                mappedLicenses = emptyMap(),
+                                unmappedLicenses = setOf(licenseUrl, "unknown-license")
+                            )
+                        ),
+                        fixtures.generatePackage(
+                            Identifier("NPM", "com.example", "example3", "1.0"),
+                            processedDeclaredLicense = ProcessedDeclaredLicense(
+                                spdxExpression = "BSD-2-Clause",
+                                mappedLicenses = emptyMap(),
+                                unmappedLicenses = emptySet()
+                            )
+                        )
+                    )
+                ).id
+
+                val licenses = service.getUnmappedDeclaredLicenses(ortRunId)
+
+                licenses shouldBe listOf("custom-license", licenseUrl, "unknown-license")
             }
         }
     }

--- a/services/ort-run/src/test/kotlin/PackageServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/PackageServiceTest.kt
@@ -25,6 +25,7 @@ import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.containsInOrder
 import io.kotest.matchers.collections.shouldBeSingleton
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.maps.containExactly as containExactlyEntries
 import io.kotest.matchers.should
@@ -561,6 +562,65 @@ class PackageServiceTest : WordSpec() {
                 results.totalCount shouldBe 1
             }
 
+            "match curated declared licenses in declaredLicense IN filter" {
+                val pkgMit = fixtures.generatePackage(
+                    Identifier("Maven", "com.example", "mit", "1.0"),
+                    processedDeclaredLicense = ProcessedDeclaredLicense("MIT", emptyMap(), emptySet())
+                )
+                val pkgMapped = fixtures.generatePackage(
+                    Identifier("Maven", "com.example", "mapped", "1.0"),
+                    declaredLicenses = setOf("custom-foo"),
+                    processedDeclaredLicense = ProcessedDeclaredLicense(null, emptyMap(), setOf("custom-foo"))
+                )
+
+                val ortRunId = createAnalyzerRunWithPackages(setOf(pkgMit, pkgMapped)).id
+
+                addLicenseMappingCuration(ortRunId, pkgMapped.identifier, mapOf("custom-foo" to "Apache-2.0"))
+
+                val results = service.listForOrtRunId(
+                    ortRunId,
+                    filters = PackageFilters(
+                        declaredLicense = FilterOperatorAndValue(
+                            ComparisonOperator.IN,
+                            setOf("Apache-2.0")
+                        )
+                    )
+                )
+
+                results.data.map { it.identifier.name }.shouldContainExactly("mapped")
+                results.totalCount shouldBe 1
+            }
+
+            "keep packages whose curations resolve a declaredLicense NOT_IN value" {
+                val pkgMapped = fixtures.generatePackage(
+                    Identifier("Maven", "com.example", "mapped", "1.0"),
+                    declaredLicenses = setOf("custom-foo"),
+                    processedDeclaredLicense = ProcessedDeclaredLicense(null, emptyMap(), setOf("custom-foo"))
+                )
+                val pkgOther = fixtures.generatePackage(
+                    Identifier("Maven", "com.example", "other", "1.0"),
+                    processedDeclaredLicense = ProcessedDeclaredLicense("MIT", emptyMap(), emptySet())
+                )
+
+                val ortRunId = createAnalyzerRunWithPackages(setOf(pkgMapped, pkgOther)).id
+
+                addLicenseMappingCuration(ortRunId, pkgMapped.identifier, mapOf("custom-foo" to "Apache-2.0"))
+
+                val results = service.listForOrtRunId(
+                    ortRunId,
+                    ListQueryParameters(listOf(OrderField("identifier", OrderDirection.ASCENDING))),
+                    PackageFilters(
+                        declaredLicense = FilterOperatorAndValue(
+                            ComparisonOperator.NOT_IN,
+                            setOf("custom-foo")
+                        )
+                    )
+                )
+
+                results.data.map { it.identifier.name }.shouldContainExactly("mapped", "other")
+                results.totalCount shouldBe 2
+            }
+
             "allow filtering by direct dependencies" {
                 val project = fixtures.getProject()
                 val directIdentifier = Identifier("Maven", "com.example", "direct", "1.0")
@@ -851,6 +911,24 @@ class PackageServiceTest : WordSpec() {
 
                 licenses shouldBe listOf("Apache-2.0", "Apache-2.0 OR LGPL-2.1-or-later", "MIT")
             }
+
+            "include curated SPDX expressions from declared license mappings" {
+                val pkgMit = fixtures.generatePackage(
+                    Identifier("Maven", "com.example", "mit", "1.0"),
+                    processedDeclaredLicense = ProcessedDeclaredLicense("MIT", emptyMap(), emptySet())
+                )
+                val pkgMapped = fixtures.generatePackage(
+                    Identifier("Maven", "com.example", "mapped", "1.0"),
+                    declaredLicenses = setOf("custom-foo"),
+                    processedDeclaredLicense = ProcessedDeclaredLicense(null, emptyMap(), setOf("custom-foo"))
+                )
+
+                val ortRunId = createAnalyzerRunWithPackages(setOf(pkgMit, pkgMapped)).id
+
+                addLicenseMappingCuration(ortRunId, pkgMapped.identifier, mapOf("custom-foo" to "Apache-2.0"))
+
+                service.getProcessedDeclaredLicenses(ortRunId).shouldContainExactly("Apache-2.0", "MIT")
+            }
         }
 
         "getUnmappedDeclaredLicenses" should {
@@ -889,7 +967,46 @@ class PackageServiceTest : WordSpec() {
 
                 licenses shouldBe listOf("custom-license", licenseUrl, "unknown-license")
             }
+
+            "exclude unmapped declared licenses that curations resolve" {
+                val pkgMapped = fixtures.generatePackage(
+                    Identifier("Maven", "com.example", "mapped", "1.0"),
+                    declaredLicenses = setOf("custom-foo"),
+                    processedDeclaredLicense = ProcessedDeclaredLicense(null, emptyMap(), setOf("custom-foo"))
+                )
+                val pkgOther = fixtures.generatePackage(
+                    Identifier("Maven", "com.example", "other", "1.0"),
+                    declaredLicenses = setOf("other-unmapped"),
+                    processedDeclaredLicense = ProcessedDeclaredLicense(null, emptyMap(), setOf("other-unmapped"))
+                )
+
+                val ortRunId = createAnalyzerRunWithPackages(setOf(pkgMapped, pkgOther)).id
+
+                addLicenseMappingCuration(ortRunId, pkgMapped.identifier, mapOf("custom-foo" to "Apache-2.0"))
+
+                service.getUnmappedDeclaredLicenses(ortRunId).shouldContainExactly("other-unmapped")
+            }
         }
+    }
+
+    private fun addLicenseMappingCuration(
+        ortRunId: Long,
+        identifier: Identifier,
+        mapping: Map<String, String>
+    ) {
+        val curation = PackageCuration(
+            id = identifier,
+            data = PackageCurationData(declaredLicenseMapping = mapping)
+        )
+        val resolvedPackageCurations = ResolvedPackageCurations(
+            provider = PackageCurationProviderConfig("test"),
+            curations = listOf(curation)
+        )
+        fixtures.resolvedConfigurationRepository.addPackageCurations(ortRunId, listOf(resolvedPackageCurations))
+        fixtures.resolvedConfigurationRepository.addPackageCurationAssociations(
+            ortRunId,
+            mapOf(identifier to listOf(AppliedPackageCurationRef(providerName = "test", curationRank = 0)))
+        )
     }
 
     private fun createAnalyzerRunWithPackages(

--- a/ui/src/@types/@tanstack/react-table.d.ts
+++ b/ui/src/@types/@tanstack/react-table.d.ts
@@ -50,6 +50,7 @@ declare module '@tanstack/react-table' {
       label: string;
       value: TValue;
       icon?: React.ComponentType<{ className?: string }>;
+      group?: string;
     }[];
     setSelected: (selected: TValue[]) => void;
     align?: 'start' | 'end' | 'center';

--- a/ui/src/components/data-table/filter-multi-select.tsx
+++ b/ui/src/components/data-table/filter-multi-select.tsx
@@ -37,14 +37,17 @@ import {
 } from '@/components/ui/popover';
 import { cn } from '@/lib/utils';
 
+type FilterOption<TValue> = {
+  label: string;
+  value: TValue;
+  icon?: React.ComponentType<{ className?: string }>;
+  group?: string;
+};
+
 interface FilterMultiSelectProps<TValue> {
   title?: string;
   showTitle?: boolean; // Whether to show the title next to the filter icon
-  options: {
-    label: string;
-    value: TValue;
-    icon?: React.ComponentType<{ className?: string }>;
-  }[];
+  options: FilterOption<TValue>[];
   selected: TValue[];
   setSelected: (selected: TValue[]) => void;
   align?: 'start' | 'end' | 'center';
@@ -58,6 +61,52 @@ export function FilterMultiSelect<TValue>({
   setSelected,
   align = 'start',
 }: FilterMultiSelectProps<TValue>) {
+  const optionGroups = options.reduce<
+    { group?: string; options: FilterOption<TValue>[] }[]
+  >((groups, option) => {
+    const previousGroup = groups.at(-1);
+
+    if (previousGroup && previousGroup.group === option.group) {
+      previousGroup.options.push(option);
+    } else {
+      groups.push({ group: option.group, options: [option] });
+    }
+
+    return groups;
+  }, []);
+
+  const renderOption = (option: FilterOption<TValue>) => {
+    const isSelected = selected.includes(option.value);
+
+    return (
+      <CommandItem
+        key={String(option.value)}
+        onSelect={() => {
+          if (isSelected) {
+            setSelected(selected.filter((value) => value !== option.value));
+          } else {
+            setSelected([...selected, option.value]);
+          }
+        }}
+      >
+        <div
+          className={cn(
+            'border-primary mr-2 flex h-4 w-4 items-center justify-center rounded-sm border',
+            isSelected
+              ? 'bg-primary text-primary-foreground'
+              : 'opacity-50 [&_svg]:invisible'
+          )}
+        >
+          <Check className={cn('h-4 w-4')} />
+        </div>
+        {option.icon && (
+          <option.icon className='text-muted-foreground mr-2 h-4 w-4' />
+        )}
+        <span>{option.label}</span>
+      </CommandItem>
+    );
+  };
+
   return (
     <Popover>
       <PopoverTrigger asChild>
@@ -76,40 +125,14 @@ export function FilterMultiSelect<TValue>({
           {options.length > 5 && <CommandInput placeholder={title} />}
           <CommandList>
             <CommandEmpty>No results found.</CommandEmpty>
-            <CommandGroup>
-              {options.map((option) => {
-                const isSelected = selected.includes(option.value);
-                return (
-                  <CommandItem
-                    key={String(option.value)}
-                    onSelect={() => {
-                      if (isSelected) {
-                        setSelected(
-                          selected.filter((value) => value !== option.value)
-                        );
-                      } else {
-                        setSelected([...selected, option.value]);
-                      }
-                    }}
-                  >
-                    <div
-                      className={cn(
-                        'border-primary mr-2 flex h-4 w-4 items-center justify-center rounded-sm border',
-                        isSelected
-                          ? 'bg-primary text-primary-foreground'
-                          : 'opacity-50 [&_svg]:invisible'
-                      )}
-                    >
-                      <Check className={cn('h-4 w-4')} />
-                    </div>
-                    {option.icon && (
-                      <option.icon className='text-muted-foreground mr-2 h-4 w-4' />
-                    )}
-                    <span>{option.label}</span>
-                  </CommandItem>
-                );
-              })}
-            </CommandGroup>
+            {optionGroups.map((group, index) => (
+              <React.Fragment key={group.group ?? `group-${index}`}>
+                {index > 0 && <CommandSeparator />}
+                <CommandGroup heading={group.group}>
+                  {group.options.map(renderOption)}
+                </CommandGroup>
+              </React.Fragment>
+            ))}
             {selected.length > 0 && (
               <>
                 <CommandSeparator />

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
@@ -379,7 +379,7 @@ const PackagesComponent = () => {
         ...(packageIdType === 'ORT_ID'
           ? { identifier: packageId }
           : { purl: packageId }),
-        processedDeclaredLicense: declaredLicense?.join(','),
+        declaredLicense: declaredLicense?.join(','),
         isDirectDependency,
       },
     }),
@@ -488,13 +488,22 @@ const PackagesComponent = () => {
           filter: {
             filterVariant: 'select',
             align: 'end',
-            selectOptions:
-              declaredLicensesOptions.processedDeclaredLicenses.map(
+            selectOptions: [
+              ...declaredLicensesOptions.processedDeclaredLicenses.map(
                 (license) => ({
                   label: license,
                   value: license,
+                  group: 'Processed licenses',
                 })
               ),
+              ...(declaredLicensesOptions.unmappedDeclaredLicenses ?? []).map(
+                (license) => ({
+                  label: license,
+                  value: license,
+                  group: 'Unmapped licenses',
+                })
+              ),
+            ],
             setSelected: (licenses: string[]) => {
               navigate({
                 search: {


### PR DESCRIPTION
This PR aligns the detected license filter options in the UI with the license data shown in the package cards, by adding the unmapped licenses to the filter options, and fixing a bug, where package curations for licenses were not taken into account when constructing the filter options.

### Also unmapped licenses can be included in the detected license filter

<img width="1132" height="493" alt="Screenshot from 2026-06-12 07-32-47" src="https://github.com/user-attachments/assets/7daeef69-db7f-4e38-87f4-95d5ccff1725" />

### After the bug fix, curated licenses are properly shown in the filter

<img width="1151" height="512" alt="Screenshot from 2026-06-12 07-31-09" src="https://github.com/user-attachments/assets/99d3d3d5-3d17-4d60-b2fc-be37a5798a21" />

<img width="1075" height="187" alt="Screenshot from 2026-06-12 07-32-06" src="https://github.com/user-attachments/assets/5cf8c561-ad39-4c49-901f-60bb5657b200" />

Please see the commits for details.