### PR TITLE
Prepare Analyzer for execution in multiple phases

### DIFF
--- a/workers/analyzer/src/main/kotlin/AnalyzerDownloader.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerDownloader.kt
@@ -21,6 +21,8 @@ package org.eclipse.apoapsis.ortserver.workers.analyzer
 
 import java.io.File
 
+import kotlin.io.path.createTempDirectory
+
 import org.eclipse.apoapsis.ortserver.model.SubmoduleFetchStrategy
 
 import org.ossreviewtoolkit.downloader.VcsHost
@@ -28,22 +30,53 @@ import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.plugins.api.PluginConfig
-import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 
 import org.slf4j.LoggerFactory
 
 private val logger = LoggerFactory.getLogger(AnalyzerDownloader::class.java)
 
 class AnalyzerDownloader {
+    companion object {
+        /**
+         * Look up the directory of the download for the given [runId] under the given [root] directory based on the
+         * naming conventions applied by this class. Return *null* if the directory cannot be determined or an error
+         * occurs. This is useful if the download was done in a different phase of the analyzer run.
+         */
+        fun findDownloadDir(root: File, runId: Long): File? =
+            runCatching {
+                val dirName = downloadDirName(runId)
+
+                root.listFiles { file -> file.isDirectory && dirName in file.name }.single()
+            }.onFailure {
+                logger.warn("Could not find download directory for runId '$runId' under root '$root'.", it)
+            }.getOrNull()
+
+        /**
+         * Generate a name for a directory in which to download the repository for the run with the given [runId].
+         * Based on this name, a temporary directory is created.
+         */
+        private fun downloadDirName(runId: Long?): String {
+            val runComponent = runId?.let { "-$it" }.orEmpty()
+            return "analyzer-worker$runComponent-download"
+        }
+    }
+
+    /**
+     * Download a VCS repository with the given [repositoryUrl], [revision], and optional [path] using ORT's Downloader
+     * component. In case of a Git repository, apply the given [submoduleFetchStrategy]. Allow specifying the parent
+     * [targetDir] for the download and the name of the download folder based on the provided [runId].
+     */
     fun downloadRepository(
         repositoryUrl: String,
         revision: String,
         path: String = "",
-        submoduleFetchStrategy: SubmoduleFetchStrategy? = SubmoduleFetchStrategy.FULLY_RECURSIVE
+        submoduleFetchStrategy: SubmoduleFetchStrategy? = SubmoduleFetchStrategy.FULLY_RECURSIVE,
+        targetDir: File? = null,
+        runId: Long? = null
     ): DownloadResult {
         logger.info("Downloading repository '$repositoryUrl' revision '$revision'.")
 
-        val outputDir = createOrtTempDir("analyzer-worker")
+        val outputDir = createTempDirectory(targetDir?.toPath(), downloadDirName(runId)).toFile()
 
         val config = buildCustomVcsPluginConfigMap(repositoryUrl, submoduleFetchStrategy)
         val vcs = VersionControlSystem.forUrl(repositoryUrl, config)

--- a/workers/analyzer/src/main/kotlin/AnalyzerRunner.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerRunner.kt
@@ -134,32 +134,19 @@ class AnalyzerRunner(
     }
 
     /**
-     * Run the analyzer for the given [inputDir] using the provided [config] and return the resulting [OrtResult].
-     * Depending on the [environmentConfig], the analyzer is run in the same JVM or in a forked JVM with a customized
-     * environment.
+     * Run the analyzer for the given [inputDir] using the provided [runnerConfig] and return the resulting
+     * [OrtResult]. Depending on the [environmentConfig], the analyzer is run in the same JVM or in a forked JVM with a
+     * customized environment.
      */
     suspend fun run(
         context: WorkerContext,
         inputDir: File,
-        config: AnalyzerJobConfiguration,
+        runnerConfig: AnalyzerRunnerConfig,
         environmentConfig: ResolvedEnvironmentConfig
-    ): OrtResult {
-        val packageCurationProviderConfigs = context.resolveProviderPluginConfigSecrets(config.packageCurationProviders)
-        val runnerConfig = AnalyzerRunnerConfig(
-            allowDynamicVersions = config.allowDynamicVersions,
-            disabledPackageManagers = config.disabledPackageManagers,
-            enabledPackageManagers = config.enabledPackageManagers,
-            packageCurationProviders = packageCurationProviderConfigs,
-            packageManagerOptions = config.packageManagerOptions,
-            repositoryConfigPath = config.repositoryConfigPath,
-            skipExcluded = config.skipExcluded
-        )
-
-        return if (environmentConfig.environmentVariables.isEmpty()) {
-            runInProcess(inputDir, runnerConfig)
-        } else {
-            runForked(context, inputDir, runnerConfig, environmentConfig)
-        }
+    ): OrtResult = if (environmentConfig.environmentVariables.isEmpty()) {
+        runInProcess(inputDir, runnerConfig)
+    } else {
+        runForked(context, inputDir, runnerConfig, environmentConfig)
     }
 
     /**

--- a/workers/analyzer/src/main/kotlin/AnalyzerWorker.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerWorker.kt
@@ -21,6 +21,7 @@ package org.eclipse.apoapsis.ortserver.workers.analyzer
 
 import org.eclipse.apoapsis.ortserver.components.resolutions.issues.IssueResolutionService
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
+import org.eclipse.apoapsis.ortserver.model.AnalyzerJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
 import org.eclipse.apoapsis.ortserver.model.RepositoryId
 import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.AppliedPackageCurationRef
@@ -32,6 +33,7 @@ import org.eclipse.apoapsis.ortserver.services.ortrun.mapToModel
 import org.eclipse.apoapsis.ortserver.transport.EndpointComponent
 import org.eclipse.apoapsis.ortserver.workers.common.JobIgnoredException
 import org.eclipse.apoapsis.ortserver.workers.common.RunResult
+import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContextFactory
 import org.eclipse.apoapsis.ortserver.workers.common.env.EnvironmentService
 import org.eclipse.apoapsis.ortserver.workers.common.resolutions.OrtServerResolutionProvider
@@ -108,7 +110,12 @@ internal class AnalyzerWorker(
                 envConfigFromJob,
                 repositoryServices
             )
-            val ortResult = runner.run(context, downloadResult.directory, job.configuration, resolvedEnvConfig)
+            val ortResult = runner.run(
+                context,
+                downloadResult.directory,
+                job.configuration.toRunnerConfig(context),
+                resolvedEnvConfig
+            )
 
             ortRunService.storeRepositoryInformation(ortRun.id, ortResult.repository)
             ortRunService.storeResolvedPackageCurations(job.ortRunId, ortResult.resolvedConfiguration.packageCurations)
@@ -220,3 +227,18 @@ internal class AnalyzerWorker(
 }
 
 private class AnalyzerException(message: String) : Exception(message)
+
+/**
+ * Create an [AnalyzerRunnerConfig] from this [AnalyzerJobConfiguration] to be used to analyze the current project.
+ * Use the given [context] to resolve the secrets in the plugin configuration.
+ */
+private suspend fun AnalyzerJobConfiguration.toRunnerConfig(context: WorkerContext): AnalyzerRunnerConfig =
+    AnalyzerRunnerConfig(
+        skipExcluded = skipExcluded,
+        allowDynamicVersions = allowDynamicVersions,
+        enabledPackageManagers = enabledPackageManagers,
+        disabledPackageManagers = disabledPackageManagers,
+        packageManagerOptions = packageManagerOptions,
+        repositoryConfigPath = repositoryConfigPath,
+        packageCurationProviders = context.resolveProviderPluginConfigSecrets(packageCurationProviders)
+    )

--- a/workers/analyzer/src/test/kotlin/AnalyzerDownloaderTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerDownloaderTest.kt
@@ -21,159 +21,160 @@ package org.eclipse.apoapsis.ortserver.workers.analyzer
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
-import io.kotest.matchers.file.beEmptyDirectory
-import io.kotest.matchers.file.shouldContainFile
-import io.kotest.matchers.file.shouldNotExist
 import io.kotest.matchers.maps.shouldBeEmpty
 import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.maps.shouldNotBeEmpty
-import io.kotest.matchers.nulls.shouldNotBeNull
-import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNot
 
 import io.mockk.every
+import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.verify
 
 import java.io.IOException
 
 import org.eclipse.apoapsis.ortserver.model.SubmoduleFetchStrategy
 
 import org.ossreviewtoolkit.downloader.VersionControlSystem
-import org.ossreviewtoolkit.model.VcsInfo
+import org.ossreviewtoolkit.downloader.WorkingTree
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.plugins.api.PluginConfig
-import org.ossreviewtoolkit.plugins.versioncontrolsystems.git.GitFactory
-import org.ossreviewtoolkit.utils.common.ProcessCapture
 
 class AnalyzerDownloaderTest : WordSpec({
     val downloader = AnalyzerDownloader()
 
+    val repositoryUrl = "https://github.com/oss-review-toolkit/ort-test-data-scanner.git"
+    val revision = "abc123def456"
+    val resolvedRevision = "def456abc123def456abc123def456abc123def456"
+
+    fun createMockVcs(mockWorkingTree: WorkingTree): VersionControlSystem =
+        mockk<VersionControlSystem> {
+            every { type } returns VcsType.GIT
+            every { initWorkingTree(any(), any()) } returns mockWorkingTree
+            every { updateWorkingTree(any(), any(), any(), any()) } returns Result.success(resolvedRevision)
+            every { getWorkingTree(any()) } returns mockWorkingTree
+        }
+
+    fun createMockWorkingTree(): WorkingTree =
+        mockk<WorkingTree> {
+            every { getRevision() } returns resolvedRevision
+        }
+
     "downloadRepository" should {
         "use the default branch if an empty revision is given" {
-            val repositoryUrl = "https://github.com/oss-review-toolkit/ort-test-data-scanner.git"
+            val defaultBranch = "main"
+            val mockWorkingTree = createMockWorkingTree()
+            val mockVcs = createMockVcs(mockWorkingTree)
+            every { mockVcs.getDefaultBranchName(repositoryUrl) } returns defaultBranch
+            every {
+                mockVcs.updateWorkingTree(any(), defaultBranch, any(), any())
+            } returns Result.success(resolvedRevision)
 
-            val result = downloader.downloadRepository(repositoryUrl, revision = "")
+            mockkObject(VersionControlSystem) {
+                every { VersionControlSystem.forUrl(repositoryUrl, any()) } returns mockVcs
 
-            result.initRevision shouldBe "main"
+                val result = downloader.downloadRepository(repositoryUrl, revision = "")
 
-            with(ProcessCapture("git", "branch", "--show-current", workingDir = result.directory).requireSuccess()) {
-                stdout.trim() shouldBe "main"
+                result.initRevision shouldBe defaultBranch
+                result.resolvedRevision shouldBe resolvedRevision
             }
         }
 
         "return the initial and resolved revisions" {
-            val repositoryUrl = "https://github.com/oss-review-toolkit/ort-test-data-scanner.git"
+            val mockWorkingTree = createMockWorkingTree()
+            val mockVcs = createMockVcs(mockWorkingTree)
 
-            val result = downloader.downloadRepository(repositoryUrl, revision = "main")
+            mockkObject(VersionControlSystem) {
+                every { VersionControlSystem.forUrl(repositoryUrl, any()) } returns mockVcs
 
-            result.initRevision shouldBe "main"
-            result.resolvedRevision shouldBe GitFactory.create().getWorkingTree(result.directory).getRevision()
+                val result = downloader.downloadRepository(repositoryUrl, revision = revision)
+
+                result.initRevision shouldBe revision
+                result.resolvedRevision shouldBe resolvedRevision
+            }
         }
 
         "not recursively clone a Git repository if submoduleFetchStrategy is DISABLED" {
-            val repositoryUrl = "https://github.com/oss-review-toolkit/ort-test-data-git-submodules.git"
-            val revision = "fcea94bab5835172e826afddb9f6427274c983b9"
+            val mockWorkingTree = createMockWorkingTree()
+            val mockVcs = createMockVcs(mockWorkingTree)
 
-            val outputDir = downloader.downloadRepository(
-                repositoryUrl, revision, submoduleFetchStrategy = SubmoduleFetchStrategy.DISABLED
-            ).directory
+            mockkObject(VersionControlSystem) {
+                every { VersionControlSystem.forUrl(repositoryUrl, any()) } returns mockVcs
 
-            outputDir shouldContainFile "LICENSE"
-            outputDir shouldContainFile "README.md"
+                downloader.downloadRepository(
+                    repositoryUrl,
+                    revision,
+                    submoduleFetchStrategy = SubmoduleFetchStrategy.DISABLED
+                )
 
-            outputDir.resolve("commons-text") should beEmptyDirectory()
-            outputDir.resolve("test-data-npm") should beEmptyDirectory()
-
-            val workingTree = VersionControlSystem.forDirectory(outputDir)
-            workingTree.shouldNotBeNull()
-            workingTree.getNested().shouldBeEmpty()
+                verify(exactly = 1) { mockVcs.updateWorkingTree(any(), any(), any(), recursive = false) }
+            }
         }
 
         "clone only the top level of a Git repository if submoduleFetchStrategy is TOP_LEVEL_ONLY" {
-            val repositoryUrl = "https://github.com/oss-review-toolkit/ort-test-data-git-submodules.git"
-            val revision = "fcea94bab5835172e826afddb9f6427274c983b9"
+            val submodulesRepositoryUrl = "https://github.com/oss-review-toolkit/ort-test-data-git-submodules.git"
+            val mockWorkingTree = createMockWorkingTree()
+            val mockVcs = createMockVcs(mockWorkingTree)
 
-            val outputDir = downloader.downloadRepository(
-                repositoryUrl, revision, submoduleFetchStrategy = SubmoduleFetchStrategy.TOP_LEVEL_ONLY
-            ).directory
+            mockkObject(VersionControlSystem) {
+                every { VersionControlSystem.forUrl(submodulesRepositoryUrl, any()) } returns mockVcs
 
-            outputDir shouldContainFile "LICENSE"
-            outputDir shouldContainFile "README.md"
-
-            outputDir.resolve("commons-text") shouldNot beEmptyDirectory()
-            outputDir.resolve("test-data-npm") shouldNot beEmptyDirectory()
-
-            val workingTree = VersionControlSystem.forDirectory(outputDir)
-            workingTree.shouldNotBeNull()
-            workingTree.getNested() shouldContainExactly mapOf(
-                "commons-text" to VcsInfo(
-                    type = VcsType.GIT,
-                    url = "https://github.com/apache/commons-text.git",
-                    revision = "7643b12421100d29fd2b78053e77bcb04a251b2e"
-                ),
-                "test-data-npm" to VcsInfo(
-                    type = VcsType.GIT,
-                    url = "https://github.com/oss-review-toolkit/ort-test-data-npm.git",
-                    revision = "ad0367b7b9920144a47b8d30cc0c84cea102b821"
+                downloader.downloadRepository(
+                    submodulesRepositoryUrl,
+                    revision,
+                    submoduleFetchStrategy = SubmoduleFetchStrategy.TOP_LEVEL_ONLY
                 )
-            )
+
+                verify(exactly = 1) {
+                    VersionControlSystem.forUrl(
+                        submodulesRepositoryUrl,
+                        match { config ->
+                            config[VcsType.GIT.toString()]?.options?.get("updateNestedSubmodules") == false.toString()
+                        }
+                    )
+                }
+                verify(exactly = 1) { mockVcs.updateWorkingTree(any(), any(), any(), recursive = true) }
+            }
         }
 
         "fully recursively clone a Git repository if submoduleFetchStrategy is FULLY_RECURSIVE" {
-            val repositoryUrl = "https://github.com/oss-review-toolkit/ort-test-data-git-submodules.git"
-            val revision = "fcea94bab5835172e826afddb9f6427274c983b9"
+            val submodulesRepositoryUrl = "https://github.com/oss-review-toolkit/ort-test-data-git-submodules.git"
+            val mockWorkingTree = createMockWorkingTree()
+            val mockVcs = createMockVcs(mockWorkingTree)
 
-            val outputDir = downloader.downloadRepository(
-                repositoryUrl, revision, submoduleFetchStrategy = SubmoduleFetchStrategy.FULLY_RECURSIVE
-            ).directory
+            mockkObject(VersionControlSystem) {
+                every { VersionControlSystem.forUrl(submodulesRepositoryUrl, any()) } returns mockVcs
 
-            outputDir shouldContainFile "LICENSE"
-            outputDir shouldContainFile "README.md"
-
-            outputDir.resolve("commons-text") shouldNot beEmptyDirectory()
-            outputDir.resolve("test-data-npm") shouldNot beEmptyDirectory()
-
-            val workingTree = VersionControlSystem.forDirectory(outputDir)
-            workingTree.shouldNotBeNull()
-            workingTree.getNested() shouldContainExactly mapOf(
-                "commons-text" to VcsInfo(
-                    type = VcsType.GIT,
-                    url = "https://github.com/apache/commons-text.git",
-                    revision = "7643b12421100d29fd2b78053e77bcb04a251b2e"
-                ),
-                "test-data-npm" to VcsInfo(
-                    type = VcsType.GIT,
-                    url = "https://github.com/oss-review-toolkit/ort-test-data-npm.git",
-                    revision = "ad0367b7b9920144a47b8d30cc0c84cea102b821"
-                ),
-                "test-data-npm/isarray" to VcsInfo(
-                    type = VcsType.GIT,
-                    url = "https://github.com/juliangruber/isarray.git",
-                    revision = "63ea4ca0a0d6b0574d6a470ebd26880c3026db4a"
-                ),
-                "test-data-npm/long.js" to VcsInfo(
-                    type = VcsType.GIT,
-                    url = "https://github.com/dcodeIO/long.js.git",
-                    revision = "941c5c62471168b5d18153755c2a7b38d2560e58"
+                downloader.downloadRepository(
+                    submodulesRepositoryUrl,
+                    revision,
+                    submoduleFetchStrategy = SubmoduleFetchStrategy.FULLY_RECURSIVE
                 )
-            )
+
+                verify(exactly = 1) {
+                    VersionControlSystem.forUrl(submodulesRepositoryUrl, emptyMap())
+                }
+                verify(exactly = 1) { mockVcs.updateWorkingTree(any(), any(), any(), recursive = true) }
+            }
         }
 
         "clone a sub-directory of a Git repository" {
-            val repositoryUrl = "https://github.com/oss-review-toolkit/ort-test-data-scanner.git"
-            val revision = "63b81fda7961c7426672469caaf4fb350a9d4ee0"
             val subPath = "pkg1"
+            val mockWorkingTree = createMockWorkingTree()
+            val mockVcs = createMockVcs(mockWorkingTree)
 
-            val outputDir = downloader.downloadRepository(repositoryUrl, revision, subPath).directory
+            mockkObject(VersionControlSystem) {
+                every { VersionControlSystem.forUrl(repositoryUrl, any()) } returns mockVcs
 
-            outputDir shouldContainFile "LICENSE"
-            outputDir shouldContainFile "README.md"
+                downloader.downloadRepository(repositoryUrl, revision, subPath)
 
-            outputDir.resolve("pkg1") shouldNot beEmptyDirectory()
-            outputDir.resolve("pkg2").shouldNotExist()
-            outputDir.resolve("pkg3").shouldNotExist()
-            outputDir.resolve("pkg4").shouldNotExist()
+                verify(exactly = 1) {
+                    mockVcs.initWorkingTree(
+                        any(),
+                        match { vcsInfo -> vcsInfo.path == subPath }
+                    )
+                }
+            }
         }
 
         "throw an exception if the VCS type cannot be determined from the URL" {
@@ -187,39 +188,43 @@ class AnalyzerDownloaderTest : WordSpec({
         }
 
         "throw an exception if the repository cannot be cloned" {
-            val repositoryUrl = "https://github.com/oss-review-toolkit/ort-test-data-git-submodules.git"
-            val revision = "invalid-revision"
+            val mockWorkingTree = createMockWorkingTree()
+            val mockVcs = createMockVcs(mockWorkingTree)
+            every {
+                mockVcs.updateWorkingTree(any(), any(), any(), any())
+            } returns Result.failure(IOException("Failed to update working tree to revision 'invalid-revision'."))
 
-            shouldThrow<IOException> {
-                downloader.downloadRepository(repositoryUrl, revision)
+            mockkObject(VersionControlSystem) {
+                every { VersionControlSystem.forUrl(repositoryUrl, any()) } returns mockVcs
+
+                shouldThrow<IOException> {
+                    downloader.downloadRepository(repositoryUrl, revision = "invalid-revision")
+                }
             }
         }
     }
 
     "buildCustomVcsPluginConfigurations" should {
         "return an empty map if the submoduleFetchStrategy is null" {
-            val repositoryUrl = "https://github.com/oss-review-toolkit/ort-test-data-git-submodules.git"
-            val submoduleFetchStrategy = null
-
-            val configurations = downloader.buildCustomVcsPluginConfigMap(repositoryUrl, submoduleFetchStrategy)
+            val configurations = downloader.buildCustomVcsPluginConfigMap(repositoryUrl, null)
 
             configurations.shouldBeEmpty()
         }
 
         "return an empty map if the submoduleFetchStrategy is DISABLED" {
-            val repositoryUrl = "https://github.com/oss-review-toolkit/ort-test-data-git-submodules.git"
-            val submoduleFetchStrategy = SubmoduleFetchStrategy.DISABLED
-
-            val configurations = downloader.buildCustomVcsPluginConfigMap(repositoryUrl, submoduleFetchStrategy)
+            val configurations = downloader.buildCustomVcsPluginConfigMap(
+                repositoryUrl,
+                SubmoduleFetchStrategy.DISABLED
+            )
 
             configurations.shouldBeEmpty()
         }
 
         "return custom configuration for git if the submoduleFetchStrategy is TOP_LEVEL_ONLY" {
-            val repositoryUrl = "https://github.com/oss-review-toolkit/ort-test-data-git-submodules.git"
-            val submoduleFetchStrategy = SubmoduleFetchStrategy.TOP_LEVEL_ONLY
-
-            val configurations = downloader.buildCustomVcsPluginConfigMap(repositoryUrl, submoduleFetchStrategy)
+            val configurations = downloader.buildCustomVcsPluginConfigMap(
+                repositoryUrl,
+                SubmoduleFetchStrategy.TOP_LEVEL_ONLY
+            )
 
             configurations.shouldNotBeEmpty()
 
@@ -231,21 +236,18 @@ class AnalyzerDownloaderTest : WordSpec({
         }
 
         "return an empty map if the submoduleFetchStrategy is FULLY_RECURSIVE" {
-            val repositoryUrl = "https://github.com/oss-review-toolkit/ort-test-data-git-submodules.git"
-            val submoduleFetchStrategy = SubmoduleFetchStrategy.FULLY_RECURSIVE
-
-            val configurations = downloader.buildCustomVcsPluginConfigMap(repositoryUrl, submoduleFetchStrategy)
+            val configurations = downloader.buildCustomVcsPluginConfigMap(
+                repositoryUrl,
+                SubmoduleFetchStrategy.FULLY_RECURSIVE
+            )
 
             configurations.shouldBeEmpty()
         }
 
         "throw an IllegalArgumentException if the submoduleFetchStrategy is TOP_LEVEL_ONLY " +
                 "and the VCS type is not GIT" {
-            val repositoryUrl = "https://example.com"
-            val submoduleFetchStrategy = SubmoduleFetchStrategy.TOP_LEVEL_ONLY
-
             shouldThrow<IllegalArgumentException> {
-                downloader.buildCustomVcsPluginConfigMap(repositoryUrl, submoduleFetchStrategy)
+                downloader.buildCustomVcsPluginConfigMap("https://example.com", SubmoduleFetchStrategy.TOP_LEVEL_ONLY)
             }
         }
     }

--- a/workers/analyzer/src/test/kotlin/AnalyzerDownloaderTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerDownloaderTest.kt
@@ -21,10 +21,14 @@ package org.eclipse.apoapsis.ortserver.workers.analyzer
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.maps.shouldBeEmpty
 import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.maps.shouldNotBeEmpty
+import io.kotest.matchers.nulls.beNull
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 
 import io.mockk.every
 import io.mockk.mockk
@@ -202,6 +206,28 @@ class AnalyzerDownloaderTest : WordSpec({
                 }
             }
         }
+
+        "allow customizing the download folder" {
+            val targetDir = tempdir()
+            val runId = 20260630054526L
+            val mockWorkingTree = createMockWorkingTree()
+            val mockVcs = createMockVcs(mockWorkingTree)
+
+            mockkObject(VersionControlSystem) {
+                every { VersionControlSystem.forUrl(repositoryUrl, any()) } returns mockVcs
+
+                val result = downloader.downloadRepository(
+                    repositoryUrl,
+                    revision = revision,
+                    targetDir = targetDir,
+                    runId = runId
+                )
+
+                result.directory.isDirectory shouldBe true
+                result.directory.parentFile shouldBe targetDir
+                result.directory.name shouldContain runId.toString()
+            }
+        }
     }
 
     "buildCustomVcsPluginConfigurations" should {
@@ -249,6 +275,50 @@ class AnalyzerDownloaderTest : WordSpec({
             shouldThrow<IllegalArgumentException> {
                 downloader.buildCustomVcsPluginConfigMap("https://example.com", SubmoduleFetchStrategy.TOP_LEVEL_ONLY)
             }
+        }
+    }
+
+    "findDownloadDir" should {
+        "find an existing download directory" {
+            val runId = 20260630061242L
+            val root = tempdir()
+            val downloadDir = root.resolve("Temp-analyzer-worker-$runId-download0123456789")
+            downloadDir.mkdirs()
+            val otherDirs = listOf("foo", "bar", "baz", "analyzer-worker-20260630061243-download")
+            otherDirs.forEach { root.resolve(it).mkdirs() }
+
+            val foundDir = AnalyzerDownloader.findDownloadDir(root, runId)
+
+            foundDir shouldBe downloadDir
+        }
+
+        "return null if no directory for the given runId can be found" {
+            val runId = 20260630065648L
+            val root = tempdir()
+            val dirs = listOf("foo", "bar", "baz", "analyzer-worker-20260630061242-download")
+            dirs.forEach { root.resolve(it).mkdirs() }
+
+            val foundDir = AnalyzerDownloader.findDownloadDir(root, runId)
+
+            foundDir should beNull()
+        }
+
+        "return null if no unique directory for the given runId can be found" {
+            val runId = 20260630065927L
+            val root = tempdir()
+            val dirs = listOf(
+                "analyzer-worker-$runId-download-1",
+                "analyzer-worker-$runId-download-2"
+            )
+            dirs.forEach { root.resolve(it).mkdirs() }
+
+            val foundDir = AnalyzerDownloader.findDownloadDir(root, runId)
+
+            foundDir should beNull()
+        }
+
+        "return null for a non-existing root directory" {
+            AnalyzerDownloader.findDownloadDir(tempdir().resolve("non-existing"), 20260630065927L) should beNull()
         }
     }
 })

--- a/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
@@ -25,9 +25,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.core.test.TestCase
 import io.kotest.engine.spec.tempdir
 import io.kotest.engine.test.TestResult
-import io.kotest.extensions.system.OverrideMode
 import io.kotest.extensions.system.withEnvironment
-import io.kotest.extensions.system.withSystemProperties
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNot
@@ -38,10 +36,10 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkClass
+import io.mockk.mockkObject
 import io.mockk.runs
 
 import java.io.File
-import java.util.Properties
 
 import kotlin.time.Instant
 
@@ -84,6 +82,8 @@ import org.koin.test.KoinTest
 import org.koin.test.inject
 import org.koin.test.mock.MockProvider
 import org.koin.test.mock.declareMock
+
+import org.ossreviewtoolkit.utils.common.Os
 
 private const val JOB_ID = 1L
 private const val TRACE_ID = "42"
@@ -358,13 +358,12 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
 
             val repositoryFolder = File("src/test/resources/mavenProject")
             val homeFolder = tempdir()
-            val properties = Properties().apply {
-                setProperty("user.home", homeFolder.absolutePath)
-            }
 
             val environmentService by inject<EnvironmentService>()
 
-            withSystemProperties(properties, mode = OverrideMode.SetOrOverride) {
+            mockkObject(Os) {
+                every { Os.userHomeDirectory } returns homeFolder
+
                 environmentService.setUpEnvironment(context, repositoryFolder, null, emptyList())
             }
 

--- a/workers/analyzer/src/test/kotlin/AnalyzerRunnerTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerRunnerTest.kt
@@ -36,7 +36,6 @@ import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.string.shouldContain
 
 import io.mockk.coEvery
-import io.mockk.coVerify
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
@@ -55,9 +54,7 @@ import java.time.Instant
 import org.eclipse.apoapsis.ortserver.model.AnalyzerJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.ProviderPluginConfiguration
 import org.eclipse.apoapsis.ortserver.model.ResolvableProviderPluginConfig
-import org.eclipse.apoapsis.ortserver.model.ResolvableSecret
 import org.eclipse.apoapsis.ortserver.model.Secret
-import org.eclipse.apoapsis.ortserver.model.SecretSource
 import org.eclipse.apoapsis.ortserver.model.runs.PackageManagerConfiguration
 import org.eclipse.apoapsis.ortserver.services.ortrun.mapToOrt
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
@@ -108,6 +105,20 @@ import org.ossreviewtoolkit.utils.spdxexpression.toSpdx
 
 private val projectDir = File("src/test/resources/mavenProject/").absoluteFile
 
+private val testRunnerConfig = AnalyzerRunnerConfig(
+    allowDynamicVersions = false,
+    skipExcluded = false,
+    enabledPackageManagers = listOf("Maven", "Gradle"),
+    disabledPackageManagers = listOf("NPM"),
+    packageManagerOptions = mapOf(
+        "Maven" to PackageManagerConfiguration(
+            listOf("Gradle"),
+            options = mapOf("foo" to "bar")
+        )
+    ),
+    repositoryConfigPath = null
+)
+
 class AnalyzerRunnerTest : WordSpec({
     fun createWorkerContext(
         providerPluginConfigs: List<ResolvableProviderPluginConfig> = emptyList(),
@@ -122,7 +133,7 @@ class AnalyzerRunnerTest : WordSpec({
     suspend fun run(
         context: WorkerContext = createWorkerContext(),
         inputDir: File = projectDir,
-        config: AnalyzerJobConfiguration = AnalyzerJobConfiguration(),
+        config: AnalyzerRunnerConfig = testRunnerConfig,
         environmentConfig: ResolvedEnvironmentConfig = ResolvedEnvironmentConfig(),
         runner: AnalyzerRunner = AnalyzerRunner(ConfigFactory.empty())
     ): OrtResult =
@@ -238,7 +249,7 @@ class AnalyzerRunnerTest : WordSpec({
         }
 
         "use the .ort.yml defined by repositoryConfigPath" {
-            val repository = run(config = AnalyzerJobConfiguration(repositoryConfigPath = ".custom.ort.yml")).repository
+            val repository = run(config = testRunnerConfig.copy(repositoryConfigPath = ".custom.ort.yml")).repository
 
             repository.config shouldBe RepositoryConfiguration(
                 analyzer = RepositoryAnalyzerConfiguration(
@@ -259,49 +270,16 @@ class AnalyzerRunnerTest : WordSpec({
 
         "fail if repositoryConfigPath points to a file outside the analyzed directory" {
             shouldThrow<IllegalArgumentException> {
-                run(config = AnalyzerJobConfiguration(repositoryConfigPath = "../.ort.yml"))
+                run(config = testRunnerConfig.copy(repositoryConfigPath = "../.ort.yml"))
             }
         }
 
-        "pass all the properties to ORT Analyzer" {
-            val enabledPackageManagers = listOf("conan", "npm")
-            val disabledPackageManagers = listOf("maven")
-            val packageManagerOptions = mapOf("conan" to PackageManagerConfiguration(listOf("npm")))
-            val packageCurationProviderConfigs = listOf(ResolvableProviderPluginConfig(type = "OrtConfig"))
-            val resolvedPackageCurationProviderConfigs = listOf(ProviderPluginConfiguration(type = "OrtConfig"))
-
-            val config = AnalyzerJobConfiguration(
-                allowDynamicVersions = true,
-                enabledPackageManagers = enabledPackageManagers,
-                disabledPackageManagers = disabledPackageManagers,
-                packageCurationProviders = packageCurationProviderConfigs,
-                packageManagerOptions = packageManagerOptions,
-                skipExcluded = true
-            )
-
-            val result = run(
-                context = createWorkerContext(packageCurationProviderConfigs, resolvedPackageCurationProviderConfigs),
-                config = config
-            )
-            val analyzerResult = result.analyzer.shouldNotBeNull()
-
-            analyzerResult.config shouldBe AnalyzerConfiguration(
-                true,
-                enabledPackageManagers,
-                disabledPackageManagers,
-                packageManagerOptions.map { entry -> entry.key to entry.value.mapToOrt() }.toMap(),
-                true
-            )
-
-            result.resolvedConfiguration.packageCurations.map { it.provider.id } should
-                    containExactly("RepositoryConfiguration", "OrtConfig")
-        }
-
         "return an unmanaged project for a directory with only an empty subdirectory" {
+            val config = testRunnerConfig.copy(enabledPackageManagers = null)
             val inputDir = createOrtTempDir().resolve("project")
             inputDir.resolve("subdirectory").safeMkdirs()
 
-            val result = run(inputDir = inputDir).analyzer?.result
+            val result = run(inputDir = inputDir, config = config).analyzer?.result
 
             result.shouldNotBeNull()
             result.projects.map { it.id } should containExactly(Identifier("Unmanaged::project"))
@@ -353,7 +331,7 @@ class AnalyzerRunnerTest : WordSpec({
             val ortResult = OrtResult.EMPTY.copy(analyzer = analyzerRun)
             exchangeDir.resolve("analyzer-result.yml").writeValue(ortResult)
 
-            val jobConfig = AnalyzerJobConfiguration(skipExcluded = true)
+            val runnerConfig = testRunnerConfig.copy(skipExcluded = true)
 
             val runner = spyk(AnalyzerRunner(ConfigFactory.empty()))
             coEvery {
@@ -362,15 +340,15 @@ class AnalyzerRunnerTest : WordSpec({
 
             val result = run(
                 context,
-                config = jobConfig,
+                config = runnerConfig,
                 environmentConfig = environmentConfig,
                 inputDir = inputDir,
                 runner = runner
             )
 
             result shouldBe ortResult
-            val persistedConfig = exchangeDir.resolve("analyzer-config.json").readValue<AnalyzerJobConfiguration>()
-            persistedConfig shouldBe jobConfig
+            val persistedConfig = exchangeDir.resolve("analyzer-config.json").readValue<AnalyzerRunnerConfig>()
+            persistedConfig shouldBe runnerConfig
 
             verify {
                 processBuilder.start()
@@ -437,145 +415,6 @@ class AnalyzerRunnerTest : WordSpec({
             }
 
             exception.message shouldContain "The forked process died"
-        }
-
-        "resolve package curation provider secrets when running in process" {
-            val inputDir = createOrtTempDir().resolve("project").safeMkdirs()
-
-            val packageCurationProviderConfigs = listOf(
-                ResolvableProviderPluginConfig(
-                    type = "type1",
-                    options = mapOf("path" to "path1"),
-                    secrets = mapOf("secret1" to ResolvableSecret("ref1", SecretSource.ADMIN))
-                ),
-                ResolvableProviderPluginConfig(
-                    type = "type2",
-                    options = mapOf("path" to "path2"),
-                    secrets = mapOf("secret2" to ResolvableSecret("ref2", SecretSource.ADMIN))
-                )
-            )
-
-            val resolvedPackageCurationProviderConfigs = listOf(
-                ProviderPluginConfiguration(
-                    type = "type1",
-                    options = mapOf("path" to "path1"),
-                    secrets = mapOf("secret1" to "value1")
-                ),
-                ProviderPluginConfiguration(
-                    type = "type2",
-                    options = mapOf("path" to "path2"),
-                    secrets = mapOf("secret2" to "value2")
-                )
-            )
-
-            val config = AnalyzerJobConfiguration(packageCurationProviders = packageCurationProviderConfigs)
-
-            val runner = spyk(AnalyzerRunner(ConfigFactory.empty()))
-
-            run(
-                context = createWorkerContext(
-                    providerPluginConfigs = packageCurationProviderConfigs,
-                    resolvedProviderPluginConfigs = resolvedPackageCurationProviderConfigs
-                ),
-                config = config,
-                inputDir = inputDir,
-                runner = runner
-            )
-
-            verify(exactly = 1) {
-                runner.runInProcess(
-                    inputDir,
-                    AnalyzerRunnerConfig(
-                        allowDynamicVersions = config.allowDynamicVersions,
-                        disabledPackageManagers = config.disabledPackageManagers,
-                        enabledPackageManagers = config.enabledPackageManagers,
-                        packageCurationProviders = resolvedPackageCurationProviderConfigs,
-                        packageManagerOptions = config.packageManagerOptions,
-                        repositoryConfigPath = config.repositoryConfigPath,
-                        skipExcluded = config.skipExcluded
-                    )
-                )
-            }
-        }
-
-        "resolve package curation provider secrets when running in a fork" {
-            val inputDir = createOrtTempDir().resolve("project").safeMkdirs()
-
-            val packageCurationProviderConfigs = listOf(
-                ResolvableProviderPluginConfig(
-                    type = "type1",
-                    options = mapOf("path" to "path1"),
-                    secrets = mapOf("secret1" to ResolvableSecret("ref1", SecretSource.ADMIN))
-                ),
-                ResolvableProviderPluginConfig(
-                    type = "type2",
-                    options = mapOf("path" to "path2"),
-                    secrets = mapOf("secret2" to ResolvableSecret("ref2", SecretSource.ADMIN))
-                )
-            )
-
-            val resolvedPackageCurationProviderConfigs = listOf(
-                ProviderPluginConfiguration(
-                    type = "type1",
-                    options = mapOf("path" to "path1"),
-                    secrets = mapOf("secret1" to "value1")
-                ),
-                ProviderPluginConfiguration(
-                    type = "type2",
-                    options = mapOf("path" to "path2"),
-                    secrets = mapOf("secret2" to "value2")
-                )
-            )
-
-            val environmentConfig = ResolvedEnvironmentConfig(
-                environmentVariables = setOf(
-                    SecretVariableDefinition("ENV_VAR", mockk())
-                )
-            )
-
-            val process = createProcessMock()
-            val processBuilder = mockk<ProcessBuilder> {
-                every { start() } returns process
-                every { command() } returns listOf("some", "command")
-            }
-
-            val config = AnalyzerJobConfiguration(packageCurationProviders = packageCurationProviderConfigs)
-
-            val runner = spyk(AnalyzerRunner(ConfigFactory.empty()))
-
-            coEvery { runner.createProcessBuilder(any(), any(), any(), any()) } returns processBuilder
-
-            // Expect an exception because making the run succeed would require additional setup which is not required
-            // for this test. The relevant part is that the `runForked` call can be verified below.
-            shouldThrow<IOException> {
-                run(
-                    context = createWorkerContext(
-                        providerPluginConfigs = packageCurationProviderConfigs,
-                        resolvedProviderPluginConfigs = resolvedPackageCurationProviderConfigs
-                    ),
-                    config = config,
-                    inputDir = inputDir,
-                    runner = runner,
-                    environmentConfig = environmentConfig
-                )
-            }
-
-            coVerify(exactly = 1) {
-                runner.runForked(
-                    any(),
-                    inputDir,
-                    AnalyzerRunnerConfig(
-                        allowDynamicVersions = config.allowDynamicVersions,
-                        disabledPackageManagers = config.disabledPackageManagers,
-                        enabledPackageManagers = config.enabledPackageManagers,
-                        packageCurationProviders = resolvedPackageCurationProviderConfigs,
-                        packageManagerOptions = config.packageManagerOptions,
-                        repositoryConfigPath = config.repositoryConfigPath,
-                        skipExcluded = config.skipExcluded
-                    ),
-                    environmentConfig
-                )
-            }
         }
     }
 

--- a/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
@@ -59,6 +59,7 @@ import org.eclipse.apoapsis.ortserver.model.JobConfigurations
 import org.eclipse.apoapsis.ortserver.model.JobStatus
 import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.OrtRunStatus
+import org.eclipse.apoapsis.ortserver.model.ProviderPluginConfiguration
 import org.eclipse.apoapsis.ortserver.model.Repository
 import org.eclipse.apoapsis.ortserver.model.RepositoryType
 import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.AppliedPackageCurationRef
@@ -159,11 +160,7 @@ class AnalyzerWorkerTest : StringSpec({
                     DownloadResult(projectDir, "main", "resolvedRevision")
         }
 
-        val context = mockk<WorkerContext> {
-            coEvery { resolveProviderPluginConfigSecrets(any()) } returns mockk(relaxed = true)
-            every { this@mockk.configManager } returns mockConfigManager()
-            every { this@mockk.ortRun } returns org.eclipse.apoapsis.ortserver.workers.analyzer.ortRun
-        }
+        val context = mockWorkerContext()
 
         val contextFactory = mockContextFactory(context)
 
@@ -227,11 +224,7 @@ class AnalyzerWorkerTest : StringSpec({
                     DownloadResult(projectDir, "main", "resolvedRevision")
         }
 
-        val context = mockk<WorkerContext> {
-            coEvery { resolveProviderPluginConfigSecrets(any()) } returns mockk(relaxed = true)
-            every { this@mockk.configManager } returns mockConfigManager()
-            every { this@mockk.ortRun } returns org.eclipse.apoapsis.ortserver.workers.analyzer.ortRun
-        }
+        val context = mockWorkerContext()
 
         val contextFactory = mockContextFactory(context)
 
@@ -293,11 +286,7 @@ class AnalyzerWorkerTest : StringSpec({
                     DownloadResult(projectDir, "main", "resolvedRevision")
         }
 
-        val context = mockk<WorkerContext> {
-            coEvery { resolveProviderPluginConfigSecrets(any()) } returns mockk(relaxed = true)
-            every { this@mockk.configManager } returns mockConfigManager()
-            every { this@mockk.ortRun } returns org.eclipse.apoapsis.ortserver.workers.analyzer.ortRun
-        }
+        val context = mockWorkerContext()
 
         val contextFactory = mockContextFactory(context)
 
@@ -338,7 +327,8 @@ class AnalyzerWorkerTest : StringSpec({
         val envConfig = mockk<EnvironmentConfig>()
         val jobConfig = AnalyzerJobConfiguration(
             environmentConfig = envConfig,
-            enabledPackageManagers = listOf("Maven")
+            enabledPackageManagers = listOf("Maven"),
+            packageCurationProviders = listOf(mockk())
         )
         val job = analyzerJob.copy(configuration = jobConfig)
 
@@ -360,9 +350,11 @@ class AnalyzerWorkerTest : StringSpec({
                     DownloadResult(projectDir, "main", "resolvedRevision")
         }
 
-        val context = mockk<WorkerContext> {
-            every { this@mockk.configManager } returns mockConfigManager()
-            every { this@mockk.ortRun } returns org.eclipse.apoapsis.ortserver.workers.analyzer.ortRun
+        val packageCurationProvidersConfigs = listOf(mockk<ProviderPluginConfiguration>())
+        val context = mockWorkerContext {
+            coEvery {
+                resolveProviderPluginConfigSecrets(jobConfig.packageCurationProviders)
+            } returns packageCurationProvidersConfigs
         }
 
         val contextFactory = mockContextFactory(context)
@@ -373,9 +365,10 @@ class AnalyzerWorkerTest : StringSpec({
             coEvery { setUpEnvironment(context, projectDir, envConfig, emptyList()) } returns resolvedEnvConfig
         }
 
+        val runnerConfig = runnerConfig(jobConfig, packageCurationProvidersConfigs)
         val testException = IllegalStateException("AnalyzerRunner test exception")
         val runner = mockk<AnalyzerRunner> {
-            coEvery { run(context, any(), jobConfig, resolvedEnvConfig) } throws testException
+            coEvery { run(context, any(), runnerConfig, resolvedEnvConfig) } throws testException
         }
 
         val worker = AnalyzerWorker(
@@ -416,10 +409,7 @@ class AnalyzerWorkerTest : StringSpec({
                     DownloadResult(projectDir, "main", "resolvedRevision")
         }
 
-        val context = mockk<WorkerContext> {
-            every { this@mockk.configManager } returns mockConfigManager()
-            every { this@mockk.ortRun } returns org.eclipse.apoapsis.ortserver.workers.analyzer.ortRun
-        }
+        val context = mockWorkerContext()
 
         val contextFactory = mockContextFactory(context)
 
@@ -435,7 +425,7 @@ class AnalyzerWorkerTest : StringSpec({
                 run(
                     context,
                     any(),
-                    analyzerJob.configuration,
+                    runnerConfig(analyzerJob.configuration),
                     resolvedEnvConfig
                 )
             } throws testException
@@ -543,11 +533,7 @@ class AnalyzerWorkerTest : StringSpec({
                     DownloadResult(projectDir, "main", "resolvedRevision")
         }
 
-        val context = mockk<WorkerContext> {
-            coEvery { resolveProviderPluginConfigSecrets(any()) } returns mockk(relaxed = true)
-            every { this@mockk.configManager } returns mockConfigManager()
-            every { this@mockk.ortRun } returns org.eclipse.apoapsis.ortserver.workers.analyzer.ortRun
-        }
+        val context = mockWorkerContext()
 
         val contextFactory = mockContextFactory(context)
 
@@ -642,9 +628,8 @@ class AnalyzerWorkerTest : StringSpec({
                     DownloadResult(projectDir, "main", "resolvedRevision")
         }
 
-        val context = mockk<WorkerContext> {
-            coEvery { resolveProviderPluginConfigSecrets(any()) } returns mockk(relaxed = true)
-            every { this@mockk.configManager } returns mockk<ConfigManager> {
+        val context = mockWorkerContext {
+            every { configManager } returns mockk<ConfigManager> {
                 every { getFile(any(), any()) } returns ByteArrayInputStream(
                     """
                         ---
@@ -654,7 +639,6 @@ class AnalyzerWorkerTest : StringSpec({
                     """.trimIndent().toByteArray()
                 )
             }
-            every { this@mockk.ortRun } returns org.eclipse.apoapsis.ortserver.workers.analyzer.ortRun
         }
 
         val contextFactory = mockContextFactory(context)
@@ -721,11 +705,7 @@ class AnalyzerWorkerTest : StringSpec({
             every { downloadRepository(any(), any()) } returns DownloadResult(projectDir, "main", "resolvedRevision")
         }
 
-        val context = mockk<WorkerContext> {
-            coEvery { resolveProviderPluginConfigSecrets(any()) } returns mockk(relaxed = true)
-            every { this@mockk.configManager } returns mockConfigManager()
-            every { this@mockk.ortRun } returns org.eclipse.apoapsis.ortserver.workers.analyzer.ortRun
-        }
+        val context = mockWorkerContext()
 
         val contextFactory = mockContextFactory(context)
 
@@ -788,11 +768,7 @@ class AnalyzerWorkerTest : StringSpec({
             every { downloadRepository(any(), any()) } returns DownloadResult(projectDir, "main", "resolvedRevision")
         }
 
-        val context = mockk<WorkerContext> {
-            coEvery { resolveProviderPluginConfigSecrets(any()) } returns mockk(relaxed = true)
-            every { this@mockk.configManager } returns mockConfigManager()
-            every { this@mockk.ortRun } returns org.eclipse.apoapsis.ortserver.workers.analyzer.ortRun
-        }
+        val context = mockWorkerContext()
 
         val contextFactory = mockContextFactory(context)
 
@@ -854,11 +830,7 @@ class AnalyzerWorkerTest : StringSpec({
             every { downloadRepository(any(), any()) } returns DownloadResult(projectDir, "main", "resolvedRevision")
         }
 
-        val context = mockk<WorkerContext> {
-            coEvery { resolveProviderPluginConfigSecrets(any()) } returns mockk(relaxed = true)
-            every { this@mockk.configManager } returns mockConfigManager()
-            every { this@mockk.ortRun } returns org.eclipse.apoapsis.ortserver.workers.analyzer.ortRun
-        }
+        val context = mockWorkerContext()
 
         val contextFactory = mockContextFactory(context)
 
@@ -921,11 +893,7 @@ class AnalyzerWorkerTest : StringSpec({
                     DownloadResult(projectDir, "main", "resolvedRevision")
         }
 
-        val context = mockk<WorkerContext> {
-            coEvery { resolveProviderPluginConfigSecrets(any()) } returns mockk(relaxed = true)
-            every { this@mockk.configManager } returns mockConfigManager()
-            every { this@mockk.ortRun } returns org.eclipse.apoapsis.ortserver.workers.analyzer.ortRun
-        }
+        val context = mockWorkerContext()
 
         val contextFactory = mockContextFactory(context)
 
@@ -985,11 +953,7 @@ class AnalyzerWorkerTest : StringSpec({
                     DownloadResult(projectDir, "main", "resolvedRevision")
         }
 
-        val context = mockk<WorkerContext> {
-            coEvery { resolveProviderPluginConfigSecrets(any()) } returns mockk(relaxed = true)
-            every { this@mockk.configManager } returns mockConfigManager()
-            every { this@mockk.ortRun } returns org.eclipse.apoapsis.ortserver.workers.analyzer.ortRun
-        }
+        val context = mockWorkerContext()
 
         val contextFactory = mockContextFactory(context)
 
@@ -1065,11 +1029,7 @@ class AnalyzerWorkerTest : StringSpec({
                     DownloadResult(projectDir, "main", "resolvedRevision")
         }
 
-        val context = mockk<WorkerContext> {
-            coEvery { resolveProviderPluginConfigSecrets(any()) } returns mockk(relaxed = true)
-            every { this@mockk.configManager } returns mockConfigManager()
-            every { this@mockk.ortRun } returns org.eclipse.apoapsis.ortserver.workers.analyzer.ortRun
-        }
+        val context = mockWorkerContext()
 
         val contextFactory = mockContextFactory(context)
 
@@ -1123,3 +1083,32 @@ private fun mockConfigManager() = mockk<ConfigManager> {
 private fun mockIssueResolutionService() = mockk<IssueResolutionService> {
     every { getResolutionsForRepository(any()) } returns Ok(emptyList())
 }
+
+/**
+ * Return an [AnalyzerRunnerConfig] based on the given [jobConfig] and optional [packageCurationProviderConfigs].
+ */
+private fun runnerConfig(
+    jobConfig: AnalyzerJobConfiguration,
+    packageCurationProviderConfigs: List<ProviderPluginConfiguration>? = null
+): AnalyzerRunnerConfig =
+    AnalyzerRunnerConfig(
+        allowDynamicVersions = jobConfig.allowDynamicVersions,
+        skipExcluded = jobConfig.skipExcluded,
+        enabledPackageManagers = jobConfig.enabledPackageManagers,
+        disabledPackageManagers = jobConfig.disabledPackageManagers,
+        packageManagerOptions = jobConfig.packageManagerOptions,
+        repositoryConfigPath = jobConfig.repositoryConfigPath,
+        packageCurationProviders = packageCurationProviderConfigs.orEmpty()
+    )
+
+/**
+ * Create a mock [WorkerContext] with default stubs for the properties commonly used in tests.
+ * An optional [extraSetup] block can be used to override or add additional stubs.
+ */
+private fun mockWorkerContext(extraSetup: WorkerContext.() -> Unit = {}): WorkerContext =
+    mockk {
+        coEvery { resolveProviderPluginConfigSecrets(any()) } returns emptyList()
+        every { configManager } returns mockConfigManager()
+        every { ortRun } returns org.eclipse.apoapsis.ortserver.workers.analyzer.ortRun
+        extraSetup()
+    }

--- a/workers/common/build.gradle.kts
+++ b/workers/common/build.gradle.kts
@@ -69,6 +69,7 @@ dependencies {
     testImplementation(testFixtures(projects.storage.storageSpi))
 
     testImplementation(libs.jsonSchemaValidator)
+    testImplementation(libs.koinTest)
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)

--- a/workers/common/src/main/kotlin/context/SecretResolverService.kt
+++ b/workers/common/src/main/kotlin/context/SecretResolverService.kt
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.common.context
+
+import org.eclipse.apoapsis.ortserver.components.secrets.SecretService
+import org.eclipse.apoapsis.ortserver.model.Hierarchy
+import org.eclipse.apoapsis.ortserver.model.Secret
+import org.eclipse.apoapsis.ortserver.secrets.SecretValue
+import org.eclipse.apoapsis.ortserver.utils.logging.runBlocking
+
+/**
+ * Definition of a service interface that provides read access to secret values.
+ *
+ * An object implementing this interface is used by the [WorkerContext] to resolve the secrets not associated with
+ * infrastructure services; for instance, secrets referenced by plugin configurations or environment variables.
+ */
+interface SecretResolverService {
+    companion object {
+        /**
+         * Return a [SecretResolverService] implementation that wraps the given [service] and thus provides a
+         * read-only view of the secrets managed by the service.
+         */
+        fun wrapSecretService(service: SecretService): SecretResolverService = SecretResolverServiceImpl(service)
+    }
+
+    /**
+     * Get the value of a [secret]. Return *null* if the value is not found.
+     */
+    fun getSecretValue(secret: Secret): SecretValue?
+
+    /**
+     * List all secrets for the provided [hierarchy]. If there are secrets with the same name in different levels of the
+     * hierarchy, only the one closest to the repository is returned.
+     */
+    fun listForHierarchy(hierarchy: Hierarchy): List<Secret>
+}
+
+/**
+ * An implementation of [SecretResolverService] that wraps a [SecretService] to which it delegates all requests.
+ */
+private class SecretResolverServiceImpl(
+    /** The [SecretService] to delegate requests to. */
+    private val secretService: SecretService
+) : SecretResolverService {
+    override fun getSecretValue(secret: Secret): SecretValue? = secretService.getSecretValue(secret)
+
+    override fun listForHierarchy(hierarchy: Hierarchy): List<Secret> =
+        runBlocking { secretService.listForHierarchy(hierarchy) }
+}

--- a/workers/common/src/main/kotlin/context/WorkerContextFactory.kt
+++ b/workers/common/src/main/kotlin/context/WorkerContextFactory.kt
@@ -19,7 +19,6 @@
 
 package org.eclipse.apoapsis.ortserver.workers.common.context
 
-import org.eclipse.apoapsis.ortserver.components.secrets.SecretService
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.RepositoryRepository
@@ -41,7 +40,7 @@ class WorkerContextFactory(
     private val repositoryRepository: RepositoryRepository,
 
     /** The service for accessing secrets. */
-    private val secretService: SecretService
+    private val secretService: SecretResolverService
 ) {
     /**
      * Create a new [WorkerContext] for the given [ID of an ORT run][ortRunId] and execute the given [block] passing

--- a/workers/common/src/main/kotlin/context/WorkerContextImpl.kt
+++ b/workers/common/src/main/kotlin/context/WorkerContextImpl.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.withContext
 
-import org.eclipse.apoapsis.ortserver.components.secrets.SecretService
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.config.Context
 import org.eclipse.apoapsis.ortserver.config.Path as ConfigPath
@@ -45,7 +44,6 @@ import org.eclipse.apoapsis.ortserver.model.Secret
 import org.eclipse.apoapsis.ortserver.model.SecretSource
 import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.RepositoryRepository
-import org.eclipse.apoapsis.ortserver.utils.logging.runBlocking
 import org.eclipse.apoapsis.ortserver.workers.common.ResolvedInfrastructureService
 import org.eclipse.apoapsis.ortserver.workers.common.auth.AuthenticationInfo
 import org.eclipse.apoapsis.ortserver.workers.common.auth.AuthenticationListener
@@ -80,7 +78,7 @@ internal class WorkerContextImpl(
     private val ortRunId: Long,
 
     /** The service for accessing secrets. */
-    private val secretService: SecretService
+    private val secretService: SecretResolverService
 ) : WorkerContext {
     /** A cache for the secrets that have already been loaded. */
     private val secretsCache = ConcurrentHashMap<Secret, Deferred<String>>()
@@ -117,7 +115,7 @@ internal class WorkerContextImpl(
     }
 
     private val hierarchySecrets by lazy {
-        runBlocking { secretService.listForHierarchy(hierarchy) }.associateBy { it.name }
+        secretService.listForHierarchy(hierarchy).associateBy { it.name }
     }
 
     override val secretResolverFun: SecretResolverFun

--- a/workers/common/src/main/kotlin/context/WorkerContextModule.kt
+++ b/workers/common/src/main/kotlin/context/WorkerContextModule.kt
@@ -36,16 +36,23 @@ import org.koin.dsl.module
 /**
  * Return a [Module] with bean definitions required to obtain a [WorkerContextFactory] and other functionality that is
  * typically needed by workers. Workers requiring a [WorkerContext] can integrate this module and then obtain a
- * factory via injection.
+ * factory via injection. Per default, the module provides a [SecretResolverService] that queries the configured
+ * secret storage. It is possible to override this by passing in a non-null [secretResolverService]. This is useful to
+ * restrict the access to secrets in some scenarios.
  */
-fun workerContextModule(): Module = module {
+fun workerContextModule(secretResolverService: SecretResolverService? = null): Module = module {
     single<OrtRunRepository> { DaoOrtRunRepository(get()) }
     single<RepositoryRepository> { DaoRepositoryRepository(get()) }
-    single<SecretRepository> { DaoSecretRepository(get()) }
 
-    single {
-        val secretStorage = SecretStorage.createStorage(get())
-        SecretService(get(), get(), secretStorage)
+    if (secretResolverService != null) {
+        single { secretResolverService }
+    } else {
+        single<SecretRepository> { DaoSecretRepository(get()) }
+        single {
+            val secretStorage = SecretStorage.createStorage(get())
+            SecretService(get(), get(), secretStorage)
+        }
+        single { SecretResolverService.wrapSecretService(get()) }
     }
 
     singleOf(::WorkerContextFactory)

--- a/workers/common/src/main/kotlin/env/ConfigFileBuilder.kt
+++ b/workers/common/src/main/kotlin/env/ConfigFileBuilder.kt
@@ -33,6 +33,9 @@ import org.eclipse.apoapsis.ortserver.workers.common.auth.InfraSecretResolverFun
 import org.eclipse.apoapsis.ortserver.workers.common.auth.SecretResolverFun
 import org.eclipse.apoapsis.ortserver.workers.common.auth.resolveSecrets
 
+import org.ossreviewtoolkit.utils.common.Os
+import org.ossreviewtoolkit.utils.common.div
+
 import org.slf4j.LoggerFactory
 
 /**
@@ -66,7 +69,13 @@ class ConfigFileBuilder(
      * An optional globally configured Maven Central mirror that can be used when generating config files for package
      * managers that use the Maven ecosystem.
      */
-    val globalMavenCentralMirror: MavenCentralMirror? = null
+    val globalMavenCentralMirror: MavenCentralMirror? = null,
+
+    /**
+     * An optional alternative directory to be used as user home path. This can be used to generate configuration files
+     * in a different location, for instance, during a preparation step before performing the actual analysis.
+     */
+    val userHomeDir: File? = null
 ) {
     companion object {
         private val logger = LoggerFactory.getLogger(ConfigFileBuilder::class.java)
@@ -190,7 +199,8 @@ class ConfigFileBuilder(
      * given [block].
      */
     suspend fun buildInUserHome(name: String, block: suspend PrintWriter.() -> Unit) {
-        build(File(System.getProperty("user.home"), name), block)
+        val target = (userHomeDir ?: Os.userHomeDirectory) / name
+        build(target, block)
     }
 
     /**

--- a/workers/common/src/main/kotlin/env/EnvironmentForkHelper.kt
+++ b/workers/common/src/main/kotlin/env/EnvironmentForkHelper.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.apoapsis.ortserver.workers.common.env
 
+import java.io.File
 import java.io.InputStream
 import java.io.OutputStream
 
@@ -28,6 +29,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.json.encodeToStream
 
+import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.model.InfrastructureServiceDeclaration
 import org.eclipse.apoapsis.ortserver.model.Secret
 import org.eclipse.apoapsis.ortserver.workers.common.ResolvedInfrastructureService
@@ -64,12 +66,11 @@ object EnvironmentForkHelper {
     fun prepareFork(out: OutputStream) {
         logger.info("Preparing forked process...")
 
-        val authenticator = OrtServerAuthenticator.install()
-        val authInfo = authenticator.authenticationInfo
+        val authInfo = fetchAuthenticationInfo()
         val mdcContext = MDC.getCopyOfContextMap().orEmpty()
 
         val forkData = SerializableForkData(
-            authInfo = authInfo.toSerializableAuthenticationInfo(),
+            authInfo = authInfo,
             mdcContext = mdcContext
         )
 
@@ -77,6 +78,16 @@ object EnvironmentForkHelper {
 
         logger.info("Wrote authentication information about {} services to forked process.", authInfo.services.size)
         logger.info("Wrote MDC context with {} entries to forked process.", mdcContext.size)
+    }
+
+    /**
+     * Write the current authentication information (the set of infrastructure services with their credentials) to the
+     * specified [target] file. At a later point of time, it is then possible to restore this information again.
+     */
+    fun persistAuthenticationInfo(target: File) {
+        target.outputStream().use { out ->
+            Json.encodeToStream(fetchAuthenticationInfo(), out)
+        }
     }
 
     /**
@@ -110,10 +121,43 @@ object EnvironmentForkHelper {
     }
 
     /**
+     * Set up authentication information from the given [source] file and the provided [configManager]. Using this
+     * function, the data previously stored via [persistAuthenticationInfo] can be restored.
+     */
+    fun setupAuthentication(source: File, configManager: ConfigManager) {
+        val authInfo = source.inputStream().use { stream ->
+            Json.decodeFromStream<SerializableAuthenticationInfo>(stream)
+        }
+
+        restoreAuthentication(authInfo, configManager)
+    }
+
+    /**
      * Restore the MDC context from the given [context] map.
      */
     private fun restoreMdcContext(context: Map<String, String>) =
         if (context.isEmpty()) MDC.clear() else MDC.setContextMap(context)
+
+    /**
+     * Obtain authentication information from the authenticator and return it in a form that can be serialized.
+     */
+    private fun fetchAuthenticationInfo(): SerializableAuthenticationInfo {
+        val authenticator = OrtServerAuthenticator.install()
+        val authInfo = authenticator.authenticationInfo
+        return authInfo.toSerializableAuthenticationInfo()
+    }
+
+    /**
+     * Initialize the authenticator with the given deserialized [serAuthInfo] and the provided [configManager].
+     */
+    private fun restoreAuthentication(serAuthInfo: SerializableAuthenticationInfo, configManager: ConfigManager) {
+        val authInfo = serAuthInfo.toAuthenticationInfo()
+        val authenticator = OrtServerAuthenticator.install(infraSecretResolverFromConfig(configManager))
+        authenticator.updateAuthenticationInfo(authInfo)
+
+        val netrcManager = NetRcManager.create(secretResolver(authInfo))
+        authenticator.updateAuthenticationListener(netrcManager)
+    }
 
     /**
      * Convert this [AuthenticationInfo] to a [SerializableAuthenticationInfo] that can be passed to a forked process.

--- a/workers/common/src/main/kotlin/env/EnvironmentService.kt
+++ b/workers/common/src/main/kotlin/env/EnvironmentService.kt
@@ -100,28 +100,33 @@ class EnvironmentService(
      * checked out to the given [repositoryFolder]. The credentials of this repository - if any - are defined by the
      * given [repositoryServices]. If an optional [config] is provided, it will be merged with the parsed configuration.
      * In case of overlapping entries, the provided [config] will take priority over the parsed configuration.
+     * Optionally, generate configuration files in the specified [userHome] directory; if this is undefined, obtain the
+     * location of this folder from the corresponding system property.
      */
     suspend fun setUpEnvironment(
         context: WorkerContext,
         repositoryFolder: File,
         config: EnvironmentConfig?,
-        repositoryServices: List<InfrastructureService>
+        repositoryServices: List<InfrastructureService>,
+        userHome: File? = null
     ): ResolvedEnvironmentConfig {
         val environmentConfigPath = context.ortRun.environmentConfigPath
         val mergedConfig = configLoader.resolveAndParse(repositoryFolder, environmentConfigPath).merge(config)
         val resolvedConfig = configLoader.resolve(mergedConfig, context.hierarchy)
 
-        return setUpEnvironmentForConfig(context, resolvedConfig, repositoryServices)
+        return setUpEnvironmentForConfig(context, resolvedConfig, repositoryServices, userHome)
     }
 
     /**
      * Set up the analysis environment based on the given resolved [config]. Use the given [context]. Also take the
-     * given [repositoryServices] into account that have been used to download the repository.
+     * given [repositoryServices] into account that have been used to download the repository. Generate configuration
+     * files in the given [userHome] directory.
      */
     private suspend fun setUpEnvironmentForConfig(
         context: WorkerContext,
         config: ResolvedEnvironmentConfig,
-        repositoryServices: List<InfrastructureService>
+        repositoryServices: List<InfrastructureService>,
+        userHome: File?
     ): ResolvedEnvironmentConfig {
         val environmentServices = config.environmentDefinitions.map { it.service }
         val infraServices = config.infrastructureServices.toMutableSet()
@@ -138,18 +143,20 @@ class EnvironmentService(
 
         assignServicesToOrtRun(context, adjustedServices)
 
-        generateConfigFiles(context, allEnvironmentDefinitions)
+        generateConfigFiles(context, allEnvironmentDefinitions, userHome)
 
         return config
     }
 
     /**
      * Generate all configuration files supported by the managed [EnvironmentConfigGenerator]s based on the passed in
-     * [definitions]. Use the given [context] to access required information.
+     * [definitions]. Use the given [context] to access required information. Generate configuration files in the
+     * specified [userHome] directory.
      */
     private suspend fun generateConfigFiles(
         context: WorkerContext,
-        definitions: Collection<EnvironmentServiceDefinition>
+        definitions: Collection<EnvironmentServiceDefinition>,
+        userHome: File?
     ) {
         val adminConfig = adminConfigService.loadAdminConfig(
             context.resolvedConfigurationContext,
@@ -164,7 +171,8 @@ class EnvironmentService(
                 val builder = ConfigFileBuilder(
                     context.secretResolverFun,
                     context.configManager::getSecret,
-                    adminConfig.mavenCentralMirror
+                    adminConfig.mavenCentralMirror,
+                    userHome
                 )
                 async { generator.generateApplicable(builder, definitions) }
             }.awaitAll()
@@ -179,7 +187,7 @@ class EnvironmentService(
      */
     suspend fun setupAuthentication(context: WorkerContext, services: Collection<InfrastructureService>) {
         val definitions = resolveInfrastructureServices(context, services).map(::EnvironmentServiceDefinition)
-        generateConfigFiles(context, definitions)
+        generateConfigFiles(context, definitions, null)
     }
 
     /**

--- a/workers/common/src/test/kotlin/context/SecretResolverServiceTest.kt
+++ b/workers/common/src/test/kotlin/context/SecretResolverServiceTest.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.common.context
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+
+import org.eclipse.apoapsis.ortserver.components.secrets.SecretService
+import org.eclipse.apoapsis.ortserver.model.Hierarchy
+import org.eclipse.apoapsis.ortserver.model.Secret
+import org.eclipse.apoapsis.ortserver.secrets.SecretValue
+
+class SecretResolverServiceTest : WordSpec({
+    "SecretResolverServiceImpl" should {
+        "return the value of a secret" {
+            val secret = mockk<Secret>()
+            val secretValue = SecretValue("verySecretValue")
+            val service = mockk<SecretService> {
+                every { getSecretValue(secret) } returns secretValue
+            }
+
+            val resolverService = SecretResolverService.wrapSecretService(service)
+
+            resolverService.getSecretValue(secret) shouldBe secretValue
+        }
+
+        "list the secrets from the hierarchy" {
+            val hierarchy = mockk<Hierarchy>()
+            val hierarchySecrets = listOf(mockk<Secret>(), mockk<Secret>())
+            val service = mockk<SecretService> {
+                coEvery { listForHierarchy(hierarchy) } returns hierarchySecrets
+            }
+
+            val resolverService = SecretResolverService.wrapSecretService(service)
+
+            resolverService.listForHierarchy(hierarchy) shouldBe hierarchySecrets
+        }
+    }
+})

--- a/workers/common/src/test/kotlin/context/WorkerContextModuleTest.kt
+++ b/workers/common/src/test/kotlin/context/WorkerContextModuleTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.common.context
+
+import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.shouldBe
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkClass
+
+import org.eclipse.apoapsis.ortserver.components.secrets.SecretService
+import org.eclipse.apoapsis.ortserver.dao.databaseModule
+import org.eclipse.apoapsis.ortserver.dao.test.withMockDatabaseModule
+import org.eclipse.apoapsis.ortserver.model.Secret
+import org.eclipse.apoapsis.ortserver.secrets.SecretValue
+
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.core.module.Module
+import org.koin.test.KoinTest
+import org.koin.test.get
+import org.koin.test.mock.MockProvider
+import org.koin.test.mock.declareMock
+
+class WorkerContextModuleTest : KoinTest, StringSpec() {
+    init {
+        afterEach {
+            stopKoin()
+        }
+
+        "A resolver service wrapping the secret service should be returned" {
+            val secret = mockk<Secret>()
+            val secretValue = SecretValue("The correctly resolved secret value")
+
+            runModuleTest {
+                declareMock<SecretService> {
+                    every { getSecretValue(secret) } returns secretValue
+                }
+
+                val secretResolverService = get<SecretResolverService>()
+
+                secretResolverService.getSecretValue(secret) shouldBe secretValue
+            }
+        }
+
+        "A custom secret resolver service should be returned" {
+            val secret = mockk<Secret>()
+            val secretValue = SecretValue("The correctly resolved secret value")
+            val resolverService = mockk<SecretResolverService> {
+                every { getSecretValue(secret) } returns secretValue
+            }
+
+            runModuleTest(workerContextModule(resolverService)) {
+                val secretResolverService = get<SecretResolverService>()
+
+                secretResolverService.getSecretValue(secret) shouldBe secretValue
+            }
+        }
+    }
+
+    /**
+     * Prepare the test environment for a test of the given [workerModule] and then execute the given test [block].
+     */
+    private suspend fun runModuleTest(workerModule: Module = workerContextModule(), block: suspend () -> Unit) {
+        withMockDatabaseModule {
+            startKoin {
+                modules(
+                    databaseModule(),
+                    workerModule
+                )
+            }
+
+            MockProvider.register { mockkClass(it) }
+
+            block()
+        }
+    }
+}

--- a/workers/common/src/test/kotlin/context/WorkerContextTest.kt
+++ b/workers/common/src/test/kotlin/context/WorkerContextTest.kt
@@ -784,8 +784,12 @@ private class ContextFactoryTestHelper {
     )
 
     /** The factory to be tested. */
-    val factory: WorkerContextFactory =
-        WorkerContextFactory(config, ortRunRepository, repositoryRepository, secretService)
+    val factory: WorkerContextFactory = WorkerContextFactory(
+            config,
+            ortRunRepository,
+            repositoryRepository,
+            SecretResolverService.wrapSecretService(secretService)
+        )
 
     /**
      * Prepare the mock [OrtRunRepository] to be queried for the test run ID. Return a mock run that is also returned

--- a/workers/common/src/test/kotlin/env/ConfigFileBuilderTest.kt
+++ b/workers/common/src/test/kotlin/env/ConfigFileBuilderTest.kt
@@ -24,12 +24,12 @@ import io.kotest.engine.spec.tempdir
 import io.kotest.engine.spec.tempfile
 import io.kotest.extensions.system.OverrideMode
 import io.kotest.extensions.system.withEnvironment
-import io.kotest.extensions.system.withSystemProperties
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.should
 
-import java.util.Properties
+import io.mockk.every
+import io.mockk.mockkObject
 
 import org.eclipse.apoapsis.ortserver.model.Secret
 import org.eclipse.apoapsis.ortserver.workers.common.auth.SecretResolverFun
@@ -37,6 +37,8 @@ import org.eclipse.apoapsis.ortserver.workers.common.auth.undefinedInfraSecretRe
 import org.eclipse.apoapsis.ortserver.workers.common.auth.undefinedSecretResolver
 import org.eclipse.apoapsis.ortserver.workers.common.env.ConfigFileBuilder.Companion.printLines
 import org.eclipse.apoapsis.ortserver.workers.common.env.ConfigFileBuilder.Companion.printProxySettings
+
+import org.ossreviewtoolkit.utils.common.Os
 
 class ConfigFileBuilderTest : StringSpec({
     "A PrintWriter is exposed" {
@@ -119,11 +121,10 @@ class ConfigFileBuilderTest : StringSpec({
         val tempDir = tempdir()
         val fileName = "test.conf"
         val content = "test file content"
-        val systemProperties = Properties().apply {
-            setProperty("user.home", tempDir.absolutePath)
-        }
 
-        withSystemProperties(systemProperties, OverrideMode.SetOrOverride) {
+        mockkObject(Os) {
+            every { Os.userHomeDirectory } returns tempDir
+
             val builder = ConfigFileBuilder(undefinedSecretResolver, undefinedInfraSecretResolver)
             builder.buildInUserHome(fileName) {
                 printLines(content)
@@ -131,6 +132,24 @@ class ConfigFileBuilderTest : StringSpec({
         }
 
         val file = tempDir.resolve(fileName)
+        file.readLines() should containExactly(content)
+    }
+
+    "An alternative user home directory can be specified" {
+        val overriddenHome = tempdir()
+        val fileName = "test.conf"
+        val content = "test file content"
+
+        val builder = ConfigFileBuilder(
+            undefinedSecretResolver,
+            undefinedInfraSecretResolver,
+            userHomeDir = overriddenHome
+        )
+        builder.buildInUserHome(fileName) {
+            printLines(content)
+        }
+
+        val file = overriddenHome.resolve(fileName)
         file.readLines() should containExactly(content)
     }
 

--- a/workers/common/src/test/kotlin/env/EnvironmentForkHelperTest.kt
+++ b/workers/common/src/test/kotlin/env/EnvironmentForkHelperTest.kt
@@ -22,8 +22,6 @@ package org.eclipse.apoapsis.ortserver.workers.common.env
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.engine.spec.tempdir
 import io.kotest.engine.spec.tempfile
-import io.kotest.extensions.system.OverrideMode
-import io.kotest.extensions.system.withSystemProperty
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -55,6 +53,8 @@ import org.eclipse.apoapsis.ortserver.workers.common.auth.AuthenticationListener
 import org.eclipse.apoapsis.ortserver.workers.common.auth.InfraSecretResolverFun
 import org.eclipse.apoapsis.ortserver.workers.common.auth.OrtServerAuthenticator
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerOrtConfig
+
+import org.ossreviewtoolkit.utils.common.Os
 
 import org.slf4j.MDC
 
@@ -139,7 +139,9 @@ class EnvironmentForkHelperTest : StringSpec({
         val authenticator = installAuthenticatorMock(authInfo)
 
         val userHomeDir = tempdir()
-        withSystemProperty("user.home", userHomeDir.absolutePath, mode = OverrideMode.SetOrOverride) {
+        mockkObject(Os) {
+            every { Os.userHomeDirectory } returns userHomeDir
+
             doFork()
 
             val slotListener = slot<AuthenticationListener>()

--- a/workers/common/src/test/kotlin/env/EnvironmentForkHelperTest.kt
+++ b/workers/common/src/test/kotlin/env/EnvironmentForkHelperTest.kt
@@ -21,6 +21,7 @@ package org.eclipse.apoapsis.ortserver.workers.common.env
 
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.engine.spec.tempdir
+import io.kotest.engine.spec.tempfile
 import io.kotest.extensions.system.OverrideMode
 import io.kotest.extensions.system.withSystemProperty
 import io.kotest.matchers.nulls.beNull
@@ -42,6 +43,7 @@ import java.io.ByteArrayInputStream
 import java.io.ByteArrayOutputStream
 import java.net.URI
 
+import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.config.Path
 import org.eclipse.apoapsis.ortserver.model.CredentialsType
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
@@ -189,6 +191,49 @@ class EnvironmentForkHelperTest : StringSpec({
         MDC.get("ortRunId") shouldBe "456"
         MDC.get("analyzerJobId") shouldBe "789"
         MDC.get("component") shouldBe "analyzer-worker"
+    }
+
+    "Authentication information should be correctly persisted and restored" {
+        val usernameSecret = createSecret("user")
+        val repoPasswordSecret = createSecret("repoPassword")
+        val artifactoryPasswordSecret = createSecret("artifactoryPassword")
+        val repoService = createService("repo", usernameSecret, repoPasswordSecret)
+        val artifactoryService = createService("artifactory", usernameSecret, artifactoryPasswordSecret)
+        val secrets = mapOf(
+            usernameSecret.toAuthenticationInfo(),
+            repoPasswordSecret.toAuthenticationInfo(),
+            artifactoryPasswordSecret.toAuthenticationInfo()
+        )
+        val authInfo = AuthenticationInfo(
+            secrets = secrets,
+            services = listOf(repoService, artifactoryService)
+        )
+        val authenticator = installAuthenticatorMock(authInfo)
+        val testSecret = Path("testSecret")
+        val testSecretValue = "value of test secret"
+        val configManager = mockk<ConfigManager>()
+        every { configManager.getSecret(testSecret) } returns testSecretValue
+
+        val file = tempfile()
+        EnvironmentForkHelper.persistAuthenticationInfo(file)
+        EnvironmentForkHelper.setupAuthentication(file, configManager)
+
+        val slotResolver = mutableListOf<InfraSecretResolverFun>()
+        verify(exactly = 2) {
+            OrtServerAuthenticator.install(capture(slotResolver))
+        }
+        slotResolver.last().invoke(testSecret) shouldBe testSecretValue
+
+        val slotAuthInfo = slot<AuthenticationInfo>()
+        verify {
+            authenticator.updateAuthenticationInfo(capture(slotAuthInfo))
+        }
+
+        with(slotAuthInfo.captured) {
+            resolveSecret(usernameSecret) shouldBe secretValue(usernameSecret.name)
+            resolveSecret(repoPasswordSecret) shouldBe secretValue(repoPasswordSecret.name)
+            resolveSecret(artifactoryPasswordSecret) shouldBe secretValue(artifactoryPasswordSecret.name)
+        }
     }
 })
 

--- a/workers/common/src/test/kotlin/env/EnvironmentServiceTest.kt
+++ b/workers/common/src/test/kotlin/env/EnvironmentServiceTest.kt
@@ -20,6 +20,7 @@
 package org.eclipse.apoapsis.ortserver.workers.common.env
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldBeSingleton
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
@@ -514,6 +515,44 @@ class EnvironmentServiceTest : WordSpec({
             val args2 = generator2.verify(context, definitions)
 
             args1.first shouldNotBe args2.first
+        }
+
+        "generate configuration files in a specific directory" {
+            val userHome = tempdir()
+            val definitions = listOf(
+                EnvironmentServiceDefinition(createInfrastructureService())
+            )
+            val context = mockContext()
+            val generator = mockGenerator()
+
+            val envConfig = mockk<EnvironmentConfig>(relaxed = true)
+            val resolvedConfig = ResolvedEnvironmentConfig(emptyList(), definitions)
+            val configLoader = mockConfigLoader(envConfig, resolvedConfig)
+
+            val service = mockk<InfrastructureServiceService>()
+            service.expectServiceAssignments()
+
+            val environmentService = EnvironmentService(
+                service,
+                mockk(),
+                listOf(generator),
+                configLoader,
+                createMockAdminConfigService()
+            )
+
+            val configResult = environmentService.setUpEnvironment(
+                context,
+                repositoryFolder,
+                envConfig,
+                emptyList(),
+                userHome
+            )
+
+            configResult shouldBe resolvedConfig
+
+            val (builder, _) = generator.verify(context, definitions)
+
+            builder.userHomeDir shouldBe userHome
         }
 
         "handle infrastructure services not referenced by environment definitions" {


### PR DESCRIPTION
This PR adds some functionality and refactorings that are needed to split the Analyzer execution into multiple phases with different configuration options. This split will be implemented in a follow-up PR.