### PR TITLE
ui: Add support to package configuration providers to ORT run create form

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/evaluator-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/evaluator-fields.tsx
@@ -19,6 +19,8 @@
 
 import { UseFormReturn } from 'react-hook-form';
 
+import { PreconfiguredPluginDescriptor, Secret } from '@/api';
+import { PluginMultiSelectField } from '@/components/form/plugin-multi-select-field.tsx';
 import {
   AccordionContent,
   AccordionItem,
@@ -31,7 +33,6 @@ import {
   FormItem,
   FormLabel,
 } from '@/components/ui/form';
-import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { CreateRunFormValues } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components';
 
@@ -40,6 +41,9 @@ type EvaluatorFieldsProps = {
   value: string;
   onToggle: () => void;
   isSuperuser: boolean;
+  packageConfigurationProviderPlugins: PreconfiguredPluginDescriptor[];
+  secrets: Secret[];
+  isRerun: boolean;
 };
 
 export const EvaluatorFields = ({
@@ -47,6 +51,9 @@ export const EvaluatorFields = ({
   value,
   onToggle,
   isSuperuser,
+  packageConfigurationProviderPlugins,
+  secrets,
+  isRerun,
 }: EvaluatorFieldsProps) => {
   return (
     <div className='flex flex-row align-middle'>
@@ -60,19 +67,32 @@ export const EvaluatorFields = ({
                 className='my-4 mr-4 data-[state=checked]:bg-green-500'
                 checked={field.value}
                 onCheckedChange={field.onChange}
-                id='evaluator-enabled-switch'
               />
-              {!isSuperuser && (
-                <Label htmlFor='evaluator-enabled-switch'>Evaluator</Label>
-              )}
             </>
           </FormControl>
         )}
       />
-      {isSuperuser && (
-        <AccordionItem value={value} className='flex-1'>
-          <AccordionTrigger onClick={onToggle}>Evaluator</AccordionTrigger>
-          <AccordionContent>
+      <AccordionItem value={value} className='flex-1'>
+        <AccordionTrigger onClick={onToggle}>Evaluator</AccordionTrigger>
+        <AccordionContent className='flex flex-col gap-6'>
+          <PluginMultiSelectField
+            form={form}
+            name='jobConfigs.evaluator.packageConfigurationProviders'
+            configName='jobConfigs.evaluator.packageConfigurationProviderConfig'
+            label='Package configuration providers'
+            description={
+              <>
+                Configure the package configuration providers to use. Providers
+                higher in the list take precedence over lower providers. Change
+                the order of providers via drag & drop.
+              </>
+            }
+            plugins={packageConfigurationProviderPlugins}
+            secrets={secrets}
+            enableReordering
+            showSelectedPluginsFirst={isRerun}
+          />
+          {isSuperuser && (
             <FormField
               control={form.control}
               name='jobConfigs.evaluator.keepAliveWorker'
@@ -95,9 +115,9 @@ export const EvaluatorFields = ({
                 </FormItem>
               )}
             />
-          </AccordionContent>
-        </AccordionItem>
-      )}
+          )}
+        </AccordionContent>
+      </AccordionItem>
     </div>
   );
 };

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/reporter-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/reporter-fields.tsx
@@ -19,8 +19,9 @@
 
 import { UseFormReturn } from 'react-hook-form';
 
-import { PreconfiguredPluginDescriptor } from '@/api';
+import { PreconfiguredPluginDescriptor, Secret } from '@/api';
 import { MultiSelectField } from '@/components/form/multi-select-field';
+import { PluginMultiSelectField } from '@/components/form/plugin-multi-select-field.tsx';
 import {
   AccordionContent,
   AccordionItem,
@@ -42,6 +43,9 @@ type ReporterFieldsProps = {
   onToggle: () => void;
   reporterPlugins: PreconfiguredPluginDescriptor[];
   isSuperuser: boolean;
+  packageConfigurationProviderPlugins: PreconfiguredPluginDescriptor[];
+  secrets: Secret[];
+  isRerun: boolean;
 };
 
 export const ReporterFields = ({
@@ -50,12 +54,16 @@ export const ReporterFields = ({
   onToggle,
   reporterPlugins,
   isSuperuser,
+  packageConfigurationProviderPlugins,
+  secrets,
+  isRerun,
 }: ReporterFieldsProps) => {
   const reporterOptions = reporterPlugins.map((plugin) => ({
     id: plugin.id,
     label: plugin.displayName,
     summary: plugin.summary,
   }));
+  const evaluatorEnabled = form.watch('jobConfigs.evaluator.enabled');
 
   return (
     <div className='flex flex-row align-middle'>
@@ -74,7 +82,7 @@ export const ReporterFields = ({
       />
       <AccordionItem value={value} className='flex-1'>
         <AccordionTrigger onClick={onToggle}>Reporter</AccordionTrigger>
-        <AccordionContent>
+        <AccordionContent className='flex flex-col gap-6'>
           <MultiSelectField
             form={form}
             name='jobConfigs.reporter.formats'
@@ -84,6 +92,25 @@ export const ReporterFields = ({
             }
             options={reporterOptions}
           />
+          {!evaluatorEnabled && (
+            <PluginMultiSelectField
+              form={form}
+              name='jobConfigs.reporter.packageConfigurationProviders'
+              configName='jobConfigs.reporter.packageConfigurationProviderConfig'
+              label='Package configuration providers'
+              description={
+                <>
+                  Configure the package configuration providers to use.
+                  Providers higher in the list take precedence over lower
+                  providers. Change the order of providers via drag & drop.
+                </>
+              }
+              plugins={packageConfigurationProviderPlugins}
+              secrets={secrets}
+              enableReordering
+              showSelectedPluginsFirst={isRerun}
+            />
+          )}
           {form.watch('jobConfigs.reporter.formats').includes('WebApp') && (
             <FormField
               control={form.control}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/default-values.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/default-values.ts
@@ -37,7 +37,8 @@ export function defaultValues(
   advisorPlugins: PreconfiguredPluginDescriptor[],
   scannerPlugins: PreconfiguredPluginDescriptor[],
   isSuperuser: boolean,
-  packageCurationProviderPlugins: PreconfiguredPluginDescriptor[]
+  packageCurationProviderPlugins: PreconfiguredPluginDescriptor[],
+  packageConfigurationProviderPlugins: PreconfiguredPluginDescriptor[]
 ): CreateRunFormValues {
   /**
    * Constructs the default options for a package manager, either as a blank set of options
@@ -93,6 +94,16 @@ export function defaultValues(
   const packageCurationProviderFormValues = providerPluginConfigsToFormValues(
     ortRun?.jobConfigs.analyzer?.packageCurationProviders
   );
+  const packageConfigurationProviderPluginDefaultValues =
+    getPluginDefaultValues(packageConfigurationProviderPlugins);
+  const evaluatorPackageConfigurationProviderFormValues =
+    providerPluginConfigsToFormValues(
+      ortRun?.jobConfigs.evaluator?.packageConfigurationProviders
+    );
+  const reporterPackageConfigurationProviderFormValues =
+    providerPluginConfigsToFormValues(
+      ortRun?.jobConfigs.reporter?.packageConfigurationProviders
+    );
   const scannerDefaults = {
     scanners: ['ScanCode'],
     scannerScopes: {
@@ -170,12 +181,18 @@ export function defaultValues(
         copyrightGarbageFile: '',
         resolutionsFile: '',
         keepAliveWorker: false,
+        packageConfigurationProviders: [],
+        packageConfigurationProviderConfig:
+          packageConfigurationProviderPluginDefaultValues,
       },
       reporter: {
         enabled: true,
         formats: ['CycloneDX', 'SpdxDocument', 'WebApp'],
         deduplicateDependencyTree: false,
         keepAliveWorker: false,
+        packageConfigurationProviders: [],
+        packageConfigurationProviderConfig:
+          packageConfigurationProviderPluginDefaultValues,
       },
       notifier: {
         enabled: false,
@@ -289,6 +306,12 @@ export function defaultValues(
             enabled:
               ortRun.jobConfigs.evaluator !== undefined &&
               ortRun.jobConfigs.evaluator !== null,
+            packageConfigurationProviders:
+              evaluatorPackageConfigurationProviderFormValues.selectedPluginIds,
+            packageConfigurationProviderConfig: mergePluginConfigs(
+              evaluatorPackageConfigurationProviderFormValues.config,
+              packageConfigurationProviderPluginDefaultValues
+            ),
             keepAliveWorker:
               (ortRun.jobConfigs.evaluator?.keepAliveWorker && isSuperuser) ||
               baseDefaults.jobConfigs.evaluator.keepAliveWorker,
@@ -303,6 +326,12 @@ export function defaultValues(
               ) || baseDefaults.jobConfigs.reporter.formats,
             deduplicateDependencyTree:
               deduplicateDependencyTreeEnabled || undefined,
+            packageConfigurationProviders:
+              reporterPackageConfigurationProviderFormValues.selectedPluginIds,
+            packageConfigurationProviderConfig: mergePluginConfigs(
+              reporterPackageConfigurationProviderFormValues.config,
+              packageConfigurationProviderPluginDefaultValues
+            ),
             keepAliveWorker:
               (ortRun.jobConfigs.reporter?.keepAliveWorker && isSuperuser) ||
               baseDefaults.jobConfigs.reporter.keepAliveWorker,
@@ -362,7 +391,7 @@ if (import.meta.vitest) {
       labels: {},
     } as unknown as OrtRun;
 
-    const defaults = defaultValues(ortRun, [], [], false, []);
+    const defaults = defaultValues(ortRun, [], [], false, [], []);
 
     expect(defaults.jobConfigs.analyzer.environmentDefinitions).toEqual(
       ortRun.jobConfigs.analyzer?.environmentConfig?.environmentDefinitions
@@ -370,26 +399,33 @@ if (import.meta.vitest) {
   });
 
   it('uses package curation provider plugin default values for fresh runs', () => {
-    const defaults = defaultValues(null, [], [], false, [
-      {
-        id: 'ClearlyDefined',
-        type: 'PACKAGE_CURATION_PROVIDER',
-        displayName: 'ClearlyDefined',
-        summary: 'A package curation provider plugin',
-        description: 'A package curation provider plugin.',
-        options: [
-          {
-            name: 'serverUrl',
-            description: 'Backend URL.',
-            type: 'STRING',
-            defaultValue: 'https://api.clearlydefined.io',
-            isFixed: true,
-            isNullable: false,
-            isRequired: true,
-          },
-        ],
-      },
-    ]);
+    const defaults = defaultValues(
+      null,
+      [],
+      [],
+      false,
+      [
+        {
+          id: 'ClearlyDefined',
+          type: 'PACKAGE_CURATION_PROVIDER',
+          displayName: 'ClearlyDefined',
+          summary: 'A package curation provider plugin',
+          description: 'A package curation provider plugin.',
+          options: [
+            {
+              name: 'serverUrl',
+              description: 'Backend URL.',
+              type: 'STRING',
+              defaultValue: 'https://api.clearlydefined.io',
+              isFixed: true,
+              isNullable: false,
+              isRequired: true,
+            },
+          ],
+        },
+      ],
+      []
+    );
 
     expect(defaults.jobConfigs.analyzer.packageCurationProviders).toEqual([]);
     expect(defaults.jobConfigs.analyzer.packageCurationProviderConfig).toEqual({
@@ -426,7 +462,7 @@ if (import.meta.vitest) {
       labels: {},
     } as unknown as OrtRun;
 
-    const defaults = defaultValues(ortRun, [], [], false, []);
+    const defaults = defaultValues(ortRun, [], [], false, [], []);
 
     expect(defaults.jobConfigs.analyzer.packageCurationProviders).toEqual([
       'ClearlyDefined',
@@ -438,6 +474,136 @@ if (import.meta.vitest) {
         },
         secrets: {
           token: 'clearly-defined-token',
+        },
+      },
+    });
+  });
+
+  it('uses package configuration provider plugin default values for fresh runs', () => {
+    const defaults = defaultValues(
+      null,
+      [],
+      [],
+      false,
+      [],
+      [
+        {
+          id: 'OrtConfig',
+          type: 'PACKAGE_CONFIGURATION_PROVIDER',
+          displayName: 'ORT Config',
+          summary: 'A package configuration provider plugin',
+          description: 'A package configuration provider plugin.',
+          options: [
+            {
+              name: 'path',
+              description: 'Provider path.',
+              type: 'STRING',
+              defaultValue: 'package-configurations.yml',
+              isFixed: true,
+              isNullable: false,
+              isRequired: true,
+            },
+          ],
+        },
+      ]
+    );
+
+    expect(defaults.jobConfigs.evaluator.packageConfigurationProviders).toEqual(
+      []
+    );
+    expect(
+      defaults.jobConfigs.evaluator.packageConfigurationProviderConfig
+    ).toEqual({
+      OrtConfig: {
+        options: {
+          path: 'package-configurations.yml',
+        },
+        secrets: {},
+      },
+    });
+    expect(defaults.jobConfigs.reporter.packageConfigurationProviders).toEqual(
+      []
+    );
+    expect(
+      defaults.jobConfigs.reporter.packageConfigurationProviderConfig
+    ).toEqual({
+      OrtConfig: {
+        options: {
+          path: 'package-configurations.yml',
+        },
+        secrets: {},
+      },
+    });
+  });
+
+  it('preserves package configuration provider config from reruns', () => {
+    const ortRun = {
+      revision: 'main',
+      path: '',
+      jobConfigs: {
+        evaluator: {
+          packageConfigurationProviders: [
+            {
+              type: 'OrtConfig',
+              id: 'OrtConfig',
+              enabled: true,
+              options: {
+                path: 'evaluator-package-configurations.yml',
+              },
+              secrets: {
+                token: 'evaluator-token',
+              },
+            },
+          ],
+        },
+        reporter: {
+          packageConfigurationProviders: [
+            {
+              type: 'OrtConfig',
+              id: 'OrtConfig',
+              enabled: true,
+              options: {
+                path: 'reporter-package-configurations.yml',
+              },
+              secrets: {
+                token: 'reporter-token',
+              },
+            },
+          ],
+        },
+      },
+      labels: {},
+    } as unknown as OrtRun;
+
+    const defaults = defaultValues(ortRun, [], [], false, [], []);
+
+    expect(defaults.jobConfigs.evaluator.packageConfigurationProviders).toEqual(
+      ['OrtConfig']
+    );
+    expect(
+      defaults.jobConfigs.evaluator.packageConfigurationProviderConfig
+    ).toEqual({
+      OrtConfig: {
+        options: {
+          path: 'evaluator-package-configurations.yml',
+        },
+        secrets: {
+          token: 'evaluator-token',
+        },
+      },
+    });
+    expect(defaults.jobConfigs.reporter.packageConfigurationProviders).toEqual([
+      'OrtConfig',
+    ]);
+    expect(
+      defaults.jobConfigs.reporter.packageConfigurationProviderConfig
+    ).toEqual({
+      OrtConfig: {
+        options: {
+          path: 'reporter-package-configurations.yml',
+        },
+        secrets: {
+          token: 'reporter-token',
         },
       },
     });
@@ -468,6 +634,7 @@ if (import.meta.vitest) {
         },
       ],
       false,
+      [],
       []
     );
 

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/payload.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/payload.ts
@@ -19,6 +19,7 @@
 
 import {
   AnalyzerJobConfiguration,
+  EvaluatorJobConfiguration,
   PostRepositoryRun,
   ReporterJobConfiguration,
 } from '@/api';
@@ -228,8 +229,13 @@ export function formValuesToPayload(
   // Evaluator configuration
   //
 
-  const evaluatorConfig = values.jobConfigs.evaluator.enabled
+  const evaluatorConfig: EvaluatorJobConfiguration | undefined = values
+    .jobConfigs.evaluator.enabled
     ? {
+        packageConfigurationProviders: createProviderPluginPayload(
+          values.jobConfigs.evaluator.packageConfigurationProviderConfig,
+          values.jobConfigs.evaluator.packageConfigurationProviders
+        ),
         keepAliveWorker:
           values.jobConfigs.evaluator.keepAliveWorker || undefined,
       }
@@ -290,6 +296,12 @@ export function formValuesToPayload(
     ? {
         formats: values.jobConfigs.reporter.formats,
         config: Object.keys(config).length > 0 ? config : undefined,
+        packageConfigurationProviders: evaluatorConfig
+          ? undefined
+          : createProviderPluginPayload(
+              values.jobConfigs.reporter.packageConfigurationProviderConfig,
+              values.jobConfigs.reporter.packageConfigurationProviders
+            ),
         keepAliveWorker:
           values.jobConfigs.reporter.keepAliveWorker || undefined,
       }
@@ -345,7 +357,7 @@ if (import.meta.vitest) {
 
   function createFormValues(): CreateRunFormValues {
     return {
-      ...defaultValues(null, [], [], false, []),
+      ...defaultValues(null, [], [], false, [], []),
       revision: 'main',
       path: '',
     };
@@ -446,6 +458,151 @@ if (import.meta.vitest) {
 
       expect(
         payload.jobConfigs.analyzer?.packageCurationProviders
+      ).toBeUndefined();
+    });
+
+    it('adds selected evaluator package configuration providers', () => {
+      const values = createFormValues();
+      values.jobConfigs.evaluator.packageConfigurationProviders = ['OrtConfig'];
+      values.jobConfigs.evaluator.packageConfigurationProviderConfig = {
+        OrtConfig: {
+          options: {
+            path: 'evaluator-package-configurations.yml',
+          },
+          secrets: {
+            token: 'evaluator-token',
+          },
+        },
+        File: {
+          options: {
+            path: 'ignored-package-configurations.yml',
+          },
+          secrets: {},
+        },
+      };
+
+      const payload = formValuesToPayload(values);
+
+      expect(
+        payload.jobConfigs.evaluator?.packageConfigurationProviders
+      ).toEqual([
+        {
+          type: 'OrtConfig',
+          id: 'OrtConfig',
+          enabled: true,
+          options: {
+            path: 'evaluator-package-configurations.yml',
+          },
+          secrets: {
+            token: 'evaluator-token',
+          },
+        },
+      ]);
+    });
+
+    it('adds selected reporter package configuration providers when evaluator is disabled', () => {
+      const values = createFormValues();
+      values.jobConfigs.evaluator.enabled = false;
+      values.jobConfigs.reporter.packageConfigurationProviders = ['OrtConfig'];
+      values.jobConfigs.reporter.packageConfigurationProviderConfig = {
+        OrtConfig: {
+          options: {
+            path: 'reporter-package-configurations.yml',
+          },
+          secrets: {
+            token: 'reporter-token',
+          },
+        },
+      };
+
+      const payload = formValuesToPayload(values);
+
+      expect(payload.jobConfigs.evaluator).toBeUndefined();
+      expect(
+        payload.jobConfigs.reporter?.packageConfigurationProviders
+      ).toEqual([
+        {
+          type: 'OrtConfig',
+          id: 'OrtConfig',
+          enabled: true,
+          options: {
+            path: 'reporter-package-configurations.yml',
+          },
+          secrets: {
+            token: 'reporter-token',
+          },
+        },
+      ]);
+    });
+
+    it('omits package configuration providers if none are selected', () => {
+      const values = createFormValues();
+      values.jobConfigs.evaluator.packageConfigurationProviders = [];
+      values.jobConfigs.evaluator.packageConfigurationProviderConfig = {
+        OrtConfig: {
+          options: {
+            path: 'evaluator-package-configurations.yml',
+          },
+          secrets: {},
+        },
+      };
+      values.jobConfigs.reporter.packageConfigurationProviders = [];
+      values.jobConfigs.reporter.packageConfigurationProviderConfig = {
+        OrtConfig: {
+          options: {
+            path: 'reporter-package-configurations.yml',
+          },
+          secrets: {},
+        },
+      };
+
+      const payload = formValuesToPayload(values);
+
+      expect(
+        payload.jobConfigs.evaluator?.packageConfigurationProviders
+      ).toBeUndefined();
+      expect(
+        payload.jobConfigs.reporter?.packageConfigurationProviders
+      ).toBeUndefined();
+    });
+
+    it('omits reporter package configuration providers when evaluator is enabled', () => {
+      const values = createFormValues();
+      values.jobConfigs.evaluator.packageConfigurationProviders = ['OrtConfig'];
+      values.jobConfigs.evaluator.packageConfigurationProviderConfig = {
+        OrtConfig: {
+          options: {
+            path: 'evaluator-package-configurations.yml',
+          },
+          secrets: {},
+        },
+      };
+      values.jobConfigs.reporter.packageConfigurationProviders = ['File'];
+      values.jobConfigs.reporter.packageConfigurationProviderConfig = {
+        File: {
+          options: {
+            path: 'reporter-package-configurations.yml',
+          },
+          secrets: {},
+        },
+      };
+
+      const payload = formValuesToPayload(values);
+
+      expect(
+        payload.jobConfigs.evaluator?.packageConfigurationProviders
+      ).toEqual([
+        {
+          type: 'OrtConfig',
+          id: 'OrtConfig',
+          enabled: true,
+          options: {
+            path: 'evaluator-package-configurations.yml',
+          },
+        },
+      ]);
+      expect(
+        payload.jobConfigs.reporter?.packageConfigurationProviders
       ).toBeUndefined();
     });
 

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/plugin-utils.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/plugin-utils.ts
@@ -80,7 +80,7 @@ export function validateRequiredPluginOptions(
     | Record<string, Record<string, Record<string, unknown>> | undefined>
     | undefined,
   ctx: z.RefinementCtx,
-  configPath = 'config'
+  configPath: string | string[] = 'config'
 ): void {
   for (const plugin of plugins) {
     if (!selectedPluginIds.includes(plugin.id)) continue;
@@ -98,7 +98,12 @@ export function validateRequiredPluginOptions(
           code: 'invalid_type',
           expected: 'string',
           received: 'undefined',
-          path: [configPath, plugin.id, section, option.name],
+          path: [
+            ...(Array.isArray(configPath) ? configPath : [configPath]),
+            plugin.id,
+            section,
+            option.name,
+          ],
           message: `Required option "${option.name}" is missing for "${plugin.displayName}".`,
         });
       }

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/run-schema.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/run-schema.ts
@@ -23,6 +23,7 @@ import { z } from 'zod';
 import { PreconfiguredPluginDescriptor } from '@/api';
 import { zInfrastructureService } from '@/api/zod.gen';
 import { environmentDefinitionsSchema } from '@/lib/types';
+import { defaultValues } from './default-values';
 import {
   environmentVariableSchema,
   keyValueSchema,
@@ -36,7 +37,8 @@ import {
 export const createRunFormSchema = (
   advisorPlugins: PreconfiguredPluginDescriptor[],
   scannerPlugins: PreconfiguredPluginDescriptor[],
-  packageCurationProviderPlugins: PreconfiguredPluginDescriptor[]
+  packageCurationProviderPlugins: PreconfiguredPluginDescriptor[],
+  packageConfigurationProviderPlugins: PreconfiguredPluginDescriptor[]
 ) => {
   const advisorConfigSchema: Record<string, z.ZodTypeAny> = {};
 
@@ -55,144 +57,195 @@ export const createRunFormSchema = (
       createPluginConfigSchema(plugin);
   });
 
+  const packageConfigurationProviderConfigSchema: Record<string, z.ZodTypeAny> =
+    {};
+  packageConfigurationProviderPlugins.forEach((plugin) => {
+    packageConfigurationProviderConfigSchema[plugin.id] =
+      createPluginConfigSchema(plugin);
+  });
+
   return z.object({
     revision: z.string(),
     path: z.string(),
-    jobConfigs: z.object({
-      analyzer: z
-        .object({
+    jobConfigs: z
+      .object({
+        analyzer: z
+          .object({
+            enabled: z.boolean(),
+            repositoryConfigPath: z.string().optional(),
+            allowDynamicVersions: z.boolean(),
+            skipExcluded: z.boolean(),
+            environmentDefinitions: environmentDefinitionsSchema.optional(),
+            environmentVariables: z.array(environmentVariableSchema).optional(),
+            infrastructureServices: z.array(zInfrastructureService).optional(),
+            keepAliveWorker: z.boolean(),
+            packageCurationProviders: z.array(z.string()),
+            packageCurationProviderConfig: z
+              .object(packageCurationProviderConfigSchema)
+              .optional(),
+            packageManagers: z
+              .object({
+                Bazel: packageManagerOptionsSchema,
+                Bower: packageManagerOptionsSchema,
+                Bundler: packageManagerOptionsSchema,
+                Cargo: packageManagerOptionsSchema,
+                Carthage: packageManagerOptionsSchema,
+                CocoaPods: packageManagerOptionsSchema,
+                Composer: packageManagerOptionsSchema,
+                Conan: packageManagerOptionsSchema,
+                Gleam: packageManagerOptionsSchema,
+                GoMod: packageManagerOptionsSchema,
+                Gradle: packageManagerOptionsSchema,
+                GradleInspector: packageManagerOptionsSchema,
+                Maven: packageManagerOptionsSchema,
+                NPM: packageManagerOptionsSchema,
+                NuGet: packageManagerOptionsSchema,
+                OrtProjectFile: packageManagerOptionsSchema,
+                PIP: packageManagerOptionsSchema,
+                Pipenv: packageManagerOptionsSchema,
+                PNPM: packageManagerOptionsSchema,
+                Poetry: packageManagerOptionsSchema,
+                Pub: packageManagerOptionsSchema,
+                SBT: packageManagerOptionsSchema,
+                SPDX: packageManagerOptionsSchema,
+                SpdxDocumentFile: packageManagerOptionsSchema,
+                Stack: packageManagerOptionsSchema,
+                SwiftPM: packageManagerOptionsSchema,
+                Tycho: packageManagerOptionsSchema,
+                Yarn: packageManagerOptionsSchema,
+                Yarn2: packageManagerOptionsSchema,
+              })
+              .refine((schema) => {
+                // Ensure that not both Gradle and GradleInspector are enabled at the same time.
+                return !(
+                  schema.Gradle.enabled && schema.GradleInspector.enabled
+                );
+              }, '"Gradle Legacy" and "Gradle" cannot be enabled at the same time.'),
+          })
+          .superRefine((data, ctx) => {
+            validateRequiredPluginOptions(
+              packageCurationProviderPlugins,
+              data.packageCurationProviders,
+              data.packageCurationProviderConfig as
+                | Record<
+                    string,
+                    Record<string, Record<string, unknown>> | undefined
+                  >
+                | undefined,
+              ctx,
+              'packageCurationProviderConfig'
+            );
+          }),
+        advisor: z
+          .object({
+            enabled: z.boolean(),
+            skipExcluded: z.boolean(),
+            keepAliveWorker: z.boolean(),
+            advisors: z.array(z.string()),
+            config: z.object(advisorConfigSchema).optional(),
+          })
+          .superRefine((data, ctx) => {
+            validateRequiredPluginOptions(
+              advisorPlugins,
+              data.advisors,
+              data.config as
+                | Record<
+                    string,
+                    Record<string, Record<string, unknown>> | undefined
+                  >
+                | undefined,
+              ctx
+            );
+          }),
+        scanner: z
+          .object({
+            enabled: z.boolean(),
+            skipConcluded: z.boolean(),
+            skipExcluded: z.boolean(),
+            keepAliveWorker: z.boolean(),
+            scanners: z.array(z.string()),
+            scannerScopes: z.record(
+              z.string(),
+              z.enum(['both', 'packages', 'projects']).optional()
+            ),
+            config: z.object(scannerConfigSchema).optional(),
+          })
+          .superRefine((data, ctx) => {
+            validateRequiredPluginOptions(
+              scannerPlugins,
+              data.scanners,
+              data.config as
+                | Record<
+                    string,
+                    Record<string, Record<string, unknown>> | undefined
+                  >
+                | undefined,
+              ctx
+            );
+          }),
+        evaluator: z.object({
           enabled: z.boolean(),
-          repositoryConfigPath: z.string().optional(),
-          allowDynamicVersions: z.boolean(),
-          skipExcluded: z.boolean(),
-          environmentDefinitions: environmentDefinitionsSchema.optional(),
-          environmentVariables: z.array(environmentVariableSchema).optional(),
-          infrastructureServices: z.array(zInfrastructureService).optional(),
+          ruleSet: z.string().optional(),
+          licenseClassificationsFile: z.string().optional(),
+          copyrightGarbageFile: z.string().optional(),
+          resolutionsFile: z.string().optional(),
           keepAliveWorker: z.boolean(),
-          packageCurationProviders: z.array(z.string()),
-          packageCurationProviderConfig: z
-            .object(packageCurationProviderConfigSchema)
+          packageConfigurationProviders: z.array(z.string()),
+          packageConfigurationProviderConfig: z
+            .object(packageConfigurationProviderConfigSchema)
             .optional(),
-          packageManagers: z
-            .object({
-              Bazel: packageManagerOptionsSchema,
-              Bower: packageManagerOptionsSchema,
-              Bundler: packageManagerOptionsSchema,
-              Cargo: packageManagerOptionsSchema,
-              Carthage: packageManagerOptionsSchema,
-              CocoaPods: packageManagerOptionsSchema,
-              Composer: packageManagerOptionsSchema,
-              Conan: packageManagerOptionsSchema,
-              Gleam: packageManagerOptionsSchema,
-              GoMod: packageManagerOptionsSchema,
-              Gradle: packageManagerOptionsSchema,
-              GradleInspector: packageManagerOptionsSchema,
-              Maven: packageManagerOptionsSchema,
-              NPM: packageManagerOptionsSchema,
-              NuGet: packageManagerOptionsSchema,
-              OrtProjectFile: packageManagerOptionsSchema,
-              PIP: packageManagerOptionsSchema,
-              Pipenv: packageManagerOptionsSchema,
-              PNPM: packageManagerOptionsSchema,
-              Poetry: packageManagerOptionsSchema,
-              Pub: packageManagerOptionsSchema,
-              SBT: packageManagerOptionsSchema,
-              SPDX: packageManagerOptionsSchema,
-              SpdxDocumentFile: packageManagerOptionsSchema,
-              Stack: packageManagerOptionsSchema,
-              SwiftPM: packageManagerOptionsSchema,
-              Tycho: packageManagerOptionsSchema,
-              Yarn: packageManagerOptionsSchema,
-              Yarn2: packageManagerOptionsSchema,
-            })
-            .refine((schema) => {
-              // Ensure that not both Gradle and GradleInspector are enabled at the same time.
-              return !(schema.Gradle.enabled && schema.GradleInspector.enabled);
-            }, '"Gradle Legacy" and "Gradle" cannot be enabled at the same time.'),
-        })
-        .superRefine((data, ctx) => {
+        }),
+        reporter: z.object({
+          enabled: z.boolean(),
+          formats: z.array(z.string()),
+          deduplicateDependencyTree: z.boolean().optional(),
+          keepAliveWorker: z.boolean(),
+          packageConfigurationProviders: z.array(z.string()),
+          packageConfigurationProviderConfig: z
+            .object(packageConfigurationProviderConfigSchema)
+            .optional(),
+        }),
+        notifier: z.object({
+          enabled: z.boolean(),
+          recipientAddresses: z
+            .array(z.object({ email: z.string() }))
+            .optional(),
+          keepAliveWorker: z.boolean(),
+        }),
+        parameters: z.array(keyValueSchema).optional(),
+        ruleSet: z.string().optional(),
+      })
+      .superRefine((data, ctx) => {
+        if (data.evaluator.enabled) {
           validateRequiredPluginOptions(
-            packageCurationProviderPlugins,
-            data.packageCurationProviders,
-            data.packageCurationProviderConfig as
+            packageConfigurationProviderPlugins,
+            data.evaluator.packageConfigurationProviders,
+            data.evaluator.packageConfigurationProviderConfig as
               | Record<
                   string,
                   Record<string, Record<string, unknown>> | undefined
                 >
               | undefined,
             ctx,
-            'packageCurationProviderConfig'
+            ['evaluator', 'packageConfigurationProviderConfig']
           );
-        }),
-      advisor: z
-        .object({
-          enabled: z.boolean(),
-          skipExcluded: z.boolean(),
-          keepAliveWorker: z.boolean(),
-          advisors: z.array(z.string()),
-          config: z.object(advisorConfigSchema).optional(),
-        })
-        .superRefine((data, ctx) => {
+        }
+
+        if (data.reporter.enabled && !data.evaluator.enabled) {
           validateRequiredPluginOptions(
-            advisorPlugins,
-            data.advisors,
-            data.config as
+            packageConfigurationProviderPlugins,
+            data.reporter.packageConfigurationProviders,
+            data.reporter.packageConfigurationProviderConfig as
               | Record<
                   string,
                   Record<string, Record<string, unknown>> | undefined
                 >
               | undefined,
-            ctx
+            ctx,
+            ['reporter', 'packageConfigurationProviderConfig']
           );
-        }),
-      scanner: z
-        .object({
-          enabled: z.boolean(),
-          skipConcluded: z.boolean(),
-          skipExcluded: z.boolean(),
-          keepAliveWorker: z.boolean(),
-          scanners: z.array(z.string()),
-          scannerScopes: z.record(
-            z.string(),
-            z.enum(['both', 'packages', 'projects']).optional()
-          ),
-          config: z.object(scannerConfigSchema).optional(),
-        })
-        .superRefine((data, ctx) => {
-          validateRequiredPluginOptions(
-            scannerPlugins,
-            data.scanners,
-            data.config as
-              | Record<
-                  string,
-                  Record<string, Record<string, unknown>> | undefined
-                >
-              | undefined,
-            ctx
-          );
-        }),
-      evaluator: z.object({
-        enabled: z.boolean(),
-        ruleSet: z.string().optional(),
-        licenseClassificationsFile: z.string().optional(),
-        copyrightGarbageFile: z.string().optional(),
-        resolutionsFile: z.string().optional(),
-        keepAliveWorker: z.boolean(),
+        }
       }),
-      reporter: z.object({
-        enabled: z.boolean(),
-        formats: z.array(z.string()),
-        deduplicateDependencyTree: z.boolean().optional(),
-        keepAliveWorker: z.boolean(),
-      }),
-      notifier: z.object({
-        enabled: z.boolean(),
-        recipientAddresses: z.array(z.object({ email: z.string() })).optional(),
-        keepAliveWorker: z.boolean(),
-      }),
-      parameters: z.array(keyValueSchema).optional(),
-      ruleSet: z.string().optional(),
-    }),
     labels: z.array(keyValueSchema).optional(),
     jobConfigContext: z.string().optional(),
     environmentConfigPath: z.string().optional(),
@@ -244,3 +297,94 @@ export const flattenErrors = (
 
   return result;
 };
+
+if (import.meta.vitest) {
+  const { describe, expect, it } = import.meta.vitest;
+
+  const packageConfigurationProviderPlugin: PreconfiguredPluginDescriptor = {
+    id: 'Dir',
+    type: 'PACKAGE_CONFIGURATION_PROVIDER',
+    displayName: 'Directory',
+    summary: 'A package configuration provider plugin.',
+    description: 'A package configuration provider plugin.',
+    options: [
+      {
+        name: 'path',
+        description: 'Provider path.',
+        type: 'STRING',
+        isFixed: false,
+        isNullable: false,
+        isRequired: true,
+      },
+    ],
+  };
+
+  function createValidFormData() {
+    const formData = defaultValues(
+      null,
+      [],
+      [],
+      false,
+      [],
+      [packageConfigurationProviderPlugin]
+    );
+
+    formData.revision = 'main';
+    formData.jobConfigs.evaluator.packageConfigurationProviders = ['Dir'];
+    formData.jobConfigs.evaluator.packageConfigurationProviderConfig = {
+      Dir: {
+        options: {
+          path: 'evaluator-package-configurations',
+        },
+        secrets: {},
+      },
+    };
+    formData.jobConfigs.reporter.packageConfigurationProviders = ['Dir'];
+    formData.jobConfigs.reporter.packageConfigurationProviderConfig = {
+      Dir: {
+        options: {},
+        secrets: {},
+      },
+    };
+
+    return formData;
+  }
+
+  describe('createRunFormSchema', () => {
+    it('ignores reporter package configuration providers when evaluator is enabled', () => {
+      const schema = createRunFormSchema(
+        [],
+        [],
+        [],
+        [packageConfigurationProviderPlugin]
+      );
+
+      const result = schema.safeParse(createValidFormData());
+
+      expect(result.success).toBe(true);
+    });
+
+    it('validates reporter package configuration providers when evaluator is disabled', () => {
+      const schema = createRunFormSchema(
+        [],
+        [],
+        [],
+        [packageConfigurationProviderPlugin]
+      );
+      const formData = createValidFormData();
+      formData.jobConfigs.evaluator.enabled = false;
+
+      const result = schema.safeParse(formData);
+
+      expect(result.success).toBe(false);
+      expect(result.error?.issues.map((issue) => issue.path)).toContainEqual([
+        'jobConfigs',
+        'reporter',
+        'packageConfigurationProviderConfig',
+        'Dir',
+        'options',
+        'path',
+      ]);
+    });
+  });
+}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -100,6 +100,10 @@ const CreateRunPage = () => {
     plugins?.data?.filter(
       (plugin) => plugin.type === 'PACKAGE_CURATION_PROVIDER'
     ) || [];
+  const packageConfigurationProviderPlugins =
+    plugins?.data?.filter(
+      (plugin) => plugin.type === 'PACKAGE_CONFIGURATION_PROVIDER'
+    ) || [];
 
   const {
     data: organization,
@@ -184,7 +188,8 @@ const CreateRunPage = () => {
   const formSchema = createRunFormSchema(
     advisorPlugins,
     scannerPlugins,
-    packageCurationProviderPlugins
+    packageCurationProviderPlugins,
+    packageConfigurationProviderPlugins
   );
 
   const form = useForm<z.infer<typeof formSchema>>({
@@ -194,7 +199,8 @@ const CreateRunPage = () => {
       advisorPlugins,
       scannerPlugins,
       isSuperuser,
-      packageCurationProviderPlugins
+      packageCurationProviderPlugins,
+      packageConfigurationProviderPlugins
     ),
   });
 
@@ -547,6 +553,11 @@ const CreateRunPage = () => {
                 value='evaluator'
                 onToggle={() => toggleAccordionOpen('evaluator')}
                 isSuperuser={isSuperuser}
+                packageConfigurationProviderPlugins={
+                  packageConfigurationProviderPlugins
+                }
+                secrets={secrets.data || []}
+                isRerun={ortRun?.data != null}
               />
               <ReporterFields
                 form={form}
@@ -554,6 +565,11 @@ const CreateRunPage = () => {
                 onToggle={() => toggleAccordionOpen('reporter')}
                 reporterPlugins={reporterPlugins}
                 isSuperuser={isSuperuser}
+                packageConfigurationProviderPlugins={
+                  packageConfigurationProviderPlugins
+                }
+                secrets={secrets.data || []}
+                isRerun={ortRun?.data != null}
               />
               <NotifierFields
                 form={form}


### PR DESCRIPTION
As requested, the reporter section is only rendered, when evaluator job is disabled. As with package curation providers, order of the package configuration providers matter, so drag-and-drop is supported and its behavior is similar to #5295.

<img width="1129" height="640" alt="Screenshot from 2026-06-23 05-56-14" src="https://github.com/user-attachments/assets/67219128-90c0-4738-ae8c-67c2573246a1" />

<img width="439" height="365" alt="Screenshot from 2026-06-23 05-56-37" src="https://github.com/user-attachments/assets/2f8616df-fbc5-49a3-b8ee-41888427f600" />
