### PR TITLE
refactor: Move `Identifier` to shared API model

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
@@ -33,7 +33,6 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.EnvironmentVariableDeclaratio
 import org.eclipse.apoapsis.ortserver.api.v1.model.EvaluatorJob as ApiEvaluatorJob
 import org.eclipse.apoapsis.ortserver.api.v1.model.EvaluatorJobConfiguration as ApiEvaluatorJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.FilterOperatorAndValue as ApiFilterOperatorAndValue
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier as ApiIdentifier
 import org.eclipse.apoapsis.ortserver.api.v1.model.Issue as ApiIssue
 import org.eclipse.apoapsis.ortserver.api.v1.model.JobConfigurations as ApiJobConfigurations
 import org.eclipse.apoapsis.ortserver.api.v1.model.JobStatus as ApiJobStatus
@@ -128,7 +127,6 @@ import org.eclipse.apoapsis.ortserver.model.VulnerabilityFilters
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityForRunsFilters
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityRating
 import org.eclipse.apoapsis.ortserver.model.authentication.OidcConfig
-import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
 import org.eclipse.apoapsis.ortserver.model.runs.LicenseSource
 import org.eclipse.apoapsis.ortserver.model.runs.Package
@@ -655,10 +653,6 @@ fun LicenseSource.mapToApi() = when (this) {
     LicenseSource.DECLARED -> ApiLicenseSource.DECLARED
     LicenseSource.DETECTED -> ApiLicenseSource.DETECTED
 }
