### PR TITLE
build(gradle): Avoid using property delegates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,11 +19,11 @@
 
 import git.semver.plugin.gradle.PrintTask
 
-val dockerBaseBuildArgs: String by project
-val dockerBaseImageTag: String by project
-val dockerImageTag: String by project
-val containerEngineCommand: String by project
-val javaLanguageVersion: String by project
+val dockerBaseBuildArgs = project.property("dockerBaseBuildArgs") as String
+val dockerBaseImageTag = project.property("dockerBaseImageTag") as String
+val dockerImageTag = project.property("dockerImageTag") as String
+val containerEngineCommand = project.property("containerEngineCommand") as String
+val javaLanguageVersion = project.property("javaLanguageVersion") as String
 
 plugins {
     alias(libs.plugins.gitSemver)
@@ -176,7 +176,7 @@ rootDir.walk().maxDepth(4).filter { it.isFile && it.extension == "Dockerfile" }.
     }
 }
 
-val buildAllWorkerImages by tasks.registering {
+val buildAllWorkerImages = tasks.register("buildAllWorkerImages") {
     group = "Docker"
     description = "Builds all worker Docker images."
 

--- a/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-conventions.gradle.kts
@@ -22,7 +22,7 @@ import kotlin.enums.enumEntries
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-val javaLanguageVersion: String by project
+val javaLanguageVersion = project.property("javaLanguageVersion") as String
 
 plugins {
     // Apply precompiled plugins.

--- a/components/snippet-findings/backend/build.gradle.kts
+++ b/components/snippet-findings/backend/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
     implementation(projects.dao)
 
     routesApi(projects.components.authorization.authorizationBackend)
-    
+
     routesImplementation(ktorLibs.server.core)
     routesImplementation(projects.shared.apiMappings)
     routesImplementation(projects.shared.ktorUtils)

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -17,10 +17,10 @@
  * License-Filename: LICENSE
  */
 
-val dockerImagePrefix: String by project
-val dockerImageTag: String by project
-val dockerBaseImagePrefix: String by project
-val dockerBaseImageTag: String by project
+val dockerImagePrefix = project.property("dockerImagePrefix") as String
+val dockerImageTag = project.property("dockerImageTag") as String
+val dockerBaseImagePrefix = project.property("dockerBaseImagePrefix") as String
+val dockerBaseImageTag = project.property("dockerBaseImageTag") as String
 
 plugins {
     // Apply core plugins.
@@ -208,7 +208,7 @@ tinyJib {
     }
 }
 
-val test by testing.suites.existing(JvmTestSuite::class)
+val test = testing.suites.withType(JvmTestSuite::class)
 
 tasks.register<Test>("generateOpenApiSpec") {
     group = "API"

--- a/orchestrator/build.gradle.kts
+++ b/orchestrator/build.gradle.kts
@@ -17,10 +17,10 @@
  * License-Filename: LICENSE
  */
 
-val dockerImagePrefix: String by project
-val dockerImageTag: String by project
-val dockerBaseImagePrefix: String by project
-val dockerBaseImageTag: String by project
+val dockerImagePrefix = project.property("dockerImagePrefix") as String
+val dockerImageTag = project.property("dockerImageTag") as String
+val dockerBaseImagePrefix = project.property("dockerBaseImagePrefix") as String
+val dockerBaseImageTag = project.property("dockerBaseImageTag") as String
 
 plugins {
     // Apply precompiled plugins.

--- a/tasks/build.gradle.kts
+++ b/tasks/build.gradle.kts
@@ -17,10 +17,10 @@
  * License-Filename: LICENSE
  */
 
-val dockerImagePrefix: String by project
-val dockerImageTag: String by project
-val dockerBaseImagePrefix: String by project
-val dockerBaseImageTag: String by project
+val dockerImagePrefix = project.property("dockerImagePrefix") as String
+val dockerImageTag = project.property("dockerImageTag") as String
+val dockerBaseImagePrefix = project.property("dockerBaseImagePrefix") as String
+val dockerBaseImageTag = project.property("dockerBaseImageTag") as String
 
 plugins {
     // Apply precompiled plugins.

--- a/workers/advisor/build.gradle.kts
+++ b/workers/advisor/build.gradle.kts
@@ -17,10 +17,10 @@
  * License-Filename: LICENSE
  */
 
-val dockerImagePrefix: String by project
-val dockerImageTag: String by project
-val dockerBaseImagePrefix: String by project
-val dockerBaseImageTag: String by project
+val dockerImagePrefix = project.property("dockerImagePrefix") as String
+val dockerImageTag = project.property("dockerImageTag") as String
+val dockerBaseImagePrefix = project.property("dockerBaseImagePrefix") as String
+val dockerBaseImageTag = project.property("dockerBaseImageTag") as String
 
 plugins {
     // Apply core plugins.

--- a/workers/analyzer/build.gradle.kts
+++ b/workers/analyzer/build.gradle.kts
@@ -17,10 +17,10 @@
  * License-Filename: LICENSE
  */
 
-val dockerImagePrefix: String by project
-val dockerImageTag: String by project
-val dockerBaseImagePrefix: String by project
-val dockerBaseImageTag: String by project
+val dockerImagePrefix = project.property("dockerImagePrefix") as String
+val dockerImageTag = project.property("dockerImageTag") as String
+val dockerBaseImagePrefix = project.property("dockerBaseImagePrefix") as String
+val dockerBaseImageTag = project.property("dockerBaseImageTag") as String
 
 plugins {
     // Apply core plugins.

--- a/workers/config/build.gradle.kts
+++ b/workers/config/build.gradle.kts
@@ -17,10 +17,10 @@
  * License-Filename: LICENSE
  */
 
-val dockerBaseImagePrefix: String by project
-val dockerBaseImageTag: String by project
-val dockerImagePrefix: String by project
-val dockerImageTag: String by project
+val dockerBaseImagePrefix = project.property("dockerBaseImagePrefix") as String
+val dockerBaseImageTag = project.property("dockerBaseImageTag") as String
+val dockerImagePrefix = project.property("dockerImagePrefix") as String
+val dockerImageTag = project.property("dockerImageTag") as String
 
 plugins {
     // Apply core plugins.

--- a/workers/evaluator/build.gradle.kts
+++ b/workers/evaluator/build.gradle.kts
@@ -17,10 +17,10 @@
  * License-Filename: LICENSE
  */
 
-val dockerImagePrefix: String by project
-val dockerImageTag: String by project
-val dockerBaseImagePrefix: String by project
-val dockerBaseImageTag: String by project
+val dockerImagePrefix = project.property("dockerImagePrefix") as String
+val dockerImageTag = project.property("dockerImageTag") as String
+val dockerBaseImagePrefix = project.property("dockerBaseImagePrefix") as String
+val dockerBaseImageTag = project.property("dockerBaseImageTag") as String
 
 plugins {
     // Apply core plugins.

--- a/workers/notifier/build.gradle.kts
+++ b/workers/notifier/build.gradle.kts
@@ -17,10 +17,10 @@
  * License-Filename: LICENSE
  */
 
-val dockerImagePrefix: String by project
-val dockerImageTag: String by project
-val dockerBaseImagePrefix: String by project
-val dockerBaseImageTag: String by project
+val dockerImagePrefix = project.property("dockerImagePrefix") as String
+val dockerImageTag = project.property("dockerImageTag") as String
+val dockerBaseImagePrefix = project.property("dockerBaseImagePrefix") as String
+val dockerBaseImageTag = project.property("dockerBaseImageTag") as String
 
 plugins {
     // Apply core plugins.

--- a/workers/reporter/build.gradle.kts
+++ b/workers/reporter/build.gradle.kts
@@ -17,10 +17,10 @@
  * License-Filename: LICENSE
  */
 
-val dockerImagePrefix: String by project
-val dockerImageTag: String by project
-val dockerBaseImagePrefix: String by project
-val dockerBaseImageTag: String by project
+val dockerImagePrefix = project.property("dockerImagePrefix") as String
+val dockerImageTag = project.property("dockerImageTag") as String
+val dockerBaseImagePrefix = project.property("dockerBaseImagePrefix") as String
+val dockerBaseImageTag = project.property("dockerBaseImageTag") as String
 
 plugins {
     // Apply core plugins.

--- a/workers/scanner/build.gradle.kts
+++ b/workers/scanner/build.gradle.kts
@@ -17,10 +17,10 @@
  * License-Filename: LICENSE
  */
 
-val dockerImagePrefix: String by project
-val dockerImageTag: String by project
-val dockerBaseImagePrefix: String by project
-val dockerBaseImageTag: String by project
+val dockerImagePrefix = project.property("dockerImagePrefix") as String
+val dockerImageTag = project.property("dockerImageTag") as String
+val dockerBaseImagePrefix = project.property("dockerBaseImagePrefix") as String
+val dockerBaseImageTag = project.property("dockerBaseImageTag") as String
 
 plugins {
     // Apply core plugins.


### PR DESCRIPTION
Gradle 9.6 will deprecate Kotlin DSL property delegates [1], so avoid using them as a preparation for the upgrade.

[1]: https://github.com/gradle/gradle/issues/37555