### PR TITLE
ui: Wrap long labels

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/repository-runs-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/repository-runs-table.tsx
@@ -200,11 +200,11 @@ const SummaryCard = ({ summary }: { summary: OrtRunSummary }) => {
                     )}
                 </div>
                 {hasLabels && (
-                  <div className='flex flex-wrap justify-end gap-2'>
+                  <div className='flex w-full flex-wrap justify-end gap-2'>
                     {Object.entries(summary.labels!).map(([key, value]) => (
                       <Badge
                         key={key}
-                        className='bg-gray-200 text-gray-800 dark:bg-gray-700 dark:text-gray-200'
+                        className='max-w-full min-w-0 shrink bg-gray-200 break-words whitespace-normal text-gray-800 dark:bg-gray-700 dark:text-gray-200'
                       >
                         {key}: {value}
                       </Badge>


### PR DESCRIPTION
### Before

<img width="1202" height="214" alt="Screenshot from 2026-06-19 11-17-01" src="https://github.com/user-attachments/assets/d0de5229-3a3f-4c4c-afaf-9c27ee280fbb" />

### After

<img width="1203" height="247" alt="Screenshot from 2026-06-19 11-32-37" src="https://github.com/user-attachments/assets/4dee2e9c-9819-46a7-8e20-9c0fe4d04d70" />

Please see the commit for details.