### PR TITLE
Home screen

### DIFF
--- a/ui/src/components/favorite-button.tsx
+++ b/ui/src/components/favorite-button.tsx
@@ -1,0 +1,228 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { Star } from 'lucide-react';
+import { ComponentProps } from 'react';
+
+import type { Organization, OrtRun, Product, Repository } from '@/api';
+import {
+  getOrganizationOptions,
+  getProductOptions,
+  getRepositoryOptions,
+} from '@/api/@tanstack/react-query.gen';
+import { Button } from '@/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+import {
+  buildOrganizationFavorite,
+  buildProductFavorite,
+  buildRepositoryFavorite,
+  buildRunFavorite,
+  FavoriteItemInput,
+  useHomeFavoriteActions,
+  useIsHomeDataEnabled,
+  useIsHomeFavorite,
+} from '@/providers/home-data';
+
+type FavoriteButtonProps = Omit<
+  ComponentProps<typeof Button>,
+  'aria-label' | 'aria-pressed' | 'onClick' | 'type'
+> & {
+  favorite: FavoriteItemInput;
+};
+
+type EntityFavoriteButtonProps = Omit<FavoriteButtonProps, 'favorite'>;
+
+type FavoriteEntityId = number | string;
+
+const toNumber = (id: FavoriteEntityId) =>
+  typeof id === 'number' ? id : Number.parseInt(id);
+
+export const FavoriteButton = ({
+  favorite,
+  className,
+  disabled,
+  size = 'icon',
+  variant = 'outline',
+  ...props
+}: FavoriteButtonProps) => {
+  const isFavorite = useIsHomeFavorite(favorite.id);
+  const isEnabled = useIsHomeDataEnabled();
+  const { toggleFavorite } = useHomeFavoriteActions();
+  // Disable the button when favorites cannot be persisted (e.g. no user is
+  // known yet), so a click is never silently dropped.
+  const isDisabled = disabled || !isEnabled;
+  const label = isFavorite ? 'Remove from favorites' : 'Add to favorites';
+  const tooltip = isEnabled ? label : 'Sign in to manage favorites';
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          aria-label={`${label}: ${favorite.name}`}
+          aria-pressed={isFavorite}
+          className={className}
+          disabled={isDisabled}
+          onClick={() => toggleFavorite(favorite)}
+          size={size}
+          type='button'
+          variant={variant}
+          {...props}
+        >
+          <Star
+            className={cn(
+              'h-4 w-4 text-white/50',
+              isFavorite && 'fill-white text-white'
+            )}
+          />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
+  );
+};
+
+export const OrganizationFavoriteButton = ({
+  organization,
+  ...props
+}: EntityFavoriteButtonProps & { organization: Organization }) => (
+  <FavoriteButton
+    favorite={buildOrganizationFavorite(organization)}
+    {...props}
+  />
+);
+
+export const ProductFavoriteButton = ({
+  organization,
+  organizationId,
+  product,
+  ...props
+}: EntityFavoriteButtonProps & {
+  organization?: Organization;
+  organizationId: FavoriteEntityId;
+  product: Product;
+}) => {
+  const { data: loadedOrganization } = useQuery({
+    ...getOrganizationOptions({
+      path: { organizationId: toNumber(organizationId) },
+    }),
+    enabled: organization === undefined,
+  });
+  const favoriteOrganization = organization ?? loadedOrganization;
+
+  return favoriteOrganization ? (
+    <FavoriteButton
+      favorite={buildProductFavorite(favoriteOrganization, product)}
+      {...props}
+    />
+  ) : null;
+};
+
+export const RepositoryFavoriteButton = ({
+  organization,
+  organizationId,
+  product,
+  productId,
+  repository,
+  ...props
+}: EntityFavoriteButtonProps & {
+  organization?: Organization;
+  organizationId: FavoriteEntityId;
+  product?: Product;
+  productId: FavoriteEntityId;
+  repository: Repository;
+}) => {
+  const { data: loadedOrganization } = useQuery({
+    ...getOrganizationOptions({
+      path: { organizationId: toNumber(organizationId) },
+    }),
+    enabled: organization === undefined,
+  });
+  const { data: loadedProduct } = useQuery({
+    ...getProductOptions({ path: { productId: toNumber(productId) } }),
+    enabled: product === undefined,
+  });
+  const favoriteOrganization = organization ?? loadedOrganization;
+  const favoriteProduct = product ?? loadedProduct;
+
+  return favoriteOrganization && favoriteProduct ? (
+    <FavoriteButton
+      favorite={buildRepositoryFavorite(
+        favoriteOrganization,
+        favoriteProduct,
+        repository
+      )}
+      {...props}
+    />
+  ) : null;
+};
+
+export const RunFavoriteButton = ({
+  organization,
+  organizationId,
+  product,
+  productId,
+  repository,
+  repositoryId,
+  run,
+  ...props
+}: EntityFavoriteButtonProps & {
+  organization?: Organization;
+  organizationId: FavoriteEntityId;
+  product?: Product;
+  productId: FavoriteEntityId;
+  repository?: Repository;
+  repositoryId: FavoriteEntityId;
+  run: Pick<OrtRun, 'id' | 'index'>;
+}) => {
+  const { data: loadedOrganization } = useQuery({
+    ...getOrganizationOptions({
+      path: { organizationId: toNumber(organizationId) },
+    }),
+    enabled: organization === undefined,
+  });
+  const { data: loadedProduct } = useQuery({
+    ...getProductOptions({ path: { productId: toNumber(productId) } }),
+    enabled: product === undefined,
+  });
+  const { data: loadedRepository } = useQuery({
+    ...getRepositoryOptions({ path: { repositoryId: toNumber(repositoryId) } }),
+    enabled: repository === undefined,
+  });
+  const favoriteOrganization = organization ?? loadedOrganization;
+  const favoriteProduct = product ?? loadedProduct;
+  const favoriteRepository = repository ?? loadedRepository;
+
+  return favoriteOrganization && favoriteProduct && favoriteRepository ? (
+    <FavoriteButton
+      favorite={buildRunFavorite(
+        favoriteOrganization,
+        favoriteProduct,
+        favoriteRepository,
+        run
+      )}
+      {...props}
+    />
+  ) : null;
+};

--- a/ui/src/components/providers.tsx
+++ b/ui/src/components/providers.tsx
@@ -28,6 +28,7 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 import { config } from '@/config';
 import { TOKEN_FLOW_MARKER_KEY } from '@/helpers/token-flow';
 import { queryClient } from '@/lib/query-client';
+import { HomeDataProvider } from '@/providers/home-data';
 
 const oidcConfig = config.oidcConfig;
 
