### PR TITLE
ui: Add package curation providers section to analyzer form

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -18,6 +18,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@dnd-kit/react": "0.5.0",
     "@hookform/resolvers": "5.4.0",
     "@radix-ui/react-accordion": "1.2.13",
     "@radix-ui/react-alert-dialog": "1.1.16",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/react':
+        specifier: 0.5.0
+        version: 0.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       '@hookform/resolvers':
         specifier: 5.4.0
         version: 5.4.0(react-hook-form@7.78.0(react@19.2.7))
@@ -311,6 +314,27 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@dnd-kit/abstract@0.5.0':
+    resolution: {integrity: sha512-hi13iMJgjPX/KDYVKg5VeDIhmYiV6buc9bAX+tCLYf4QdyYjPbsXjn2sPo6m7fQ6SGJBEFgHJ2PemeKDUbwBaA==}
+
+  '@dnd-kit/collision@0.5.0':
+    resolution: {integrity: sha512-xUqRn3lS7oqLkT0AnnHS/STh/Czvwe1UapZFYiLbsUGxopMsQd4teaPCzPouOThoMdGEe+dHWjfqJl6t9iG4mQ==}
+
+  '@dnd-kit/dom@0.5.0':
+    resolution: {integrity: sha512-f2xFJp5SYQ8EW/Fbtaa8iBb66hpkWc7qa8vU826KW11/tb44sH+AisZnGtwOOTWTQ0GraqBDr5ixTErww+eKXw==}
+
+  '@dnd-kit/geometry@0.5.0':
+    resolution: {integrity: sha512-ubHQS1CiSDH8ssYH2xG5BnpwPSFP1tStXXjug7/Ba6qnQdu/EUH47l6QXKIksQnnanfVfDf0aGeevRxgZlj28A==}
+
+  '@dnd-kit/react@0.5.0':
+    resolution: {integrity: sha512-abQPLI8lmfVE+v/n+pqy5WFxrw6T2Yg0UQZsL78dp5DKci7dKTVDjvLWqvass+XTFtzJmsZEjk1NdqE6xG8Jiw==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@dnd-kit/state@0.5.0':
+    resolution: {integrity: sha512-y7XbabQqjF58Lk8YmDQuR8l6QjN+Kh4qlGEjUvHuIeasLk1QP+9L5diXS98VMxQIivyMmUtX2//f+3N7qPJX4w==}
+
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
@@ -487,6 +511,9 @@ packages:
     resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@preact/signals-core@1.14.2':
+    resolution: {integrity: sha512-RZHdBj9ZF4n40Rp4jS052EHHjBWf96P9oNdXPfhQTovCuWY9iQn3Gq+gOTJSgBO9A/JBuPfMOWsSX/lIU9Pc/A==}
 
   '@radix-ui/number@1.1.2':
     resolution: {integrity: sha512-ceTwaxc4I5IOi97DgCotl3pqiyRGvffcc0oOsE2dQYaJOFIDsDt4VWG6xEbg1QePv9QWausCEIppud/tJ1wNig==}
@@ -3447,6 +3474,45 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@dnd-kit/abstract@0.5.0':
+    dependencies:
+      '@dnd-kit/geometry': 0.5.0
+      '@dnd-kit/state': 0.5.0
+      tslib: 2.8.1
+
+  '@dnd-kit/collision@0.5.0':
+    dependencies:
+      '@dnd-kit/abstract': 0.5.0
+      '@dnd-kit/geometry': 0.5.0
+      tslib: 2.8.1
+
+  '@dnd-kit/dom@0.5.0':
+    dependencies:
+      '@dnd-kit/abstract': 0.5.0
+      '@dnd-kit/collision': 0.5.0
+      '@dnd-kit/geometry': 0.5.0
+      '@dnd-kit/state': 0.5.0
+      tslib: 2.8.1
+
+  '@dnd-kit/geometry@0.5.0':
+    dependencies:
+      '@dnd-kit/state': 0.5.0
+      tslib: 2.8.1
+
+  '@dnd-kit/react@0.5.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7)':
+    dependencies:
+      '@dnd-kit/abstract': 0.5.0
+      '@dnd-kit/dom': 0.5.0
+      '@dnd-kit/state': 0.5.0
+      react: 19.2.7
+      react-dom: 19.2.7(react@19.2.7)
+      tslib: 2.8.1
+
+  '@dnd-kit/state@0.5.0':
+    dependencies:
+      '@preact/signals-core': 1.14.2
+      tslib: 2.8.1
+
   '@emnapi/core@1.10.0':
     dependencies:
       '@emnapi/wasi-threads': 1.2.1
@@ -3646,6 +3712,8 @@ snapshots:
   '@playwright/test@1.60.0':
     dependencies:
       playwright: 1.60.0
+
+  '@preact/signals-core@1.14.2': {}
 
   '@radix-ui/number@1.1.2': {}
 

--- a/ui/src/components/form/plugin-multi-select-field.tsx
+++ b/ui/src/components/form/plugin-multi-select-field.tsx
@@ -295,9 +295,6 @@ export const PluginMultiSelectField = <
                               {option.type}
                             </Badge>
                           </FormLabel>
-                          <FormDescription>
-                            {option.description}
-                          </FormDescription>
                           <FormControl>
                             {option.type === 'BOOLEAN' ? (
                               <Checkbox
@@ -384,6 +381,9 @@ export const PluginMultiSelectField = <
                               />
                             )}
                           </FormControl>
+                          <FormDescription>
+                            {option.description}
+                          </FormDescription>
                           {option.isFixed && (
                             <FormDescription className='font-semibold text-yellow-700'>
                               This option is set by an administrator and cannot

--- a/ui/src/components/form/plugin-multi-select-field.tsx
+++ b/ui/src/components/form/plugin-multi-select-field.tsx
@@ -114,7 +114,7 @@ export const PluginMultiSelectField = <
       render={({ field }) => (
         <FormItem
           className={cn(
-            'mb-4 flex flex-col justify-between rounded-lg border p-4',
+            'flex flex-col justify-between rounded-lg border p-4',
             className
           )}
         >
@@ -223,14 +223,14 @@ export const PluginMultiSelectField = <
                   }}
                 />
               </FormControl>
-              <div className='flex flex-col space-y-2'>
+              <div className='flex flex-col'>
                 <FormLabel className='font-normal'>
                   {plugin.displayName}
                 </FormLabel>
                 {plugin.summary != null && (
                   <MarkdownRenderer
                     markdown={plugin.summary}
-                    className='text-muted-foreground max-w-none pb-4 [&_p]:my-0'
+                    className='text-muted-foreground max-w-none pb-1 [&_p]:my-0'
                   />
                 )}
                 {scannerScopeName && field.value?.includes(plugin.id) && (
@@ -285,7 +285,7 @@ export const PluginMultiSelectField = <
                         `${configName}.${plugin.id}.${option.type === 'SECRET' ? 'secrets' : 'options'}.${option.name}` as Path<TFieldValues>
                       }
                       render={({ field }) => (
-                        <FormItem className='ml-4 flex flex-col space-y-0.5 pb-4'>
+                        <FormItem className='ml-4 flex flex-col pb-4'>
                           <FormLabel>
                             {option.name}
                             <Badge

--- a/ui/src/components/form/plugin-multi-select-field.tsx
+++ b/ui/src/components/form/plugin-multi-select-field.tsx
@@ -17,7 +17,10 @@
  * License-Filename: LICENSE
  */
 
+import { DragDropProvider } from '@dnd-kit/react';
+import { isSortable, useSortable } from '@dnd-kit/react/sortable';
 import { CheckedState } from '@radix-ui/react-checkbox';
+import { GripVerticalIcon } from 'lucide-react';
 import React from 'react';
 import {
   FieldPathByValue,
@@ -72,6 +75,87 @@ function getSecretSelectDisplayValue(
   return value;
 }
 
+function moveItem<T>(items: readonly T[], fromIndex: number, toIndex: number) {
+  const newItems = [...items];
+  const [removed] = newItems.splice(fromIndex, 1);
+
+  if (removed !== undefined) {
+    newItems.splice(toIndex, 0, removed);
+  }
+
+  return newItems;
+}
+
+function getPluginsInDisplayOrder<T extends { id: string }>(
+  plugins: readonly T[],
+  selectedPluginIds: readonly string[],
+  showSelectedPluginsFirst: boolean,
+  pluginOrder?: readonly string[]
+) {
+  const pluginsById = new Map(plugins.map((plugin) => [plugin.id, plugin]));
+  const pluginIds = plugins.map((plugin) => plugin.id);
+  const selectedPluginIdSet = new Set(selectedPluginIds);
+  const selectedPluginIdsInPayloadOrder = selectedPluginIds.filter((pluginId) =>
+    pluginsById.has(pluginId)
+  );
+  const fallbackPluginOrder = showSelectedPluginsFirst
+    ? [
+        ...selectedPluginIdsInPayloadOrder,
+        ...pluginIds.filter((pluginId) => !selectedPluginIdSet.has(pluginId)),
+      ]
+    : pluginIds;
+  const orderedPluginIds = pluginOrder ?? fallbackPluginOrder;
+  const pluginOrderSet = new Set(orderedPluginIds);
+
+  return [
+    ...orderedPluginIds.flatMap((pluginId) => {
+      const plugin = pluginsById.get(pluginId);
+      return plugin ? [plugin] : [];
+    }),
+    ...plugins.filter((plugin) => !pluginOrderSet.has(plugin.id)),
+  ];
+}
+
+type SortablePluginListItemProps = {
+  id: string;
+  index: number;
+  children: (dragHandle: React.ReactNode) => React.ReactNode;
+};
+
+function SortablePluginListItem({
+  id,
+  index,
+  children,
+}: SortablePluginListItemProps) {
+  const { ref, handleRef, isDragging } = useSortable({
+    id,
+    index,
+    type: 'plugin',
+    accept: 'plugin',
+  });
+
+  return (
+    <FormItem
+      ref={ref}
+      className={cn(
+        'flex flex-row items-start space-y-0 space-x-3',
+        isDragging && 'opacity-60'
+      )}
+    >
+      {children(
+        <button
+          ref={handleRef}
+          type='button'
+          aria-label={`Reorder ${id}`}
+          className='text-muted-foreground flex h-4 w-4 cursor-grab items-center justify-center rounded-sm hover:text-black focus-visible:ring-2 focus-visible:outline-none active:cursor-grabbing'
+        >
+          <GripVerticalIcon className='h-4 w-4' />
+        </button>
+      )}
+    </FormItem>
+  );
+}
+
 type PluginMultiSelectFieldProps<
   TFieldValues extends FieldValues,
   TName extends FieldPathByValue<TFieldValues, Array<string>>,
@@ -90,6 +174,18 @@ type PluginMultiSelectFieldProps<
   description?: React.ReactNode;
   plugins: readonly PreconfiguredPluginDescriptor[];
   secrets: readonly Secret[];
+  /**
+   * Enable drag-and-drop reordering for plugins. In this mode, all plugins are
+   * displayed in a sortable list and selected plugins are stored in the same
+   * order in which they appear in the list.
+   */
+  enableReordering?: boolean;
+  /**
+   * Show selected plugins first in their form value order before the user has
+   * reordered the list. This is intended for reruns, where an existing payload
+   * order should be reflected in the UI.
+   */
+  showSelectedPluginsFirst?: boolean;
   className?: string;
 };
 
@@ -105,92 +201,56 @@ export const PluginMultiSelectField = <
   description,
   plugins,
   secrets,
+  enableReordering = false,
+  showSelectedPluginsFirst = false,
   className,
 }: PluginMultiSelectFieldProps<TFieldValues, TName>) => {
+  const [pluginOrder, setPluginOrder] = React.useState<string[]>();
+
   return (
     <FormField
       control={form.control}
       name={name}
-      render={({ field }) => (
-        <FormItem
-          className={cn(
-            'flex flex-col justify-between rounded-lg border p-4',
-            className
-          )}
-        >
-          <FormLabel>{label}</FormLabel>
-          <FormDescription className='pb-4'>{description}</FormDescription>
-          <div className='flex items-center space-x-3'>
-            <Checkbox
-              id='check-all-items'
-              checked={
-                plugins.every((plugin) =>
-                  form.getValues(name).includes(plugin.id)
-                )
-                  ? true
-                  : plugins.some((plugin) =>
-                        form.getValues(name).includes(plugin.id)
-                      )
-                    ? 'indeterminate'
-                    : false
-              }
-              onCheckedChange={(checked) => {
-                const enabledItems = checked
-                  ? plugins.map((plugin) => plugin.id)
-                  : [];
-                form.setValue(
-                  name,
-                  // TypeScript doesn't get this, but TName extends FieldPathByValue<TFieldValues, Array<string>>,
-                  // so the field behind TName is always an Array<string>
-                  // and options.map((option) => option.id) is also Array<string>,
-                  // so this type cast is safe.
-                  enabledItems as FieldPathValue<TFieldValues, TName>
-                );
-                if (scannerScopeName) {
-                  if (checked) {
-                    plugins.forEach((plugin) => {
-                      const scopePath =
-                        `${scannerScopeName}.${plugin.id}` as Path<TFieldValues>;
-                      if (!form.getValues(scopePath)) {
-                        form.setValue(
-                          scopePath,
-                          'both' as FieldPathValue<
-                            TFieldValues,
-                            Path<TFieldValues>
-                          >
-                        );
-                      }
-                    });
-                  } else {
-                    plugins.forEach((plugin) => {
-                      form.setValue(
-                        `${scannerScopeName}.${plugin.id}` as Path<TFieldValues>,
-                        undefined as FieldPathValue<
-                          TFieldValues,
-                          Path<TFieldValues>
-                        >
-                      );
-                    });
-                  }
-                }
-              }}
-            />
-            <Label htmlFor='check-all-items' className='font-bold'>
-              Enable/disable all
-            </Label>
-          </div>
-          <Separator className='my-2' />
-          {plugins.map((plugin) => (
-            <FormItem
-              key={plugin.id}
-              className='flex flex-row items-start space-y-0 space-x-3'
-            >
+      render={({ field }) => {
+        const selectedPluginIds = (field.value ?? []) as string[];
+        const selectedPluginIdSet = new Set(selectedPluginIds);
+        const pluginsInDisplayOrder = getPluginsInDisplayOrder(
+          plugins,
+          selectedPluginIds,
+          showSelectedPluginsFirst,
+          pluginOrder
+        );
+
+        const selectedPluginIdsInOrder = (
+          orderedPlugins: readonly PreconfiguredPluginDescriptor[],
+          selectedIds: ReadonlySet<string>
+        ) =>
+          orderedPlugins
+            .map((plugin) => plugin.id)
+            .filter((pluginId) => selectedIds.has(pluginId));
+
+        const renderPluginItemContent = (
+          plugin: PreconfiguredPluginDescriptor,
+          dragHandle?: React.ReactNode
+        ) => {
+          const isSelected = selectedPluginIdSet.has(plugin.id);
+
+          return (
+            <>
+              {dragHandle}
               <FormControl>
                 <Checkbox
-                  checked={field.value?.includes(plugin.id)}
+                  checked={isSelected}
                   onCheckedChange={(checked) => {
-                    if (checked) {
-                      field.onChange([...field.value, plugin.id]);
+                    if (checked === true) {
+                      field.onChange(
+                        enableReordering
+                          ? selectedPluginIdsInOrder(
+                              pluginsInDisplayOrder,
+                              new Set([...selectedPluginIds, plugin.id])
+                            )
+                          : [...selectedPluginIds, plugin.id]
+                      );
                       if (scannerScopeName) {
                         const scopePath =
                           `${scannerScopeName}.${plugin.id}` as Path<TFieldValues>;
@@ -205,10 +265,17 @@ export const PluginMultiSelectField = <
                         }
                       }
                     } else {
+                      const nextSelectedPluginIds = selectedPluginIds.filter(
+                        (value: string) => value !== plugin.id
+                      );
+
                       field.onChange(
-                        field.value?.filter(
-                          (value: string) => value !== plugin.id
-                        )
+                        enableReordering
+                          ? selectedPluginIdsInOrder(
+                              pluginsInDisplayOrder,
+                              new Set(nextSelectedPluginIds)
+                            )
+                          : nextSelectedPluginIds
                       );
                       if (scannerScopeName) {
                         form.setValue(
@@ -233,7 +300,7 @@ export const PluginMultiSelectField = <
                     className='text-muted-foreground max-w-none pb-1 [&_p]:my-0'
                   />
                 )}
-                {scannerScopeName && field.value?.includes(plugin.id) && (
+                {scannerScopeName && isSelected && (
                   <FormField
                     control={form.control}
                     name={
@@ -276,7 +343,7 @@ export const PluginMultiSelectField = <
                     )}
                   />
                 )}
-                {field.value?.includes(plugin.id) &&
+                {isSelected &&
                   plugin.options.map((option) => (
                     <FormField
                       control={form.control}
@@ -395,17 +462,197 @@ export const PluginMultiSelectField = <
                     />
                   ))}
               </div>
-            </FormItem>
-          ))}
-          <FormMessage />
-        </FormItem>
-      )}
+            </>
+          );
+        };
+
+        const renderStaticPluginItem = (
+          plugin: PreconfiguredPluginDescriptor
+        ) => (
+          <FormItem
+            key={plugin.id}
+            className='flex flex-row items-start space-y-0 space-x-3'
+          >
+            {renderPluginItemContent(plugin)}
+          </FormItem>
+        );
+
+        return (
+          <FormItem
+            className={cn(
+              'flex flex-col justify-between rounded-lg border p-4',
+              className
+            )}
+          >
+            <FormLabel>{label}</FormLabel>
+            <FormDescription className='pb-4'>{description}</FormDescription>
+            <div className='flex items-center space-x-3'>
+              <Checkbox
+                id='check-all-items'
+                checked={
+                  plugins.every((plugin) =>
+                    form.getValues(name).includes(plugin.id)
+                  )
+                    ? true
+                    : plugins.some((plugin) =>
+                          form.getValues(name).includes(plugin.id)
+                        )
+                      ? 'indeterminate'
+                      : false
+                }
+                onCheckedChange={(checked) => {
+                  const enabledItems =
+                    checked === true
+                      ? enableReordering
+                        ? pluginsInDisplayOrder.map((plugin) => plugin.id)
+                        : plugins.map((plugin) => plugin.id)
+                      : [];
+
+                  form.setValue(
+                    name,
+                    // TypeScript doesn't get this, but TName extends FieldPathByValue<TFieldValues, Array<string>>,
+                    // so the field behind TName is always an Array<string>
+                    // and options.map((option) => option.id) is also Array<string>,
+                    // so this type cast is safe.
+                    enabledItems as FieldPathValue<TFieldValues, TName>
+                  );
+                  if (scannerScopeName) {
+                    if (checked === true) {
+                      plugins.forEach((plugin) => {
+                        const scopePath =
+                          `${scannerScopeName}.${plugin.id}` as Path<TFieldValues>;
+                        if (!form.getValues(scopePath)) {
+                          form.setValue(
+                            scopePath,
+                            'both' as FieldPathValue<
+                              TFieldValues,
+                              Path<TFieldValues>
+                            >
+                          );
+                        }
+                      });
+                    } else {
+                      plugins.forEach((plugin) => {
+                        form.setValue(
+                          `${scannerScopeName}.${plugin.id}` as Path<TFieldValues>,
+                          undefined as FieldPathValue<
+                            TFieldValues,
+                            Path<TFieldValues>
+                          >
+                        );
+                      });
+                    }
+                  }
+                }}
+              />
+              <Label htmlFor='check-all-items' className='font-bold'>
+                Enable/disable all
+              </Label>
+            </div>
+            <Separator className='my-2' />
+            {enableReordering ? (
+              <DragDropProvider
+                onDragEnd={(event) => {
+                  if (event.canceled) return;
+
+                  const { source } = event.operation;
+
+                  if (isSortable(source)) {
+                    const { initialIndex, index } = source;
+
+                    if (initialIndex !== index) {
+                      const nextPluginOrder = moveItem(
+                        pluginsInDisplayOrder.map((plugin) => plugin.id),
+                        initialIndex,
+                        index
+                      );
+
+                      setPluginOrder(nextPluginOrder);
+                      field.onChange(
+                        nextPluginOrder.filter((pluginId) =>
+                          selectedPluginIdSet.has(pluginId)
+                        )
+                      );
+                    }
+                  }
+                }}
+              >
+                <div className='flex flex-col gap-2'>
+                  {pluginsInDisplayOrder.map((plugin, index) => (
+                    <SortablePluginListItem
+                      key={plugin.id}
+                      id={plugin.id}
+                      index={index}
+                    >
+                      {(dragHandle) =>
+                        renderPluginItemContent(plugin, dragHandle)
+                      }
+                    </SortablePluginListItem>
+                  ))}
+                </div>
+              </DragDropProvider>
+            ) : (
+              plugins.map(renderStaticPluginItem)
+            )}
+            <FormMessage />
+          </FormItem>
+        );
+      }}
     />
   );
 };
 
 if (import.meta.vitest) {
   const { describe, expect, it } = import.meta.vitest;
+
+  describe('moveItem', () => {
+    it('moves an item from one index to another', () => {
+      expect(moveItem(['File', 'ClearlyDefined', 'OrtConfig'], 0, 2)).toEqual([
+        'ClearlyDefined',
+        'OrtConfig',
+        'File',
+      ]);
+    });
+  });
+
+  describe('getPluginsInDisplayOrder', () => {
+    const plugins = [
+      { id: 'ClearlyDefined' },
+      { id: 'DefaultFile' },
+      { id: 'OrtConfig' },
+    ];
+
+    it('keeps plugins in their original order by default', () => {
+      expect(
+        getPluginsInDisplayOrder(
+          plugins,
+          ['DefaultFile', 'ClearlyDefined'],
+          false
+        ).map((plugin) => plugin.id)
+      ).toEqual(['ClearlyDefined', 'DefaultFile', 'OrtConfig']);
+    });
+
+    it('shows enabled plugins first in payload order for an existing selection', () => {
+      expect(
+        getPluginsInDisplayOrder(
+          plugins,
+          ['DefaultFile', 'ClearlyDefined'],
+          true
+        ).map((plugin) => plugin.id)
+      ).toEqual(['DefaultFile', 'ClearlyDefined', 'OrtConfig']);
+    });
+
+    it('uses the explicitly sorted plugin order when set', () => {
+      expect(
+        getPluginsInDisplayOrder(
+          plugins,
+          ['DefaultFile', 'ClearlyDefined'],
+          false,
+          ['OrtConfig', 'DefaultFile', 'ClearlyDefined']
+        ).map((plugin) => plugin.id)
+      ).toEqual(['OrtConfig', 'DefaultFile', 'ClearlyDefined']);
+    });
+  });
 
   describe('mapSecretSelectValue', () => {
     it('maps the explicit not defined option to undefined', () => {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
@@ -71,6 +71,7 @@ type AnalyzerFieldsProps = {
   isSuperuser: boolean;
   packageCurationProviderPlugins: PreconfiguredPluginDescriptor[];
   pluginSecrets: Secret[];
+  isRerun: boolean;
   permissions: {
     organization: OrganizationPermissions | undefined;
     product: ProductPermissions | undefined;
@@ -85,6 +86,7 @@ export const AnalyzerFields = ({
   isSuperuser,
   packageCurationProviderPlugins,
   pluginSecrets,
+  isRerun,
   permissions,
 }: AnalyzerFieldsProps) => {
   const { orgId, productId, repoId } = useParams({ strict: false });
@@ -379,10 +381,16 @@ export const AnalyzerFields = ({
             configName='jobConfigs.analyzer.packageCurationProviderConfig'
             label='Package curation providers'
             description={
-              <>Select the package curation providers enabled for this run.</>
+              <>
+                Configure the package curation providers to use. Providers
+                higher in the list take precedence over lower providers. Change
+                the order of providers via drag & drop.
+              </>
             }
             plugins={packageCurationProviderPlugins}
             secrets={pluginSecrets}
+            enableReordering
+            showSelectedPluginsFirst={isRerun}
           />
           {isSuperuser && (
             <FormField

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
@@ -22,7 +22,12 @@ import { PlusIcon, TrashIcon } from 'lucide-react';
 import { useEffect } from 'react';
 import { useFieldArray, UseFormReturn } from 'react-hook-form';
 
-import { InfrastructureService } from '@/api';
+import {
+  InfrastructureService,
+  PreconfiguredPluginDescriptor,
+  Secret,
+} from '@/api';
+import { PluginMultiSelectField } from '@/components/form/plugin-multi-select-field.tsx';
 import { InlineCode } from '@/components/typography.tsx';
 import {
   AccordionContent,
@@ -64,6 +69,8 @@ type AnalyzerFieldsProps = {
   value: string;
   onToggle: () => void;
   isSuperuser: boolean;
+  packageCurationProviderPlugins: PreconfiguredPluginDescriptor[];
+  pluginSecrets: Secret[];
   permissions: {
     organization: OrganizationPermissions | undefined;
     product: ProductPermissions | undefined;
@@ -76,6 +83,8 @@ export const AnalyzerFields = ({
   value,
   onToggle,
   isSuperuser,
+  packageCurationProviderPlugins,
+  pluginSecrets,
   permissions,
 }: AnalyzerFieldsProps) => {
   const { orgId, productId, repoId } = useParams({ strict: false });
@@ -364,6 +373,17 @@ export const AnalyzerFields = ({
             infrastructureServices={infrastructureServices}
           />
           <PackageManagerField form={form} />
+          <PluginMultiSelectField
+            form={form}
+            name='jobConfigs.analyzer.packageCurationProviders'
+            configName='jobConfigs.analyzer.packageCurationProviderConfig'
+            label='Package curation providers'
+            description={
+              <>Select the package curation providers enabled for this run.</>
+            }
+            plugins={packageCurationProviderPlugins}
+            secrets={pluginSecrets}
+          />
           {isSuperuser && (
             <FormField
               control={form.control}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/package-manager-field.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/package-manager-field.tsx
@@ -60,7 +60,7 @@ export const PackageManagerField = ({
       render={({ field }) => (
         <FormItem
           className={cn(
-            'mb-4 flex flex-col justify-between rounded-lg border p-4',
+            'flex flex-col justify-between rounded-lg border p-4',
             className
           )}
         >

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/default-values.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/default-values.ts
@@ -23,6 +23,7 @@ import { convertMapToArray } from './form-primitives';
 import {
   getPluginDefaultValues,
   mergePluginConfigs,
+  providerPluginConfigsToFormValues,
   reconstructScannerSelection,
 } from './plugin-utils';
 import type { CreateRunFormValues } from './run-schema';
@@ -35,7 +36,8 @@ export function defaultValues(
   ortRun: OrtRun | null,
   advisorPlugins: PreconfiguredPluginDescriptor[],
   scannerPlugins: PreconfiguredPluginDescriptor[],
-  isSuperuser: boolean
+  isSuperuser: boolean,
+  packageCurationProviderPlugins: PreconfiguredPluginDescriptor[]
 ): CreateRunFormValues {
   /**
    * Constructs the default options for a package manager, either as a blank set of options
@@ -85,6 +87,12 @@ export function defaultValues(
 
   const advisorPluginDefaultValues = getPluginDefaultValues(advisorPlugins);
   const scannerPluginDefaultValues = getPluginDefaultValues(scannerPlugins);
+  const packageCurationProviderPluginDefaultValues = getPluginDefaultValues(
+    packageCurationProviderPlugins
+  );
+  const packageCurationProviderFormValues = providerPluginConfigsToFormValues(
+    ortRun?.jobConfigs.analyzer?.packageCurationProviders
+  );
   const scannerDefaults = {
     scanners: ['ScanCode'],
     scannerScopes: {
@@ -105,6 +113,9 @@ export function defaultValues(
         keepAliveWorker: false,
         environmentDefinitions: undefined,
         infrastructureServices: [],
+        packageCurationProviders: [],
+        packageCurationProviderConfig:
+          packageCurationProviderPluginDefaultValues,
         packageManagers: {
           Bazel: defaultPackageManagerOptions('Bazel'),
           Bower: defaultPackageManagerOptions('Bower'),
@@ -223,6 +234,12 @@ export function defaultValues(
               ortRun.jobConfigs.analyzer?.environmentConfig
                 ?.infrastructureServices ||
               baseDefaults.jobConfigs.analyzer.infrastructureServices,
+            packageCurationProviders:
+              packageCurationProviderFormValues.selectedPluginIds,
+            packageCurationProviderConfig: mergePluginConfigs(
+              packageCurationProviderFormValues.config,
+              packageCurationProviderPluginDefaultValues
+            ),
             keepAliveWorker:
               (ortRun.jobConfigs.analyzer?.keepAliveWorker && isSuperuser) ||
               baseDefaults.jobConfigs.analyzer.keepAliveWorker,
@@ -345,11 +362,85 @@ if (import.meta.vitest) {
       labels: {},
     } as unknown as OrtRun;
 
-    const defaults = defaultValues(ortRun, [], [], false);
+    const defaults = defaultValues(ortRun, [], [], false, []);
 
     expect(defaults.jobConfigs.analyzer.environmentDefinitions).toEqual(
       ortRun.jobConfigs.analyzer?.environmentConfig?.environmentDefinitions
     );
+  });
+
+  it('uses package curation provider plugin default values for fresh runs', () => {
+    const defaults = defaultValues(null, [], [], false, [
+      {
+        id: 'ClearlyDefined',
+        type: 'PACKAGE_CURATION_PROVIDER',
+        displayName: 'ClearlyDefined',
+        summary: 'A package curation provider plugin',
+        description: 'A package curation provider plugin.',
+        options: [
+          {
+            name: 'serverUrl',
+            description: 'Backend URL.',
+            type: 'STRING',
+            defaultValue: 'https://api.clearlydefined.io',
+            isFixed: true,
+            isNullable: false,
+            isRequired: true,
+          },
+        ],
+      },
+    ]);
+
+    expect(defaults.jobConfigs.analyzer.packageCurationProviders).toEqual([]);
+    expect(defaults.jobConfigs.analyzer.packageCurationProviderConfig).toEqual({
+      ClearlyDefined: {
+        options: {
+          serverUrl: 'https://api.clearlydefined.io',
+        },
+        secrets: {},
+      },
+    });
+  });
+
+  it('preserves package curation provider config from reruns', () => {
+    const ortRun = {
+      revision: 'main',
+      path: '',
+      jobConfigs: {
+        analyzer: {
+          packageCurationProviders: [
+            {
+              type: 'ClearlyDefined',
+              id: 'ClearlyDefined',
+              enabled: true,
+              options: {
+                serverUrl: 'https://api.clearlydefined.io',
+              },
+              secrets: {
+                token: 'clearly-defined-token',
+              },
+            },
+          ],
+        },
+      },
+      labels: {},
+    } as unknown as OrtRun;
+
+    const defaults = defaultValues(ortRun, [], [], false, []);
+
+    expect(defaults.jobConfigs.analyzer.packageCurationProviders).toEqual([
+      'ClearlyDefined',
+    ]);
+    expect(defaults.jobConfigs.analyzer.packageCurationProviderConfig).toEqual({
+      ClearlyDefined: {
+        options: {
+          serverUrl: 'https://api.clearlydefined.io',
+        },
+        secrets: {
+          token: 'clearly-defined-token',
+        },
+      },
+    });
   });
 
   it('uses scanner plugin default values for fresh runs', () => {
@@ -376,7 +467,8 @@ if (import.meta.vitest) {
           ],
         },
       ],
-      false
+      false,
+      []
     );
 
     expect(defaults.jobConfigs.scanner.config).toEqual({

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/payload.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/payload.ts
@@ -24,7 +24,10 @@ import {
 } from '@/api';
 import { defaultValues } from './default-values';
 import { convertArrayToMap } from './form-primitives';
-import { createPluginPayload } from './plugin-utils';
+import {
+  createPluginPayload,
+  createProviderPluginPayload,
+} from './plugin-utils';
 import type { CreateRunFormValues } from './run-schema';
 
 /**
@@ -146,6 +149,10 @@ export function formValuesToPayload(
     // that have options set in the form.
     packageManagerOptions: getPackageManagerOptions(
       values.jobConfigs.analyzer.packageManagers
+    ),
+    packageCurationProviders: createProviderPluginPayload(
+      values.jobConfigs.analyzer.packageCurationProviderConfig,
+      values.jobConfigs.analyzer.packageCurationProviders
     ),
     keepAliveWorker: values.jobConfigs.analyzer.keepAliveWorker || undefined,
   };
@@ -338,7 +345,7 @@ if (import.meta.vitest) {
 
   function createFormValues(): CreateRunFormValues {
     return {
-      ...defaultValues(null, [], [], false),
+      ...defaultValues(null, [], [], false, []),
       revision: 'main',
       path: '',
     };
@@ -384,6 +391,62 @@ if (import.meta.vitest) {
       expect(
         payload.jobConfigs.analyzer?.environmentConfig?.environmentDefinitions
       ).toEqual(values.jobConfigs.analyzer.environmentDefinitions);
+    });
+
+    it('adds selected package curation providers', () => {
+      const values = createFormValues();
+      values.jobConfigs.analyzer.packageCurationProviders = ['ClearlyDefined'];
+      values.jobConfigs.analyzer.packageCurationProviderConfig = {
+        ClearlyDefined: {
+          options: {
+            serverUrl: 'https://api.clearlydefined.io',
+          },
+          secrets: {
+            token: 'clearly-defined-token',
+          },
+        },
+        File: {
+          options: {
+            path: 'curations.yml',
+          },
+          secrets: {},
+        },
+      };
+
+      const payload = formValuesToPayload(values);
+
+      expect(payload.jobConfigs.analyzer?.packageCurationProviders).toEqual([
+        {
+          type: 'ClearlyDefined',
+          id: 'ClearlyDefined',
+          enabled: true,
+          options: {
+            serverUrl: 'https://api.clearlydefined.io',
+          },
+          secrets: {
+            token: 'clearly-defined-token',
+          },
+        },
+      ]);
+    });
+
+    it('omits package curation providers if none are selected', () => {
+      const values = createFormValues();
+      values.jobConfigs.analyzer.packageCurationProviders = [];
+      values.jobConfigs.analyzer.packageCurationProviderConfig = {
+        ClearlyDefined: {
+          options: {
+            serverUrl: 'https://api.clearlydefined.io',
+          },
+          secrets: {},
+        },
+      };
+
+      const payload = formValuesToPayload(values);
+
+      expect(
+        payload.jobConfigs.analyzer?.packageCurationProviders
+      ).toBeUndefined();
     });
 
     it('omits infrastructure services from environment configs', () => {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/plugin-utils.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/plugin-utils.ts
@@ -23,6 +23,7 @@ import {
   PluginConfig,
   PluginOptionType,
   PreconfiguredPluginDescriptor,
+  ProviderPluginConfiguration,
 } from '@/api';
 
 function isNonBlankString(value: unknown): value is string {
@@ -78,7 +79,8 @@ export function validateRequiredPluginOptions(
   config:
     | Record<string, Record<string, Record<string, unknown>> | undefined>
     | undefined,
-  ctx: z.RefinementCtx
+  ctx: z.RefinementCtx,
+  configPath = 'config'
 ): void {
   for (const plugin of plugins) {
     if (!selectedPluginIds.includes(plugin.id)) continue;
@@ -96,7 +98,7 @@ export function validateRequiredPluginOptions(
           code: 'invalid_type',
           expected: 'string',
           received: 'undefined',
-          path: ['config', plugin.id, section, option.name],
+          path: [configPath, plugin.id, section, option.name],
           message: `Required option "${option.name}" is missing for "${plugin.displayName}".`,
         });
       }
@@ -265,6 +267,38 @@ export function getPluginDefaultValues(
   );
 }
 
+type ProviderPluginFormValues = {
+  selectedPluginIds: string[];
+  config: Record<string, PluginConfig>;
+};
+
+/**
+ * Convert provider plugin configurations from a previous run to the form representation.
+ */
+export function providerPluginConfigsToFormValues(
+  providers: ProviderPluginConfiguration[] | null | undefined
+): ProviderPluginFormValues {
+  const result: ProviderPluginFormValues = {
+    selectedPluginIds: [],
+    config: {},
+  };
+
+  providers?.forEach((provider) => {
+    const pluginId = provider.id || provider.type;
+
+    if (provider.enabled !== false) {
+      result.selectedPluginIds.push(pluginId);
+    }
+
+    result.config[pluginId] = {
+      options: provider.options ?? {},
+      secrets: provider.secrets ?? {},
+    };
+  });
+
+  return result;
+}
+
 /**
  * Convert the plugin config from form values to the payload format expected by the back-end. Configuration for plugins
  * which are not enabled is not included in the payload.
@@ -323,6 +357,34 @@ export function createPluginPayload(
     : undefined;
 }
 
+/**
+ * Convert selected provider plugins and their configuration to the payload format expected by the back-end.
+ */
+export function createProviderPluginPayload(
+  config: Record<string, unknown> | undefined,
+  enabledPlugins: string[]
+): ProviderPluginConfiguration[] | undefined {
+  if (enabledPlugins.length === 0) return undefined;
+
+  const pluginPayload = createPluginPayload(config, enabledPlugins);
+
+  return enabledPlugins.map((pluginId) => {
+    const pluginConfig = pluginPayload?.[pluginId];
+
+    return {
+      type: pluginId,
+      id: pluginId,
+      enabled: true,
+      ...(pluginConfig?.options && Object.keys(pluginConfig.options).length > 0
+        ? { options: pluginConfig.options }
+        : {}),
+      ...(pluginConfig?.secrets && Object.keys(pluginConfig.secrets).length > 0
+        ? { secrets: pluginConfig.secrets }
+        : {}),
+    };
+  });
+}
+
 if (import.meta.vitest) {
   const { expect, it } = import.meta.vitest;
 
@@ -351,6 +413,45 @@ if (import.meta.vitest) {
     expect(defaults.SCANOSS?.secrets).toEqual({});
   });
 
+  it('providerPluginConfigsToFormValues reconstructs selected providers and config', () => {
+    const formValues = providerPluginConfigsToFormValues([
+      {
+        type: 'ClearlyDefined',
+        id: 'ClearlyDefined',
+        enabled: true,
+        options: {
+          serverUrl: 'https://api.clearlydefined.io',
+        },
+        secrets: {
+          token: 'clearly-defined-token',
+        },
+      },
+      {
+        type: 'File',
+        id: 'File',
+        enabled: false,
+      },
+    ]);
+
+    expect(formValues).toEqual({
+      selectedPluginIds: ['ClearlyDefined'],
+      config: {
+        ClearlyDefined: {
+          options: {
+            serverUrl: 'https://api.clearlydefined.io',
+          },
+          secrets: {
+            token: 'clearly-defined-token',
+          },
+        },
+        File: {
+          options: {},
+          secrets: {},
+        },
+      },
+    });
+  });
+
   it('createPluginPayload omits blank secret values from the payload', () => {
     const payload = createPluginPayload(
       {
@@ -374,6 +475,39 @@ if (import.meta.vitest) {
         secrets: {},
       },
     });
+  });
+
+  it('createProviderPluginPayload creates provider configurations for selected plugins', () => {
+    const payload = createProviderPluginPayload(
+      {
+        ClearlyDefined: {
+          options: {
+            serverUrl: 'https://api.clearlydefined.io',
+          },
+          secrets: {
+            token: '',
+          },
+        },
+        File: {
+          options: {
+            path: 'curations.yml',
+          },
+          secrets: {},
+        },
+      },
+      ['ClearlyDefined']
+    );
+
+    expect(payload).toEqual([
+      {
+        type: 'ClearlyDefined',
+        id: 'ClearlyDefined',
+        enabled: true,
+        options: {
+          serverUrl: 'https://api.clearlydefined.io',
+        },
+      },
+    ]);
   });
 
   it('reconstructScannerSelection rebuilds scanner scopes for rerun values', () => {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/run-schema.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/run-schema.ts
@@ -35,7 +35,8 @@ import {
 
 export const createRunFormSchema = (
   advisorPlugins: PreconfiguredPluginDescriptor[],
-  scannerPlugins: PreconfiguredPluginDescriptor[]
+  scannerPlugins: PreconfiguredPluginDescriptor[],
+  packageCurationProviderPlugins: PreconfiguredPluginDescriptor[]
 ) => {
   const advisorConfigSchema: Record<string, z.ZodTypeAny> = {};
 
@@ -48,56 +49,81 @@ export const createRunFormSchema = (
     scannerConfigSchema[plugin.id] = createPluginConfigSchema(plugin);
   });
 
+  const packageCurationProviderConfigSchema: Record<string, z.ZodTypeAny> = {};
+  packageCurationProviderPlugins.forEach((plugin) => {
+    packageCurationProviderConfigSchema[plugin.id] =
+      createPluginConfigSchema(plugin);
+  });
+
   return z.object({
     revision: z.string(),
     path: z.string(),
     jobConfigs: z.object({
-      analyzer: z.object({
-        enabled: z.boolean(),
-        repositoryConfigPath: z.string().optional(),
-        allowDynamicVersions: z.boolean(),
-        skipExcluded: z.boolean(),
-        environmentDefinitions: environmentDefinitionsSchema.optional(),
-        environmentVariables: z.array(environmentVariableSchema).optional(),
-        infrastructureServices: z.array(zInfrastructureService).optional(),
-        keepAliveWorker: z.boolean(),
-        packageManagers: z
-          .object({
-            Bazel: packageManagerOptionsSchema,
-            Bower: packageManagerOptionsSchema,
-            Bundler: packageManagerOptionsSchema,
-            Cargo: packageManagerOptionsSchema,
-            Carthage: packageManagerOptionsSchema,
-            CocoaPods: packageManagerOptionsSchema,
-            Composer: packageManagerOptionsSchema,
-            Conan: packageManagerOptionsSchema,
-            Gleam: packageManagerOptionsSchema,
-            GoMod: packageManagerOptionsSchema,
-            Gradle: packageManagerOptionsSchema,
-            GradleInspector: packageManagerOptionsSchema,
-            Maven: packageManagerOptionsSchema,
-            NPM: packageManagerOptionsSchema,
-            NuGet: packageManagerOptionsSchema,
-            OrtProjectFile: packageManagerOptionsSchema,
-            PIP: packageManagerOptionsSchema,
-            Pipenv: packageManagerOptionsSchema,
-            PNPM: packageManagerOptionsSchema,
-            Poetry: packageManagerOptionsSchema,
-            Pub: packageManagerOptionsSchema,
-            SBT: packageManagerOptionsSchema,
-            SPDX: packageManagerOptionsSchema,
-            SpdxDocumentFile: packageManagerOptionsSchema,
-            Stack: packageManagerOptionsSchema,
-            SwiftPM: packageManagerOptionsSchema,
-            Tycho: packageManagerOptionsSchema,
-            Yarn: packageManagerOptionsSchema,
-            Yarn2: packageManagerOptionsSchema,
-          })
-          .refine((schema) => {
-            // Ensure that not both Gradle and GradleInspector are enabled at the same time.
-            return !(schema.Gradle.enabled && schema.GradleInspector.enabled);
-          }, '"Gradle Legacy" and "Gradle" cannot be enabled at the same time.'),
-      }),
+      analyzer: z
+        .object({
+          enabled: z.boolean(),
+          repositoryConfigPath: z.string().optional(),
+          allowDynamicVersions: z.boolean(),
+          skipExcluded: z.boolean(),
+          environmentDefinitions: environmentDefinitionsSchema.optional(),
+          environmentVariables: z.array(environmentVariableSchema).optional(),
+          infrastructureServices: z.array(zInfrastructureService).optional(),
+          keepAliveWorker: z.boolean(),
+          packageCurationProviders: z.array(z.string()),
+          packageCurationProviderConfig: z
+            .object(packageCurationProviderConfigSchema)
+            .optional(),
+          packageManagers: z
+            .object({
+              Bazel: packageManagerOptionsSchema,
+              Bower: packageManagerOptionsSchema,
+              Bundler: packageManagerOptionsSchema,
+              Cargo: packageManagerOptionsSchema,
+              Carthage: packageManagerOptionsSchema,
+              CocoaPods: packageManagerOptionsSchema,
+              Composer: packageManagerOptionsSchema,
+              Conan: packageManagerOptionsSchema,
+              Gleam: packageManagerOptionsSchema,
+              GoMod: packageManagerOptionsSchema,
+              Gradle: packageManagerOptionsSchema,
+              GradleInspector: packageManagerOptionsSchema,
+              Maven: packageManagerOptionsSchema,
+              NPM: packageManagerOptionsSchema,
+              NuGet: packageManagerOptionsSchema,
+              OrtProjectFile: packageManagerOptionsSchema,
+              PIP: packageManagerOptionsSchema,
+              Pipenv: packageManagerOptionsSchema,
+              PNPM: packageManagerOptionsSchema,
+              Poetry: packageManagerOptionsSchema,
+              Pub: packageManagerOptionsSchema,
+              SBT: packageManagerOptionsSchema,
+              SPDX: packageManagerOptionsSchema,
+              SpdxDocumentFile: packageManagerOptionsSchema,
+              Stack: packageManagerOptionsSchema,
+              SwiftPM: packageManagerOptionsSchema,
+              Tycho: packageManagerOptionsSchema,
+              Yarn: packageManagerOptionsSchema,
+              Yarn2: packageManagerOptionsSchema,
+            })
+            .refine((schema) => {
+              // Ensure that not both Gradle and GradleInspector are enabled at the same time.
+              return !(schema.Gradle.enabled && schema.GradleInspector.enabled);
+            }, '"Gradle Legacy" and "Gradle" cannot be enabled at the same time.'),
+        })
+        .superRefine((data, ctx) => {
+          validateRequiredPluginOptions(
+            packageCurationProviderPlugins,
+            data.packageCurationProviders,
+            data.packageCurationProviderConfig as
+              | Record<
+                  string,
+                  Record<string, Record<string, unknown>> | undefined
+                >
+              | undefined,
+            ctx,
+            'packageCurationProviderConfig'
+          );
+        }),
       advisor: z
         .object({
           enabled: z.boolean(),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -464,6 +464,7 @@ const CreateRunPage = () => {
                 isSuperuser={isSuperuser}
                 packageCurationProviderPlugins={packageCurationProviderPlugins}
                 pluginSecrets={secrets.data || []}
+                isRerun={ortRun?.data != null}
                 permissions={permissions}
               />
               <AdvisorFields

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -88,6 +88,10 @@ const CreateRunPage = () => {
     plugins?.data?.filter((plugin) => plugin.type === 'REPORTER') || [];
   const scannerPlugins =
     plugins?.data?.filter((plugin) => plugin.type === 'SCANNER') || [];
+  const packageCurationProviderPlugins =
+    plugins?.data?.filter(
+      (plugin) => plugin.type === 'PACKAGE_CURATION_PROVIDER'
+    ) || [];
 
   type AccordionSection =
     | 'analyzer'
@@ -130,7 +134,11 @@ const CreateRunPage = () => {
     },
   });
 
-  const formSchema = createRunFormSchema(advisorPlugins, scannerPlugins);
+  const formSchema = createRunFormSchema(
+    advisorPlugins,
+    scannerPlugins,
+    packageCurationProviderPlugins
+  );
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),
@@ -138,7 +146,8 @@ const CreateRunPage = () => {
       ortRun?.data ?? null,
       advisorPlugins,
       scannerPlugins,
-      isSuperuser
+      isSuperuser,
+      packageCurationProviderPlugins
     ),
   });
 

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -462,6 +462,8 @@ const CreateRunPage = () => {
                 value='analyzer'
                 onToggle={() => toggleAccordionOpen('analyzer')}
                 isSuperuser={isSuperuser}
+                packageCurationProviderPlugins={packageCurationProviderPlugins}
+                pluginSecrets={secrets.data || []}
                 permissions={permissions}
               />
               <AdvisorFields


### PR DESCRIPTION
### Select providers from the list - the options are carried out from plugin options

Form:

<img width="1081" height="712" alt="Screenshot from 2026-06-17 13-08-12" src="https://github.com/user-attachments/assets/6abf7813-0bb4-433a-bafb-e117ba7e5a0a" />

Run payload: 

<img width="491" height="328" alt="Screenshot from 2026-06-17 13-08-34" src="https://github.com/user-attachments/assets/cc32d641-6f22-4b31-9a45-5ff68ec14b15" />

### The order of applying providers can be changed by drag-and-drop

The order of curation providers matters in the run payload: the providers on top of the form override curations of earlier providers in the list. Here, Default File is applied with higher priority than ClearlyDefined, as it's higher on the list.

Form:

<img width="1085" height="718" alt="Screenshot from 2026-06-17 13-09-11" src="https://github.com/user-attachments/assets/75ab05df-530a-4e11-a4e4-be4c38d662f7" />

Run payload:

<img width="483" height="323" alt="Screenshot from 2026-06-17 13-09-32" src="https://github.com/user-attachments/assets/c9502049-f4ba-4c12-92f1-41d0395b0d32" />

Please see the commits for details.