-
-fun Identifier.mapToApi() = ApiIdentifier(type = type, namespace = namespace, name = name, version = version)
-
-fun ApiIdentifier.mapToModel() = Identifier(type = type, namespace = namespace, name = name, version = version)
 
 fun VulnerabilityReference.mapToApi() = ApiVulnerabilityReference(
     url = url,

--- a/api/v1/model/src/commonMain/kotlin/Issue.kt
+++ b/api/v1/model/src/commonMain/kotlin/Issue.kt
@@ -24,6 +24,7 @@ import kotlin.time.Instant
 import kotlinx.serialization.Serializable
 
 import org.eclipse.apoapsis.ortserver.shared.apimodel.AppliedIssueResolution
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 import org.eclipse.apoapsis.ortserver.shared.apimodel.IssueResolution
 
 /**

--- a/api/v1/model/src/commonMain/kotlin/Package.kt
+++ b/api/v1/model/src/commonMain/kotlin/Package.kt
@@ -21,6 +21,8 @@ package org.eclipse.apoapsis.ortserver.api.v1.model
 
 import kotlinx.serialization.Serializable
 
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
+
 @Serializable
 data class Package(
     val identifier: Identifier,

--- a/api/v1/model/src/commonMain/kotlin/Project.kt
+++ b/api/v1/model/src/commonMain/kotlin/Project.kt
@@ -21,6 +21,8 @@ package org.eclipse.apoapsis.ortserver.api.v1.model
 
 import kotlinx.serialization.Serializable
 
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
+
 @Serializable
 data class Project(
     val identifier: Identifier,

--- a/api/v1/model/src/commonMain/kotlin/RuleViolation.kt
+++ b/api/v1/model/src/commonMain/kotlin/RuleViolation.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.api.v1.model
 import kotlinx.serialization.Serializable
 
 import org.eclipse.apoapsis.ortserver.shared.apimodel.AppliedRuleViolationResolution
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 import org.eclipse.apoapsis.ortserver.shared.apimodel.RuleViolationResolution
 
 @Serializable

--- a/api/v1/model/src/commonMain/kotlin/ShortestDependencyPath.kt
+++ b/api/v1/model/src/commonMain/kotlin/ShortestDependencyPath.kt
@@ -21,6 +21,8 @@ package org.eclipse.apoapsis.ortserver.api.v1.model
 
 import kotlinx.serialization.Serializable
 
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
+
 /** The shortest dependency path for a Package. */
 @Serializable
 data class ShortestDependencyPath(

--- a/api/v1/model/src/commonMain/kotlin/VulnerabilityWithDetails.kt
+++ b/api/v1/model/src/commonMain/kotlin/VulnerabilityWithDetails.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.api.v1.model
 import kotlinx.serialization.Serializable
 
 import org.eclipse.apoapsis.ortserver.shared.apimodel.AppliedVulnerabilityResolution
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 import org.eclipse.apoapsis.ortserver.shared.apimodel.VulnerabilityResolution
 
 /**

--- a/api/v1/model/src/commonMain/kotlin/VulnerabilityWithStats.kt
+++ b/api/v1/model/src/commonMain/kotlin/VulnerabilityWithStats.kt
@@ -21,6 +21,8 @@ package org.eclipse.apoapsis.ortserver.api.v1.model
 
 import kotlinx.serialization.Serializable
 
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
+
 /**
  * A response object that gathers relevant information about a [Vulnerability].
  */

--- a/components/dependency-graph/api-model/build.gradle.kts
+++ b/components/dependency-graph/api-model/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                api(projects.api.v1.apiV1Model)
+                api(projects.shared.apiModel)
 
                 api(libs.kotlinxSerializationCore)
             }

--- a/components/dependency-graph/api-model/src/commonMain/kotlin/DependencyGraph.kt
+++ b/components/dependency-graph/api-model/src/commonMain/kotlin/DependencyGraph.kt
@@ -21,7 +21,7 @@ package org.eclipse.apoapsis.ortserver.components.dependencygraph
 
 import kotlinx.serialization.Serializable
 
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 
 @Serializable
 data class DependencyGraphs(

--- a/components/dependency-graph/backend/src/main/kotlin/DependencyGraphService.kt
+++ b/components/dependency-graph/backend/src/main/kotlin/DependencyGraphService.kt
@@ -19,7 +19,6 @@
 
 package org.eclipse.apoapsis.ortserver.components.dependencygraph.backend
 
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
 import org.eclipse.apoapsis.ortserver.components.dependencygraph.DependencyGraph
 import org.eclipse.apoapsis.ortserver.components.dependencygraph.DependencyGraphEdge
 import org.eclipse.apoapsis.ortserver.components.dependencygraph.DependencyGraphNode
@@ -42,6 +41,7 @@ import org.eclipse.apoapsis.ortserver.model.runs.DependencyGraph as ModelDepende
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier as ModelIdentifier
 import org.eclipse.apoapsis.ortserver.model.runs.Project as ModelProject
 import org.eclipse.apoapsis.ortserver.model.util.OrderField
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.and

--- a/components/dependency-graph/backend/src/routes/kotlin/routes/GetDependencyGraph.kt
+++ b/components/dependency-graph/backend/src/routes/kotlin/routes/GetDependencyGraph.kt
@@ -36,6 +36,7 @@ import org.eclipse.apoapsis.ortserver.model.repositories.AnalyzerJobRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.AnalyzerRunRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
 import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToModel
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.jsonBody
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.processSortParameter
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireIdParameter
@@ -69,7 +70,7 @@ internal fun Route.getRunDependencyGraph(
                             graphs = mapOf(
                                 "Maven" to DependencyGraph(
                                     packages = listOf(
-                                        org.eclipse.apoapsis.ortserver.api.v1.model.Identifier(
+                                        Identifier(
                                             type = "Maven",
                                             namespace = "com.example",
                                             name = "root",

--- a/components/dependency-graph/backend/src/test/kotlin/DependencyGraphServiceTest.kt
+++ b/components/dependency-graph/backend/src/test/kotlin/DependencyGraphServiceTest.kt
@@ -22,7 +22,6 @@ package org.eclipse.apoapsis.ortserver.components.dependencygraph.backend
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.shouldBe
 
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
 import org.eclipse.apoapsis.ortserver.components.dependencygraph.DependencyGraph
 import org.eclipse.apoapsis.ortserver.components.dependencygraph.DependencyGraphEdge
 import org.eclipse.apoapsis.ortserver.components.dependencygraph.DependencyGraphNode
@@ -42,6 +41,7 @@ import org.eclipse.apoapsis.ortserver.model.runs.repository.PackageCuration
 import org.eclipse.apoapsis.ortserver.model.runs.repository.PackageCurationData
 import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
 import org.eclipse.apoapsis.ortserver.model.util.OrderField
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 
 import org.jetbrains.exposed.v1.jdbc.Database
 

--- a/components/dependency-graph/backend/src/test/kotlin/routes/GetDependencyGraphIntegrationTest.kt
+++ b/components/dependency-graph/backend/src/test/kotlin/routes/GetDependencyGraphIntegrationTest.kt
@@ -26,7 +26,6 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
 import org.eclipse.apoapsis.ortserver.components.dependencygraph.DependencyGraph
 import org.eclipse.apoapsis.ortserver.components.dependencygraph.DependencyGraphEdge
 import org.eclipse.apoapsis.ortserver.components.dependencygraph.DependencyGraphNode
@@ -38,6 +37,7 @@ import org.eclipse.apoapsis.ortserver.model.runs.DependencyGraphEdge as ModelDep
 import org.eclipse.apoapsis.ortserver.model.runs.DependencyGraphNode as ModelDependencyGraphNode
 import org.eclipse.apoapsis.ortserver.model.runs.DependencyGraphRoot as ModelDependencyGraphRoot
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier as ModelIdentifier
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 
 class GetDependencyGraphIntegrationTest : DependencyGraphIntegrationTest({
     "GetDependencyGraph" should {

--- a/components/license-findings/api-model/build.gradle.kts
+++ b/components/license-findings/api-model/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                api(projects.api.v1.apiV1Model)
+                api(projects.shared.apiModel)
 
                 api(libs.kotlinxSerializationCore)
             }

--- a/components/license-findings/backend/build.gradle.kts
+++ b/components/license-findings/backend/build.gradle.kts
@@ -44,7 +44,6 @@ dependencies {
     testImplementation(testFixtures(projects.dao))
     testImplementation(testFixtures(projects.shared.ktorUtils))
 
-    testImplementation(projects.api.v1.apiV1Mapping)
     testImplementation(ktorLibs.server.testHost)
     testImplementation(libs.kotestAssertionsCore)
 }

--- a/components/license-findings/backend/src/main/kotlin/LicenseFindingService.kt
+++ b/components/license-findings/backend/src/main/kotlin/LicenseFindingService.kt
@@ -19,7 +19,6 @@
 
 package org.eclipse.apoapsis.ortserver.components.licensefindings
 
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
 import org.eclipse.apoapsis.ortserver.dao.QueryParametersException
 import org.eclipse.apoapsis.ortserver.dao.blockingQuery
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerjob.AnalyzerJobsTable
@@ -40,6 +39,7 @@ import org.eclipse.apoapsis.ortserver.dao.utils.applyILike
 import org.eclipse.apoapsis.ortserver.dao.utils.toSortOrder
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 
 import org.jetbrains.exposed.v1.core.Count
 import org.jetbrains.exposed.v1.core.CustomFunction

--- a/components/license-findings/backend/src/routes/kotlin/routes/GetRunPackagesWithDetectedLicense.kt
+++ b/components/license-findings/backend/src/routes/kotlin/routes/GetRunPackagesWithDetectedLicense.kt
@@ -23,13 +23,13 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
 import org.eclipse.apoapsis.ortserver.components.authorization.routes.get
 import org.eclipse.apoapsis.ortserver.components.licensefindings.LicenseFindingService
 import org.eclipse.apoapsis.ortserver.components.licensefindings.PackageIdentifier
 import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
 import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToApi
 import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToModel
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagingData
 import org.eclipse.apoapsis.ortserver.shared.apimodel.SortDirection

--- a/components/license-findings/backend/src/test/kotlin/LicenseFindingServiceTest.kt
+++ b/components/license-findings/backend/src/test/kotlin/LicenseFindingServiceTest.kt
@@ -27,7 +27,6 @@ import io.kotest.matchers.shouldBe
 
 import kotlin.time.Clock
 
-import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToApi
 import org.eclipse.apoapsis.ortserver.dao.blockingQuery
 import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsPackageProvenancesTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsScanResultsTable
@@ -48,6 +47,7 @@ import org.eclipse.apoapsis.ortserver.model.runs.VcsInfo
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
 import org.eclipse.apoapsis.ortserver.model.util.OrderField
+import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToApi
 
 import org.jetbrains.exposed.v1.jdbc.Database
 

--- a/components/license-findings/backend/src/test/kotlin/routes/GetRunPackagesWithDetectedLicenseIntegrationTest.kt
+++ b/components/license-findings/backend/src/test/kotlin/routes/GetRunPackagesWithDetectedLicenseIntegrationTest.kt
@@ -27,12 +27,12 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 
-import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToApi
 import org.eclipse.apoapsis.ortserver.components.licensefindings.LicenseFindingIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.licensefindings.PackageIdentifier
 import org.eclipse.apoapsis.ortserver.components.licensefindings.SeedResult
 import org.eclipse.apoapsis.ortserver.components.licensefindings.seedData
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters.Companion.DEFAULT_LIMIT
+import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToApi
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagingData
 import org.eclipse.apoapsis.ortserver.shared.apimodel.SortDirection

--- a/components/search/api-model/build.gradle.kts
+++ b/components/search/api-model/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                api(projects.api.v1.apiV1Model)
+                api(projects.shared.apiModel)
 
                 api(libs.kotlinxSerializationCore)
             }

--- a/components/search/api-model/src/commonMain/kotlin/RunWithPackage.kt
+++ b/components/search/api-model/src/commonMain/kotlin/RunWithPackage.kt
@@ -23,7 +23,7 @@ import kotlin.time.Instant
 
 import kotlinx.serialization.Serializable
 
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 
 @Serializable
 data class RunWithPackage(

--- a/components/search/api-model/src/commonMain/kotlin/RunWithVulnerability.kt
+++ b/components/search/api-model/src/commonMain/kotlin/RunWithVulnerability.kt
@@ -23,7 +23,7 @@ import kotlin.time.Instant
 
 import kotlinx.serialization.Serializable
 
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 
 @Serializable
 data class RunWithVulnerability(

--- a/components/search/backend/src/main/kotlin/SearchService.kt
+++ b/components/search/backend/src/main/kotlin/SearchService.kt
@@ -19,7 +19,6 @@
 
 package org.eclipse.apoapsis.ortserver.components.search.backend
 
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
 import org.eclipse.apoapsis.ortserver.components.authorization.rights.RepositoryPermission
 import org.eclipse.apoapsis.ortserver.components.authorization.service.AuthorizationService
 import org.eclipse.apoapsis.ortserver.components.search.apimodel.RunWithPackage
@@ -52,6 +51,7 @@ import org.eclipse.apoapsis.ortserver.model.CompoundHierarchyId
 import org.eclipse.apoapsis.ortserver.model.HierarchyId
 import org.eclipse.apoapsis.ortserver.model.HierarchyLevel
 import org.eclipse.apoapsis.ortserver.model.util.HierarchyFilter
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 
 import org.jetbrains.exposed.v1.core.CustomFunction
 import org.jetbrains.exposed.v1.core.Expression

--- a/components/search/backend/src/routes/kotlin/routes/GetRunsWithPackage.kt
+++ b/components/search/backend/src/routes/kotlin/routes/GetRunsWithPackage.kt
@@ -25,12 +25,12 @@ import io.ktor.server.routing.Route
 
 import kotlin.time.Clock
 
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
 import org.eclipse.apoapsis.ortserver.components.authorization.routes.OrtServerPrincipal.Companion.requirePrincipal
 import org.eclipse.apoapsis.ortserver.components.authorization.routes.get
 import org.eclipse.apoapsis.ortserver.components.search.apimodel.RunWithPackage
 import org.eclipse.apoapsis.ortserver.components.search.backend.SearchService
 import org.eclipse.apoapsis.ortserver.dao.QueryParametersException
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.jsonBody
 
 @Suppress("LongMethod")

--- a/components/search/backend/src/routes/kotlin/routes/GetRunsWithVulnerability.kt
+++ b/components/search/backend/src/routes/kotlin/routes/GetRunsWithVulnerability.kt
@@ -25,12 +25,12 @@ import io.ktor.server.routing.Route
 
 import kotlin.time.Clock
 
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
 import org.eclipse.apoapsis.ortserver.components.authorization.routes.OrtServerPrincipal.Companion.requirePrincipal
 import org.eclipse.apoapsis.ortserver.components.authorization.routes.get
 import org.eclipse.apoapsis.ortserver.components.search.apimodel.RunWithVulnerability
 import org.eclipse.apoapsis.ortserver.components.search.backend.SearchService
 import org.eclipse.apoapsis.ortserver.dao.QueryParametersException
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.jsonBody
 
 @Suppress("LongMethod")

--- a/components/search/backend/src/test/kotlin/Utils.kt
+++ b/components/search/backend/src/test/kotlin/Utils.kt
@@ -21,7 +21,6 @@ package ort.eclipse.apoapsis.ortserver.components.search
 
 import kotlin.time.Clock
 
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier as ApiIdentifier
 import org.eclipse.apoapsis.ortserver.components.search.apimodel.RunWithPackage
 import org.eclipse.apoapsis.ortserver.components.search.apimodel.RunWithVulnerability
 import org.eclipse.apoapsis.ortserver.dao.test.Fixtures
@@ -32,6 +31,7 @@ import org.eclipse.apoapsis.ortserver.model.runs.advisor.AdvisorResult
 import org.eclipse.apoapsis.ortserver.model.runs.advisor.Vulnerability
 import org.eclipse.apoapsis.ortserver.model.runs.repository.PackageCuration
 import org.eclipse.apoapsis.ortserver.model.runs.repository.PackageCurationData
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier as ApiIdentifier
 
 fun createRunWithPackage(
     fixtures: Fixtures,

--- a/components/snippet-findings/api-model/build.gradle.kts
+++ b/components/snippet-findings/api-model/build.gradle.kts
@@ -36,7 +36,7 @@ kotlin {
     sourceSets {
         commonMain {
             dependencies {
-                api(projects.api.v1.apiV1Model)
+                api(projects.shared.apiModel)
             }
         }
     }

--- a/components/snippet-findings/api-model/src/commonMain/kotlin/SnippetFindingProvenance.kt
+++ b/components/snippet-findings/api-model/src/commonMain/kotlin/SnippetFindingProvenance.kt
@@ -21,7 +21,7 @@ package org.eclipse.apoapsis.ortserver.components.snippetfindings
 
 import kotlinx.serialization.Serializable
 
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 
 @Serializable
 data class SnippetFindingProvenance(

--- a/components/snippet-findings/backend/src/main/kotlin/SnippetFindingService.kt
+++ b/components/snippet-findings/backend/src/main/kotlin/SnippetFindingService.kt
@@ -19,7 +19,6 @@
 
 package org.eclipse.apoapsis.ortserver.components.snippetfindings
 
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
 import org.eclipse.apoapsis.ortserver.dao.QueryParametersException
 import org.eclipse.apoapsis.ortserver.dao.blockingQuery
 import org.eclipse.apoapsis.ortserver.dao.repositories.scannerjob.ScannerJobsTable
@@ -42,6 +41,7 @@ import org.eclipse.apoapsis.ortserver.dao.utils.toSortOrder
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
 import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 
 import org.jetbrains.exposed.v1.core.Count
 import org.jetbrains.exposed.v1.core.Join

--- a/components/snippet-findings/backend/src/routes/kotlin/routes/GetRunSnippetFindingProvenances.kt
+++ b/components/snippet-findings/backend/src/routes/kotlin/routes/GetRunSnippetFindingProvenances.kt
@@ -23,13 +23,13 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
 import org.eclipse.apoapsis.ortserver.components.authorization.routes.get
 import org.eclipse.apoapsis.ortserver.components.snippetfindings.SnippetFindingProvenance
 import org.eclipse.apoapsis.ortserver.components.snippetfindings.SnippetFindingService
 import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
 import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToApi
 import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToModel
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagingData
 import org.eclipse.apoapsis.ortserver.shared.apimodel.SortDirection

--- a/components/snippet-findings/backend/src/test/kotlin/SnippetFindingServiceTest.kt
+++ b/components/snippet-findings/backend/src/test/kotlin/SnippetFindingServiceTest.kt
@@ -28,7 +28,6 @@ import io.kotest.matchers.shouldBe
 
 import kotlin.time.Clock
 
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier as ApiIdentifier
 import org.eclipse.apoapsis.ortserver.dao.blockingQuery
 import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsPackageProvenancesTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsScanResultsTable
@@ -53,6 +52,7 @@ import org.eclipse.apoapsis.ortserver.model.runs.VcsInfo
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
 import org.eclipse.apoapsis.ortserver.model.util.OrderField
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier as ApiIdentifier
 
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.SizedCollection

--- a/components/snippet-findings/backend/src/test/kotlin/routes/GetRunSnippetFindingProvenancesIntegrationTest.kt
+++ b/components/snippet-findings/backend/src/test/kotlin/routes/GetRunSnippetFindingProvenancesIntegrationTest.kt
@@ -25,12 +25,12 @@ import io.ktor.client.call.body
 import io.ktor.client.request.get
 import io.ktor.http.HttpStatusCode
 
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
 import org.eclipse.apoapsis.ortserver.components.snippetfindings.SeedResult
 import org.eclipse.apoapsis.ortserver.components.snippetfindings.SnippetFindingIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.snippetfindings.SnippetFindingProvenance
 import org.eclipse.apoapsis.ortserver.components.snippetfindings.seedData
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters.Companion.DEFAULT_LIMIT
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagingData
 import org.eclipse.apoapsis.ortserver.shared.apimodel.SortDirection

--- a/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/OrganizationsDocs.kt
@@ -26,7 +26,6 @@ import io.ktor.http.HttpStatusCode
 import org.eclipse.apoapsis.ortserver.api.v1.model.ComparisonOperator
 import org.eclipse.apoapsis.ortserver.api.v1.model.EcosystemStats
 import org.eclipse.apoapsis.ortserver.api.v1.model.FilterOperatorAndValue
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
 import org.eclipse.apoapsis.ortserver.api.v1.model.Organization
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatistics
 import org.eclipse.apoapsis.ortserver.api.v1.model.PatchOrganization
@@ -44,6 +43,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityRating
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityReference
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityWithStats
 import org.eclipse.apoapsis.ortserver.components.authorization.api.OrganizationRole
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedSearchResponse
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagingData

--- a/core/src/main/kotlin/apiDocs/ProductsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/ProductsDocs.kt
@@ -28,7 +28,6 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.AnalyzerJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.ComparisonOperator
 import org.eclipse.apoapsis.ortserver.api.v1.model.EcosystemStats
 import org.eclipse.apoapsis.ortserver.api.v1.model.FilterOperatorAndValue
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
 import org.eclipse.apoapsis.ortserver.api.v1.model.JobConfigurations
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRun
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatistics
@@ -50,6 +49,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityRating
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityReference
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityWithStats
 import org.eclipse.apoapsis.ortserver.components.authorization.api.ProductRole
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedSearchResponse
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagingData

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -29,7 +29,6 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.AdvisorDetails
 import org.eclipse.apoapsis.ortserver.api.v1.model.ComparisonOperator
 import org.eclipse.apoapsis.ortserver.api.v1.model.EcosystemStats
 import org.eclipse.apoapsis.ortserver.api.v1.model.FilterOperatorAndValue
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
 import org.eclipse.apoapsis.ortserver.api.v1.model.Issue
 import org.eclipse.apoapsis.ortserver.api.v1.model.JobSummaries
 import org.eclipse.apoapsis.ortserver.api.v1.model.LicenseSource
@@ -61,6 +60,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityWithDetails
 import org.eclipse.apoapsis.ortserver.shared.apimodel.AppliedIssueResolution
 import org.eclipse.apoapsis.ortserver.shared.apimodel.AppliedRuleViolationResolution
 import org.eclipse.apoapsis.ortserver.shared.apimodel.AppliedVulnerabilityResolution
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 import org.eclipse.apoapsis.ortserver.shared.apimodel.IssueResolution
 import org.eclipse.apoapsis.ortserver.shared.apimodel.IssueResolutionReason
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse

--- a/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
@@ -106,6 +106,7 @@ import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters.Companion.D
 import org.eclipse.apoapsis.ortserver.model.util.asPresent as asPresent2
 import org.eclipse.apoapsis.ortserver.services.OrganizationService
 import org.eclipse.apoapsis.ortserver.services.ProductService
+import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToApi
 import org.eclipse.apoapsis.ortserver.shared.apimodel.ErrorResponse
 import org.eclipse.apoapsis.ortserver.shared.apimodel.OptionalValue
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse

--- a/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
@@ -124,6 +124,7 @@ import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters.Companion.D
 import org.eclipse.apoapsis.ortserver.model.util.asPresent as asPresent2
 import org.eclipse.apoapsis.ortserver.services.OrganizationService
 import org.eclipse.apoapsis.ortserver.services.ProductService
+import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToApi
 import org.eclipse.apoapsis.ortserver.shared.apimodel.ErrorResponse
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedSearchResponse

--- a/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
@@ -71,7 +71,6 @@ import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToModel
 import org.eclipse.apoapsis.ortserver.api.v1.model.ComparisonOperator
 import org.eclipse.apoapsis.ortserver.api.v1.model.EcosystemStats
 import org.eclipse.apoapsis.ortserver.api.v1.model.FilterOperatorAndValue
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier as ApiIdentifier
 import org.eclipse.apoapsis.ortserver.api.v1.model.Issue as ApiIssue
 import org.eclipse.apoapsis.ortserver.api.v1.model.JobSummaries
 import org.eclipse.apoapsis.ortserver.api.v1.model.Jobs
@@ -143,7 +142,9 @@ import org.eclipse.apoapsis.ortserver.model.runs.repository.VulnerabilityResolut
 import org.eclipse.apoapsis.ortserver.model.util.asPresent
 import org.eclipse.apoapsis.ortserver.services.OrganizationService
 import org.eclipse.apoapsis.ortserver.services.ProductService
+import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToApi
 import org.eclipse.apoapsis.ortserver.shared.apimodel.ErrorResponse
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier as ApiIdentifier
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedSearchResponse
 import org.eclipse.apoapsis.ortserver.shared.apimodel.SortDirection

--- a/services/ort-run/src/main/kotlin/VulnerabilityService.kt
+++ b/services/ort-run/src/main/kotlin/VulnerabilityService.kt
@@ -24,7 +24,6 @@ import com.github.michaelbull.result.getOr
 import java.util.SortedSet
 
 import org.eclipse.apoapsis.ortserver.api.v1.model.AdvisorDetails
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier
 import org.eclipse.apoapsis.ortserver.api.v1.model.Vulnerability
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityRating
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityReference
@@ -58,6 +57,7 @@ import org.eclipse.apoapsis.ortserver.services.ResourceNotFoundException
 import org.eclipse.apoapsis.ortserver.services.utils.toSortOrder
 import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToApi
 import org.eclipse.apoapsis.ortserver.shared.apimodel.AppliedVulnerabilityResolution
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 import org.eclipse.apoapsis.ortserver.shared.apimodel.ResolutionSource
 import org.eclipse.apoapsis.ortserver.shared.apimodel.VulnerabilityResolution
 

--- a/services/ort-run/src/test/kotlin/PackageServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/PackageServiceTest.kt
@@ -57,6 +57,8 @@ import org.eclipse.apoapsis.ortserver.model.util.FilterOperatorAndValue
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
 import org.eclipse.apoapsis.ortserver.model.util.OrderField
+import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToApi
+import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToModel
 
 import org.jetbrains.exposed.v1.jdbc.Database
 

--- a/services/ort-run/src/test/kotlin/VulnerabilityServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/VulnerabilityServiceTest.kt
@@ -34,7 +34,6 @@ import io.mockk.mockk
 import kotlin.time.Clock
 
 import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToApi
-import org.eclipse.apoapsis.ortserver.api.v1.model.Identifier as ApiIdentifier
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityRating as ApiVulnerabilityRating
 import org.eclipse.apoapsis.ortserver.components.resolutions.vulnerabilities.VulnerabilityResolutionEventStore
 import org.eclipse.apoapsis.ortserver.components.resolutions.vulnerabilities.VulnerabilityResolutionService
@@ -74,6 +73,7 @@ import org.eclipse.apoapsis.ortserver.model.util.OrderField
 import org.eclipse.apoapsis.ortserver.services.RepositoryService
 import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToApi
 import org.eclipse.apoapsis.ortserver.shared.apimodel.AppliedVulnerabilityResolution
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier as ApiIdentifier
 import org.eclipse.apoapsis.ortserver.shared.apimodel.ResolutionSource as ApiResolutionSource
 import org.eclipse.apoapsis.ortserver.shared.apimodel.VulnerabilityResolution as ApiVulnerabilityResolution
 import org.eclipse.apoapsis.ortserver.shared.apimodel.VulnerabilityResolutionReason as ApiVulnerabilityResolutionReason

--- a/shared/api-mappings/src/commonMain/kotlin/IdentifierMappings.kt
+++ b/shared/api-mappings/src/commonMain/kotlin/IdentifierMappings.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,11 @@
  * License-Filename: LICENSE
  */
 
-package org.eclipse.apoapsis.ortserver.api.v1.model
+package org.eclipse.apoapsis.ortserver.shared.apimappings
 
-import kotlinx.serialization.Serializable
+import org.eclipse.apoapsis.ortserver.model.runs.Identifier
+import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier as ApiIdentifier
 
-@Serializable
-data class Identifier(
-    val type: String,
-    val namespace: String,
-    val name: String,
-    val version: String
-)
+fun Identifier.mapToApi() = ApiIdentifier(type = type, namespace = namespace, name = name, version = version)
+
+fun ApiIdentifier.mapToModel() = Identifier(type = type, namespace = namespace, name = name, version = version)

--- a/shared/api-model/src/commonMain/kotlin/Identifier.kt
+++ b/shared/api-model/src/commonMain/kotlin/Identifier.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,14 +17,14 @@
  * License-Filename: LICENSE
  */
 
-package org.eclipse.apoapsis.ortserver.components.licensefindings
+package org.eclipse.apoapsis.ortserver.shared.apimodel
 
 import kotlinx.serialization.Serializable
 
-import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
-
 @Serializable
-data class PackageIdentifier(
-    val identifier: Identifier,
-    val purl: String?
+data class Identifier(
+    val type: String,
+    val namespace: String,
+    val name: String,
+    val version: String
 )


### PR DESCRIPTION
Components should not depend on the legacy API model but the shared API model instead.