@@ -55,7 +56,9 @@ export const Providers = ({ children }: { children: ReactNode }) => {
           defaultColorTheme='default'
           storageKeyColorTheme='vite-ui-theme-color'
         >
-          <TooltipProvider>{children}</TooltipProvider>
+          <HomeDataProvider>
+            <TooltipProvider>{children}</TooltipProvider>
+          </HomeDataProvider>
         </ThemeProvider>
       </QueryClientProvider>
       <Toaster

--- a/ui/src/providers/home-data/favorite-builders.ts
+++ b/ui/src/providers/home-data/favorite-builders.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import type { Organization, OrtRun, Product, Repository } from '@/api';
+import {
+  buildOrganizationFavoriteId,
+  buildProductFavoriteId,
+  buildRepositoryFavoriteId,
+  buildRunFavoriteId,
+} from './favorites';
+import { buildRecentRunId } from './recent-runs';
+import type { FavoriteItemInput, RecentRunItemInput } from './types';
+
+const getRepositoryName = (repository: Repository) =>
+  repository.name || repository.url;
+
+export const buildOrganizationFavorite = (
+  organization: Organization
+): FavoriteItemInput => ({
+  id: buildOrganizationFavoriteId(organization.id),
+  type: 'organization',
+  name: organization.name,
+  breadcrumbs: [organization.name],
+  to: '/organizations/$orgId',
+  params: { orgId: organization.id.toString() },
+});
+
+export const buildProductFavorite = (
+  organization: Organization,
+  product: Product
+): FavoriteItemInput => ({
+  id: buildProductFavoriteId(organization.id, product.id),
+  type: 'product',
+  name: product.name,
+  breadcrumbs: [organization.name, product.name],
+  to: '/organizations/$orgId/products/$productId',
+  params: {
+    orgId: organization.id.toString(),
+    productId: product.id.toString(),
+  },
+});
+
+/** Build a repository favorite using the repository name, falling back to its URL. */
+export const buildRepositoryFavorite = (
+  organization: Organization,
+  product: Product,
+  repository: Repository
+): FavoriteItemInput => ({
+  id: buildRepositoryFavoriteId(organization.id, product.id, repository.id),
+  type: 'repository',
+  name: getRepositoryName(repository),
+  breadcrumbs: [organization.name, product.name, getRepositoryName(repository)],
+  to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs',
+  params: {
+    orgId: organization.id.toString(),
+    productId: product.id.toString(),
+    repoId: repository.id.toString(),
+  },
+});
+
+export const buildRunFavorite = (
+  organization: Organization,
+  product: Product,
+  repository: Repository,
+  run: Pick<OrtRun, 'id' | 'index'>
+): FavoriteItemInput => ({
+  id: buildRunFavoriteId(run.id),
+  type: 'run',
+  name: `Run ${run.index}`,
+  breadcrumbs: [
+    organization.name,
+    product.name,
+    getRepositoryName(repository),
+    `Run ${run.index}`,
+  ],
+  to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex',
+  params: {
+    orgId: organization.id.toString(),
+    productId: product.id.toString(),
+    repoId: repository.id.toString(),
+    runIndex: run.index.toString(),
+  },
+});
+
+/** Build a recent run snapshot from the current organization, product, repository, and run. */
+export const buildRecentRun = (
+  organization: Organization,
+  product: Product,
+  repository: Repository,
+  run: OrtRun
+): RecentRunItemInput => ({
+  id: buildRecentRunId(run.id),
+  runId: run.id,
+  runIndex: run.index,
+  organizationId: organization.id,
+  organizationName: organization.name,
+  productId: product.id,
+  productName: product.name,
+  repositoryId: repository.id,
+  repositoryName: getRepositoryName(repository),
+  revision: run.revision,
+  path: run.path ?? undefined,
+  status: run.status,
+  to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex',
+  params: {
+    orgId: organization.id.toString(),
+    productId: product.id.toString(),
+    repoId: repository.id.toString(),
+    runIndex: run.index.toString(),
+  },
+  createdAt: run.createdAt,
+});

--- a/ui/src/providers/home-data/favorites.ts
+++ b/ui/src/providers/home-data/favorites.ts
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import type { FavoriteItem, FavoriteItemInput, FavoriteType } from './types';
+
+export const DEFAULT_FAVORITE_GROUP_ORDER: FavoriteType[] = [
+  'run',
+  'repository',
+  'product',
+  'organization',
+];
+
+/** Clean up a saved favorite group order so it contains each known group once. */
+export const normalizeFavoriteGroupOrder = (
+  favoriteGroupOrder: readonly FavoriteType[] | undefined
+): FavoriteType[] => {
+  const knownFavoriteTypes = new Set(DEFAULT_FAVORITE_GROUP_ORDER);
+  const orderedFavoriteTypes = favoriteGroupOrder?.filter((type) =>
+    knownFavoriteTypes.has(type)
+  );
+
+  return [
+    ...new Set(orderedFavoriteTypes),
+    ...DEFAULT_FAVORITE_GROUP_ORDER.filter(
+      (type) => !orderedFavoriteTypes?.includes(type)
+    ),
+  ];
+};
+
+export const buildFavoriteId = (
+  type: FavoriteType,
+  ...ids: Array<number | string>
+) => `${type}:${ids.map((id) => id.toString()).join(':')}`;
+
+export const buildOrganizationFavoriteId = (organizationId: number | string) =>
+  buildFavoriteId('organization', organizationId);
+
+export const buildProductFavoriteId = (
+  organizationId: number | string,
+  productId: number | string
+) => buildFavoriteId('product', organizationId, productId);
+
+export const buildRepositoryFavoriteId = (
+  organizationId: number | string,
+  productId: number | string,
+  repositoryId: number | string
+) => buildFavoriteId('repository', organizationId, productId, repositoryId);
+
+export const buildRunFavoriteId = (runId: number | string) =>
+  buildFavoriteId('run', runId);
+
+/** Create a stored favorite item and assign a timestamp if none is provided. */
+export const createFavoriteItem = (
+  favorite: FavoriteItemInput,
+  now = new Date()
+): FavoriteItem => ({
+  ...favorite,
+  breadcrumbs: [...favorite.breadcrumbs],
+  starredAt: favorite.starredAt ?? now.toISOString(),
+});
+
+/** Add or replace a favorite, keeping the newest entry first. */
+export const addFavoriteItem = (
+  favorites: FavoriteItem[],
+  favorite: FavoriteItemInput,
+  now = new Date()
+): FavoriteItem[] => {
+  const item = createFavoriteItem(favorite, now);
+
+  return [item, ...favorites.filter((existing) => existing.id !== item.id)];
+};
+
+/** Update an existing favorite without adding it if it is not already stored. */
+export const updateFavoriteItem = (
+  favorites: FavoriteItem[],
+  favorite: FavoriteItemInput,
+  now = new Date()
+): FavoriteItem[] => {
+  if (!favorites.some((existing) => existing.id === favorite.id)) {
+    return favorites;
+  }
+
+  const item = createFavoriteItem(favorite, now);
+
+  return favorites.map((existing) =>
+    existing.id === item.id ? item : existing
+  );
+};
+
+export const removeFavoriteItem = (
+  favorites: FavoriteItem[],
+  favoriteId: string
+): FavoriteItem[] => favorites.filter((favorite) => favorite.id !== favoriteId);
+
+/** Remove an existing favorite or add it if it is not stored yet. */
+export const toggleFavoriteItem = (
+  favorites: FavoriteItem[],
+  favorite: FavoriteItemInput,
+  now = new Date()
+): FavoriteItem[] => {
+  if (favorites.some((existing) => existing.id === favorite.id)) {
+    return removeFavoriteItem(favorites, favorite.id);
+  }
+
+  return addFavoriteItem(favorites, favorite, now);
+};
+
+if (import.meta.vitest) {
+  const { describe, expect, it } = import.meta.vitest;
+
+  describe('favorite helpers', () => {
+    const now = new Date('2026-06-16T12:00:00.000Z');
+
+    const favorite: FavoriteItemInput = {
+      id: buildOrganizationFavoriteId(1),
+      type: 'organization',
+      name: 'Acme',
+      breadcrumbs: ['Acme'],
+      to: '/organizations/$orgId',
+      params: { orgId: '1' },
+    };
+
+    it('normalizes favorite group order', () => {
+      expect(
+        normalizeFavoriteGroupOrder(['product', 'run', 'product'])
+      ).toStrictEqual(['product', 'run', 'repository', 'organization']);
+    });
+
+    it('builds stable favorite IDs', () => {
+      expect(buildOrganizationFavoriteId(123)).toBe('organization:123');
+      expect(buildProductFavoriteId(123, 456)).toBe('product:123:456');
+      expect(buildRepositoryFavoriteId(123, 456, 789)).toBe(
+        'repository:123:456:789'
+      );
+      expect(buildRunFavoriteId(42)).toBe('run:42');
+    });
+
+    it('adds favorites newest first', () => {
+      expect(addFavoriteItem([], favorite, now)).toStrictEqual([
+        { ...favorite, starredAt: now.toISOString() },
+      ]);
+    });
+
+    it('de-duplicates favorites by ID', () => {
+      const first = addFavoriteItem([], favorite, now);
+      const updated = addFavoriteItem(
+        first,
+        { ...favorite, name: 'Acme Updated' },
+        new Date('2026-06-16T13:00:00.000Z')
+      );
+
+      expect(updated).toStrictEqual([
+        {
+          ...favorite,
+          name: 'Acme Updated',
+          starredAt: '2026-06-16T13:00:00.000Z',
+        },
+      ]);
+    });
+
+    it('updates a favorite in place', () => {
+      const favorites = addFavoriteItem([], favorite, now);
+
+      expect(
+        updateFavoriteItem(favorites, {
+          ...favorite,
+          name: 'Acme Updated',
+          starredAt: now.toISOString(),
+        })
+      ).toStrictEqual([
+        {
+          ...favorite,
+          name: 'Acme Updated',
+          starredAt: now.toISOString(),
+        },
+      ]);
+    });
+
+    it('removes favorites by ID', () => {
+      const favorites = addFavoriteItem([], favorite, now);
+
+      expect(removeFavoriteItem(favorites, favorite.id)).toStrictEqual([]);
+    });
+
+    it('toggles favorites', () => {
+      const favorites = toggleFavoriteItem([], favorite, now);
+
+      expect(favorites).toStrictEqual([
+        { ...favorite, starredAt: now.toISOString() },
+      ]);
+      expect(toggleFavoriteItem(favorites, favorite, now)).toStrictEqual([]);
+    });
+  });
+}

--- a/ui/src/providers/home-data/home-data-context.ts
+++ b/ui/src/providers/home-data/home-data-context.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { createContext, useContext } from 'react';
+
+import { localHomeDataProvider } from './local-home-data-provider';
+import type { HomeDataProviderValue } from './types';
+
+export const HomeDataContext = createContext<HomeDataProviderValue>(
+  localHomeDataProvider
+);
+
+export const useHomeDataProvider = () => useContext(HomeDataContext);
+
+export const useIsHomeDataEnabled = () => useHomeDataProvider().useIsEnabled();
+
+export const useHomeFavorites = () => useHomeDataProvider().useFavorites();
+
+export const useHomeFavoriteGroupOrder = () =>
+  useHomeDataProvider().useFavoriteGroupOrder();
+
+export const useIsHomeFavorite = (favoriteId: string) =>
+  useHomeDataProvider().useIsFavorite(favoriteId);
+
+export const useHomeFavoriteActions = () =>
+  useHomeDataProvider().useFavoriteActions();
+
+export const useHomeRecentRuns = () => useHomeDataProvider().useRecentRuns();
+
+export const useHomeRecentRunActions = () =>
+  useHomeDataProvider().useRecentRunActions();

--- a/ui/src/providers/home-data/home-data-provider.tsx
+++ b/ui/src/providers/home-data/home-data-provider.tsx
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { ReactNode, useMemo } from 'react';
+import { useAuth } from 'react-oidc-context';
+
+import { HomeDataContext } from './home-data-context';
+import { createLocalHomeDataProvider } from './local-home-data-provider';
+import type { HomeDataProviderValue } from './types';
+
+type HomeDataProviderProps = {
+  value?: HomeDataProviderValue;
+  children: ReactNode;
+};
+
+const getHomeDataUserId = (
+  profile: Record<string, unknown> | undefined
+): string | undefined => {
+  const subject = profile?.sub;
+
+  return typeof subject === 'string' && subject ? subject : undefined;
+};
+
+/** Provide home page data using the authenticated user's local storage scope. */
+export const HomeDataProvider = ({
+  value,
+  children,
+}: HomeDataProviderProps) => {
+  const auth = useAuth();
+  const userId = getHomeDataUserId(auth.user?.profile);
+  const localProvider = useMemo(
+    () => createLocalHomeDataProvider(userId),
+    [userId]
+  );
+
+  return (
+    <HomeDataContext.Provider value={value ?? localProvider}>
+      {children}
+    </HomeDataContext.Provider>
+  );
+};

--- a/ui/src/providers/home-data/index.ts
+++ b/ui/src/providers/home-data/index.ts
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+export * from './favorite-builders';
+export * from './favorites';
+export * from './home-data-context';
+export * from './home-data-provider';
+export * from './local-home-data-provider';
+export * from './recent-runs';
+export * from './types';

--- a/ui/src/providers/home-data/local-home-data-provider.ts
+++ b/ui/src/providers/home-data/local-home-data-provider.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { useMemo } from 'react';
+
+import { useFavoritesStore } from '@/store/favorites.store';
+import { useRecentRunsStore } from '@/store/recent-runs.store';
+import { DEFAULT_FAVORITE_GROUP_ORDER } from './favorites';
+import type {
+  FavoriteItem,
+  FavoriteItemInput,
+  FavoriteType,
+  HomeDataProviderValue,
+  HomeFavoriteActions,
+  HomeRecentRunActions,
+  RecentRunItem,
+  RecentRunItemInput,
+} from './types';
+
+const EMPTY_HOME_DATA_USER_ID = '';
+const EMPTY_FAVORITES: FavoriteItem[] = [];
+const EMPTY_RECENT_RUNS: RecentRunItem[] = [];
+
+const isHomeDataUserAvailable = (
+  userId: string | undefined
+): userId is string => Boolean(userId);
+
+/** Create a home data provider backed by user-scoped local storage. */
+export const createLocalHomeDataProvider = (
+  userId: string | undefined
+): HomeDataProviderValue => {
+  const scopedUserId = userId ?? EMPTY_HOME_DATA_USER_ID;
+
+  const useLocalIsEnabled = () => isHomeDataUserAvailable(userId);
+
+  const useLocalFavorites = () =>
+    useFavoritesStore(
+      (state) => state.favoritesByUser[scopedUserId] ?? EMPTY_FAVORITES
+    );
+
+  const useLocalFavoriteGroupOrder = () =>
+    useFavoritesStore(
+      (state) =>
+        state.favoriteGroupOrderByUser[scopedUserId] ??
+        DEFAULT_FAVORITE_GROUP_ORDER
+    );
+
+  const useLocalIsFavorite = (favoriteId: string) =>
+    useFavoritesStore((state) =>
+      (state.favoritesByUser[scopedUserId] ?? []).some(
+        (favorite) => favorite.id === favoriteId
+      )
+    );
+
+  const useLocalFavoriteActions = () => {
+    const currentUserId = userId;
+    const addFavorite = useFavoritesStore((state) => state.addFavorite);
+    const updateFavorite = useFavoritesStore((state) => state.updateFavorite);
+    const removeFavorite = useFavoritesStore((state) => state.removeFavorite);
+    const toggleFavorite = useFavoritesStore((state) => state.toggleFavorite);
+    const setFavoriteGroupOrder = useFavoritesStore(
+      (state) => state.setFavoriteGroupOrder
+    );
+
+    return useMemo<HomeFavoriteActions>(
+      () => ({
+        addFavorite: (favorite: FavoriteItemInput) => {
+          if (isHomeDataUserAvailable(currentUserId)) {
+            addFavorite(currentUserId, favorite);
+          }
+        },
+        updateFavorite: (favorite: FavoriteItemInput) => {
+          if (isHomeDataUserAvailable(currentUserId)) {
+            updateFavorite(currentUserId, favorite);
+          }
+        },
+        removeFavorite: (favoriteId: string) => {
+          if (isHomeDataUserAvailable(currentUserId)) {
+            removeFavorite(currentUserId, favoriteId);
+          }
+        },
+        toggleFavorite: (favorite: FavoriteItemInput) => {
+          if (isHomeDataUserAvailable(currentUserId)) {
+            toggleFavorite(currentUserId, favorite);
+          }
+        },
+        setFavoriteGroupOrder: (favoriteGroupOrder: FavoriteType[]) => {
+          if (isHomeDataUserAvailable(currentUserId)) {
+            setFavoriteGroupOrder(currentUserId, favoriteGroupOrder);
+          }
+        },
+      }),
+      [
+        addFavorite,
+        currentUserId,
+        removeFavorite,
+        setFavoriteGroupOrder,
+        toggleFavorite,
+        updateFavorite,
+      ]
+    );
+  };
+
+  const useLocalRecentRuns = () =>
+    useRecentRunsStore(
+      (state) => state.recentRunsByUser[scopedUserId] ?? EMPTY_RECENT_RUNS
+    );
+
+  const useLocalRecentRunActions = () => {
+    const currentUserId = userId;
+    const recordRecentRun = useRecentRunsStore(
+      (state) => state.recordRecentRun
+    );
+    const removeRecentRun = useRecentRunsStore(
+      (state) => state.removeRecentRun
+    );
+    const clearRecentRuns = useRecentRunsStore(
+      (state) => state.clearRecentRuns
+    );
+
+    return useMemo<HomeRecentRunActions>(
+      () => ({
+        recordRecentRun: (recentRun: RecentRunItemInput) => {
+          if (isHomeDataUserAvailable(currentUserId)) {
+            recordRecentRun(currentUserId, recentRun);
+          }
+        },
+        removeRecentRun: (recentRunId: string) => {
+          if (isHomeDataUserAvailable(currentUserId)) {
+            removeRecentRun(currentUserId, recentRunId);
+          }
+        },
+        clearRecentRuns: () => {
+          if (isHomeDataUserAvailable(currentUserId)) {
+            clearRecentRuns(currentUserId);
+          }
+        },
+      }),
+      [clearRecentRuns, currentUserId, recordRecentRun, removeRecentRun]
+    );
+  };
+
+  return {
+    useIsEnabled: useLocalIsEnabled,
+    useFavorites: useLocalFavorites,
+    useFavoriteGroupOrder: useLocalFavoriteGroupOrder,
+    useIsFavorite: useLocalIsFavorite,
+    useFavoriteActions: useLocalFavoriteActions,
+    useRecentRuns: useLocalRecentRuns,
+    useRecentRunActions: useLocalRecentRunActions,
+  };
+};
+
+export const localHomeDataProvider = createLocalHomeDataProvider(undefined);

--- a/ui/src/providers/home-data/recent-runs.ts
+++ b/ui/src/providers/home-data/recent-runs.ts
@@ -1,0 +1,167 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import type { RecentRunItem, RecentRunItemInput } from './types';
+
+export const DEFAULT_MAX_RECENT_RUNS = 10;
+
+export const buildRecentRunId = (runId: number | string) =>
+  `run:${runId.toString()}`;
+
+/** Create a stored recent run item and assign a timestamp if none is provided. */
+export const createRecentRunItem = (
+  recentRun: RecentRunItemInput,
+  now = new Date()
+): RecentRunItem => ({
+  ...recentRun,
+  recordedAt: recentRun.recordedAt ?? now.toISOString(),
+});
+
+/**
+ * Add a run to the front of the recent-runs list.
+ *
+ * If the run is already in the list, replace the old entry and keep only the
+ * configured number of entries.
+ */
+export const addRecentRunItem = (
+  recentRuns: RecentRunItem[],
+  recentRun: RecentRunItemInput,
+  maxItems = DEFAULT_MAX_RECENT_RUNS,
+  now = new Date()
+): RecentRunItem[] => {
+  const item = createRecentRunItem(recentRun, now);
+
+  return [
+    item,
+    ...recentRuns.filter((existing) => existing.id !== item.id),
+  ].slice(0, maxItems);
+};
+
+export const removeRecentRunItem = (
+  recentRuns: RecentRunItem[],
+  recentRunId: string
+): RecentRunItem[] =>
+  recentRuns.filter((recentRun) => recentRun.id !== recentRunId);
+
+export const clearRecentRunItems = (): RecentRunItem[] => [];
+
+if (import.meta.vitest) {
+  const { describe, expect, it } = import.meta.vitest;
+
+  describe('recent run helpers', () => {
+    const createInput = (runId: number): RecentRunItemInput => ({
+      id: buildRecentRunId(runId),
+      runId,
+      runIndex: runId,
+      organizationId: 1,
+      organizationName: 'Acme',
+      productId: 2,
+      productName: 'Product',
+      repositoryId: 3,
+      repositoryName: 'Repository',
+      revision: `rev-${runId}`,
+      status: 'CREATED',
+      to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex',
+      params: {
+        orgId: '1',
+        productId: '2',
+        repoId: '3',
+        runIndex: runId.toString(),
+      },
+      createdAt: `2026-06-16T12:00:0${runId}.000Z`,
+    });
+
+    it('builds stable recent run IDs', () => {
+      expect(buildRecentRunId(42)).toBe('run:42');
+    });
+
+    it('adds recent runs newest first', () => {
+      const first = addRecentRunItem(
+        [],
+        createInput(1),
+        10,
+        new Date('2026-06-16T12:00:01.000Z')
+      );
+      const second = addRecentRunItem(
+        first,
+        createInput(2),
+        10,
+        new Date('2026-06-16T12:00:02.000Z')
+      );
+
+      expect(second.map((run) => run.runId)).toStrictEqual([2, 1]);
+    });
+
+    it('de-duplicates recent runs by ID', () => {
+      const first = addRecentRunItem(
+        [],
+        createInput(1),
+        10,
+        new Date('2026-06-16T12:00:01.000Z')
+      );
+      const updated = addRecentRunItem(
+        first,
+        { ...createInput(1), revision: 'updated' },
+        10,
+        new Date('2026-06-16T12:00:02.000Z')
+      );
+
+      expect(updated).toHaveLength(1);
+      expect(updated[0]).toMatchObject({ runId: 1, revision: 'updated' });
+      expect(updated[0]?.recordedAt).toBe('2026-06-16T12:00:02.000Z');
+    });
+
+    it('limits the number of recent runs', () => {
+      const runs = [1, 2, 3].reduce<RecentRunItem[]>(
+        (recentRuns, runId) =>
+          addRecentRunItem(
+            recentRuns,
+            createInput(runId),
+            2,
+            new Date(`2026-06-16T12:00:0${runId}.000Z`)
+          ),
+        []
+      );
+
+      expect(runs.map((run) => run.runId)).toStrictEqual([3, 2]);
+    });
+
+    it('removes a recent run by ID', () => {
+      const runs = [1, 2, 3].reduce<RecentRunItem[]>(
+        (recentRuns, runId) =>
+          addRecentRunItem(
+            recentRuns,
+            createInput(runId),
+            10,
+            new Date(`2026-06-16T12:00:0${runId}.000Z`)
+          ),
+        []
+      );
+
+      expect(removeRecentRunItem(runs, buildRecentRunId(2))).toStrictEqual([
+        runs[0],
+        runs[2],
+      ]);
+    });
+
+    it('clears recent runs', () => {
+      expect(clearRecentRunItems()).toStrictEqual([]);
+    });
+  });
+}

--- a/ui/src/providers/home-data/types.ts
+++ b/ui/src/providers/home-data/types.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import type { OrtRunStatus } from '@/api';
+
+export type FavoriteType = 'organization' | 'product' | 'repository' | 'run';
+
+export type FavoriteRouteParams = Record<string, string>;
+
+export type FavoriteItem = {
+  id: string;
+  type: FavoriteType;
+  name: string;
+  breadcrumbs: string[];
+  to: string;
+  params?: FavoriteRouteParams;
+  starredAt: string;
+};
+
+export type FavoriteItemInput = Omit<FavoriteItem, 'starredAt'> & {
+  starredAt?: string;
+};
+
+export type RecentRunRouteParams = Record<string, string>;
+
+export type RecentRunItem = {
+  id: string;
+  runId: number;
+  runIndex: number;
+  organizationId: number;
+  organizationName: string;
+  productId: number;
+  productName: string;
+  repositoryId: number;
+  repositoryName: string;
+  revision?: string;
+  path?: string;
+  status?: OrtRunStatus;
+  to: string;
+  params: RecentRunRouteParams;
+  createdAt?: string;
+  recordedAt: string;
+};
+
+export type RecentRunItemInput = Omit<RecentRunItem, 'recordedAt'> & {
+  recordedAt?: string;
+};
+
+export type HomeFavoriteActions = {
+  addFavorite: (favorite: FavoriteItemInput) => void;
+  updateFavorite: (favorite: FavoriteItemInput) => void;
+  removeFavorite: (favoriteId: string) => void;
+  toggleFavorite: (favorite: FavoriteItemInput) => void;
+  setFavoriteGroupOrder: (favoriteGroupOrder: FavoriteType[]) => void;
+};
+
+export type HomeRecentRunActions = {
+  recordRecentRun: (recentRun: RecentRunItemInput) => void;
+  removeRecentRun: (recentRunId: string) => void;
+  clearRecentRuns: () => void;
+};
+
+export type HomeDataProviderValue = {
+  /** Whether home data can currently be read and written (e.g. a user is known). */
+  useIsEnabled: () => boolean;
+  useFavorites: () => FavoriteItem[];
+  useFavoriteGroupOrder: () => FavoriteType[];
+  useIsFavorite: (favoriteId: string) => boolean;
+  useFavoriteActions: () => HomeFavoriteActions;
+  useRecentRuns: () => RecentRunItem[];
+  useRecentRunActions: () => HomeRecentRunActions;
+};

--- a/ui/src/routes/-components/home-empty-state.tsx
+++ b/ui/src/routes/-components/home-empty-state.tsx
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import type { ReactNode } from 'react';
+
+export const HomeEmptyState = ({ children }: { children: ReactNode }) => (
+  <div className='text-muted-foreground rounded-lg border border-dashed p-6 text-sm'>
+    {children}
+  </div>
+);

--- a/ui/src/routes/-components/home-favorites-section.tsx
+++ b/ui/src/routes/-components/home-favorites-section.tsx
@@ -1,0 +1,437 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { DragDropProvider } from '@dnd-kit/react';
+import { isSortable, useSortable } from '@dnd-kit/react/sortable';
+import { useQuery } from '@tanstack/react-query';
+import { Link, type LinkProps } from '@tanstack/react-router';
+import { AxiosError } from 'axios';
+import {
+  Building2,
+  FolderGit2,
+  GripVerticalIcon,
+  Package,
+  PlayCircle,
+  Star,
+} from 'lucide-react';
+import { useEffect, useMemo, type ReactNode } from 'react';
+
+import type { Organization, OrtRun, Product, Repository } from '@/api';
+import {
+  getOrganizationOptions,
+  getProductOptions,
+  getRepositoryOptions,
+  getRepositoryRunOptions,
+} from '@/api/@tanstack/react-query.gen';
+import { FavoriteButton } from '@/components/favorite-button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { cn } from '@/lib/utils';
+import {
+  buildOrganizationFavorite,
+  buildProductFavorite,
+  buildRepositoryFavorite,
+  buildRunFavorite,
+  FavoriteItem,
+  FavoriteItemInput,
+  FavoriteRouteParams,
+  FavoriteType,
+  useHomeFavoriteActions,
+  useHomeFavoriteGroupOrder,
+} from '@/providers/home-data';
+import { HomeEmptyState } from './home-empty-state';
+
+const moveItem = <T,>(
+  items: readonly T[],
+  fromIndex: number,
+  toIndex: number
+) => {
+  const nextItems = [...items];
+  const [movedItem] = nextItems.splice(fromIndex, 1);
+
+  if (movedItem !== undefined) {
+    nextItems.splice(toIndex, 0, movedItem);
+  }
+
+  return nextItems;
+};
+
+const isNotFoundError = (error: unknown) =>
+  error instanceof AxiosError &&
+  (error.status ?? error.response?.status) === 404;
+
+const favoriteRefreshQueryOptions = {
+  // Favorite refreshes only keep persisted display data (names / breadcrumbs) up to date.
+  // They are not foreground page data, so avoid eager refetches on every mount or focus.
+  staleTime: 5 * 60 * 1000,
+  refetchOnWindowFocus: false,
+};
+
+type FavoriteGroup = {
+  type: FavoriteType;
+  title: string;
+  icon: typeof Building2;
+  items: FavoriteItem[];
+};
+
+const favoriteTypeLabels: Record<FavoriteType, string> = {
+  organization: 'Organizations',
+  product: 'Products',
+  repository: 'Repositories',
+  run: 'Runs',
+};
+
+const favoriteTypeIcons: Record<FavoriteType, typeof Building2> = {
+  organization: Building2,
+  product: Package,
+  repository: FolderGit2,
+  run: PlayCircle,
+};
+
+type FavoriteRefreshData = {
+  organization?: Organization;
+  product?: Product;
+  repository?: Repository;
+  run?: Pick<OrtRun, 'id' | 'index'>;
+};
+
+type FavoriteRefreshBuilder = (
+  data: FavoriteRefreshData
+) => FavoriteItemInput | undefined;
+
+const favoriteRefreshBuilders: Record<FavoriteType, FavoriteRefreshBuilder> = {
+  organization: ({ organization }) =>
+    organization ? buildOrganizationFavorite(organization) : undefined,
+  product: ({ organization, product }) =>
+    organization && product
+      ? buildProductFavorite(organization, product)
+      : undefined,
+  repository: ({ organization, product, repository }) =>
+    organization && product && repository
+      ? buildRepositoryFavorite(organization, product, repository)
+      : undefined,
+  run: ({ organization, product, repository, run }) =>
+    organization && product && repository && run
+      ? buildRunFavorite(organization, product, repository, run)
+      : undefined,
+};
+
+/** Return a numeric route parameter from a persisted favorite, if present. */
+const getFavoriteRouteParam = (favorite: FavoriteItem, param: string) => {
+  const value = favorite.params?.[param];
+  const numberValue = value ? Number.parseInt(value) : Number.NaN;
+
+  return Number.isNaN(numberValue) ? undefined : numberValue;
+};
+
+const areArraysEqual = (first: string[], second: string[]) =>
+  first.length === second.length &&
+  first.every((value, index) => value === second[index]);
+
+const areRouteParamsEqual = (
+  first?: FavoriteRouteParams,
+  second?: FavoriteRouteParams
+) => {
+  const firstParams = first ?? {};
+  const secondParams = second ?? {};
+  const firstKeys = Object.keys(firstParams);
+  const secondKeys = Object.keys(secondParams);
+
+  return (
+    firstKeys.length === secondKeys.length &&
+    firstKeys.every((key) => firstParams[key] === secondParams[key])
+  );
+};
+
+/** Return whether a stored favorite already matches the refreshed display data. */
+const areFavoritesEqual = (
+  favorite: FavoriteItem,
+  refreshedFavorite: FavoriteItemInput
+) =>
+  favorite.id === refreshedFavorite.id &&
+  favorite.type === refreshedFavorite.type &&
+  favorite.name === refreshedFavorite.name &&
+  favorite.to === refreshedFavorite.to &&
+  areRouteParamsEqual(favorite.params, refreshedFavorite.params) &&
+  areArraysEqual(favorite.breadcrumbs, refreshedFavorite.breadcrumbs);
+
+/** Render a favorite and refresh its stored display data if backing data changed. */
+const FavoriteListItem = ({ favorite }: { favorite: FavoriteItem }) => {
+  const { updateFavorite, removeFavorite } = useHomeFavoriteActions();
+  const orgId = getFavoriteRouteParam(favorite, 'orgId');
+  const productId = getFavoriteRouteParam(favorite, 'productId');
+  const repoId = getFavoriteRouteParam(favorite, 'repoId');
+  const runIndex = getFavoriteRouteParam(favorite, 'runIndex');
+  const needsOrganization = orgId !== undefined;
+  const needsProduct =
+    favorite.type !== 'organization' && productId !== undefined;
+  const needsRepository =
+    (favorite.type === 'repository' || favorite.type === 'run') &&
+    repoId !== undefined;
+  const needsRun =
+    favorite.type === 'run' && repoId !== undefined && runIndex !== undefined;
+
+  const organizationQuery = useQuery({
+    ...getOrganizationOptions({ path: { organizationId: orgId ?? 0 } }),
+    ...favoriteRefreshQueryOptions,
+    enabled: needsOrganization,
+    retry: (failureCount, error) => !isNotFoundError(error) && failureCount < 3,
+  });
+
+  const productQuery = useQuery({
+    ...getProductOptions({ path: { productId: productId ?? 0 } }),
+    ...favoriteRefreshQueryOptions,
+    enabled: needsProduct,
+    retry: (failureCount, error) => !isNotFoundError(error) && failureCount < 3,
+  });
+
+  const repositoryQuery = useQuery({
+    ...getRepositoryOptions({ path: { repositoryId: repoId ?? 0 } }),
+    ...favoriteRefreshQueryOptions,
+    enabled: needsRepository,
+    retry: (failureCount, error) => !isNotFoundError(error) && failureCount < 3,
+  });
+
+  const runQuery = useQuery({
+    ...getRepositoryRunOptions({
+      path: { repositoryId: repoId ?? 0, ortRunIndex: runIndex ?? 0 },
+    }),
+    ...favoriteRefreshQueryOptions,
+    enabled: needsRun,
+    retry: (failureCount, error) => !isNotFoundError(error) && failureCount < 3,
+  });
+
+  const refreshedFavorite = useMemo<FavoriteItemInput | undefined>(() => {
+    const organization = organizationQuery.data;
+    const product = productQuery.data;
+    const repository = repositoryQuery.data;
+    const run = runQuery.data;
+
+    const refreshed = favoriteRefreshBuilders[favorite.type]({
+      organization,
+      product,
+      repository,
+      run,
+    });
+
+    return refreshed
+      ? { ...refreshed, starredAt: favorite.starredAt }
+      : undefined;
+  }, [
+    favorite.starredAt,
+    favorite.type,
+    organizationQuery.data,
+    productQuery.data,
+    repositoryQuery.data,
+    runQuery.data,
+  ]);
+
+  useEffect(() => {
+    if (
+      isNotFoundError(organizationQuery.error) ||
+      isNotFoundError(productQuery.error) ||
+      isNotFoundError(repositoryQuery.error) ||
+      isNotFoundError(runQuery.error)
+    ) {
+      removeFavorite(favorite.id);
+    }
+  }, [
+    favorite.id,
+    organizationQuery.error,
+    productQuery.error,
+    removeFavorite,
+    repositoryQuery.error,
+    runQuery.error,
+  ]);
+
+  useEffect(() => {
+    if (refreshedFavorite && !areFavoritesEqual(favorite, refreshedFavorite)) {
+      updateFavorite(refreshedFavorite);
+    }
+  }, [favorite, refreshedFavorite, updateFavorite]);
+
+  return (
+    <li className='flex items-center justify-between gap-3 rounded-lg border p-2'>
+      <Link
+        to={favorite.to as LinkProps['to']}
+        params={favorite.params as LinkProps['params']}
+        className='min-w-0 flex-1 text-sm break-words text-blue-400 hover:underline'
+      >
+        {favorite.breadcrumbs.join(' / ')}
+      </Link>
+      <FavoriteButton
+        favorite={favorite}
+        size='xs'
+        variant='ghost'
+        className='size-6 p-0'
+      />
+    </li>
+  );
+};
+
+const FavoriteGroupCard = ({
+  group,
+  dragHandle,
+}: {
+  group: FavoriteGroup;
+  dragHandle?: ReactNode;
+}) => {
+  const Icon = group.icon;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className='flex items-center gap-2 text-base'>
+          {dragHandle}
+          <Icon className='h-4 w-4' />
+          {group.title}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {group.items.length > 0 ? (
+          <ul className='space-y-2'>
+            {group.items.map((favorite) => (
+              <FavoriteListItem key={favorite.id} favorite={favorite} />
+            ))}
+          </ul>
+        ) : (
+          <HomeEmptyState>
+            No favorite {group.title.toLowerCase()} yet.
+          </HomeEmptyState>
+        )}
+      </CardContent>
+    </Card>
+  );
+};
+
+const SortableFavoriteGroupCard = ({
+  group,
+  index,
+}: {
+  group: FavoriteGroup;
+  index: number;
+}) => {
+  const { ref, handleRef, isDragging } = useSortable({
+    id: group.type,
+    index,
+    type: 'favorite-group',
+    accept: 'favorite-group',
+  });
+
+  return (
+    <div ref={ref} className={cn(isDragging && 'opacity-60')}>
+      <FavoriteGroupCard
+        group={group}
+        dragHandle={
+          <button
+            ref={handleRef}
+            type='button'
+            aria-label={`Reorder ${group.title}`}
+            className='text-muted-foreground flex h-4 w-4 cursor-grab items-center justify-center rounded-sm hover:text-black focus-visible:ring-2 focus-visible:outline-none active:cursor-grabbing'
+          >
+            <GripVerticalIcon className='h-4 w-4' />
+          </button>
+        }
+      />
+    </div>
+  );
+};
+
+/** Render favorite groups and allow users to persist their preferred group order. */
+export const HomeFavoritesSection = ({
+  favorites,
+}: {
+  favorites: FavoriteItem[];
+}) => {
+  const favoriteGroupOrder = useHomeFavoriteGroupOrder();
+  const { setFavoriteGroupOrder } = useHomeFavoriteActions();
+  const groups: FavoriteGroup[] = favoriteGroupOrder.map((type) => ({
+    type,
+    title: favoriteTypeLabels[type],
+    icon: favoriteTypeIcons[type],
+    items: [...favorites.filter((favorite) => favorite.type === type)].sort(
+      (first, second) =>
+        first.breadcrumbs
+          .join(' / ')
+          .localeCompare(second.breadcrumbs.join(' / '), undefined, {
+            sensitivity: 'base',
+          })
+    ),
+  }));
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className='flex items-center gap-2'>
+          <Star className='h-5 w-5 fill-white text-white' />
+          Favorites
+        </CardTitle>
+        <CardDescription>
+          Star organizations, products, repositories, and runs to keep them on
+          your home page.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {favorites.length > 0 ? (
+          <DragDropProvider
+            onDragEnd={(event) => {
+              if (event.canceled) return;
+
+              const { source } = event.operation;
+
+              if (isSortable(source)) {
+                const { initialIndex, index } = source;
+
+                if (initialIndex !== index) {
+                  setFavoriteGroupOrder(
+                    moveItem(
+                      groups.map((group) => group.type),
+                      initialIndex,
+                      index
+                    )
+                  );
+                }
+              }
+            }}
+          >
+            <div className='flex flex-col gap-4'>
+              {groups.map((group, index) => (
+                <SortableFavoriteGroupCard
+                  key={group.type}
+                  group={group}
+                  index={index}
+                />
+              ))}
+            </div>
+          </DragDropProvider>
+        ) : (
+          <HomeEmptyState>
+            Use the star button on organization, product, repository, or run
+            pages to add favorites here.
+          </HomeEmptyState>
+        )}
+      </CardContent>
+    </Card>
+  );
+};

