### PR TITLE
ui: Fixes for dependency graph

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/dependencies/-components/dependency-tree-node.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/dependencies/-components/dependency-tree-node.tsx
@@ -27,7 +27,6 @@ import {
 import type { PackageIdType } from '@/schemas';
 import {
   formatDependencyGraphPackageLabel,
-  matchesSearch,
   type AdjacencyMap,
 } from './dependency-graph-utils';
 import { HighlightedMatch } from './highlighted-match';
@@ -62,25 +61,27 @@ export const DependencyTreeNode = ({
   const childIndexes = (adjacency.get(nodeIndex) ?? []).filter(
     (childNodeIndex) => graph.nodes[childNodeIndex]
   );
-  const visibleChildIndexes = searchTerm
-    ? childIndexes.filter(matchesNodeSubtree)
-    : childIndexes;
   const nodeLabel = formatDependencyGraphPackageLabel(
     graph,
     node.pkg,
     packageIdType
   );
-  const nodeMatches = matchesSearch(nodeLabel, searchTerm);
-  const hasChildren = visibleChildIndexes.length > 0;
-  const isVisible = !searchTerm || nodeMatches || hasChildren;
+  const hasChildren = childIndexes.length > 0;
+  // While searching, the full graph stays intact: a node only starts out
+  // expanded when one of its descendants matches, so the path to a finding is
+  // revealed while the finding's own subtree (and unrelated branches) stay
+  // collapsed. This is only the initial state (`defaultOpen`) — the node stays
+  // uncontrolled so it can still be toggled by hand. The tree is remounted when
+  // the search term changes (see the keys in the route), which recomputes these
+  // defaults for the new search.
+  const defaultOpen =
+    searchTerm.length > 0 && childIndexes.some(matchesNodeSubtree);
   const nextPath = new Set(path);
   nextPath.add(nodeIndex);
 
-  if (!isVisible) return null;
-
   return (
     <TreeBranch isLast={isLast}>
-      <Collapsible open={searchTerm ? hasChildren : undefined}>
+      <Collapsible defaultOpen={defaultOpen}>
         {hasChildren ? (
           <CollapsibleTrigger asChild>
             <button
@@ -116,9 +117,8 @@ export const DependencyTreeNode = ({
 
         {hasChildren && (
           <CollapsibleContent className='space-y-2 pt-2'>
-            {visibleChildIndexes.map((childNodeIndex, childPosition) => {
-              const childIsLast =
-                childPosition === visibleChildIndexes.length - 1;
+            {childIndexes.map((childNodeIndex, childPosition) => {
+              const childIsLast = childPosition === childIndexes.length - 1;
 
               if (path.has(childNodeIndex)) {
                 const childNode = graph.nodes[childNodeIndex];

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/dependencies/-components/dependency-tree-node.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/dependencies/-components/dependency-tree-node.tsx
@@ -26,7 +26,6 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible';
-import { cn } from '@/lib/utils';
 import type { PackageIdType } from '@/schemas';
 import {
   formatDependencyGraphPackageLabel,
@@ -34,10 +33,12 @@ import {
   type AdjacencyMap,
 } from './dependency-graph-utils';
 import { HighlightedMatch } from './highlighted-match';
+import { TreeBranch } from './tree-branch';
 
 export const DependencyTreeNode = ({
   adjacency,
   graph,
+  isLast,
   matchesNodeSubtree,
   nodeIndex,
   packageIdType,
@@ -46,6 +47,7 @@ export const DependencyTreeNode = ({
 }: {
   adjacency: AdjacencyMap;
   graph: DependencyGraph;
+  isLast: boolean;
   matchesNodeSubtree: (nodeIndex: number) => boolean;
   nodeIndex: number;
   packageIdType: PackageIdType;
@@ -78,7 +80,7 @@ export const DependencyTreeNode = ({
   if (!isVisible) return null;
 
   return (
-    <div className={cn('space-y-2', path.size > 0 && 'ml-4 border-l pl-4')}>
+    <TreeBranch isLast={isLast}>
       <Collapsible open={searchTerm ? hasChildren : undefined}>
         {hasChildren ? (
           <CollapsibleTrigger asChild>
@@ -115,7 +117,10 @@ export const DependencyTreeNode = ({
 
         {hasChildren && (
           <CollapsibleContent className='space-y-2 pt-2'>
-            {visibleChildIndexes.map((childNodeIndex) => {
+            {visibleChildIndexes.map((childNodeIndex, childPosition) => {
+              const childIsLast =
+                childPosition === visibleChildIndexes.length - 1;
+
               if (path.has(childNodeIndex)) {
                 const childNode = graph.nodes[childNodeIndex];
                 const childLabel = childNode
@@ -127,9 +132,9 @@ export const DependencyTreeNode = ({
                   : '';
 
                 return (
-                  <div
+                  <TreeBranch
                     key={`${nodeIndex}-${childNodeIndex}-cycle`}
-                    className='ml-4 border-l pl-4'
+                    isLast={childIsLast}
                   >
                     <div className='flex flex-wrap items-center gap-2'>
                       <span className='min-w-0 text-sm font-medium break-all'>
@@ -140,7 +145,7 @@ export const DependencyTreeNode = ({
                       </span>
                       <Badge variant='outline'>cycle</Badge>
                     </div>
-                  </div>
+                  </TreeBranch>
                 );
               }
 
@@ -149,6 +154,7 @@ export const DependencyTreeNode = ({
                   key={`${nodeIndex}-${childNodeIndex}`}
                   adjacency={adjacency}
                   graph={graph}
+                  isLast={childIsLast}
                   matchesNodeSubtree={matchesNodeSubtree}
                   nodeIndex={childNodeIndex}
                   packageIdType={packageIdType}
@@ -160,6 +166,6 @@ export const DependencyTreeNode = ({
           </CollapsibleContent>
         )}
       </Collapsible>
-    </div>
+    </TreeBranch>
   );
 };

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/dependencies/-components/dependency-tree-node.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/dependencies/-components/dependency-tree-node.tsx
@@ -17,8 +17,6 @@
  * License-Filename: LICENSE
  */
 
-import { ChevronRight } from 'lucide-react';
-
 import type { DependencyGraph } from '@/api';
 import { Badge } from '@/components/ui/badge';
 import {
@@ -34,6 +32,7 @@ import {
 } from './dependency-graph-utils';
 import { HighlightedMatch } from './highlighted-match';
 import { TreeBranch } from './tree-branch';
+import { TreeToggleIcon } from './tree-toggle-icon';
 
 export const DependencyTreeNode = ({
   adjacency,
@@ -86,9 +85,9 @@ export const DependencyTreeNode = ({
           <CollapsibleTrigger asChild>
             <button
               type='button'
-              className='flex w-full items-start gap-2 rounded-sm text-left'
+              className='group/toggle flex w-full items-start gap-2 rounded-sm text-left'
             >
-              <ChevronRight className='text-muted-foreground mt-0.5 size-4 shrink-0 transition-transform group-data-[state=open]:rotate-90' />
+              <TreeToggleIcon />
               <div className='flex min-w-0 flex-1 flex-wrap items-center gap-2'>
                 <span className='min-w-0 text-sm font-medium break-all'>
                   <HighlightedMatch searchTerm={searchTerm} text={nodeLabel} />
@@ -104,7 +103,7 @@ export const DependencyTreeNode = ({
           </CollapsibleTrigger>
         ) : (
           <div className='flex items-start gap-2'>
-            <div className='mt-0.5 size-4 shrink-0' />
+            <div className='mt-[3px] size-4 shrink-0' />
             <div className='flex min-w-0 flex-1 flex-wrap items-center gap-2'>
               <span className='min-w-0 text-sm font-medium break-all'>
                 <HighlightedMatch searchTerm={searchTerm} text={nodeLabel} />

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/dependencies/-components/tree-branch.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/dependencies/-components/tree-branch.tsx
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { cn } from '@/lib/utils';
+
+/**
+ * Wraps a single tree item and draws the connector lines that link it to its
+ * parent, rendering the hierarchy as proper "branch segments" / t-junctions
+ * instead of plain vertical lines.
+ *
+ * Each item draws a short horizontal segment from the trunk to its own row and
+ * a vertical trunk segment shared with its siblings. The last sibling only
+ * draws the trunk down to the branch point (forming an "└" junction), while the
+ * other siblings extend the trunk past their own box to bridge the gap to the
+ * next sibling (forming "├" junctions).
+ */
+export const TreeBranch = ({
+  isLast,
+  children,
+}: {
+  isLast: boolean;
+  children: React.ReactNode;
+}) => (
+  <div className='relative ml-2 pl-4'>
+    <span
+      aria-hidden
+      className={cn(
+        'bg-border absolute top-0 left-0 w-px',
+        isLast ? 'h-[11px]' : '-bottom-2'
+      )}
+    />
+    <span
+      aria-hidden
+      className='bg-border absolute top-[11px] left-0 h-px w-4'
+    />
+    {children}
+  </div>
+);

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/dependencies/-components/tree-toggle-icon.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/dependencies/-components/tree-toggle-icon.tsx
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { SquareMinus, SquarePlus } from 'lucide-react';
+
+/**
+ * State-aware expand/collapse indicator for the dependency tree.
+ * Shows a "SquarePlus" icon when the nearest collapsible ancestor is closed
+ * and a "SquareMinus" icon when it is open.
+ */
+export const TreeToggleIcon = () => (
+  <>
+    <SquarePlus className='text-muted-foreground mt-[3px] size-4 shrink-0 group-data-[state=open]/toggle:hidden' />
+    <SquareMinus className='text-muted-foreground mt-[3px] size-4 shrink-0 group-data-[state=closed]/toggle:hidden' />
+  </>
+);

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/dependencies/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/dependencies/index.tsx
@@ -19,13 +19,7 @@
 
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
-import {
-  ChevronDown,
-  ChevronRight,
-  ChevronsUpDown,
-  ChevronUp,
-  X,
-} from 'lucide-react';
+import { ChevronDown, ChevronsUpDown, ChevronUp, X } from 'lucide-react';
 import { useState } from 'react';
 
 import type { DependencyGraph } from '@/api';
@@ -68,6 +62,7 @@ import {
 import { DependencyTreeNode } from './-components/dependency-tree-node';
 import { HighlightedMatch } from './-components/highlighted-match';
 import { TreeBranch } from './-components/tree-branch';
+import { TreeToggleIcon } from './-components/tree-toggle-icon';
 
 type SortDirection = 'asc' | 'desc';
 
@@ -182,27 +177,20 @@ const PackageCountBadge = ({ count }: { count?: number | null }) => {
 
 const TreeToggle = ({
   children,
-  isOpen,
   className,
 }: {
   children: React.ReactNode;
-  isOpen?: boolean;
   className?: string;
 }) => (
   <CollapsibleTrigger asChild>
     <button
       type='button'
       className={cn(
-        'flex w-full items-start gap-2 rounded-sm text-left',
+        'group/toggle flex w-full items-start gap-2 rounded-sm text-left',
         className
       )}
     >
-      <ChevronRight
-        className={cn(
-          'text-muted-foreground mt-0.5 size-4 shrink-0 transition-transform',
-          isOpen && 'rotate-90'
-        )}
-      />
+      <TreeToggleIcon />
       <div className='min-w-0 flex-1'>{children}</div>
     </button>
   </CollapsibleTrigger>
@@ -291,10 +279,10 @@ const ManagerDependenciesTab = ({
               return projectHasVisibleScopes ? (
                 <Collapsible
                   key={projectLabel}
-                  className='group space-y-2'
+                  className='space-y-2'
                   open={searchTerm ? projectOpen : undefined}
                 >
-                  <TreeToggle isOpen={searchTerm ? projectOpen : undefined}>
+                  <TreeToggle>
                     <div className='flex min-w-0 flex-wrap items-center gap-2'>
                       <span className='block min-w-0 text-sm font-semibold break-all'>
                         <HighlightedMatch
@@ -335,12 +323,10 @@ const ManagerDependenciesTab = ({
                               }
                             >
                               <Collapsible
-                                className='group space-y-2'
+                                className='space-y-2'
                                 open={searchTerm ? scopeOpen : undefined}
                               >
-                                <TreeToggle
-                                  isOpen={searchTerm ? scopeOpen : undefined}
-                                >
+                                <TreeToggle>
                                   <div className='flex min-w-0 flex-wrap items-center gap-2'>
                                     {scopeLabel && (
                                       <Badge variant='outline'>
@@ -388,7 +374,7 @@ const ManagerDependenciesTab = ({
                 </Collapsible>
               ) : (
                 <div key={projectLabel} className='flex items-start gap-2'>
-                  <div className='mt-0.5 size-4 shrink-0' />
+                  <div className='mt-[3px] size-4 shrink-0' />
                   <div className='flex min-w-0 flex-wrap items-center gap-2'>
                     <span className='block min-w-0 text-sm font-semibold break-all'>
                       <HighlightedMatch

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/dependencies/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/dependencies/index.tsx
@@ -67,6 +67,7 @@ import {
 } from './-components/dependency-graph-utils';
 import { DependencyTreeNode } from './-components/dependency-tree-node';
 import { HighlightedMatch } from './-components/highlighted-match';
+import { TreeBranch } from './-components/tree-branch';
 
 type SortDirection = 'asc' | 'desc';
 
@@ -305,60 +306,80 @@ const ManagerDependenciesTab = ({
                     </div>
                   </TreeToggle>
 
-                  <CollapsibleContent className='ml-4 border-l pl-4'>
+                  <CollapsibleContent>
                     <div className='space-y-2'>
                       {visibleScopes.map(
-                        ({
-                          packageCount,
-                          rootNodeIndexes,
-                          scopeName,
-                          scopeLabel,
-                        }) => {
+                        (
+                          {
+                            packageCount,
+                            rootNodeIndexes,
+                            scopeName,
+                            scopeLabel,
+                          },
+                          scopePosition
+                        ) => {
                           const scopeOpen = Boolean(
                             searchTerm &&
                             rootNodeIndexes.some(matchesNodeSubtree) &&
                             !matchesSearch(scopeLabel, searchTerm)
                           );
+                          const visibleRootNodeIndexes = searchTerm
+                            ? rootNodeIndexes.filter(matchesNodeSubtree)
+                            : rootNodeIndexes;
 
                           return (
-                            <Collapsible
+                            <TreeBranch
                               key={scopeName}
-                              className='group space-y-2'
-                              open={searchTerm ? scopeOpen : undefined}
+                              isLast={
+                                scopePosition === visibleScopes.length - 1
+                              }
                             >
-                              <TreeToggle
-                                isOpen={searchTerm ? scopeOpen : undefined}
+                              <Collapsible
+                                className='group space-y-2'
+                                open={searchTerm ? scopeOpen : undefined}
                               >
-                                <div className='flex min-w-0 flex-wrap items-center gap-2'>
-                                  {scopeLabel && (
-                                    <Badge variant='outline'>
-                                      <HighlightedMatch
-                                        searchTerm={searchTerm}
-                                        text={scopeLabel}
-                                      />
-                                    </Badge>
-                                  )}
-                                  <PackageCountBadge count={packageCount} />
-                                </div>
-                              </TreeToggle>
+                                <TreeToggle
+                                  isOpen={searchTerm ? scopeOpen : undefined}
+                                >
+                                  <div className='flex min-w-0 flex-wrap items-center gap-2'>
+                                    {scopeLabel && (
+                                      <Badge variant='outline'>
+                                        <HighlightedMatch
+                                          searchTerm={searchTerm}
+                                          text={scopeLabel}
+                                        />
+                                      </Badge>
+                                    )}
+                                    <PackageCountBadge count={packageCount} />
+                                  </div>
+                                </TreeToggle>
 
-                              <CollapsibleContent className='ml-4 border-l pt-2 pl-4'>
-                                <div className='space-y-2'>
-                                  {rootNodeIndexes.map((nodeIndex) => (
-                                    <DependencyTreeNode
-                                      key={`${scopeName}-${nodeIndex}`}
-                                      adjacency={adjacency}
-                                      graph={graph}
-                                      matchesNodeSubtree={matchesNodeSubtree}
-                                      nodeIndex={nodeIndex}
-                                      packageIdType={packageIdType}
-                                      path={new Set<number>()}
-                                      searchTerm={searchTerm}
-                                    />
-                                  ))}
-                                </div>
-                              </CollapsibleContent>
-                            </Collapsible>
+                                <CollapsibleContent className='pt-2'>
+                                  <div className='space-y-2'>
+                                    {visibleRootNodeIndexes.map(
+                                      (nodeIndex, nodePosition) => (
+                                        <DependencyTreeNode
+                                          key={`${scopeName}-${nodeIndex}`}
+                                          adjacency={adjacency}
+                                          graph={graph}
+                                          isLast={
+                                            nodePosition ===
+                                            visibleRootNodeIndexes.length - 1
+                                          }
+                                          matchesNodeSubtree={
+                                            matchesNodeSubtree
+                                          }
+                                          nodeIndex={nodeIndex}
+                                          packageIdType={packageIdType}
+                                          path={new Set<number>()}
+                                          searchTerm={searchTerm}
+                                        />
+                                      )
+                                    )}
+                                  </div>
+                                </CollapsibleContent>
+                              </Collapsible>
+                            </TreeBranch>
                           );
                         }
                       )}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/dependencies/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/dependencies/index.tsx
@@ -22,7 +22,7 @@ import { createFileRoute } from '@tanstack/react-router';
 import { ChevronDown, ChevronsUpDown, ChevronUp, X } from 'lucide-react';
 import { useState } from 'react';
 
-import type { DependencyGraph } from '@/api';
+import type { DependencyGraph, DependencyGraphScope } from '@/api';
 import {
   getRepositoryRunOptions,
   getRunDependencyGraphOptions,
@@ -215,18 +215,22 @@ const ManagerDependenciesTab = ({
     packageIdType
   );
 
-  const visibleProjectGroups = graph.projectGroups.filter(
-    ({ projectLabel, scopes }) => {
-      if (!searchTerm) return true;
-      if (matchesSearch(projectLabel, searchTerm)) return true;
+  // The search never hides parts of the graph; it only decides which branches
+  // are auto-expanded to reveal the matches. A scope is considered to contain a
+  // match when its own label matches or any of its node subtrees does.
+  const scopeHasMatch = ({
+    rootNodeIndexes,
+    scopeLabel,
+  }: DependencyGraphScope) =>
+    matchesSearch(scopeLabel, searchTerm) ||
+    rootNodeIndexes.some(matchesNodeSubtree);
 
-      return scopes.some(({ rootNodeIndexes, scopeLabel }) => {
-        if (matchesSearch(scopeLabel, searchTerm)) return true;
-
-        return rootNodeIndexes.some(matchesNodeSubtree);
-      });
-    }
-  );
+  const hasMatches =
+    !searchTerm ||
+    graph.projectGroups.some(
+      ({ projectLabel, scopes }) =>
+        matchesSearch(projectLabel, searchTerm) || scopes.some(scopeHasMatch)
+    );
 
   return (
     <TabsContent value={managerName} className='space-y-4'>
@@ -250,131 +254,33 @@ const ManagerDependenciesTab = ({
         )}
       </div>
 
-      {visibleProjectGroups.length === 0 ? (
+      {searchTerm && !hasMatches && (
         <div className='text-muted-foreground text-sm'>
-          {searchTerm
-            ? 'No matching dependencies found for this package manager.'
-            : 'No scopes are available for this dependency graph.'}
+          No packages match your search. Showing the full graph.
+        </div>
+      )}
+
+      {graph.projectGroups.length === 0 ? (
+        <div className='text-muted-foreground text-sm'>
+          No scopes are available for this dependency graph.
         </div>
       ) : (
         <div className='space-y-2'>
-          {visibleProjectGroups.map(
-            ({ packageCount, projectLabel, scopes }) => {
-              const visibleScopes = scopes.filter(
-                ({ rootNodeIndexes, scopeLabel }) => {
-                  if (!searchTerm) return true;
-                  if (matchesSearch(scopeLabel, searchTerm)) return true;
+          {graph.projectGroups.map(({ packageCount, projectLabel, scopes }) => {
+            const projectOpen =
+              searchTerm.length > 0 && scopes.some(scopeHasMatch);
 
-                  return rootNodeIndexes.some(matchesNodeSubtree);
-                }
-              );
-
-              const projectHasVisibleScopes = visibleScopes.length > 0;
-              const projectOpen = Boolean(
-                searchTerm &&
-                projectHasVisibleScopes &&
-                !matchesSearch(projectLabel, searchTerm)
-              );
-
-              return projectHasVisibleScopes ? (
-                <Collapsible
-                  key={projectLabel}
-                  className='space-y-2'
-                  open={searchTerm ? projectOpen : undefined}
-                >
-                  <TreeToggle>
-                    <div className='flex min-w-0 flex-wrap items-center gap-2'>
-                      <span className='block min-w-0 text-sm font-semibold break-all'>
-                        <HighlightedMatch
-                          searchTerm={searchTerm}
-                          text={projectLabel}
-                        />
-                      </span>
-                      <PackageCountBadge count={packageCount} />
-                    </div>
-                  </TreeToggle>
-
-                  <CollapsibleContent>
-                    <div className='space-y-2'>
-                      {visibleScopes.map(
-                        (
-                          {
-                            packageCount,
-                            rootNodeIndexes,
-                            scopeName,
-                            scopeLabel,
-                          },
-                          scopePosition
-                        ) => {
-                          const scopeOpen = Boolean(
-                            searchTerm &&
-                            rootNodeIndexes.some(matchesNodeSubtree) &&
-                            !matchesSearch(scopeLabel, searchTerm)
-                          );
-                          const visibleRootNodeIndexes = searchTerm
-                            ? rootNodeIndexes.filter(matchesNodeSubtree)
-                            : rootNodeIndexes;
-
-                          return (
-                            <TreeBranch
-                              key={scopeName}
-                              isLast={
-                                scopePosition === visibleScopes.length - 1
-                              }
-                            >
-                              <Collapsible
-                                className='space-y-2'
-                                open={searchTerm ? scopeOpen : undefined}
-                              >
-                                <TreeToggle>
-                                  <div className='flex min-w-0 flex-wrap items-center gap-2'>
-                                    {scopeLabel && (
-                                      <Badge variant='outline'>
-                                        <HighlightedMatch
-                                          searchTerm={searchTerm}
-                                          text={scopeLabel}
-                                        />
-                                      </Badge>
-                                    )}
-                                    <PackageCountBadge count={packageCount} />
-                                  </div>
-                                </TreeToggle>
-
-                                <CollapsibleContent className='pt-2'>
-                                  <div className='space-y-2'>
-                                    {visibleRootNodeIndexes.map(
-                                      (nodeIndex, nodePosition) => (
-                                        <DependencyTreeNode
-                                          key={`${scopeName}-${nodeIndex}`}
-                                          adjacency={adjacency}
-                                          graph={graph}
-                                          isLast={
-                                            nodePosition ===
-                                            visibleRootNodeIndexes.length - 1
-                                          }
-                                          matchesNodeSubtree={
-                                            matchesNodeSubtree
-                                          }
-                                          nodeIndex={nodeIndex}
-                                          packageIdType={packageIdType}
-                                          path={new Set<number>()}
-                                          searchTerm={searchTerm}
-                                        />
-                                      )
-                                    )}
-                                  </div>
-                                </CollapsibleContent>
-                              </Collapsible>
-                            </TreeBranch>
-                          );
-                        }
-                      )}
-                    </div>
-                  </CollapsibleContent>
-                </Collapsible>
-              ) : (
-                <div key={projectLabel} className='flex items-start gap-2'>
-                  <div className='mt-[3px] size-4 shrink-0' />
+            return scopes.length > 0 ? (
+              // Keying on the search term remounts the tree whenever the search
+              // changes, so the `defaultOpen` auto-expansion is recomputed for
+              // the new matches while leaving nodes freely toggleable in
+              // between.
+              <Collapsible
+                key={`${projectLabel}-${searchTerm}`}
+                className='space-y-2'
+                defaultOpen={projectOpen}
+              >
+                <TreeToggle>
                   <div className='flex min-w-0 flex-wrap items-center gap-2'>
                     <span className='block min-w-0 text-sm font-semibold break-all'>
                       <HighlightedMatch
@@ -384,10 +290,92 @@ const ManagerDependenciesTab = ({
                     </span>
                     <PackageCountBadge count={packageCount} />
                   </div>
+                </TreeToggle>
+
+                <CollapsibleContent>
+                  <div className='space-y-2'>
+                    {scopes.map(
+                      (
+                        {
+                          packageCount,
+                          rootNodeIndexes,
+                          scopeName,
+                          scopeLabel,
+                        },
+                        scopePosition
+                      ) => {
+                        const scopeOpen =
+                          searchTerm.length > 0 &&
+                          rootNodeIndexes.some(matchesNodeSubtree);
+
+                        return (
+                          <TreeBranch
+                            key={scopeName}
+                            isLast={scopePosition === scopes.length - 1}
+                          >
+                            <Collapsible
+                              className='space-y-2'
+                              defaultOpen={scopeOpen}
+                            >
+                              <TreeToggle>
+                                <div className='flex min-w-0 flex-wrap items-center gap-2'>
+                                  {scopeLabel && (
+                                    <Badge variant='outline'>
+                                      <HighlightedMatch
+                                        searchTerm={searchTerm}
+                                        text={scopeLabel}
+                                      />
+                                    </Badge>
+                                  )}
+                                  <PackageCountBadge count={packageCount} />
+                                </div>
+                              </TreeToggle>
+
+                              <CollapsibleContent className='pt-2'>
+                                <div className='space-y-2'>
+                                  {rootNodeIndexes.map(
+                                    (nodeIndex, nodePosition) => (
+                                      <DependencyTreeNode
+                                        key={`${scopeName}-${nodeIndex}`}
+                                        adjacency={adjacency}
+                                        graph={graph}
+                                        isLast={
+                                          nodePosition ===
+                                          rootNodeIndexes.length - 1
+                                        }
+                                        matchesNodeSubtree={matchesNodeSubtree}
+                                        nodeIndex={nodeIndex}
+                                        packageIdType={packageIdType}
+                                        path={new Set<number>()}
+                                        searchTerm={searchTerm}
+                                      />
+                                    )
+                                  )}
+                                </div>
+                              </CollapsibleContent>
+                            </Collapsible>
+                          </TreeBranch>
+                        );
+                      }
+                    )}
+                  </div>
+                </CollapsibleContent>
+              </Collapsible>
+            ) : (
+              <div key={projectLabel} className='flex items-start gap-2'>
+                <div className='mt-[3px] size-4 shrink-0' />
+                <div className='flex min-w-0 flex-wrap items-center gap-2'>
+                  <span className='block min-w-0 text-sm font-semibold break-all'>
+                    <HighlightedMatch
+                      searchTerm={searchTerm}
+                      text={projectLabel}
+                    />
+                  </span>
+                  <PackageCountBadge count={packageCount} />
                 </div>
-              );
-            }
-          )}
+              </div>
+            );
+          })}
         </div>
       )}
     </TabsContent>

--- a/ui/tests/unit/components/dependency-tree-node.test.tsx
+++ b/ui/tests/unit/components/dependency-tree-node.test.tsx
@@ -56,6 +56,7 @@ describe('DependencyTreeNode', () => {
       <DependencyTreeNode
         adjacency={adjacency}
         graph={graph}
+        isLast={true}
         matchesNodeSubtree={() => true}
         nodeIndex={1}
         packageIdType='ORT_ID'
@@ -75,6 +76,7 @@ describe('DependencyTreeNode', () => {
           ...graph,
           edges: [{ from: 0, to: 1 }],
         }}
+        isLast={true}
         matchesNodeSubtree={(nodeIndex) => nodeIndex === 1}
         nodeIndex={0}
         packageIdType='ORT_ID'
@@ -93,6 +95,7 @@ describe('DependencyTreeNode', () => {
       <DependencyTreeNode
         adjacency={adjacency}
         graph={graph}
+        isLast={true}
         matchesNodeSubtree={() => true}
         nodeIndex={0}
         packageIdType='ORT_ID'
@@ -112,6 +115,7 @@ describe('DependencyTreeNode', () => {
           ...graph,
           edges: [{ from: 0, to: 1 }],
         }}
+        isLast={true}
         matchesNodeSubtree={() => true}
         nodeIndex={1}
         packageIdType='PURL'

--- a/ui/tests/unit/components/dependency-tree-node.test.tsx
+++ b/ui/tests/unit/components/dependency-tree-node.test.tsx
@@ -68,7 +68,7 @@ describe('DependencyTreeNode', () => {
     expect(markup).toContain('cycle');
   });
 
-  it('renders only matching branches when children are filtered', () => {
+  it('expands the path to a matching descendant', () => {
     const markup = renderToStaticMarkup(
       <DependencyTreeNode
         adjacency={new Map<number, number[]>([[0, [1]]])}
@@ -88,6 +88,80 @@ describe('DependencyTreeNode', () => {
     expect(markup).toContain('Maven:com.example:root:1.0');
     expect(markup).toContain('library');
     expect(markup).toContain('DYNAMIC');
+  });
+
+  it('keeps the full graph intact while searching, collapsing the transitive dependencies of matches', () => {
+    const searchGraph: DependencyGraph = {
+      edges: [
+        { from: 0, to: 1 },
+        { from: 0, to: 3 },
+        { from: 1, to: 2 },
+      ],
+      nodes: [
+        { fragment: 0, linkage: 'PROJECT_DYNAMIC', packageCount: 2, pkg: 0 },
+        { fragment: 1, linkage: 'DYNAMIC', packageCount: 1, pkg: 1 },
+        { fragment: 2, linkage: 'DYNAMIC', packageCount: 0, pkg: 2 },
+        { fragment: 3, linkage: 'DYNAMIC', packageCount: 0, pkg: 3 },
+      ],
+      packageCount: 4,
+      packages: [
+        {
+          name: 'root',
+          namespace: 'com.example',
+          type: 'Maven',
+          version: '1.0',
+        },
+        {
+          name: 'library',
+          namespace: 'com.example',
+          type: 'Maven',
+          version: '2.0',
+        },
+        {
+          name: 'transitive',
+          namespace: 'com.example',
+          type: 'Maven',
+          version: '3.0',
+        },
+        {
+          name: 'other',
+          namespace: 'com.example',
+          type: 'Maven',
+          version: '4.0',
+        },
+      ],
+      purls: [] as unknown as string[],
+      projectGroups: [],
+    };
+    const searchAdjacency = new Map<number, number[]>([
+      [0, [1, 3]],
+      [1, [2]],
+    ]);
+
+    const markup = renderToStaticMarkup(
+      <DependencyTreeNode
+        adjacency={searchAdjacency}
+        graph={searchGraph}
+        isLast={true}
+        // The subtrees of the root and the match contain "library".
+        matchesNodeSubtree={(nodeIndex) => nodeIndex === 0 || nodeIndex === 1}
+        nodeIndex={0}
+        packageIdType='ORT_ID'
+        path={new Set<number>()}
+        searchTerm='library'
+      />
+    );
+
+    // The path to the match is expanded and the match is shown (the label is
+    // split into spans by the search highlighter, so match on the term)...
+    expect(markup).toContain('root');
+    expect(markup).toContain('library');
+    // ...a non-matching sibling branch is still present (graph stays intact)...
+    expect(markup).toContain('Maven:com.example:other:4.0');
+    // ...but the match's own transitive dependency stays collapsed...
+    expect(markup).not.toContain('transitive');
+    // ...and the match still renders as an expandable (collapsed) node.
+    expect(markup).toContain('lucide-square-plus');
   });
 
   it('renders the node label and linkage badge', () => {


### PR DESCRIPTION
This PR fixes some bugs for the run dependency graph, while aligning it closer to the WebApp report.

### More tree-like view with branches and stateful +/- icons

<img width="1132" height="732" alt="Screenshot from 2026-07-01 10-03-31" src="https://github.com/user-attachments/assets/086423f9-c74a-4ff9-a842-fa35c24ddb9a" />

### Search now opens all matches, while keeping the rest of the graph intact

<img width="1136" height="828" alt="Screenshot from 2026-07-01 10-04-33" src="https://github.com/user-attachments/assets/97f191b4-ef91-4497-b378-1b9126fd46d8" />

Please see the commits for details.