### PR TITLE
fix(ui): Fix stars and home page icons in light mode

### DIFF
--- a/ui/src/components/favorite-button.tsx
+++ b/ui/src/components/favorite-button.tsx
@@ -92,8 +92,9 @@ export const FavoriteButton = ({
         >
           <Star
             className={cn(
-              'h-4 w-4 text-white/50',
-              isFavorite && 'fill-white text-white'
+              'text-muted-foreground h-4 w-4 dark:text-white/50',
+              isFavorite &&
+                'fill-foreground text-foreground dark:fill-white dark:text-white'
             )}
           />
         </Button>

--- a/ui/src/routes/-components/home-favorites-section.tsx
+++ b/ui/src/routes/-components/home-favorites-section.tsx
@@ -384,7 +384,7 @@ export const HomeFavoritesSection = ({
     <Card>
       <CardHeader>
         <CardTitle className='flex items-center gap-2'>
-          <Star className='h-5 w-5 fill-white text-white' />
+          <Star className='fill-foreground text-foreground h-5 w-5 dark:fill-white dark:text-white' />
           Favorites
         </CardTitle>
         <CardDescription>

--- a/ui/src/routes/-components/home-recent-runs-section.tsx
+++ b/ui/src/routes/-components/home-recent-runs-section.tsx
@@ -185,7 +185,7 @@ export const HomeRecentRunsSection = ({
   <Card>
     <CardHeader>
       <CardTitle className='flex items-center gap-2'>
-        <PlayCircle className='h-5 w-5 text-white' />
+        <PlayCircle className='text-foreground h-5 w-5 dark:text-white' />
         Recently started runs
       </CardTitle>
       <CardDescription>


### PR DESCRIPTION
The starring icon and some home page icons are missing specific handling for dark and light mode, which makes them invisible when using the UI in light mode. Fix by explicitly handling light and dark mode coloring.

<img width="976" height="389" alt="Screenshot from 2026-06-25 10-19-09" src="https://github.com/user-attachments/assets/4a58d1dc-9548-4194-be73-4c8f1d10c930" />

Please see the commit for details.