### PR TITLE
build(cli): Drop unused dynamic dependencies

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -40,7 +40,12 @@ kotlin {
         }
     }
 
-    linuxX64()
+    linuxX64 {
+        binaries.all {
+            linkerOpts("-Wl,--as-needed")
+        }
+    }
+
     macosArm64()
     @Suppress("deprecation") macosX64()
     mingwX64()


### PR DESCRIPTION
Kotlin/Native inherently links platform-declared POSIX libraries like `libcrypt.so.1` regardless of whether the application actually needs them. This causes runtime failures on modern Linux distributions where legacy implementations like `libcrypt.so.1` have been deprecated and removed [1].

Instructing the linker to only include explicitly needed libraries safely strips out these dependencies, improving the portability of the Linux build of the CLI.

[1]: https://youtrack.jetbrains.com/projects/KT/issues/KT-55643