### PR TITLE
Make the Elasticsearch log provider compatible with the JSON logs

### DIFF
--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -29,7 +29,10 @@
             <sequenceNumberGenerator class="ch.qos.logback.core.spi.BasicSequenceNumberGenerator" />
             <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
                 <encoder class="ch.qos.logback.classic.encoder.JsonEncoder">
+                    <withArguments>false</withArguments>
                     <withContext>false</withContext>
+                    <withFormattedMessage>true</withFormattedMessage>
+                    <withMessage>false</withMessage>
                 </encoder>
             </appender>
         </then>

--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -28,7 +28,7 @@
         <then>
             <sequenceNumberGenerator class="ch.qos.logback.core.spi.BasicSequenceNumberGenerator" />
             <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-                <encoder class="ch.qos.logback.classic.encoder.JsonEncoder">
+                <encoder class="org.eclipse.apoapsis.ortserver.utils.logging.OrtServerJsonEncoder">
                     <withArguments>false</withArguments>
                     <withContext>false</withContext>
                     <withFormattedMessage>true</withFormattedMessage>

--- a/logaccess/elasticsearch/README.md
+++ b/logaccess/elasticsearch/README.md
@@ -6,34 +6,50 @@ This module provides an implementation of the [Log access abstraction](../README
 
 The `ElasticsearchLogFileProvider` sends requests against the Elasticsearch Search API to retrieve the logs of a
 specific ORT run and component. Results are fetched in chronological order and paginated using Elasticsearch's
-`search_after` mechanism with a stable sort on `time` and `sortId`.
+`search_after` mechanism with a stable sort on `timestamp` and `sequenceNumber`.
 
 The provider assumes a canonical indexed schema that ORT Server can query independent of the concrete collector used
 to ship logs to Elasticsearch. Deployments are responsible for creating compatible Elasticsearch mappings and for
 normalizing metadata and extracted log fields into this shape before documents are indexed.
 
-The provider expects log documents to contain these fields:
+The provider expects log documents to follow the structured JSON schema produced by the
+[`OrtServerJsonEncoder`](../../utils/logging/src/main/kotlin/OrtServerJsonEncoder.kt) (the same field names emitted by
+the Logback JSON encoder, such as `formattedMessage`, `level`, `timestamp`, `sequenceNumber`, and the MDC entries under
+`mdc.*`). The relevant fields are:
 
-| Field | Expected Elasticsearch type | Purpose |
-|-------|-----------------------------|---------|
-| `namespace` | `keyword` | Exact-match deployment namespace filter; must match `elasticsearchNamespace`. |
-| `component` | `keyword` | Exact-match ORT component filter using ORT Server component names. |
-| `ortRunId` | `keyword` with optional `long` subfield, for example `ortRunId.numeric` | Exact-match ORT run ID filter. |
-| `level` | `keyword` | Exact-match log level filter using ORT Server log level names. |
-| `time` | `date` | ORT log event timestamp used for range queries and primary sorting. |
-| `sortId` | `keyword` | Secondary sort key for stable `search_after` pagination. |
-| `message` | present in `_source`; `text` recommended for Kibana searches | Rendered log line written to the downloaded log file. |
+| Field              | Used as                                | Expected Elasticsearch type    | Purpose                                                                                                                                         |
+|--------------------|----------------------------------------|--------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------|
+| `namespace`        | filter                                 | `keyword`                      | Exact-match deployment namespace filter; must match `elasticsearchNamespace`. The field name is configurable via `elasticsearchNamespaceField`. |
+| `mdc.component`    | filter (`mdc.component.keyword`)       | `text` with `keyword` subfield | Exact-match ORT component filter using ORT Server component names.                                                                              |
+| `mdc.ortRunId`     | filter (`mdc.ortRunId.keyword`)        | `text` with `keyword` subfield | Exact-match ORT run ID filter.                                                                                                                  |
+| `level`            | filter (`level.keyword`) and `_source` | `text` with `keyword` subfield | Exact-match log level filter; the level value is also prepended to each written log line.                                                       |
+| `timestamp`        | range filter, primary sort, `_source`  | `date` (`epoch_millis`)        | Log event timestamp; used for range queries, primary sorting, and rendered as the leading timestamp of each log line.                           |
+| `sequenceNumber`   | secondary sort                         | `long`                         | Stable tie-breaker for `search_after` pagination among hits that share the same `timestamp`.                                                    |
+| `formattedMessage` | `_source`                              | `text` recommended             | Rendered log line written to the downloaded log file.                                                                                           |
+| `throwable`        | `_source`                              | `text` recommended             | Optional rendered throwable; appended after the message when present.                                                                           |
 
-The `message` field is written to the downloaded log file unchanged, one line per hit. It does not need to be indexed
-for search by the provider, but it must be present in `_source`. Indexing `message` as a `text` field is recommended for
-Kibana, so users can search log lines, exceptions, request paths, and other free-form text. A `.keyword` subfield can be
-useful for exact matches, sorting, or aggregations, but should usually have an `ignore_above` limit to avoid indexing
-very large log lines as keyword terms.
+Filtering and sorting use the indexed (`keyword`) fields, while the log content is read from `_source`. The provider
+therefore requests only `level`, `formattedMessage`, `throwable`, and `timestamp` in `_source` and uses the indexed
+fields for the remaining filters and sorts. Each downloaded log line is rendered as `<timestamp> <level> <message>`,
+with the `throwable` (if present) appended on the following line.
 
-Although `ortRunId` contains numeric values, the provider treats it as an identifier and queries it as a keyword. This
-matches Elasticsearch's guidance for numeric-looking identifiers that are primarily used in term queries. A numeric
-multi-field can still be added for future range queries or numeric sorting without changing the provider's exact-match
-query behavior.
+The `formattedMessage` field is written to the downloaded log file, one line per hit. It does not need to be indexed
+for search by the provider, but it must be present in `_source`. Indexing `formattedMessage` as a `text` field is
+recommended for Kibana, so users can search log lines, exceptions, request paths, and other free-form text. A
+`.keyword` subfield can be useful for exact matches, sorting, or aggregations, but should usually have an
+`ignore_above` limit to avoid indexing very large log lines as keyword terms.
+
+Although `mdc.ortRunId` contains numeric values, the provider treats it as an identifier and queries its `keyword`
+subfield. This matches Elasticsearch's guidance for numeric-looking identifiers that are primarily used in term
+queries.
+
+### Field prefix
+
+If the indexing pipeline nests all log-line fields under a common prefix (for example, when Logstash is configured to
+add a custom prefix to all fields during indexing), set `elasticsearchFieldPrefix`. The provider then prepends this
+prefix to every field taken from the log line. The namespace field is *not* prefixed, because it is derived
+from deployment metadata rather than from the log line. Prefixed fields are returned by Elasticsearch as nested
+objects and resolved accordingly when reading values from `_source`.
 
 ## Configuration
 
@@ -45,6 +61,8 @@ logFileService {
   elasticsearchServerUrl = "https://elasticsearch.example.org"
   elasticsearchIndex = "ort-server-logs-*"
   elasticsearchNamespace = "prod"
+  elasticsearchNamespaceField = "namespace"
+  elasticsearchFieldPrefix = "ortserver"
   elasticsearchPageSize = 1000
   elasticsearchApiKey = "base64-api-key"
 }
@@ -52,16 +70,17 @@ logFileService {
 
 Supported properties:
 
-| Property | Variable | Description | Default | Secret |
-|----------|----------|-------------|---------|--------|
-| `elasticsearchServerUrl` | `ELASTICSEARCH_SERVER_URL` | Base URL of the Elasticsearch instance. | mandatory | no |
-| `elasticsearchIndex` | `ELASTICSEARCH_INDEX` | Index or index pattern to query. | mandatory | no |
-| `elasticsearchNamespace` | `ELASTICSEARCH_NAMESPACE` | Namespace label used to restrict queries. | mandatory | no |
-| `elasticsearchPageSize` | `ELASTICSEARCH_PAGE_SIZE` | Number of hits to fetch per search request. | `1000` | no |
-| `elasticsearchUsername` | `ELASTICSEARCH_USERNAME` | Optional username for Basic Auth. Ignored when an API key is configured. | undefined | no |
-| `elasticsearchPassword` | `ELASTICSEARCH_PASSWORD` | Optional password for Basic Auth. | undefined | yes |
-| `elasticsearchApiKey` | `ELASTICSEARCH_API_KEY` | Optional Elasticsearch API key. Takes precedence over Basic Auth. | undefined | yes |
-| `elasticsearchTimeoutSec` | `ELASTICSEARCH_TIMEOUT_SEC` | Optional request timeout in seconds. | `30` | no |
+| Property                      | Variable                        | Description                                                                               | Default     | Secret |
+|-------------------------------|---------------------------------|-------------------------------------------------------------------------------------------|-------------|--------|
+| `elasticsearchServerUrl`      | `ELASTICSEARCH_SERVER_URL`      | Base URL of the Elasticsearch instance.                                                   | mandatory   | no     |
+| `elasticsearchIndex`          | `ELASTICSEARCH_INDEX`           | Index or index pattern to query.                                                          | mandatory   | no     |
+| `elasticsearchNamespace`      | `ELASTICSEARCH_NAMESPACE`       | Namespace label used to restrict queries.                                                 | mandatory   | no     |
+| `elasticsearchNamespaceField` | `ELASTICSEARCH_NAMESPACE_FIELD` | Name of the field that holds the namespace value used by the namespace filter.            | `namespace` | no     |
+| `elasticsearchFieldPrefix`    | `ELASTICSEARCH_FIELD_PREFIX`    | Optional prefix prepended to all log-line fields (everything except the namespace field). | undefined   | no     |
+| `elasticsearchPageSize`       | `ELASTICSEARCH_PAGE_SIZE`       | Number of hits to fetch per search request.                                               | `1000`      | no     |
+| `elasticsearchUsername`       | `ELASTICSEARCH_USERNAME`        | Optional username for Basic Auth. Ignored when an API key is configured.                  | undefined   | no     |
+| `elasticsearchPassword`       | `ELASTICSEARCH_PASSWORD`        | Optional password for Basic Auth.                                                         | undefined   | yes    |
+| `elasticsearchApiKey`         | `ELASTICSEARCH_API_KEY`         | Optional Elasticsearch API key. Takes precedence over Basic Auth.                         | undefined   | yes    |
 
 If both Basic Auth credentials and an API key are configured, the API key is used and Basic Auth is ignored.
 
@@ -71,66 +90,73 @@ In addition, default properties of the HTTP client that is used to send requests
 
 Queries use a bool filter with:
 
-- namespace term filter on `namespace`
-- component term filter on `component`
-- ORT run ID term filter on `ortRunId`
-- log level terms filter on `level`
-- time range filter on `time`
+- namespace term filter on the configured namespace field (default `namespace`)
+- component term filter on `mdc.component.keyword`
+- ORT run ID term filter on `mdc.ortRunId.keyword`
+- log level terms filter on `level.keyword`
+- time range filter on `timestamp`
 
-Results are sorted ascending by `time` and `sortId` and fetched via Elasticsearch's `search_after` mechanism until all
-matching hits have been retrieved. Instead of using offset-based paging, `search_after` asks Elasticsearch for the next
-page after the sort values of the last hit from the previous page. This avoids deep paging limits.
+Results are sorted ascending by `timestamp` and `sequenceNumber` and fetched via Elasticsearch's `search_after`
+mechanism until all matching hits have been retrieved. Instead of using offset-based paging, `search_after` asks
+Elasticsearch for the next page after the sort values of the last hit from the previous page. This avoids deep paging
+limits.
 
-The secondary `sortId` field is required because multiple log lines can share the same `time` value. It should be a
-keyword-compatible value that is stable for the indexed log document and unique enough to distinguish log lines with the
-same timestamp. The value does not need to be meaningful to users.
-
-Good sources for `sortId`, in order of preference, are:
-
-- a collector-provided event ID, sequence number, or log-file offset if available
-- a deterministic hash of stable event identity fields such as pod UID, container ID, stream, log-file offset,
-  high-precision event timestamp, and, if needed, the log message
-- for the local Docker Compose setup, a hash of `container_id`, `created`, and `message`
-
-Avoid deriving `sortId` only from low-cardinality fields such as `component`, only from `time`, or from values that can
-change between reprocessing attempts. A UUID or generated event ID is acceptable if it is stored with the document and
-remains unchanged on retries or reindexing. A deterministic hash is usually easier to reproduce when debugging.
+The secondary `sequenceNumber` field is required because multiple log lines can share the same `timestamp`. It must be
+present on every document and provide a stable, monotonically increasing tie-breaker for log lines with the same
+timestamp. ORT Server's logging stack emits this value automatically; deployments only need to ensure it is indexed in
+a sortable numeric type such as `long`.
 
 ## Collector Normalization
 
-ORT Server currently queries the canonical field names listed above and does not support configuring alternate
-Elasticsearch field names per deployment. Collector pipelines must therefore normalize platform-specific metadata and
-log content into this schema before documents are indexed.
+ORT Server queries a fixed set of field names derived from its structured log schema. The only per-deployment
+customizations are the namespace field name (`elasticsearchNamespaceField`) and an optional global field prefix
+(`elasticsearchFieldPrefix`); the remaining field names are fixed. Collector pipelines must therefore normalize
+platform-specific metadata and log content into this schema before documents are indexed.
 
-For Kubernetes deployments, this typically means deriving `namespace` and `component` from pod metadata, extracting
-`ortRunId`, `level`, `time`, and `message` from the structured ORT Server log line, and adding `sortId` as described in
-the query behavior section.
+For Kubernetes deployments, this typically means deriving `namespace` from pod metadata, and ensuring that JSON logging
+is enabled by setting the `LOG_FORMAT` environment variable to `json` in all ORT Server containers.
 
 If the filter or sort fields are missing or mapped incompatibly, ORT Server queries will not find the expected log
-documents. Hits without `_source.message` are skipped because there is no rendered log line to write to the downloaded
-file.
+documents. Hits without `_source.formattedMessage` are skipped because there is no rendered log line to write to the
+downloaded file.
 
-An Elasticsearch index template for the required fields can look like this:
+An Elasticsearch index template for the required fields can look like this. The `.keyword` subfields on
+`mdc.component`, `mdc.ortRunId`, and `level` are what the provider filters and sorts on; they correspond to
+Elasticsearch's default dynamic mapping for string fields.
 
 ```json
 {
   "mappings": {
     "properties": {
       "namespace": { "type": "keyword" },
-      "component": { "type": "keyword" },
-      "ortRunId": {
-        "type": "keyword",
-        "fields": {
-          "numeric": { "type": "long" }
+      "mdc": {
+        "properties": {
+          "component": {
+            "type": "text",
+            "fields": {
+              "keyword": { "type": "keyword", "ignore_above": 256 }
+            }
+          },
+          "ortRunId": {
+            "type": "text",
+            "fields": {
+              "keyword": { "type": "keyword", "ignore_above": 256 }
+            }
+          }
         }
       },
-      "level": { "type": "keyword" },
-      "time": {
+      "level": {
+        "type": "text",
+        "fields": {
+          "keyword": { "type": "keyword", "ignore_above": 256 }
+        }
+      },
+      "timestamp": {
         "type": "date",
         "format": "strict_date_optional_time||epoch_millis"
       },
-      "sortId": { "type": "keyword" },
-      "message": {
+      "sequenceNumber": { "type": "long" },
+      "formattedMessage": {
         "type": "text",
         "fields": {
           "keyword": {
@@ -138,7 +164,8 @@ An Elasticsearch index template for the required fields can look like this:
             "ignore_above": 8191
           }
         }
-      }
+      },
+      "throwable": { "type": "text" }
     }
   }
 }

--- a/logaccess/elasticsearch/src/main/kotlin/ElasticsearchConfig.kt
+++ b/logaccess/elasticsearch/src/main/kotlin/ElasticsearchConfig.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.logaccess.elasticsearch
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.config.Path
 import org.eclipse.apoapsis.ortserver.utils.config.getIntOrDefault
+import org.eclipse.apoapsis.ortserver.utils.config.getStringOrDefault
 import org.eclipse.apoapsis.ortserver.utils.config.getStringOrNull
 
 /**
@@ -43,6 +44,15 @@ data class ElasticsearchConfig(
      * The namespace used to restrict log queries, for example the Kubernetes namespace or the local `compose` label.
      */
     val namespace: String,
+
+    /** The path of the log field that contains the Kubernetes namespace. */
+    val namespaceField: String,
+
+    /**
+     * A prefix to prepend to the log fields taken from the log lines. This is required if logstash is configured to add
+     * a custom prefix to all fields during indexing.
+     */
+    val fieldPrefix: String?,
 
     /**
      * The maximum number of hits requested per search call.
@@ -69,6 +79,12 @@ data class ElasticsearchConfig(
 
         /** The configuration property that defines the namespace label used in search filters. */
         private const val NAMESPACE_PROPERTY = "elasticsearchNamespace"
+
+        /** The configuration property that defines the path of the namespace field. Defaults to "namespace". */
+        private const val NAMESPACE_FIELD_PROPERTY = "elasticsearchNamespaceField"
+
+        /** The configuration property that defines the field prefix. */
+        private const val FIELD_PREFIX_PROPERTY = "elasticsearchFieldPrefix"
 
         /** The configuration property that defines the page size used for search requests. */
         private const val PAGE_SIZE_PROPERTY = "elasticsearchPageSize"
@@ -106,6 +122,8 @@ data class ElasticsearchConfig(
                 serverUrl = configManager.getString(SERVER_URL_PROPERTY),
                 index = configManager.getString(INDEX_PROPERTY),
                 namespace = configManager.getString(NAMESPACE_PROPERTY),
+                namespaceField = configManager.getStringOrDefault(NAMESPACE_FIELD_PROPERTY, "namespace"),
+                fieldPrefix = configManager.getStringOrNull(FIELD_PREFIX_PROPERTY),
                 pageSize = configManager.getIntOrDefault(PAGE_SIZE_PROPERTY, DEFAULT_PAGE_SIZE),
                 username = username,
                 password = password,

--- a/logaccess/elasticsearch/src/main/kotlin/ElasticsearchLogFileProvider.kt
+++ b/logaccess/elasticsearch/src/main/kotlin/ElasticsearchLogFileProvider.kt
@@ -66,17 +66,24 @@ class ElasticsearchLogFileProvider(
     private val config: ElasticsearchConfig
 ) : LogFileProvider {
     companion object {
-        /** The field used for time range filters and primary sorting. */
-        private const val TIMESTAMP_FIELD = "time"
-
-        /** The field used as a stable tie-breaker for pagination. */
-        private const val SORT_ID_FIELD = "sortId"
-
         private val logger = LoggerFactory.getLogger(ElasticsearchLogFileProvider::class.java)
     }
 
     /** The HTTP client for sending requests to the Elasticsearch instance. */
     private val elasticsearchClient = createClient()
+
+    // The Kubernetes namespace is not coming from the log lines, therefore the field prefix is not applied.
+    private val namespaceField = config.namespaceField
+
+    // Apply the configured field prefix to all fields taken from the log lines.
+    private val componentIndexField = prefix("mdc.component.keyword")
+    private val levelField = prefix("level")
+    private val levelIndexField = prefix("level.keyword")
+    private val messageField = prefix("formattedMessage")
+    private val ortRunIdIndexField = prefix("mdc.ortRunId.keyword")
+    private val sequenceNumberField = prefix("sequenceNumber")
+    private val throwableField = prefix("throwable")
+    private val timestampField = prefix("timestamp")
 
     override suspend fun downloadLogFile(
         ortRunId: Long,
@@ -96,11 +103,16 @@ class ElasticsearchLogFileProvider(
                 val hits = response.hits.hits
 
                 hits.forEach { hit ->
-                    val statement = hit.source.message
+                    val statement = hit.source.stringAtPath(messageField)
                     if (statement == null) {
                         logger.warn("Skipping Elasticsearch hit '{}' because no message field is present.", hit.id)
                     } else {
+                        hit.source.stringAtPath(timestampField)?.toLongOrNull()?.let { timestamp ->
+                            out.write("${Instant.fromEpochMilliseconds(timestamp)} ")
+                        }
+                        hit.source.stringAtPath(levelField)?.let { out.write("$it ") }
                         out.write(statement)
+                        hit.source.stringAtPath(throwableField)?.let { out.write("\n$it") }
                         out.newLine()
                     }
                 }
@@ -145,22 +157,25 @@ class ElasticsearchLogFileProvider(
         buildJsonObject {
             put("size", config.pageSize)
             putJsonArray("_source") {
-                add(JsonPrimitive("message"))
+                add(JsonPrimitive(levelField))
+                add(JsonPrimitive(messageField))
+                add(JsonPrimitive(throwableField))
+                add(JsonPrimitive(timestampField))
             }
             putJsonObject("query") {
                 putJsonObject("bool") {
                     putJsonArray("filter") {
-                        add(termQuery("namespace", JsonPrimitive(config.namespace)))
-                        add(termQuery("component", JsonPrimitive(source.component)))
-                        add(termQuery("ortRunId", JsonPrimitive(ortRunId.toString())))
-                        add(termsQuery("level", levels.map { it.name }))
+                        add(termQuery(namespaceField, JsonPrimitive(config.namespace)))
+                        add(termQuery(componentIndexField, JsonPrimitive(source.component)))
+                        add(termQuery(ortRunIdIndexField, JsonPrimitive(ortRunId.toString())))
+                        add(termsQuery(levelIndexField, levels.map { it.name }))
                         add(rangeQuery(startTime, endTime))
                     }
                 }
             }
             putJsonArray("sort") {
-                add(sortBy(TIMESTAMP_FIELD))
-                add(sortBy(SORT_ID_FIELD))
+                add(sortBy(timestampField))
+                add(sortBy(sequenceNumberField))
             }
             if (searchAfter != null) {
                 put("search_after", JsonArray(searchAfter))
@@ -189,7 +204,7 @@ class ElasticsearchLogFileProvider(
     private fun rangeQuery(startTime: Instant, endTime: Instant): JsonObject =
         buildJsonObject {
             putJsonObject("range") {
-                putJsonObject(TIMESTAMP_FIELD) {
+                putJsonObject(timestampField) {
                     put("gte", startTime.toEpochMilliseconds())
                     put("lte", endTime.toEpochMilliseconds())
                     put("format", "epoch_millis")
@@ -233,4 +248,19 @@ class ElasticsearchLogFileProvider(
 
             expectSuccess = true
         }
+
+    private fun prefix(field: String) = if (config.fieldPrefix != null) "${config.fieldPrefix}.$field" else field
+}
+
+/**
+ * Return the string value located at [path] within this object, where [path] is a dot-separated field name, or `null`,
+ * if any segment is missing or the final sigment is not a [JsonPrimitive].
+ */
+internal fun JsonObject.stringAtPath(path: String): String? {
+    var current: JsonElement = this
+    path.split('.').forEach { segment ->
+        current = (current as? JsonObject)?.get(segment) ?: return null
+    }
+
+    return (current as? JsonPrimitive)?.content
 }

--- a/logaccess/elasticsearch/src/main/kotlin/ElasticsearchModel.kt
+++ b/logaccess/elasticsearch/src/main/kotlin/ElasticsearchModel.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.logaccess.elasticsearch
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
 
 /**
  * A data class that represents the relevant parts of a response sent by Elasticsearch for a search request.
@@ -44,19 +45,13 @@ internal data class ElasticsearchHit(
     @SerialName("_id")
     val id: String? = null,
 
-    /** The source document with the log fields used by this provider. */
+    /**
+     * The raw source document. The fields read from it are configurable (including an optional field prefix), so the
+     * document is kept as a [JsonObject].
+     */
     @SerialName("_source")
-    val source: ElasticsearchSource = ElasticsearchSource(),
+    val source: JsonObject = JsonObject(emptyMap()),
 
     /** The sort values returned by Elasticsearch and used for `search_after` pagination. */
     val sort: List<JsonElement> = emptyList()
-)
-
-/**
- * A data class that represents the source fields read from an Elasticsearch hit.
- */
-@Serializable
-internal data class ElasticsearchSource(
-    /** The rendered log statement as it was written by the application. */
-    val message: String? = null
 )

--- a/logaccess/elasticsearch/src/main/resources/application.conf
+++ b/logaccess/elasticsearch/src/main/resources/application.conf
@@ -19,6 +19,8 @@ logFileService {
   elasticsearchServerUrl = ${?ELASTICSEARCH_SERVER_URL}
   elasticsearchIndex = ${?ELASTICSEARCH_INDEX}
   elasticsearchNamespace = ${?ELASTICSEARCH_NAMESPACE}
+  elasticsearchNamespaceField = ${?ELASTICSEARCH_NAMESPACE_FIELD}
+  elasticsearchFieldPrefix = ${?ELASTICSEARCH_FIELD_PREFIX}
   elasticsearchPageSize = ${?ELASTICSEARCH_PAGE_SIZE}
   elasticsearchUsername = ${?ELASTICSEARCH_USERNAME}
   elasticsearchPassword = ${?ELASTICSEARCH_PASSWORD}

--- a/logaccess/elasticsearch/src/test/kotlin/ElasticsearchConfigTest.kt
+++ b/logaccess/elasticsearch/src/test/kotlin/ElasticsearchConfigTest.kt
@@ -46,6 +46,8 @@ class ElasticsearchConfigTest : StringSpec({
             serverUrl = SERVER_URL,
             index = INDEX,
             namespace = NAMESPACE,
+            namespaceField = "namespace",
+            fieldPrefix = null,
             pageSize = pageSize,
             username = username,
             password = password,
@@ -62,7 +64,8 @@ class ElasticsearchConfigTest : StringSpec({
             "elasticsearchNamespace" to NAMESPACE
         )
         val configManager = createConfigManager(configMap)
-        val expectedConfig = ElasticsearchConfig(SERVER_URL, INDEX, NAMESPACE, 1000, null, null, null)
+        val expectedConfig =
+            ElasticsearchConfig(SERVER_URL, INDEX, NAMESPACE, "namespace", null, 1000, null, null, null)
 
         ElasticsearchConfig.create(configManager) shouldBe expectedConfig
     }
@@ -79,7 +82,7 @@ class ElasticsearchConfigTest : StringSpec({
         )
 
         ElasticsearchConfig.create(createConfigManager(configMap)) shouldBe
-            ElasticsearchConfig(SERVER_URL, INDEX, NAMESPACE, 1000, username, null, "api-key")
+            ElasticsearchConfig(SERVER_URL, INDEX, NAMESPACE, "namespace", null, 1000, username, null, "api-key")
     }
 
     "Blank auth settings should be treated as absent" {
@@ -92,7 +95,7 @@ class ElasticsearchConfigTest : StringSpec({
         )
 
         ElasticsearchConfig.create(createConfigManager(configMap)) shouldBe
-            ElasticsearchConfig(SERVER_URL, INDEX, NAMESPACE, 1000, null, null, null)
+            ElasticsearchConfig(SERVER_URL, INDEX, NAMESPACE, "namespace", null, 1000, null, null, null)
     }
 })
 

--- a/logaccess/elasticsearch/src/test/kotlin/ElasticsearchLogFileProviderTest.kt
+++ b/logaccess/elasticsearch/src/test/kotlin/ElasticsearchLogFileProviderTest.kt
@@ -54,7 +54,6 @@ import java.io.File
 import java.io.IOException
 import java.nio.file.Files
 import java.util.EnumSet
-import java.util.Locale
 import java.util.UUID
 import java.util.zip.ZipFile
 
@@ -64,6 +63,9 @@ import kotlin.time.Instant
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
 
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.logaccess.LogFileService
@@ -146,7 +148,10 @@ class ElasticsearchLogFileProviderTest : StringSpec() {
                 hits.take(2) +
                     ElasticsearchHit(
                         "missing-message",
-                        ElasticsearchSource(null),
+                        buildJsonObject {
+                            put("level", "ERROR")
+                            put("timestamp", START_TIME_MS)
+                        },
                         listOf(JsonPrimitive(99), JsonPrimitive("x"))
                     ) + hits.takeLast(2),
                 source = LogSource.CONFIG
@@ -310,6 +315,46 @@ class ElasticsearchLogFileProviderTest : StringSpec() {
             firstPage.checkLogFile(logFile)
         }
 
+        "A configured field prefix should resolve nested source fields" {
+            val timestamp = START_TIME_MS + 1
+            val message = "Prefixed log line"
+            val hit = ElasticsearchHit(
+                id = "prefixed",
+                source = buildJsonObject {
+                    putJsonObject("logs") {
+                        put("formattedMessage", message)
+                        put("level", "ERROR")
+                        put("timestamp", timestamp)
+                    }
+                },
+                sort = listOf(JsonPrimitive(1), JsonPrimitive("sort-id-1"))
+            )
+
+            server.stubFor(
+                post(urlPathEqualTo("/$INDEX/_search")).willReturn(
+                    aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBody(generateSearchResponse(listOf(hit)))
+                )
+            )
+
+            val config = server.elasticsearchConfig().copy(fieldPrefix = "logs")
+            val logFile =
+                ElasticsearchLogFileProvider(config).testRequest(LogSource.ADVISOR, EnumSet.of(LogLevel.ERROR))
+
+            logFile.readLines() shouldBe listOf("${Instant.fromEpochMilliseconds(timestamp)} ERROR $message")
+            server.verify(
+                postRequestedFor(urlPathEqualTo("/$INDEX/_search"))
+                    .withRequestBody(matchingJsonPath("$._source[0]", equalTo("logs.level")))
+                    .withRequestBody(
+                        matchingJsonPath(
+                            "$.query.bool.filter[1].term['logs.mdc.component.keyword']",
+                            equalTo(LogSource.ADVISOR.component)
+                        )
+                    )
+            )
+        }
+
         "A full page without sort values should fail" {
             val hits = generateHits(LIMIT)
             val malformedHits = hits.dropLast(1) + hits.last().copy(sort = emptyList())
@@ -331,7 +376,22 @@ private suspend fun ElasticsearchLogFileProvider.testRequest(source: LogSource, 
 }
 
 private fun List<ElasticsearchHit>.checkLogFile(logFile: File) {
-    logFile.readLines() shouldBe mapNotNull { it.source.message }
+    logFile.readLines() shouldBe flatMap { it.expectedLines() }
+}
+
+/**
+ * Return the log file lines expected for this hit, mirroring how the provider renders a hit: an optional formatted
+ * timestamp and log level prefix followed by the message, with the throwable (if present) on a separate line. Hits
+ * without a message are skipped and therefore produce no lines.
+ */
+private fun ElasticsearchHit.expectedLines(): List<String> {
+    val message = source.stringAtPath("formattedMessage") ?: return emptyList()
+    val prefix = buildString {
+        source.stringAtPath("timestamp")?.toLongOrNull()?.let { append("${Instant.fromEpochMilliseconds(it)} ") }
+        source.stringAtPath("level")?.let { append("$it ") }
+    }
+
+    return listOfNotNull("$prefix$message", source.stringAtPath("throwable"))
 }
 
 private fun File.unpackTo(targetDirectory: File) {
@@ -371,15 +431,26 @@ private fun MappingBuilder.withExpectedSearchBody(
     searchAfter: List<JsonElement>? = null
 ): MappingBuilder =
     withRequestBody(matchingJsonPath("$.size", equalTo(LIMIT.toString())))
-        .withRequestBody(matchingJsonPath("$._source[0]", equalTo("message")))
+        .withRequestBody(matchingJsonPath("$._source[0]", equalTo("level")))
+        .withRequestBody(matchingJsonPath("$._source[1]", equalTo("formattedMessage")))
+        .withRequestBody(matchingJsonPath("$._source[2]", equalTo("throwable")))
+        .withRequestBody(matchingJsonPath("$._source[3]", equalTo("timestamp")))
         .withRequestBody(matchingJsonPath("$.query.bool.filter[0].term.namespace", equalTo(NAMESPACE)))
-        .withRequestBody(matchingJsonPath("$.query.bool.filter[1].term.component", equalTo(source.component)))
-        .withRequestBody(matchingJsonPath("$.query.bool.filter[2].term.ortRunId", equalTo(RUN_ID.toString())))
-        .withRequestBody(matchingJsonPath("$.query.bool.filter[4].range.time.gte", equalTo(START_TIME_MS.toString())))
-        .withRequestBody(matchingJsonPath("$.query.bool.filter[4].range.time.lte", equalTo(END_TIME_MS.toString())))
-        .withRequestBody(matchingJsonPath("$.query.bool.filter[4].range.time.format", equalTo("epoch_millis")))
-        .withRequestBody(matchingJsonPath("$.sort[0].time.order", equalTo("asc")))
-        .withRequestBody(matchingJsonPath("$.sort[1].sortId.order", equalTo("asc")))
+        .withRequestBody(
+            matchingJsonPath("$.query.bool.filter[1].term['mdc.component.keyword']", equalTo(source.component))
+        )
+        .withRequestBody(
+            matchingJsonPath("$.query.bool.filter[2].term['mdc.ortRunId.keyword']", equalTo(RUN_ID.toString()))
+        )
+        .withRequestBody(
+            matchingJsonPath("$.query.bool.filter[4].range.timestamp.gte", equalTo(START_TIME_MS.toString()))
+        )
+        .withRequestBody(
+            matchingJsonPath("$.query.bool.filter[4].range.timestamp.lte", equalTo(END_TIME_MS.toString()))
+        )
+        .withRequestBody(matchingJsonPath("$.query.bool.filter[4].range.timestamp.format", equalTo("epoch_millis")))
+        .withRequestBody(matchingJsonPath("$.sort[0].timestamp.order", equalTo("asc")))
+        .withRequestBody(matchingJsonPath("$.sort[1].sequenceNumber.order", equalTo("asc")))
         .withExpectedLevels(levels)
         .withExpectedSearchAfter(searchAfter)
 
@@ -389,26 +460,41 @@ private fun RequestPatternBuilder.withExpectedSearchBody(
     searchAfter: List<JsonElement>? = null
 ): RequestPatternBuilder =
     withRequestBody(matchingJsonPath("$.size", equalTo(LIMIT.toString())))
-        .withRequestBody(matchingJsonPath("$._source[0]", equalTo("message")))
+        .withRequestBody(matchingJsonPath("$._source[0]", equalTo("level")))
+        .withRequestBody(matchingJsonPath("$._source[1]", equalTo("formattedMessage")))
+        .withRequestBody(matchingJsonPath("$._source[2]", equalTo("throwable")))
+        .withRequestBody(matchingJsonPath("$._source[3]", equalTo("timestamp")))
         .withRequestBody(matchingJsonPath("$.query.bool.filter[0].term.namespace", equalTo(NAMESPACE)))
-        .withRequestBody(matchingJsonPath("$.query.bool.filter[1].term.component", equalTo(source.component)))
-        .withRequestBody(matchingJsonPath("$.query.bool.filter[2].term.ortRunId", equalTo(RUN_ID.toString())))
-        .withRequestBody(matchingJsonPath("$.query.bool.filter[4].range.time.gte", equalTo(START_TIME_MS.toString())))
-        .withRequestBody(matchingJsonPath("$.query.bool.filter[4].range.time.lte", equalTo(END_TIME_MS.toString())))
-        .withRequestBody(matchingJsonPath("$.query.bool.filter[4].range.time.format", equalTo("epoch_millis")))
-        .withRequestBody(matchingJsonPath("$.sort[0].time.order", equalTo("asc")))
-        .withRequestBody(matchingJsonPath("$.sort[1].sortId.order", equalTo("asc")))
+        .withRequestBody(
+            matchingJsonPath("$.query.bool.filter[1].term['mdc.component.keyword']", equalTo(source.component))
+        )
+        .withRequestBody(
+            matchingJsonPath("$.query.bool.filter[2].term['mdc.ortRunId.keyword']", equalTo(RUN_ID.toString()))
+        )
+        .withRequestBody(
+            matchingJsonPath("$.query.bool.filter[4].range.timestamp.gte", equalTo(START_TIME_MS.toString()))
+        )
+        .withRequestBody(
+            matchingJsonPath("$.query.bool.filter[4].range.timestamp.lte", equalTo(END_TIME_MS.toString()))
+        )
+        .withRequestBody(matchingJsonPath("$.query.bool.filter[4].range.timestamp.format", equalTo("epoch_millis")))
+        .withRequestBody(matchingJsonPath("$.sort[0].timestamp.order", equalTo("asc")))
+        .withRequestBody(matchingJsonPath("$.sort[1].sequenceNumber.order", equalTo("asc")))
         .withExpectedLevels(levels)
         .withExpectedSearchAfter(searchAfter)
 
 private fun MappingBuilder.withExpectedLevels(levels: List<LogLevel>): MappingBuilder =
     levels.foldIndexed(this) { index, request, level ->
-        request.withRequestBody(matchingJsonPath("$.query.bool.filter[3].terms.level[$index]", equalTo(level.name)))
+        request.withRequestBody(
+            matchingJsonPath("$.query.bool.filter[3].terms['level.keyword'][$index]", equalTo(level.name))
+        )
     }
 
 private fun RequestPatternBuilder.withExpectedLevels(levels: List<LogLevel>): RequestPatternBuilder =
     levels.foldIndexed(this) { index, request, level ->
-        request.withRequestBody(matchingJsonPath("$.query.bool.filter[3].terms.level[$index]", equalTo(level.name)))
+        request.withRequestBody(
+            matchingJsonPath("$.query.bool.filter[3].terms['level.keyword'][$index]", equalTo(level.name))
+        )
     }
 
 private fun MappingBuilder.withExpectedSearchAfter(searchAfter: List<JsonElement>?): MappingBuilder =
@@ -429,6 +515,8 @@ private fun WireMockServer.elasticsearchConfig(): ElasticsearchConfig =
         serverUrl = "http://localhost:${port()}",
         index = INDEX,
         namespace = NAMESPACE,
+        namespaceField = "namespace",
+        fieldPrefix = null,
         pageSize = LIMIT,
         username = null,
         password = null,
@@ -440,10 +528,11 @@ private fun generateHits(count: Int, offset: Long = 0, source: LogSource = LogSo
         val sortValue = offset + index + 1
         ElasticsearchHit(
             id = UUID.randomUUID().toString(),
-            source = ElasticsearchSource(
-                "time=2025-01-01T00:00:${"%02d".format(Locale.ROOT, index)}.000 component=${source.component} " +
-                        "ortRunId=$RUN_ID level=ERROR message=\"log line $sortValue\""
-            ),
+            source = buildJsonObject {
+                put("formattedMessage", "Log line $sortValue for component ${source.component}.")
+                put("level", "ERROR")
+                put("timestamp", START_TIME_MS + sortValue)
+            },
             sort = listOf(JsonPrimitive(sortValue), JsonPrimitive("sort-id-$sortValue"))
         )
     }

--- a/orchestrator/src/main/resources/logback.xml
+++ b/orchestrator/src/main/resources/logback.xml
@@ -29,7 +29,10 @@
             <sequenceNumberGenerator class="ch.qos.logback.core.spi.BasicSequenceNumberGenerator" />
             <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
                 <encoder class="ch.qos.logback.classic.encoder.JsonEncoder">
+                    <withArguments>false</withArguments>
                     <withContext>false</withContext>
+                    <withFormattedMessage>true</withFormattedMessage>
+                    <withMessage>false</withMessage>
                 </encoder>
             </appender>
         </then>

--- a/orchestrator/src/main/resources/logback.xml
+++ b/orchestrator/src/main/resources/logback.xml
@@ -28,7 +28,7 @@
         <then>
             <sequenceNumberGenerator class="ch.qos.logback.core.spi.BasicSequenceNumberGenerator" />
             <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-                <encoder class="ch.qos.logback.classic.encoder.JsonEncoder">
+                <encoder class="org.eclipse.apoapsis.ortserver.utils.logging.OrtServerJsonEncoder">
                     <withArguments>false</withArguments>
                     <withContext>false</withContext>
                     <withFormattedMessage>true</withFormattedMessage>

--- a/tasks/src/main/resources/logback.xml
+++ b/tasks/src/main/resources/logback.xml
@@ -29,7 +29,10 @@
             <sequenceNumberGenerator class="ch.qos.logback.core.spi.BasicSequenceNumberGenerator" />
             <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
                 <encoder class="ch.qos.logback.classic.encoder.JsonEncoder">
+                    <withArguments>false</withArguments>
                     <withContext>false</withContext>
+                    <withFormattedMessage>true</withFormattedMessage>
+                    <withMessage>false</withMessage>
                 </encoder>
             </appender>
         </then>

--- a/tasks/src/main/resources/logback.xml
+++ b/tasks/src/main/resources/logback.xml
@@ -28,7 +28,7 @@
         <then>
             <sequenceNumberGenerator class="ch.qos.logback.core.spi.BasicSequenceNumberGenerator" />
             <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-                <encoder class="ch.qos.logback.classic.encoder.JsonEncoder">
+                <encoder class="org.eclipse.apoapsis.ortserver.utils.logging.OrtServerJsonEncoder">
                     <withArguments>false</withArguments>
                     <withContext>false</withContext>
                     <withFormattedMessage>true</withFormattedMessage>

--- a/utils/logging/src/main/kotlin/OrtServerJsonEncoder.kt
+++ b/utils/logging/src/main/kotlin/OrtServerJsonEncoder.kt
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.utils.logging
+
+import ch.qos.logback.classic.encoder.JsonEncoder
+import ch.qos.logback.classic.spi.IThrowableProxy
+import ch.qos.logback.classic.spi.ThrowableProxyUtil
+import ch.qos.logback.core.encoder.JsonEscapeUtil
+
+private const val THROWABLE_ATTR_NAME = "throwable"
+
+/**
+ * A [JsonEncoder] that renders a throwable as a single top-level [THROWABLE_ATTR_NAME] string field instead of the
+ * nested object produced by the base class. The string is identical to the output of the classic pattern layout (the
+ * `%ex` conversion word), making the stack trace easy to read in JSON logs and easy to consume in external tooling.
+ */
+class OrtServerJsonEncoder : JsonEncoder() {
+    override fun appendThrowableProxy(sb: StringBuilder, attributeName: String?, itp: IThrowableProxy?) {
+        if (itp == null) return
+
+        sb.append(',')
+
+        appenderMember(
+            sb,
+            org.eclipse.apoapsis.ortserver.utils.logging.THROWABLE_ATTR_NAME,
+            JsonEscapeUtil.jsonEscapeString(ThrowableProxyUtil.asString(itp))
+        )
+    }
+}

--- a/utils/logging/src/test/kotlin/OrtServerJsonEncoderTest.kt
+++ b/utils/logging/src/test/kotlin/OrtServerJsonEncoderTest.kt
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.utils.logging
+
+import ch.qos.logback.classic.Level
+import ch.qos.logback.classic.LoggerContext
+import ch.qos.logback.classic.spi.LoggingEvent
+import ch.qos.logback.classic.util.LogbackMDCAdapter
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.nulls.beNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import io.kotest.matchers.string.shouldStartWith
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+class OrtServerJsonEncoderTest : WordSpec({
+    "encode" should {
+        "render a throwable as a single 'throwable' string field" {
+            val cause = IllegalStateException("the root cause")
+            val throwable = RuntimeException("something went wrong", cause)
+
+            val json = encodeEvent("Processing failed for {}", throwable, "item-42")
+
+            json.jsonObject["throwable"]?.jsonPrimitive.shouldNotBeNull {
+                content shouldStartWith "java.lang.RuntimeException: something went wrong"
+                content shouldContain "Caused by: java.lang.IllegalStateException: the root cause"
+                content shouldContain "\tat "
+            }
+        }
+
+        "produce valid JSON even though the exception spans multiple lines" {
+            // Parsing the output without an exception already proves the multi-line stack trace is escaped correctly.
+            val json = encodeEvent(message = "boom", throwable = RuntimeException("boom"))
+
+            json.jsonObject["throwable"]?.jsonPrimitive?.content.shouldNotBeNull {
+                this shouldContain "\n"
+            }
+        }
+
+        "not add a 'throwable' field if the event has no throwable" {
+            val json = encodeEvent(message = "no error here", throwable = null)
+
+            json.jsonObject["throwable"] should beNull()
+        }
+
+        "not corrupt the output when the message contains JSON special characters" {
+            val json = encodeEvent("value is \"{}\"", RuntimeException("boom"), "a\\b")
+
+            json.jsonObject["formattedMessage"]?.jsonPrimitive?.content shouldBe "value is \"a\\b\""
+            json.jsonObject["throwable"]?.jsonPrimitive?.content.orEmpty() shouldNotContain "\u0000"
+        }
+    }
+})
+
+private fun encodeEvent(message: String, throwable: Throwable?, vararg arguments: Any?): JsonElement {
+    val loggerContext = LoggerContext().apply {
+        mdcAdapter = LogbackMDCAdapter()
+    }
+
+    val logger = loggerContext.getLogger("org.eclipse.apoapsis.ortserver.TestLogger")
+
+    val event = LoggingEvent(
+        OrtServerJsonEncoderTest::class.java.name,
+        logger,
+        Level.ERROR,
+        message,
+        throwable,
+        if (arguments.isEmpty()) null else arrayOf(*arguments)
+    )
+
+    val encoder = OrtServerJsonEncoder().apply {
+        setWithArguments(false)
+        setWithContext(false)
+        setWithFormattedMessage(true)
+        setWithMessage(false)
+        start()
+    }
+
+    val line = String(encoder.encode(event), Charsets.UTF_8)
+
+    return Json.parseToJsonElement(line)
+}

--- a/utils/test/src/commonMain/resources/logback.xml
+++ b/utils/test/src/commonMain/resources/logback.xml
@@ -28,7 +28,7 @@
         <then>
             <sequenceNumberGenerator class="ch.qos.logback.core.spi.BasicSequenceNumberGenerator" />
             <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-                <encoder class="ch.qos.logback.classic.encoder.JsonEncoder">
+                <encoder class="org.eclipse.apoapsis.ortserver.utils.logging.JsonEncoderWithExceptionField">
                     <withArguments>false</withArguments>
                     <withContext>false</withContext>
                     <withFormattedMessage>true</withFormattedMessage>

--- a/utils/test/src/commonMain/resources/logback.xml
+++ b/utils/test/src/commonMain/resources/logback.xml
@@ -29,7 +29,10 @@
             <sequenceNumberGenerator class="ch.qos.logback.core.spi.BasicSequenceNumberGenerator" />
             <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
                 <encoder class="ch.qos.logback.classic.encoder.JsonEncoder">
+                    <withArguments>false</withArguments>
                     <withContext>false</withContext>
+                    <withFormattedMessage>true</withFormattedMessage>
+                    <withMessage>false</withMessage>
                 </encoder>
             </appender>
         </then>

--- a/workers/common/src/main/resources/logback.xml
+++ b/workers/common/src/main/resources/logback.xml
@@ -29,7 +29,10 @@
             <sequenceNumberGenerator class="ch.qos.logback.core.spi.BasicSequenceNumberGenerator" />
             <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
                 <encoder class="ch.qos.logback.classic.encoder.JsonEncoder">
+                    <withArguments>false</withArguments>
                     <withContext>false</withContext>
+                    <withFormattedMessage>true</withFormattedMessage>
+                    <withMessage>false</withMessage>
                 </encoder>
             </appender>
         </then>

--- a/workers/common/src/main/resources/logback.xml
+++ b/workers/common/src/main/resources/logback.xml
@@ -28,7 +28,7 @@
         <then>
             <sequenceNumberGenerator class="ch.qos.logback.core.spi.BasicSequenceNumberGenerator" />
             <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
-                <encoder class="ch.qos.logback.classic.encoder.JsonEncoder">
+                <encoder class="org.eclipse.apoapsis.ortserver.utils.logging.OrtServerJsonEncoder">
                     <withArguments>false</withArguments>
                     <withContext>false</withContext>
                     <withFormattedMessage>true</withFormattedMessage>


### PR DESCRIPTION
Improve the optional JSON log output and make the Elasticsearch provider compatible with that. See the commit messages for details.