### PR TITLE
fix(analyzer): Correctly set the Corepack version to 0.34.7

### DIFF
--- a/workers/analyzer/docker/Analyzer.Dockerfile
+++ b/workers/analyzer/docker/Analyzer.Dockerfile
@@ -162,6 +162,7 @@ COPY --from=pythonbuild /opt/python /opt/python
 FROM ort-base-image AS nodebuild
 
 ARG BOWER_VERSION
+ARG COREPACK_VERSION
 ARG NODEJS_VERSION
 
 ENV NVM_DIR=/opt/nvm


### PR DESCRIPTION
Global ARGs (declared before the first FROM) are not automatically inherited by each stage. They must be explicitly re-declared with ARG <name> inside each stage that needs them. Since it was not done, the variable was resolved to an empty string in that stage's scope and latest version of Corepack was installed.

This is a fixup of f809480a.