--- a/ui/src/routes/-components/home-organizations-section.tsx
+++ b/ui/src/routes/-components/home-organizations-section.tsx
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { Link } from '@tanstack/react-router';
+
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+
+export const HomeOrganizationsSection = () => (
+  <Card>
+    <CardHeader>
+      <CardTitle>Organizations</CardTitle>
+      <CardDescription>
+        Browse all organizations you can access, including their products,
+        repositories, and runs.
+      </CardDescription>
+    </CardHeader>
+    <CardContent>
+      <Button asChild>
+        <Link to='/organizations'>Browse organizations</Link>
+      </Button>
+    </CardContent>
+  </Card>
+);

--- a/ui/src/routes/-components/home-recent-runs-section.tsx
+++ b/ui/src/routes/-components/home-recent-runs-section.tsx
@@ -1,0 +1,209 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { Link, type LinkProps } from '@tanstack/react-router';
+import { AxiosError } from 'axios';
+import { PlayCircle } from 'lucide-react';
+import { useEffect } from 'react';
+
+import { OrtRunStatus } from '@/api';
+import {
+  getRepositoryRunOptions,
+  getRunStatisticsOptions,
+} from '@/api/@tanstack/react-query.gen';
+import { ItemCounts } from '@/components/item-counts';
+import { OrtRunJobStatus } from '@/components/ort-run-job-status';
+import { RunDuration } from '@/components/run-duration';
+import { TimestampWithUTC } from '@/components/timestamp-with-utc';
+import { Badge } from '@/components/ui/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import { config } from '@/config';
+import { getStatusBackgroundColor } from '@/helpers/get-status-class';
+import { isJobFinished } from '@/helpers/job-helpers';
+import { RecentRunItem, useHomeRecentRunActions } from '@/providers/home-data';
+import { HomeEmptyState } from './home-empty-state';
+
+const isNotFoundError = (error: unknown) =>
+  error instanceof AxiosError &&
+  (error.status ?? error.response?.status) === 404;
+
+// Stop polling once a run has reached a terminal state, matching the behavior
+// of the run details page.
+const isRunFinished = (status: OrtRunStatus | undefined) =>
+  status === 'FINISHED' ||
+  status === 'FINISHED_WITH_ISSUES' ||
+  status === 'FAILED';
+
+/** Render a recent run and remove it from the list if the run is deleted. */
+const RecentRunListItem = ({ recentRun }: { recentRun: RecentRunItem }) => {
+  const { removeRecentRun } = useHomeRecentRunActions();
+  const runQuery = useQuery({
+    ...getRepositoryRunOptions({
+      path: {
+        repositoryId: recentRun.repositoryId,
+        ortRunIndex: recentRun.runIndex,
+      },
+    }),
+    refetchInterval: (query) =>
+      isRunFinished(query.state.data?.status) ? false : config.pollInterval,
+    retry: (failureCount, error) => !isNotFoundError(error) && failureCount < 3,
+  });
+
+  useEffect(() => {
+    if (isNotFoundError(runQuery.error)) {
+      removeRecentRun(recentRun.id);
+    }
+  }, [recentRun.id, removeRecentRun, runQuery.error]);
+
+  const run = runQuery.data;
+  const statistics = useQuery({
+    ...getRunStatisticsOptions({
+      path: { runId: run?.id ?? recentRun.runId },
+    }),
+    enabled: Boolean(run?.jobs) && !isNotFoundError(runQuery.error),
+    refetchInterval: isRunFinished(run?.status) ? false : config.pollInterval,
+  });
+
+  const status = run?.status ?? recentRun.status;
+  const createdAt = run?.createdAt ?? recentRun.createdAt;
+  const params = {
+    orgId: recentRun.organizationId.toString(),
+    productId: recentRun.productId.toString(),
+    repoId: recentRun.repositoryId.toString(),
+    runIndex: recentRun.runIndex.toString(),
+  };
+
+  return (
+    <li className='space-y-1 rounded-lg border px-3 py-2 text-sm'>
+      <div className='flex items-start justify-between gap-3'>
+        <Link
+          to={recentRun.to as LinkProps['to']}
+          params={params as LinkProps['params']}
+          className='min-w-0 font-medium hover:underline'
+        >
+          <span className='text-blue-400'>Run {recentRun.runIndex}</span>
+          <span className='text-muted-foreground'> of </span>
+          <span className='break-words'>
+            {recentRun.organizationName} / {recentRun.productName} /{' '}
+            {recentRun.repositoryName}
+          </span>
+        </Link>
+        {status && (
+          <Badge
+            className={`shrink-0 border ${getStatusBackgroundColor(status)}`}
+          >
+            {status}
+          </Badge>
+        )}
+      </div>
+
+      <div className='flex items-center justify-between gap-3'>
+        <div className='flex min-w-0 flex-wrap items-center gap-1'>
+          <span className='text-muted-foreground'>Created at</span>
+          {createdAt && <TimestampWithUTC timestamp={createdAt} />}
+          {createdAt && (
+            <div className='flex items-center gap-1'>
+              (
+              <RunDuration
+                createdAt={createdAt}
+                finishedAt={run?.finishedAt ?? undefined}
+              />
+              )
+            </div>
+          )}
+        </div>
+        {run?.jobs && (
+          <div className='shrink-0'>
+            <OrtRunJobStatus jobs={run.jobs} {...params} />
+          </div>
+        )}
+      </div>
+
+      <div className='flex min-h-6 justify-end'>
+        {run?.jobs && (
+          <ItemCounts
+            statistics={statistics.data}
+            compact
+            showIssues={Boolean(isJobFinished(run.jobs.analyzer?.status))}
+            showVulnerabilities={Boolean(
+              isJobFinished(run.jobs.advisor?.status)
+            )}
+            showRuleViolations={Boolean(
+              isJobFinished(run.jobs.evaluator?.status)
+            )}
+            link={{
+              params,
+              issuesSearch: {
+                sortBy: [{ id: 'severity', desc: true }],
+                itemResolved: ['Unresolved'],
+              },
+              vulnerabilitiesSearch: {
+                sortBy: [{ id: 'rating', desc: true }],
+                itemResolved: ['Unresolved'],
+              },
+              ruleViolationsSearch: {
+                sortBy: [{ id: 'severity', desc: true }],
+                itemResolved: ['Unresolved'],
+              },
+            }}
+          />
+        )}
+      </div>
+    </li>
+  );
+};
+
+/** Render runs recently started from this browser UI. */
+export const HomeRecentRunsSection = ({
+  recentRuns,
+}: {
+  recentRuns: RecentRunItem[];
+}) => (
+  <Card>
+    <CardHeader>
+      <CardTitle className='flex items-center gap-2'>
+        <PlayCircle className='h-5 w-5 text-white' />
+        Recently started runs
+      </CardTitle>
+      <CardDescription>
+        Runs started recently (max. 10) are shown here.
+      </CardDescription>
+    </CardHeader>
+    <CardContent>
+      {recentRuns.length > 0 ? (
+        <ul className='space-y-2'>
+          {recentRuns.map((recentRun) => (
+            <RecentRunListItem key={recentRun.id} recentRun={recentRun} />
+          ))}
+        </ul>
+      ) : (
+        <HomeEmptyState>
+          Runs you start from the UI in this browser will appear here.
+        </HomeEmptyState>
+      )}
+    </CardContent>
+  </Card>
+);

