### PR TITLE
fix(ui): Prefer fixed plugin option values over values from last run

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/default-values.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/default-values.ts
@@ -255,7 +255,8 @@ export function defaultValues(
               packageCurationProviderFormValues.selectedPluginIds,
             packageCurationProviderConfig: mergePluginConfigs(
               packageCurationProviderFormValues.config,
-              packageCurationProviderPluginDefaultValues
+              packageCurationProviderPluginDefaultValues,
+              packageCurationProviderPlugins
             ),
             keepAliveWorker:
               (ortRun.jobConfigs.analyzer?.keepAliveWorker && isSuperuser) ||
@@ -273,7 +274,8 @@ export function defaultValues(
               baseDefaults.jobConfigs.advisor.advisors,
             config: mergePluginConfigs(
               ortRun?.jobConfigs?.advisor?.config,
-              advisorPluginDefaultValues
+              advisorPluginDefaultValues,
+              advisorPlugins
             ),
             keepAliveWorker:
               (ortRun.jobConfigs.advisor?.keepAliveWorker && isSuperuser) ||
@@ -299,7 +301,8 @@ export function defaultValues(
             ),
             config: mergePluginConfigs(
               ortRun.jobConfigs.scanner?.config,
-              scannerPluginDefaultValues
+              scannerPluginDefaultValues,
+              scannerPlugins
             ),
           },
           evaluator: {
@@ -310,7 +313,8 @@ export function defaultValues(
               evaluatorPackageConfigurationProviderFormValues.selectedPluginIds,
             packageConfigurationProviderConfig: mergePluginConfigs(
               evaluatorPackageConfigurationProviderFormValues.config,
-              packageConfigurationProviderPluginDefaultValues
+              packageConfigurationProviderPluginDefaultValues,
+              packageConfigurationProviderPlugins
             ),
             keepAliveWorker:
               (ortRun.jobConfigs.evaluator?.keepAliveWorker && isSuperuser) ||
@@ -330,7 +334,8 @@ export function defaultValues(
               reporterPackageConfigurationProviderFormValues.selectedPluginIds,
             packageConfigurationProviderConfig: mergePluginConfigs(
               reporterPackageConfigurationProviderFormValues.config,
-              packageConfigurationProviderPluginDefaultValues
+              packageConfigurationProviderPluginDefaultValues,
+              packageConfigurationProviderPlugins
             ),
             keepAliveWorker:
               (ortRun.jobConfigs.reporter?.keepAliveWorker && isSuperuser) ||

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/plugin-utils.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/plugin-utils.ts
@@ -144,20 +144,24 @@ export const createPluginConfigSchema = (
 };
 
 /**
- * Merge the plugin configs from the last run with the default plugin configs. The configs from the last run take
- * precedence.
+ * Merge the plugin configs from the last run with the default plugin configs.
+ * For fixed options, values configured via plugin descriptors take precedence.
+ * For non-fixed options, values from the last run take precedence.
  */
 export function mergePluginConfigs(
   lastRunConfig: { [p: string]: PluginConfig } | null | undefined,
-  defaultConfig: Record<string, PluginConfig>
+  defaultConfig: Record<string, PluginConfig>,
+  plugins: PreconfiguredPluginDescriptor[]
 ): Record<string, PluginConfig> {
   const merged: Record<string, PluginConfig> = {};
+  const pluginById = new Map(plugins.map((plugin) => [plugin.id, plugin]));
 
   for (const pluginId of Object.keys(defaultConfig)) {
     const defaultPlugin = defaultConfig[pluginId];
     const ortPlugin = lastRunConfig?.[pluginId];
+    const pluginDescriptor = pluginById.get(pluginId);
 
-    merged[pluginId] = {
+    const mergedPlugin: PluginConfig = {
       options: {
         ...(defaultPlugin?.options ?? {}),
         ...(ortPlugin?.options ?? {}),
@@ -167,6 +171,22 @@ export function mergePluginConfigs(
         ...(ortPlugin?.secrets ?? {}),
       },
     };
+
+    for (const option of pluginDescriptor?.options ?? []) {
+      if (!option.isFixed) continue;
+
+      const section = option.type === 'SECRET' ? 'secrets' : 'options';
+      const defaultSection = defaultPlugin?.[section] ?? {};
+      const defaultValue = defaultSection[option.name];
+
+      if (defaultValue !== undefined) {
+        mergedPlugin[section][option.name] = defaultValue;
+      } else {
+        delete mergedPlugin[section][option.name];
+      }
+    }
+
+    merged[pluginId] = mergedPlugin;
   }
 
   if (lastRunConfig) {

--- a/ui/tests/unit/logic/default-values.test.ts
+++ b/ui/tests/unit/logic/default-values.test.ts
@@ -288,3 +288,155 @@ it('uses scanner plugin default values for fresh runs', () => {
     },
   });
 });
+
+it('applies fixed plugin option precedence for advisor and scanner reruns', () => {
+  const ortRun = createOrtRun({
+    jobConfigs: {
+      advisor: {
+        advisors: ['OSV'],
+        config: {
+          OSV: {
+            options: {
+              url: 'https://rerun.example/advisor',
+              fixedNoDefault: 'legacy-advisor-fixed',
+              token: 'legacy-advisor-token',
+            },
+            secrets: {
+              fixedSecret: 'legacy-advisor-secret',
+            },
+          },
+        },
+      },
+      scanner: {
+        scanners: ['SCANOSS'],
+        config: {
+          SCANOSS: {
+            options: {
+              url: 'https://rerun.example/scanner',
+              fixedNoDefault: 'legacy-scanner-fixed',
+              token: 'legacy-scanner-token',
+            },
+            secrets: {
+              fixedSecret: 'legacy-scanner-secret',
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const advisorPlugins = [
+    createPluginDescriptor({
+      id: 'OSV',
+      type: 'ADVISOR',
+      options: [
+        {
+          name: 'url',
+          description: 'Base URL.',
+          type: 'STRING',
+          defaultValue: 'https://default.example/advisor',
+          isFixed: true,
+          isNullable: false,
+          isRequired: true,
+        },
+        {
+          name: 'fixedNoDefault',
+          description: 'Fixed without default.',
+          type: 'STRING',
+          isFixed: true,
+          isNullable: false,
+          isRequired: false,
+        },
+        {
+          name: 'fixedSecret',
+          description: 'Fixed secret option.',
+          type: 'SECRET',
+          isFixed: true,
+          isNullable: false,
+          isRequired: false,
+        },
+        {
+          name: 'token',
+          description: 'Editable token.',
+          type: 'STRING',
+          defaultValue: 'default-token',
+          isFixed: false,
+          isNullable: false,
+          isRequired: false,
+        },
+      ],
+    }),
+  ];
+
+  const scannerPlugins = [
+    createPluginDescriptor({
+      id: 'SCANOSS',
+      type: 'SCANNER',
+      options: [
+        {
+          name: 'url',
+          description: 'Base URL.',
+          type: 'STRING',
+          defaultValue: 'https://default.example/scanner',
+          isFixed: true,
+          isNullable: false,
+          isRequired: true,
+        },
+        {
+          name: 'fixedNoDefault',
+          description: 'Fixed without default.',
+          type: 'STRING',
+          isFixed: true,
+          isNullable: false,
+          isRequired: false,
+        },
+        {
+          name: 'fixedSecret',
+          description: 'Fixed secret option.',
+          type: 'SECRET',
+          isFixed: true,
+          isNullable: false,
+          isRequired: false,
+        },
+        {
+          name: 'token',
+          description: 'Editable token.',
+          type: 'STRING',
+          defaultValue: 'default-token',
+          isFixed: false,
+          isNullable: false,
+          isRequired: false,
+        },
+      ],
+    }),
+  ];
+
+  const defaults = defaultValues(
+    ortRun,
+    advisorPlugins,
+    scannerPlugins,
+    false,
+    [],
+    []
+  );
+
+  expect(defaults.jobConfigs.advisor.config).toEqual({
+    OSV: {
+      options: {
+        url: 'https://default.example/advisor',
+        token: 'legacy-advisor-token',
+      },
+      secrets: {},
+    },
+  });
+
+  expect(defaults.jobConfigs.scanner.config).toEqual({
+    SCANOSS: {
+      options: {
+        url: 'https://default.example/scanner',
+        token: 'legacy-scanner-token',
+      },
+      secrets: {},
+    },
+  });
+});

--- a/ui/tests/unit/logic/plugin-utils.test.ts
+++ b/ui/tests/unit/logic/plugin-utils.test.ts
@@ -24,6 +24,7 @@ import {
   createPluginPayload,
   createProviderPluginPayload,
   getPluginDefaultValues,
+  mergePluginConfigs,
   providerPluginConfigsToFormValues,
   reconstructScannerSelection,
 } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/plugin-utils';
@@ -209,6 +210,79 @@ it('reconstructScannerSelection rebuilds scanner scopes for rerun values', () =>
     scanners: ['SCANOSS'],
     scannerScopes: {
       SCANOSS: 'both',
+    },
+  });
+});
+
+it('mergePluginConfigs enforces fixed option precedence and clears missing fixed defaults', () => {
+  const plugins = [
+    createPluginDescriptor({
+      id: 'SCANOSS',
+      type: 'SCANNER',
+      options: [
+        {
+          name: 'url',
+          description: 'The API URL.',
+          type: 'STRING',
+          defaultValue: 'https://scanner.example/api',
+          isFixed: true,
+          isNullable: false,
+          isRequired: false,
+        },
+        {
+          name: 'fixedNoDefault',
+          description: 'A fixed option without default.',
+          type: 'STRING',
+          isFixed: true,
+          isNullable: false,
+          isRequired: false,
+        },
+        {
+          name: 'fixedSecret',
+          description: 'A fixed secret option.',
+          type: 'SECRET',
+          defaultValue: 'admin-provided',
+          isFixed: true,
+          isNullable: false,
+          isRequired: true,
+        },
+        {
+          name: 'timeout',
+          description: 'Timeout in seconds.',
+          type: 'INTEGER',
+          defaultValue: '30',
+          isFixed: false,
+          isNullable: false,
+          isRequired: false,
+        },
+      ],
+    }),
+  ];
+
+  const merged = mergePluginConfigs(
+    {
+      SCANOSS: {
+        options: {
+          url: 'https://old.example/api',
+          fixedNoDefault: 'legacy-value',
+          timeout: '90',
+        },
+        secrets: {
+          fixedSecret: 'legacy-secret',
+        },
+      },
+    },
+    getPluginDefaultValues(plugins),
+    plugins
+  );
+
+  expect(merged.SCANOSS).toEqual({
+    options: {
+      url: 'https://scanner.example/api',
+      timeout: '90',
+    },
+    secrets: {
+      fixedSecret: ADMIN_SECRET_VALUE,
     },
   });
 });


### PR DESCRIPTION
If a plugin options is set to a fixed value in a plugin template, that value is enforced by the backend: If a different value for that option is sent to the API, the run request is rejected.

This could cause issues when starting a run with "rerun" and plugin templates were changed in the meantime, because a plugin option used for the last run may now not be allowed anymore.

To fix this, always prefer fixed plugin option values over values used by the last run.