### PR TITLE
feat(logs): Log whole `uri` instead of `path`

### DIFF
--- a/core/src/main/kotlin/plugins/Monitoring.kt
+++ b/core/src/main/kotlin/plugins/Monitoring.kt
@@ -25,6 +25,7 @@ import io.ktor.server.application.install
 import io.ktor.server.plugins.calllogging.CallLogging
 import io.ktor.server.request.httpMethod
 import io.ktor.server.request.path
+import io.ktor.server.request.uri
 
 import java.util.UUID
 
@@ -54,9 +55,9 @@ fun Application.configureMonitoring() {
 
             val status = call.response.status()?.value ?: "unknown"
             val method = call.request.httpMethod.value
-            val path = call.request.path()
+            val uri = call.request.uri
 
-            "clientType=$clientType $method $path: $status"
+            "clientType=$clientType $method $uri: $status"
         }
     }
 }


### PR DESCRIPTION
Instead of limiting the call logs to the `path`, log the whole `uri` of the request. This provides more detailed information about the incoming requests, including query parameters, which can be crucial for debugging and investigating the usage of the API.