--- a/ui/src/routes/admin/index.tsx
+++ b/ui/src/routes/admin/index.tsx
@@ -66,7 +66,7 @@ const OverviewContent = () => {
   return (
     <div className='space-y-4'>
       <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4'>
-        <Link to='/'>
+        <Link to='/organizations'>
           <StatisticsCard
             title='Organizations'
             icon={() => <List className='h-4 w-4' />}

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -17,21 +17,8 @@
  * License-Filename: LICENSE
  */
 
-import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
-import {
-  createColumnHelper,
-  getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
-import { PlusIcon } from 'lucide-react';
-import { useMemo } from 'react';
-import z from 'zod';
 
-import { Organization } from '@/api';
-import { getOrganizationsOptions } from '@/api/@tanstack/react-query.gen';
-import { DataTable } from '@/components/data-table/data-table';
-import { LoadingIndicator } from '@/components/loading-indicator';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -40,203 +27,25 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip';
-import { useIsSuperuser } from '@/hooks/use-authorization';
-import { toastError } from '@/lib/toast';
-import {
-  filterByNameSearchParameterSchema,
-  paginationSearchParameterSchema,
-} from '@/schemas';
-import { useTablePrefsStore } from '@/store/table-prefs.store';
 
-// Fetch the default page size to loader from the store.
-const defaultPageSize = useTablePrefsStore.getState().orgPageSize;
-
-const columnHelper = createColumnHelper<Organization>();
-
-export const IndexPage = () => {
-  const orgPageSize = useTablePrefsStore((state) => state.orgPageSize);
-  const setOrgPageSize = useTablePrefsStore((state) => state.setOrgPageSize);
-  const search = Route.useSearch();
-  const navigate = Route.useNavigate();
-  const { isSuperuser } = useIsSuperuser();
-
-  const pageIndex = useMemo(
-    () => (search.page ? search.page - 1 : 0),
-    [search.page]
-  );
-  const pageSize = useMemo(
-    () => (search.pageSize ? search.pageSize : orgPageSize),
-    [search.pageSize, orgPageSize]
-  );
-  const nameFilter = useMemo(
-    () => (search.filter ? search.filter : undefined),
-    [search.filter]
-  );
-
-  const { data: totalOrganizations } = useSuspenseQuery({
-    ...getOrganizationsOptions({
-      query: { limit: 1 },
-    }),
-  });
-
-  const {
-    data: organizations,
-    isPending,
-    isError,
-    error,
-  } = useQuery({
-    ...getOrganizationsOptions({
-      query: {
-        limit: pageSize,
-        offset: pageIndex * pageSize,
-        filter: nameFilter,
-      },
-    }),
-  });
-
-  const columns = useMemo(
-    () => [
-      columnHelper.accessor('name', {
-        id: 'organization',
-        header: 'Organizations',
-        cell: ({ row }) => (
-          <>
-            <Link
-              className='block font-semibold text-blue-400 hover:underline'
-              to={`/organizations/$orgId`}
-              params={{ orgId: row.original.id.toString() }}
-            >
-              {row.original.name}
-            </Link>
-
-            <div className='text-muted-foreground hidden text-sm md:inline'>
-              {row.original.description}
-            </div>
-          </>
-        ),
-        meta: {
-          filter: {
-            filterVariant: 'regex',
-            setFilterValue: (value: string | undefined) => {
-              navigate({
-                search: { ...search, page: 1, filter: value },
-              });
-            },
-          },
-        },
-      }),
-    ],
-    [navigate, search]
-  );
-
-  const table = useReactTable({
-    data: organizations?.data || [],
-    columns,
-    pageCount: Math.ceil(
-      (organizations?.pagination.totalCount ?? 0) / pageSize
-    ),
-    state: {
-      pagination: {
-        pageIndex,
-        pageSize,
-      },
-      columnFilters: [{ id: 'organization', value: nameFilter }],
-    },
-    getCoreRowModel: getCoreRowModel(),
-    manualPagination: true,
-  });
-
-  if (isPending) {
-    return <LoadingIndicator />;
-  }
-
-  if (isError) {
-    toastError('Unable to load data', error);
-    return;
-  }
-
-  const filtersInUse =
-    totalOrganizations.pagination.totalCount !==
-    organizations.pagination.totalCount;
-  const matching = `, ${organizations.pagination.totalCount} matching filters`;
-
+const HomePage = () => {
   return (
     <Card className='mx-auto w-full max-w-4xl'>
       <CardHeader>
-        <CardTitle>
-          Organizations ({totalOrganizations.pagination.totalCount} in total
-          {filtersInUse && matching})
-        </CardTitle>
+        <CardTitle>Home</CardTitle>
         <CardDescription>
-          Browse your organizations or create a new one
+          Browse all organizations you can access.
         </CardDescription>
-        <div className='py-2'>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                asChild
-                size='sm'
-                className='ml-auto gap-1'
-                disabled={isSuperuser === false}
-              >
-                <Link to='/create-organization'>
-                  Add organization
-                  <PlusIcon className='h-4 w-4' />
-                </Link>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              {isSuperuser !== false
-                ? 'Add an organization for managing products'
-                : 'Insufficient permissions.'}
-            </TooltipContent>
-          </Tooltip>
-        </div>
       </CardHeader>
       <CardContent>
-        <DataTable
-          table={table}
-          setCurrentPageOptions={(currentPage) => {
-            return {
-              to: Route.to,
-              search: { ...search, page: currentPage },
-            };
-          }}
-          setPageSizeOptions={(size) => {
-            // Persist the user preference for page size to local storage.
-            setOrgPageSize(size);
-            return {
-              to: Route.to,
-              search: { ...search, page: 1, pageSize: size },
-            };
-          }}
-        />
+        <Button asChild>
+          <Link to='/organizations'>Browse organizations</Link>
+        </Button>
       </CardContent>
     </Card>
   );
 };
 
 export const Route = createFileRoute('/')({
-  validateSearch: z.object({
-    ...paginationSearchParameterSchema.shape,
-    ...filterByNameSearchParameterSchema.shape,
-  }),
-  loaderDeps: ({ search: { page, pageSize } }) => ({ page, pageSize }),
-  loader: async ({ context: { queryClient }, deps: { page, pageSize } }) => {
-    queryClient.prefetchQuery({
-      ...getOrganizationsOptions({
-        query: {
-          limit: pageSize || defaultPageSize,
-          offset: page ? (page - 1) * (pageSize || defaultPageSize) : 0,
-        },
-      }),
-    });
-  },
-  component: IndexPage,
-  pendingComponent: LoadingIndicator,
+  component: HomePage,
 });

--- a/ui/src/routes/index.tsx
+++ b/ui/src/routes/index.tsx
@@ -17,32 +17,53 @@
  * License-Filename: LICENSE
  */
 
-import { createFileRoute, Link } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
+import { createFileRoute } from '@tanstack/react-router';
 
-import { Button } from '@/components/ui/button';
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
+import { getServerSettingByKeyOptions } from '@/api/@tanstack/react-query.gen';
+import { Card, CardContent } from '@/components/ui/card';
+import { useUser } from '@/hooks/use-user';
+import { useHomeFavorites, useHomeRecentRuns } from '@/providers/home-data';
+import { HomeFavoritesSection } from './-components/home-favorites-section';
+import { HomeOrganizationsSection } from './-components/home-organizations-section';
+import { HomeRecentRunsSection } from './-components/home-recent-runs-section';
+
+const PRODUCT_NAME = 'ORT Server';
 
 const HomePage = () => {
+  const favorites = useHomeFavorites();
+  const recentRuns = useHomeRecentRuns();
+  const user = useUser();
+  const userDisplayName =
+    user.fullName || user.username || user.user?.profile.email;
+  const { data: dbProductName } = useQuery({
+    ...getServerSettingByKeyOptions({ path: { key: 'MAIN_PRODUCT_NAME' } }),
+  });
+  const productName =
+    dbProductName?.value && dbProductName.isEnabled
+      ? dbProductName.value
+      : PRODUCT_NAME;
+
   return (
-    <Card className='mx-auto w-full max-w-4xl'>
-      <CardHeader>
-        <CardTitle>Home</CardTitle>
-        <CardDescription>
-          Browse all organizations you can access.
-        </CardDescription>
-      </CardHeader>
-      <CardContent>
-        <Button asChild>
-          <Link to='/organizations'>Browse organizations</Link>
-        </Button>
-      </CardContent>
-    </Card>
+    <div className='mx-auto flex w-full max-w-7xl flex-col gap-4'>
+      <div>
+        <h1 className='text-3xl font-bold tracking-tight'>
+          Welcome to {productName}
+          {userDisplayName && `, ${userDisplayName}`}!
+        </h1>
+      </div>
+      <HomeOrganizationsSection />
+      <Card>
+        <CardContent className='text-muted-foreground text-sm'>
+          Please note that the information displayed below is only persisted in
+          your current browser.
+        </CardContent>
+      </Card>
+      <div className='grid gap-4 xl:grid-cols-2'>
+        <HomeFavoritesSection favorites={favorites} />
+        <HomeRecentRunsSection recentRuns={recentRuns} />
+      </div>
+    </div>
   );
 };
 

--- a/ui/src/routes/organizations/$orgId/-components/organization-product-table.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-product-table.tsx
@@ -29,10 +29,12 @@ import { useMemo } from 'react';
 
 import { Product } from '@/api';
 import {
+  getOrganizationOptions,
   getOrganizationProductsOptions,
   getProductRepositoriesOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { DataTable } from '@/components/data-table/data-table';
+import { ProductFavoriteButton } from '@/components/favorite-button';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { toastError } from '@/lib/toast';
 import { useTablePrefsStore } from '@/store/table-prefs.store';
@@ -66,6 +68,12 @@ export const OrganizationProductTable = () => {
     [search.filter]
   );
 
+  const { data: organization } = useQuery({
+    ...getOrganizationOptions({
+      path: { organizationId: Number.parseInt(params.orgId) },
+    }),
+  });
+
   const {
     data: products,
     error: prodError,
@@ -90,16 +98,28 @@ export const OrganizationProductTable = () => {
         size: 300,
         cell: ({ row }) => (
           <>
-            <Link
-              className='block font-semibold text-blue-400 hover:underline'
-              to={`/organizations/$orgId/products/$productId`}
-              params={{
-                orgId: row.original.organizationId.toString(),
-                productId: row.original.id.toString(),
-              }}
-            >
-              {row.original.name}
-            </Link>
+            <div className='flex items-center gap-1.5'>
+              <Link
+                className='font-semibold text-blue-400 hover:underline'
+                to={`/organizations/$orgId/products/$productId`}
+                params={{
+                  orgId: row.original.organizationId.toString(),
+                  productId: row.original.id.toString(),
+                }}
+              >
+                {row.original.name}
+              </Link>
+              {organization && (
+                <ProductFavoriteButton
+                  organization={organization}
+                  organizationId={row.original.organizationId}
+                  product={row.original}
+                  size='xs'
+                  variant='ghost'
+                  className='size-6 p-0'
+                />
+              )}
+            </div>
             <div className='text-muted-foreground text-sm md:inline'>
               {row.original.description}
             </div>
@@ -241,7 +261,7 @@ export const OrganizationProductTable = () => {
         enableColumnFilter: false,
       }),
     ],
-    [navigate, search]
+    [navigate, organization, search]
   );
 
   const table = useReactTable({

--- a/ui/src/routes/organizations/$orgId/index.tsx
+++ b/ui/src/routes/organizations/$orgId/index.tsx
@@ -25,6 +25,7 @@ import z from 'zod';
 
 import { getOrganizationOptions } from '@/api/@tanstack/react-query.gen';
 import { ErrorComponent } from '@/components/error-component';
+import { OrganizationFavoriteButton } from '@/components/favorite-button';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { StatisticsCard } from '@/components/statistics-card';
 import {
@@ -74,8 +75,18 @@ const OrganizationComponent = () => {
       <div className='grid grid-cols-4 gap-2'>
         <Card className='col-span-2'>
           <CardHeader>
-            <CardTitle>{organization.name}</CardTitle>
-            <CardDescription>{organization.description}</CardDescription>
+            <div>
+              <div className='flex items-center gap-1.5'>
+                <CardTitle>{organization.name}</CardTitle>
+                <OrganizationFavoriteButton
+                  organization={organization}
+                  size='xs'
+                  variant='ghost'
+                  className='size-6 p-0'
+                />
+              </div>
+              <CardDescription>{organization.description}</CardDescription>
+            </div>
           </CardHeader>
         </Card>
         <OrganizationProductsStatisticsCard

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repository-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repository-table.tsx
@@ -27,8 +27,13 @@ import {
 import { useMemo } from 'react';
 
 import { Repository } from '@/api';
-import { getProductRepositoriesOptions } from '@/api/@tanstack/react-query.gen';
+import {
+  getOrganizationOptions,
+  getProductOptions,
+  getProductRepositoriesOptions,
+} from '@/api/@tanstack/react-query.gen';
 import { DataTable } from '@/components/data-table/data-table';
+import { RepositoryFavoriteButton } from '@/components/favorite-button';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { toastError } from '@/lib/toast';
 import { useTablePrefsStore } from '@/store/table-prefs.store';
@@ -62,6 +67,18 @@ export const ProductRepositoryTable = () => {
     [search.filter]
   );
 
+  const { data: organization } = useQuery({
+    ...getOrganizationOptions({
+      path: { organizationId: Number.parseInt(params.orgId) },
+    }),
+  });
+
+  const { data: product } = useQuery({
+    ...getProductOptions({
+      path: { productId: Number.parseInt(params.productId) },
+    }),
+  });
+
   const {
     data: repositories,
     error: reposError,
@@ -86,30 +103,58 @@ export const ProductRepositoryTable = () => {
           id: 'repository',
           header: 'Repositories',
           size: 300,
-          cell: ({ row }) => (
-            <>
-              <Link
-                className='block font-semibold text-blue-400 hover:underline'
-                to={
-                  '/organizations/$orgId/products/$productId/repositories/$repoId'
-                }
-                params={{
-                  orgId: row.original.organizationId.toString(),
-                  productId: row.original.productId.toString(),
-                  repoId: row.original.id.toString(),
-                }}
-              >
-                {row.original.name && <div>{row.original.name}</div>}
-                <div>{row.original.url}</div>
-              </Link>
-              <div className='text-muted-foreground text-sm md:inline'>
-                {row.original.type}
-                {row.original.description
-                  ? ` | ${row.original.description}`
-                  : ''}
-              </div>
-            </>
-          ),
+          cell: ({ row }) => {
+            const linkParams = {
+              orgId: row.original.organizationId.toString(),
+              productId: row.original.productId.toString(),
+              repoId: row.original.id.toString(),
+            };
+
+            return (
+              <>
+                <div className='flex flex-wrap items-center gap-1.5'>
+                  <Link
+                    className='font-semibold text-blue-400 hover:underline'
+                    to={
+                      '/organizations/$orgId/products/$productId/repositories/$repoId'
+                    }
+                    params={linkParams}
+                  >
+                    {row.original.name || row.original.url}
+                  </Link>
+                  {organization && product && (
+                    <RepositoryFavoriteButton
+                      organization={organization}
+                      organizationId={row.original.organizationId}
+                      product={product}
+                      productId={row.original.productId}
+                      repository={row.original}
+                      size='xs'
+                      variant='ghost'
+                      className='size-6 p-0'
+                    />
+                  )}
+                </div>
+                {row.original.name && (
+                  <Link
+                    className='block font-semibold text-blue-400 hover:underline'
+                    to={
+                      '/organizations/$orgId/products/$productId/repositories/$repoId'
+                    }
+                    params={linkParams}
+                  >
+                    {row.original.url}
+                  </Link>
+                )}
+                <div className='text-muted-foreground text-sm md:inline'>
+                  {row.original.type}
+                  {row.original.description
+                    ? ` | ${row.original.description}`
+                    : ''}
+                </div>
+              </>
+            );
+          },
           meta: {
             filter: {
               filterVariant: 'regex',
@@ -173,7 +218,7 @@ export const ProductRepositoryTable = () => {
         enableColumnFilter: false,
       }),
     ],
-    [navigate, search]
+    [navigate, organization, product, search]
   );
 
   const table = useReactTable({

--- a/ui/src/routes/organizations/$orgId/products/$productId/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/index.tsx
@@ -24,6 +24,7 @@ import { Suspense } from 'react';
 import z from 'zod';
 
 import { getProductOptions } from '@/api/@tanstack/react-query.gen';
+import { ProductFavoriteButton } from '@/components/favorite-button';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { StatisticsCard } from '@/components/statistics-card';
 import {
@@ -73,8 +74,19 @@ const ProductComponent = () => {
       <div className='grid grid-cols-4 gap-2'>
         <Card className='col-span-2'>
           <CardHeader>
-            <CardTitle>{product.name}</CardTitle>
-            <CardDescription>{product.description}</CardDescription>
+            <div>
+              <div className='flex items-center gap-1.5'>
+                <CardTitle>{product.name}</CardTitle>
+                <ProductFavoriteButton
+                  organizationId={params.orgId}
+                  product={product}
+                  size='xs'
+                  variant='ghost'
+                  className='size-6 p-0'
+                />
+              </div>
+              <CardDescription>{product.description}</CardDescription>
+            </div>
           </CardHeader>
         </Card>
         <ProductRepositoriesStatisticsCard

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/repository-runs-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/repository-runs-table.tsx
@@ -30,10 +30,19 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 import { Repeat, View } from 'lucide-react';
+import { useMemo } from 'react';
 
-import { JobSummary, OrtRunSummary } from '@/api';
+import {
+  JobSummary,
+  Organization,
+  OrtRunSummary,
+  Product,
+  Repository,
+} from '@/api';
 import {
   deleteRepositoryRunMutation,
+  getOrganizationOptions,
+  getProductOptions,
   getRepositoryOptions,
   getRepositoryRunsOptions,
   getRepositoryRunsQueryKey,
@@ -42,6 +51,7 @@ import {
 import { DataTable } from '@/components/data-table/data-table';
 import { DeleteDialog } from '@/components/delete-dialog';
 import { DeleteIconButton } from '@/components/delete-icon-button';
+import { FavoriteButton } from '@/components/favorite-button';
 import { ItemCounts } from '@/components/item-counts';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { OrtRunJobStatus } from '@/components/ort-run-job-status';
@@ -67,9 +77,12 @@ import { isJobFinished } from '@/helpers/job-helpers';
 import { useRepositoryPermission } from '@/hooks/use-authorization';
 import { ApiError } from '@/lib/api-error';
 import { toast, toastError } from '@/lib/toast';
+import { buildRunFavorite } from '@/providers/home-data';
 import { useTablePrefsStore } from '@/store/table-prefs.store';
 
 type RepositoryTableProps = {
+  orgId: string;
+  productId: string;
   repoId: string;
   pageIndex: number;
   pageSize: number;
@@ -220,25 +233,60 @@ const SummaryCard = ({ summary }: { summary: OrtRunSummary }) => {
   );
 };
 
-const columns = [
-  columnHelper.accessor('index', {
-    header: 'Index',
-    size: 50,
-    cell: ({ row }) => (
+type FavoriteContext = {
+  organization?: Organization;
+  product?: Product;
+  repository?: Repository;
+};
+
+const RunIndexCell = ({
+  favoriteContext,
+  summary,
+}: {
+  favoriteContext: FavoriteContext;
+  summary: OrtRunSummary;
+}) => {
+  const { organization, product, repository } = favoriteContext;
+
+  return (
+    <div className='flex items-center gap-1.5'>
       <Link
         className='font-semibold text-blue-400 hover:underline'
         to={
           '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex'
         }
         params={{
-          orgId: row.original.organizationId.toString(),
-          productId: row.original.productId.toString(),
-          repoId: row.original.repositoryId.toString(),
-          runIndex: row.original.index.toString(),
+          orgId: summary.organizationId.toString(),
+          productId: summary.productId.toString(),
+          repoId: summary.repositoryId.toString(),
+          runIndex: summary.index.toString(),
         }}
       >
-        {row.original.index}
+        {summary.index}
       </Link>
+      {organization && product && repository && (
+        <FavoriteButton
+          favorite={buildRunFavorite(
+            organization,
+            product,
+            repository,
+            summary
+          )}
+          size='xs'
+          variant='ghost'
+          className='size-6 p-0'
+        />
+      )}
+    </div>
+  );
+};
+
+const createColumns = (favoriteContext: FavoriteContext) => [
+  columnHelper.accessor('index', {
+    header: 'Index',
+    size: 50,
+    cell: ({ row }) => (
+      <RunIndexCell favoriteContext={favoriteContext} summary={row.original} />
     ),
     enableColumnFilter: false,
   }),
@@ -377,12 +425,37 @@ const columns = [
 ];
 
 export const RepositoryRunsTable = ({
+  orgId,
+  productId,
   repoId,
   pageIndex,
   pageSize,
   search,
 }: RepositoryTableProps) => {
   const setRunPageSize = useTablePrefsStore((state) => state.setRunPageSize);
+
+  const { data: organization } = useQuery({
+    ...getOrganizationOptions({
+      path: { organizationId: Number.parseInt(orgId) },
+    }),
+  });
+
+  const { data: product } = useQuery({
+    ...getProductOptions({
+      path: { productId: Number.parseInt(productId) },
+    }),
+  });
+
+  const { data: repository } = useQuery({
+    ...getRepositoryOptions({
+      path: { repositoryId: Number.parseInt(repoId) },
+    }),
+  });
+
+  const columns = useMemo(
+    () => createColumns({ organization, product, repository }),
+    [organization, product, repository]
+  );
 
   const {
     data: runs,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -18,20 +18,26 @@
  */
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { Loader2, PlusIcon, TrashIcon } from 'lucide-react';
 import { useState } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 import { z } from 'zod';
 
-import { postRepositoryRunMutation } from '@/api/@tanstack/react-query.gen';
+import {
+  getOrganizationOptions,
+  getProductOptions,
+  getRepositoryOptions,
+  postRepositoryRunMutation,
+} from '@/api/@tanstack/react-query.gen';
 import {
   getAvailableRepositorySecrets,
   getPluginsForRepository,
   getRepositoryRun,
 } from '@/api/sdk.gen';
 import { CopyToClipboard } from '@/components/copy-to-clipboard';
+import { LoadingIndicator } from '@/components/loading-indicator';
 import { InlineCode } from '@/components/typography.tsx';
 import { Accordion } from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
@@ -58,6 +64,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { useUser } from '@/hooks/use-user.ts';
 import { ApiError } from '@/lib/api-error';
 import { toast, toastError } from '@/lib/toast';
+import { buildRecentRun, useHomeRecentRunActions } from '@/providers/home-data';
 import {
   AdvisorFields,
   AnalyzerFields,
@@ -78,6 +85,7 @@ const CreateRunPage = () => {
   const navigate = useNavigate();
   const params = Route.useParams();
   const { ortRun, plugins, secrets } = Route.useLoaderData();
+  const { recordRecentRun } = useHomeRecentRunActions();
   const [isTest, setIsTest] = useState(false);
   const isSuperuser = useUser().isSuperuser || false;
   const permissions = Route.useRouteContext().permissions;
@@ -92,6 +100,39 @@ const CreateRunPage = () => {
     plugins?.data?.filter(
       (plugin) => plugin.type === 'PACKAGE_CURATION_PROVIDER'
     ) || [];
+
+  const {
+    data: organization,
+    error: orgError,
+    isPending: orgIsPending,
+    isError: orgIsError,
+  } = useQuery({
+    ...getOrganizationOptions({
+      path: { organizationId: Number.parseInt(params.orgId) },
+    }),
+  });
+
+  const {
+    data: product,
+    error: productError,
+    isPending: productIsPending,
+    isError: productIsError,
+  } = useQuery({
+    ...getProductOptions({
+      path: { productId: Number.parseInt(params.productId) },
+    }),
+  });
+
+  const {
+    data: repository,
+    error: repositoryError,
+    isPending: repositoryIsPending,
+    isError: repositoryIsError,
+  } = useQuery({
+    ...getRepositoryOptions({
+      path: { repositoryId: Number.parseInt(params.repoId) },
+    }),
+  });
 
   type AccordionSection =
     | 'analyzer'
@@ -116,6 +157,12 @@ const CreateRunPage = () => {
   const { mutateAsync, isPending } = useMutation({
     ...postRepositoryRunMutation(),
     onSuccess(response) {
+      if (organization && product && repository) {
+        recordRecentRun(
+          buildRecentRun(organization, product, repository, response)
+        );
+      }
+
       toast.info('Create Run', {
         description: 'New run created successfully for this repository.',
       });
@@ -206,6 +253,18 @@ const CreateRunPage = () => {
     // Open the accordions with errors
     setOpenAccordions(accordionsWithErrors);
   };
+
+  if (orgIsPending || productIsPending || repositoryIsPending) {
+    return <LoadingIndicator />;
+  }
+
+  if (orgIsError || productIsError || repositoryIsError) {
+    toastError(
+      'Unable to load data',
+      orgError || productError || repositoryError
+    );
+    return;
+  }
 
   return (
     <Card>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/runs/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/runs/index.tsx
@@ -26,6 +26,7 @@ import {
   getRepositoryRunsOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { JobDurations } from '@/components/charts/job-durations';
+import { RepositoryFavoriteButton } from '@/components/favorite-button';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { Button } from '@/components/ui/button';
 import {
@@ -85,8 +86,18 @@ const RepositoryRunsComponent = () => {
       <Card>
         <CardHeader>
           <CardTitle>
-            <div className='flex justify-between'>
-              <span>{repo.name}</span>
+            <div className='flex justify-between gap-2'>
+              <div className='flex items-center gap-2'>
+                <span>{repo.name}</span>
+                <RepositoryFavoriteButton
+                  organizationId={params.orgId}
+                  productId={params.productId}
+                  repository={repo}
+                  size='xs'
+                  variant='ghost'
+                  className='size-6 p-0'
+                />
+              </div>
               <div>
                 <span className='text-sm font-normal'>
                   {getRepositoryTypeLabel(repo.type)} repository
@@ -149,6 +160,8 @@ const RepositoryRunsComponent = () => {
         </CardHeader>
         <CardContent>
           <RepositoryRunsTable
+            orgId={params.orgId}
+            productId={params.productId}
             repoId={params.repoId}
             pageIndex={pageIndex}
             pageSize={pageSize}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/run-details-bar.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/-components/run-details-bar.tsx
@@ -25,6 +25,7 @@ import {
   getRepositoryRunOptions,
   getRepositoryRunsOptions,
 } from '@/api/@tanstack/react-query.gen';
+import { RunFavoriteButton } from '@/components/favorite-button';
 import { OrtRunJobStatus } from '@/components/ort-run-job-status';
 import { RunDuration } from '@/components/run-duration';
 import { Sha1Component } from '@/components/sha1-component';
@@ -166,7 +167,7 @@ export const RunDetailsBar = ({ className }: RunDetailsBarProps) => {
             runIndex={params.runIndex}
           />
         </div>
-        <div className='flex flex-col justify-start'>
+        <div className='flex items-start gap-2'>
           <Tooltip>
             <TooltipTrigger asChild>
               <Button
@@ -201,6 +202,15 @@ export const RunDetailsBar = ({ className }: RunDetailsBarProps) => {
         <div className='flex items-center gap-2 text-sm'>
           <Label className='font-semibold'>Run ID:</Label>
           <div>{ortRun.id}</div>
+          <RunFavoriteButton
+            organizationId={params.orgId}
+            productId={params.productId}
+            repositoryId={params.repoId}
+            run={ortRun}
+            size='xs'
+            variant='ghost'
+            className='size-6 p-0'
+          />
         </div>
         <div className='flex gap-2 text-sm'>
           <Label className='font-semibold'>Revision:</Label> {ortRun.revision}

--- a/ui/src/routes/organizations/$orgId/settings/index.tsx
+++ b/ui/src/routes/organizations/$orgId/settings/index.tsx
@@ -119,7 +119,7 @@ const OrganizationSettingsPage = () => {
         description: `Organization "${organization.name}" deleted successfully.`,
       });
       navigate({
-        to: '/',
+        to: '/organizations',
       });
     },
     onError(error: ApiError) {
@@ -178,7 +178,7 @@ const OrganizationSettingsPage = () => {
                   variant='outline'
                   onClick={() =>
                     navigate({
-                      to: '/',
+                      to: '/organizations',
                     })
                   }
                   disabled={isPending}

--- a/ui/src/routes/organizations/index.tsx
+++ b/ui/src/routes/organizations/index.tsx
@@ -31,6 +31,7 @@ import z from 'zod';
 import { Organization } from '@/api';
 import { getOrganizationsOptions } from '@/api/@tanstack/react-query.gen';
 import { DataTable } from '@/components/data-table/data-table';
+import { OrganizationFavoriteButton } from '@/components/favorite-button';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { Button } from '@/components/ui/button';
 import {
@@ -106,13 +107,21 @@ export const OrganizationsPage = () => {
         header: 'Organizations',
         cell: ({ row }) => (
           <>
-            <Link
-              className='block font-semibold text-blue-400 hover:underline'
-              to={`/organizations/$orgId`}
-              params={{ orgId: row.original.id.toString() }}
-            >
-              {row.original.name}
-            </Link>
+            <div className='flex items-center gap-1.5'>
+              <Link
+                className='font-semibold text-blue-400 hover:underline'
+                to={`/organizations/$orgId`}
+                params={{ orgId: row.original.id.toString() }}
+              >
+                {row.original.name}
+              </Link>
+              <OrganizationFavoriteButton
+                organization={row.original}
+                size='xs'
+                variant='ghost'
+                className='size-6 p-0'
+              />
+            </div>
 
             <div className='text-muted-foreground hidden text-sm md:inline'>
               {row.original.description}

--- a/ui/src/routes/organizations/index.tsx
+++ b/ui/src/routes/organizations/index.tsx
@@ -1,0 +1,242 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { createFileRoute, Link } from '@tanstack/react-router';
+import {
+  createColumnHelper,
+  getCoreRowModel,
+  useReactTable,
+} from '@tanstack/react-table';
+import { PlusIcon } from 'lucide-react';
+import { useMemo } from 'react';
+import z from 'zod';
+
+import { Organization } from '@/api';
+import { getOrganizationsOptions } from '@/api/@tanstack/react-query.gen';
+import { DataTable } from '@/components/data-table/data-table';
+import { LoadingIndicator } from '@/components/loading-indicator';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { useIsSuperuser } from '@/hooks/use-authorization';
+import { toastError } from '@/lib/toast';
+import {
+  filterByNameSearchParameterSchema,
+  paginationSearchParameterSchema,
+} from '@/schemas';
+import { useTablePrefsStore } from '@/store/table-prefs.store';
+
+// Fetch the default page size to loader from the store.
+const defaultPageSize = useTablePrefsStore.getState().orgPageSize;
+
+const columnHelper = createColumnHelper<Organization>();
+
+export const OrganizationsPage = () => {
+  const orgPageSize = useTablePrefsStore((state) => state.orgPageSize);
+  const setOrgPageSize = useTablePrefsStore((state) => state.setOrgPageSize);
+  const search = Route.useSearch();
+  const navigate = Route.useNavigate();
+  const { isSuperuser } = useIsSuperuser();
+
+  const pageIndex = useMemo(
+    () => (search.page ? search.page - 1 : 0),
+    [search.page]
+  );
+  const pageSize = useMemo(
+    () => (search.pageSize ? search.pageSize : orgPageSize),
+    [search.pageSize, orgPageSize]
+  );
+  const nameFilter = useMemo(
+    () => (search.filter ? search.filter : undefined),
+    [search.filter]
+  );
+
+  const { data: totalOrganizations } = useSuspenseQuery({
+    ...getOrganizationsOptions({
+      query: { limit: 1 },
+    }),
+  });
+
+  const {
+    data: organizations,
+    isPending,
+    isError,
+    error,
+  } = useQuery({
+    ...getOrganizationsOptions({
+      query: {
+        limit: pageSize,
+        offset: pageIndex * pageSize,
+        filter: nameFilter,
+      },
+    }),
+  });
+
+  const columns = useMemo(
+    () => [
+      columnHelper.accessor('name', {
+        id: 'organization',
+        header: 'Organizations',
+        cell: ({ row }) => (
+          <>
+            <Link
+              className='block font-semibold text-blue-400 hover:underline'
+              to={`/organizations/$orgId`}
+              params={{ orgId: row.original.id.toString() }}
+            >
+              {row.original.name}
+            </Link>
+
+            <div className='text-muted-foreground hidden text-sm md:inline'>
+              {row.original.description}
+            </div>
+          </>
+        ),
+        meta: {
+          filter: {
+            filterVariant: 'regex',
+            setFilterValue: (value: string | undefined) => {
+              navigate({
+                search: { ...search, page: 1, filter: value },
+              });
+            },
+          },
+        },
+      }),
+    ],
+    [navigate, search]
+  );
+
+  const table = useReactTable({
+    data: organizations?.data || [],
+    columns,
+    pageCount: Math.ceil(
+      (organizations?.pagination.totalCount ?? 0) / pageSize
+    ),
+    state: {
+      pagination: {
+        pageIndex,
+        pageSize,
+      },
+      columnFilters: [{ id: 'organization', value: nameFilter }],
+    },
+    getCoreRowModel: getCoreRowModel(),
+    manualPagination: true,
+  });
+
+  if (isPending) {
+    return <LoadingIndicator />;
+  }
+
+  if (isError) {
+    toastError('Unable to load data', error);
+    return;
+  }
+
+  const filtersInUse =
+    totalOrganizations.pagination.totalCount !==
+    organizations.pagination.totalCount;
+  const matching = `, ${organizations.pagination.totalCount} matching filters`;
+
+  return (
+    <Card className='mx-auto w-full max-w-4xl'>
+      <CardHeader>
+        <CardTitle>
+          Organizations ({totalOrganizations.pagination.totalCount} in total
+          {filtersInUse && matching})
+        </CardTitle>
+        <CardDescription>
+          Browse your organizations or create a new one
+        </CardDescription>
+        <div className='py-2'>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                asChild
+                size='sm'
+                className='ml-auto gap-1'
+                disabled={isSuperuser === false}
+              >
+                <Link to='/create-organization'>
+                  Add organization
+                  <PlusIcon className='h-4 w-4' />
+                </Link>
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent>
+              {isSuperuser !== false
+                ? 'Add an organization for managing products'
+                : 'Insufficient permissions.'}
+            </TooltipContent>
+          </Tooltip>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <DataTable
+          table={table}
+          setCurrentPageOptions={(currentPage) => {
+            return {
+              to: Route.to,
+              search: { ...search, page: currentPage },
+            };
+          }}
+          setPageSizeOptions={(size) => {
+            // Persist the user preference for page size to local storage.
+            setOrgPageSize(size);
+            return {
+              to: Route.to,
+              search: { ...search, page: 1, pageSize: size },
+            };
+          }}
+        />
+      </CardContent>
+    </Card>
+  );
+};
+
+export const Route = createFileRoute('/organizations/')({
+  validateSearch: z.object({
+    ...paginationSearchParameterSchema.shape,
+    ...filterByNameSearchParameterSchema.shape,
+  }),
+  loaderDeps: ({ search: { page, pageSize } }) => ({ page, pageSize }),
+  loader: async ({ context: { queryClient }, deps: { page, pageSize } }) => {
+    queryClient.prefetchQuery({
+      ...getOrganizationsOptions({
+        query: {
+          limit: pageSize || defaultPageSize,
+          offset: page ? (page - 1) * (pageSize || defaultPageSize) : 0,
+        },
+      }),
+    });
+  },
+  component: OrganizationsPage,
+  pendingComponent: LoadingIndicator,
+});

--- a/ui/src/store/favorites.store.ts
+++ b/ui/src/store/favorites.store.ts
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+import {
+  addFavoriteItem,
+  normalizeFavoriteGroupOrder,
+  removeFavoriteItem,
+  toggleFavoriteItem,
+  updateFavoriteItem,
+} from '@/providers/home-data/favorites';
+import type {
+  FavoriteItem,
+  FavoriteItemInput,
+  FavoriteType,
+} from '@/providers/home-data/types';
+
+type State = {
+  favoritesByUser: Record<string, FavoriteItem[]>;
+  favoriteGroupOrderByUser: Record<string, FavoriteType[]>;
+};
+
+type Actions = {
+  addFavorite: (userId: string, favorite: FavoriteItemInput) => void;
+  updateFavorite: (userId: string, favorite: FavoriteItemInput) => void;
+  removeFavorite: (userId: string, favoriteId: string) => void;
+  toggleFavorite: (userId: string, favorite: FavoriteItemInput) => void;
+  clearFavorites: (userId: string) => void;
+  setFavoriteGroupOrder: (
+    userId: string,
+    favoriteGroupOrder: FavoriteType[]
+  ) => void;
+};
+
+export const FAVORITES_STORAGE_NAME = 'home-favorites-storage';
+
+const getUserFavorites = (state: State, userId: string) =>
+  state.favoritesByUser[userId] ?? [];
+
+export const useFavoritesStore = create<State & Actions>()(
+  persist(
+    (set) => ({
+      favoritesByUser: {},
+      favoriteGroupOrderByUser: {},
+      addFavorite: (userId, favorite) =>
+        set((state) => ({
+          favoritesByUser: {
+            ...state.favoritesByUser,
+            [userId]: addFavoriteItem(
+              getUserFavorites(state, userId),
+              favorite
+            ),
+          },
+        })),
+      updateFavorite: (userId, favorite) =>
+        set((state) => ({
+          favoritesByUser: {
+            ...state.favoritesByUser,
+            [userId]: updateFavoriteItem(
+              getUserFavorites(state, userId),
+              favorite
+            ),
+          },
+        })),
+      removeFavorite: (userId, favoriteId) =>
+        set((state) => ({
+          favoritesByUser: {
+            ...state.favoritesByUser,
+            [userId]: removeFavoriteItem(
+              getUserFavorites(state, userId),
+              favoriteId
+            ),
+          },
+        })),
+      toggleFavorite: (userId, favorite) =>
+        set((state) => ({
+          favoritesByUser: {
+            ...state.favoritesByUser,
+            [userId]: toggleFavoriteItem(
+              getUserFavorites(state, userId),
+              favorite
+            ),
+          },
+        })),
+      clearFavorites: (userId) =>
+        set((state) => ({
+          favoritesByUser: {
+            ...state.favoritesByUser,
+            [userId]: [],
+          },
+        })),
+      setFavoriteGroupOrder: (userId, favoriteGroupOrder) =>
+        set((state) => ({
+          favoriteGroupOrderByUser: {
+            ...state.favoriteGroupOrderByUser,
+            [userId]: normalizeFavoriteGroupOrder(favoriteGroupOrder),
+          },
+        })),
+    }),
+    {
+      name: FAVORITES_STORAGE_NAME,
+      partialize: (state) => ({
+        favoritesByUser: state.favoritesByUser,
+        favoriteGroupOrderByUser: state.favoriteGroupOrderByUser,
+      }),
+      version: 2,
+    }
+  )
+);

--- a/ui/src/store/recent-runs.store.ts
+++ b/ui/src/store/recent-runs.store.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+import {
+  addRecentRunItem,
+  clearRecentRunItems,
+  DEFAULT_MAX_RECENT_RUNS,
+  removeRecentRunItem,
+} from '@/providers/home-data/recent-runs';
+import type {
+  RecentRunItem,
+  RecentRunItemInput,
+} from '@/providers/home-data/types';
+
+type State = {
+  recentRunsByUser: Record<string, RecentRunItem[]>;
+};
+
+type Actions = {
+  recordRecentRun: (userId: string, recentRun: RecentRunItemInput) => void;
+  removeRecentRun: (userId: string, recentRunId: string) => void;
+  clearRecentRuns: (userId: string) => void;
+};
+
+export const RECENT_RUNS_STORAGE_NAME = 'home-recent-runs-storage';
+
+const getUserRecentRuns = (state: State, userId: string) =>
+  state.recentRunsByUser[userId] ?? [];
+
+// The local store intentionally only tracks runs started from this browser UI.
+// Runs started via CLI, API, or another browser are outside this temporary
+// local-storage implementation until a backend-backed provider exists.
+export const useRecentRunsStore = create<State & Actions>()(
+  persist(
+    (set) => ({
+      recentRunsByUser: {},
+      recordRecentRun: (userId, recentRun) =>
+        set((state) => ({
+          recentRunsByUser: {
+            ...state.recentRunsByUser,
+            [userId]: addRecentRunItem(
+              getUserRecentRuns(state, userId),
+              recentRun,
+              DEFAULT_MAX_RECENT_RUNS
+            ),
+          },
+        })),
+      removeRecentRun: (userId, recentRunId) =>
+        set((state) => ({
+          recentRunsByUser: {
+            ...state.recentRunsByUser,
+            [userId]: removeRecentRunItem(
+              getUserRecentRuns(state, userId),
+              recentRunId
+            ),
+          },
+        })),
+      clearRecentRuns: (userId) =>
+        set((state) => ({
+          recentRunsByUser: {
+            ...state.recentRunsByUser,
+            [userId]: clearRecentRunItems(),
+          },
+        })),
+    }),
+    {
+      name: RECENT_RUNS_STORAGE_NAME,
+      partialize: (state) => ({ recentRunsByUser: state.recentRunsByUser }),
+      version: 2,
+    }
+  )
+);

--- a/ui/tests/smoke-test.spec.ts
+++ b/ui/tests/smoke-test.spec.ts
@@ -30,6 +30,10 @@ test('test', async ({ page }) => {
   await page.getByRole('textbox', { name: 'Password' }).fill('admin');
   await page.getByRole('button', { name: 'Sign In' }).click();
   await expect(
+    page.getByRole('link', { name: 'Browse organizations' })
+  ).toBeVisible();
+  await page.goto('/organizations');
+  await expect(
     page.getByText('Browse your organizations or create a new one')
   ).toBeVisible();
   await expect(


### PR DESCRIPTION
This PR implements a new user-tailored home page. It is now possible to mark organizations, products, repositories and runs as "favorite", and the favorite entities are shown in home page, along with recent runs created by the user.

<img width="1323" height="784" alt="Screenshot from 2026-06-23 10-58-15" src="https://github.com/user-attachments/assets/de98a9eb-3e46-4b55-ab81-e699a860fc3f" />

Please see the commits for details. For reviewers, it is encouraged to take the PR branch to local for testing - the first implementation is front-end only, so that can easily be done without recompiling the back-end / building docker images.