### PR TITLE
ui: Improvements for route loaders

### DIFF
--- a/ui/src/lib/query-client.ts
+++ b/ui/src/lib/query-client.ts
@@ -22,6 +22,8 @@ import { AxiosError } from 'axios';
 
 import { authRef } from '@/hooks/use-user';
 
+export const routePrefetchStaleTime = 30_000;
+
 export const queryClient = new QueryClient({
   queryCache: new QueryCache({
     onError: async (error) => {

--- a/ui/src/routes/admin/plugins/$pluginType/$pluginId/index.tsx
+++ b/ui/src/routes/admin/plugins/$pluginType/$pluginId/index.tsx
@@ -55,7 +55,7 @@ import {
 } from '@/components/ui/tooltip';
 import { ApiError } from '@/lib/api-error';
 import { ALL_ITEMS } from '@/lib/constants.ts';
-import { queryClient } from '@/lib/query-client.ts';
+import { queryClient, routePrefetchStaleTime } from '@/lib/query-client.ts';
 import { toast, toastError } from '@/lib/toast';
 import { getPluginTypeLabel } from '@/lib/types';
 import { Route as LayoutRoute } from '@/routes/admin/plugins/route.tsx';
@@ -383,6 +383,7 @@ const PluginTemplatesComponent = () => {
         pluginId: pluginId,
       },
     }),
+    staleTime: routePrefetchStaleTime,
   });
 
   if (!plugin) {
@@ -477,6 +478,7 @@ export const Route = createFileRoute('/admin/plugins/$pluginType/$pluginId/')({
           pluginId: params.pluginId,
         },
       }),
+      staleTime: routePrefetchStaleTime,
     });
   },
   component: PluginTemplatesComponent,

--- a/ui/src/routes/admin/runs/index.tsx
+++ b/ui/src/routes/admin/runs/index.tsx
@@ -414,15 +414,22 @@ export const Route = createFileRoute('/admin/runs/')({
     context: { queryClient },
     deps: { page, pageSize, status },
   }) => {
-    await queryClient.prefetchQuery({
-      ...getRunsOptions({
-        query: {
-          limit: pageSize || defaultPageSize,
-          offset: page ? (page - 1) * (pageSize || defaultPageSize) : 0,
-          status: status?.join(','),
-        },
+    await Promise.all([
+      queryClient.prefetchQuery({
+        ...getRunsOptions({
+          query: {
+            limit: pageSize || defaultPageSize,
+            offset: page ? (page - 1) * (pageSize || defaultPageSize) : 0,
+            status: status?.join(','),
+          },
+        }),
       }),
-    });
+      queryClient.prefetchQuery({
+        ...getRunsOptions({
+          query: { limit: 1 },
+        }),
+      }),
+    ]);
   },
   component: RunsComponent,
   pendingComponent: LoadingIndicator,

--- a/ui/src/routes/admin/runs/index.tsx
+++ b/ui/src/routes/admin/runs/index.tsx
@@ -414,7 +414,7 @@ export const Route = createFileRoute('/admin/runs/')({
     context: { queryClient },
     deps: { page, pageSize, status },
   }) => {
-    queryClient.prefetchQuery({
+    await queryClient.prefetchQuery({
       ...getRunsOptions({
         query: {
           limit: pageSize || defaultPageSize,

--- a/ui/src/routes/admin/users/index.tsx
+++ b/ui/src/routes/admin/users/index.tsx
@@ -58,6 +58,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { ApiError } from '@/lib/api-error';
+import { routePrefetchStaleTime } from '@/lib/query-client';
 import { toast, toastError } from '@/lib/toast';
 import { paginationSearchParameterSchema } from '@/schemas';
 
@@ -207,7 +208,10 @@ const Users = () => {
   const pageIndex = search.page ? search.page - 1 : 0;
   const pageSize = search.pageSize ? search.pageSize : defaultPageSize;
 
-  const { data: users } = useSuspenseQuery({ ...getUsersOptions() });
+  const { data: users } = useSuspenseQuery({
+    ...getUsersOptions(),
+    staleTime: routePrefetchStaleTime,
+  });
 
   const table = useReactTable({
     data: users || [],
@@ -274,6 +278,7 @@ export const Route = createFileRoute('/admin/users/')({
   loader: async ({ context: { queryClient } }) => {
     await queryClient.ensureQueryData({
       ...getUsersOptions(),
+      staleTime: routePrefetchStaleTime,
     });
   },
   component: Users,

--- a/ui/src/routes/admin/users/index.tsx
+++ b/ui/src/routes/admin/users/index.tsx
@@ -272,7 +272,7 @@ const Users = () => {
 export const Route = createFileRoute('/admin/users/')({
   validateSearch: paginationSearchParameterSchema,
   loader: async ({ context: { queryClient } }) => {
-    queryClient.prefetchQuery({
+    await queryClient.prefetchQuery({
       ...getUsersOptions(),
     });
   },

--- a/ui/src/routes/admin/users/index.tsx
+++ b/ui/src/routes/admin/users/index.tsx
@@ -272,7 +272,7 @@ const Users = () => {
 export const Route = createFileRoute('/admin/users/')({
   validateSearch: paginationSearchParameterSchema,
   loader: async ({ context: { queryClient } }) => {
-    await queryClient.prefetchQuery({
+    await queryClient.ensureQueryData({
       ...getUsersOptions(),
     });
   },

--- a/ui/src/routes/organizations/$orgId/index.tsx
+++ b/ui/src/routes/organizations/$orgId/index.tsx
@@ -189,13 +189,6 @@ export const Route = createFileRoute('/organizations/$orgId/')({
     ...paginationSearchParameterSchema.shape,
     ...filterByNameSearchParameterSchema.shape,
   }),
-  loader: async ({ context: { queryClient }, params }) => {
-    await queryClient.prefetchQuery({
-      ...getOrganizationOptions({
-        path: { organizationId: Number.parseInt(params.orgId) },
-      }),
-    });
-  },
   component: OrganizationComponent,
   pendingComponent: LoadingIndicator,
 });

--- a/ui/src/routes/organizations/$orgId/products/$productId/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/index.tsx
@@ -180,13 +180,6 @@ export const Route = createFileRoute(
     ...paginationSearchParameterSchema.shape,
     ...filterByNameSearchParameterSchema.shape,
   }),
-  loader: async ({ context: { queryClient }, params }) => {
-    await queryClient.prefetchQuery({
-      ...getProductOptions({
-        path: { productId: Number.parseInt(params.productId) },
-      }),
-    });
-  },
   component: ProductComponent,
   pendingComponent: LoadingIndicator,
 });

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/settings/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/settings/index.tsx
@@ -295,13 +295,5 @@ const RepositorySettingsPage = () => {
 export const Route = createFileRoute(
   '/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/settings/'
 )({
-  loader: async ({ context: { queryClient }, params }) => {
-    const repositoryId = Number.parseInt(params.repoId);
-    await queryClient.prefetchQuery({
-      ...getRepositoryOptions({
-        path: { repositoryId },
-      }),
-    });
-  },
   component: RepositorySettingsPage,
 });

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/route.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/route.tsx
@@ -38,6 +38,7 @@ export const Route = createFileRoute(
           repositoryId: repositoryId,
         },
       }),
+      revalidateIfStale: true,
     });
 
     const repositoryPermissions = await fetchRepositoryPermissions(

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/index.tsx
@@ -216,16 +216,6 @@ export const Route = createFileRoute(
   '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/config/'
 )({
   validateSearch: jobSearchParameterSchema,
-  loader: async ({ context: { queryClient }, params }) => {
-    await queryClient.prefetchQuery({
-      ...getRepositoryRunOptions({
-        path: {
-          repositoryId: Number.parseInt(params.repoId),
-          ortRunIndex: Number.parseInt(params.runIndex),
-        },
-      }),
-    });
-  },
   component: ConfigComponent,
   pendingComponent: LoadingIndicator,
 });

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/index.tsx
@@ -146,16 +146,6 @@ const RunComponent = () => {
 export const Route = createFileRoute(
   '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/'
 )({
-  loader: async ({ context: { queryClient }, params }) => {
-    await queryClient.prefetchQuery({
-      ...getRepositoryRunOptions({
-        path: {
-          repositoryId: Number.parseInt(params.repoId),
-          ortRunIndex: Number.parseInt(params.runIndex),
-        },
-      }),
-    });
-  },
   component: RunComponent,
   pendingComponent: LoadingIndicator,
 });

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues/index.tsx
@@ -588,16 +588,6 @@ export const Route = createFileRoute(
     ...sortingSearchParameterSchema.shape,
     ...markedSearchParameterSchema.shape,
   }),
-  loader: async ({ context: { queryClient }, params }) => {
-    await queryClient.prefetchQuery({
-      ...getRepositoryRunOptions({
-        path: {
-          repositoryId: Number.parseInt(params.repoId),
-          ortRunIndex: Number.parseInt(params.runIndex),
-        },
-      }),
-    });
-  },
   component: IssuesComponent,
   pendingComponent: LoadingIndicator,
 });

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/index.tsx
@@ -20,7 +20,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import z from 'zod';
 
-import { getRepositoryRunOptions } from '@/api/@tanstack/react-query.gen';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import {
   detectedLicenseSearchParameterSchema,
@@ -47,16 +46,6 @@ export const Route = createFileRoute(
   '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/'
 )({
   validateSearch: licenseFindingsSearchSchema,
-  loader: async ({ context: { queryClient }, params }) => {
-    await queryClient.prefetchQuery({
-      ...getRepositoryRunOptions({
-        path: {
-          repositoryId: Number.parseInt(params.repoId),
-          ortRunIndex: Number.parseInt(params.runIndex),
-        },
-      }),
-    });
-  },
   component: LicenseFindingsView,
   pendingComponent: LoadingIndicator,
 });

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/logs/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/logs/index.tsx
@@ -185,16 +185,6 @@ const ReportComponent = () => {
 export const Route = createFileRoute(
   '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/logs/'
 )({
-  loader: async ({ context: { queryClient }, params }) => {
-    await queryClient.prefetchQuery({
-      ...getRepositoryRunOptions({
-        path: {
-          repositoryId: Number.parseInt(params.repoId),
-          ortRunIndex: Number.parseInt(params.runIndex),
-        },
-      }),
-    });
-  },
   component: ReportComponent,
   pendingComponent: LoadingIndicator,
 });

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
@@ -623,16 +623,6 @@ export const Route = createFileRoute(
     ...isDirectDependencySearchParameterSchema.shape,
     ...markedSearchParameterSchema.shape,
   }),
-  loader: async ({ context: { queryClient }, params }) => {
-    await queryClient.prefetchQuery({
-      ...getRepositoryRunOptions({
-        path: {
-          repositoryId: Number.parseInt(params.repoId),
-          ortRunIndex: Number.parseInt(params.runIndex),
-        },
-      }),
-    });
-  },
   component: PackagesComponent,
   pendingComponent: LoadingIndicator,
 });

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
@@ -498,16 +498,6 @@ export const Route = createFileRoute(
     ...sortingSearchParameterSchema.shape,
     ...markedSearchParameterSchema.shape,
   }),
-  loader: async ({ context: { queryClient }, params }) => {
-    await queryClient.prefetchQuery({
-      ...getRepositoryRunOptions({
-        path: {
-          repositoryId: Number.parseInt(params.repoId),
-          ortRunIndex: Number.parseInt(params.runIndex),
-        },
-      }),
-    });
-  },
   component: ProjectsComponent,
   pendingComponent: LoadingIndicator,
 });

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
@@ -56,6 +56,7 @@ import {
 import { updateColumnSorting } from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-conversion';
 import { ACTION_COLUMN_SIZE, ALL_ITEMS } from '@/lib/constants';
+import { routePrefetchStaleTime } from '@/lib/query-client';
 import { toastError } from '@/lib/toast';
 import { getRepositoryTypeLabel } from '@/lib/types';
 import {
@@ -264,6 +265,7 @@ const ProjectsComponent = () => {
       path: { runId: ortRun.id },
       query: { limit: ALL_ITEMS },
     }),
+    staleTime: routePrefetchStaleTime,
   });
 
   // Use memoizing to ensure that the filter options (decuplidated SPDX expressions
@@ -513,6 +515,7 @@ export const Route = createFileRoute(
         path: { runId: ortRun.id },
         query: { limit: ALL_ITEMS },
       }),
+      staleTime: routePrefetchStaleTime,
     });
   },
   component: ProjectsComponent,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
@@ -498,6 +498,23 @@ export const Route = createFileRoute(
     ...sortingSearchParameterSchema.shape,
     ...markedSearchParameterSchema.shape,
   }),
+  loader: async ({ context: { queryClient }, params }) => {
+    const ortRun = await queryClient.ensureQueryData({
+      ...getRepositoryRunOptions({
+        path: {
+          repositoryId: Number.parseInt(params.repoId),
+          ortRunIndex: Number.parseInt(params.runIndex),
+        },
+      }),
+    });
+
+    await queryClient.prefetchQuery({
+      ...getRunProjectsOptions({
+        path: { runId: ortRun.id },
+        query: { limit: ALL_ITEMS },
+      }),
+    });
+  },
   component: ProjectsComponent,
   pendingComponent: LoadingIndicator,
 });

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/reports/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/reports/index.tsx
@@ -145,16 +145,6 @@ const ReportComponent = () => {
 export const Route = createFileRoute(
   '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/reports/'
 )({
-  loader: async ({ context: { queryClient }, params }) => {
-    await queryClient.prefetchQuery({
-      ...getRepositoryRunOptions({
-        path: {
-          repositoryId: Number.parseInt(params.repoId),
-          ortRunIndex: Number.parseInt(params.runIndex),
-        },
-      }),
-    });
-  },
   component: ReportComponent,
   pendingComponent: LoadingIndicator,
 });

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/route.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/route.tsx
@@ -185,6 +185,7 @@ export const Route = createFileRoute(
           ortRunIndex: Number.parseInt(params.runIndex),
         },
       }),
+      revalidateIfStale: true,
     });
     context.breadcrumbs.run = run.index.toString();
   },

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
@@ -593,16 +593,6 @@ export const Route = createFileRoute(
     ...sortingSearchParameterSchema.shape,
     ...markedSearchParameterSchema.shape,
   }),
-  loader: async ({ context: { queryClient }, params }) => {
-    await queryClient.prefetchQuery({
-      ...getRepositoryRunOptions({
-        path: {
-          repositoryId: Number.parseInt(params.repoId),
-          ortRunIndex: Number.parseInt(params.runIndex),
-        },
-      }),
-    });
-  },
   component: RuleViolationsComponent,
   pendingComponent: LoadingIndicator,
 });

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/sbom/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/sbom/index.tsx
@@ -269,16 +269,6 @@ const SBOMComponent = () => {
 export const Route = createFileRoute(
   '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/sbom/'
 )({
-  loader: async ({ context: { queryClient }, params }) => {
-    await queryClient.prefetchQuery({
-      ...getRepositoryRunOptions({
-        path: {
-          repositoryId: Number.parseInt(params.repoId),
-          ortRunIndex: Number.parseInt(params.runIndex),
-        },
-      }),
-    });
-  },
   component: SBOMComponent,
   pendingComponent: LoadingIndicator,
 });

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/index.tsx
@@ -20,7 +20,6 @@
 import { createFileRoute } from '@tanstack/react-router';
 import z from 'zod';
 
-import { getRepositoryRunOptions } from '@/api/@tanstack/react-query.gen';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import {
   findingsPaginationSearchParameterSchema,
@@ -61,16 +60,6 @@ export const Route = createFileRoute(
   '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/'
 )({
   validateSearch: snippetFindingsSearchSchema,
-  loader: async ({ context: { queryClient }, params }) => {
-    await queryClient.prefetchQuery({
-      ...getRepositoryRunOptions({
-        path: {
-          repositoryId: Number.parseInt(params.repoId),
-          ortRunIndex: Number.parseInt(params.runIndex),
-        },
-      }),
-    });
-  },
   component: SnippetFindingsView,
   pendingComponent: LoadingIndicator,
 });

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
@@ -637,16 +637,6 @@ export const Route = createFileRoute(
     ...externalIdSearchParameterSchema.shape,
     ...markedSearchParameterSchema.shape,
   }),
-  loader: async ({ context: { queryClient }, params }) => {
-    await queryClient.prefetchQuery({
-      ...getRepositoryRunOptions({
-        path: {
-          repositoryId: Number.parseInt(params.repoId),
-          ortRunIndex: Number.parseInt(params.runIndex),
-        },
-      }),
-    });
-  },
   component: VulnerabilitiesComponent,
   pendingComponent: LoadingIndicator,
 });

--- a/ui/src/routes/organizations/$orgId/products/$productId/route.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/route.tsx
@@ -133,6 +133,7 @@ export const Route = createFileRoute(
         ...getProductOptions({
           path: { productId: productId },
         }),
+        revalidateIfStale: true,
       });
 
       const productPermissions = await fetchProductPermissions(

--- a/ui/src/routes/organizations/$orgId/products/$productId/settings/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/settings/index.tsx
@@ -226,13 +226,5 @@ const ProductSettingsPage = () => {
 export const Route = createFileRoute(
   '/organizations/$orgId/products/$productId/settings/'
 )({
-  loader: async ({ context: { queryClient }, params }) => {
-    const productId = Number.parseInt(params.productId);
-    await queryClient.prefetchQuery({
-      ...getProductOptions({
-        path: { productId },
-      }),
-    });
-  },
   component: ProductSettingsPage,
 });

--- a/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
@@ -33,7 +33,6 @@ import z from 'zod';
 
 import { VulnerabilityRating, VulnerabilityWithStats } from '@/api';
 import {
-  getProductOptions,
   getProductVulnerabilitiesOptions,
   getProductVulnerabilityAdvisorsOptions,
 } from '@/api/@tanstack/react-query.gen';
@@ -582,13 +581,6 @@ export const Route = createFileRoute(
     ...externalIdSearchParameterSchema.shape,
     ...markedSearchParameterSchema.shape,
   }),
-  loader: async ({ context: { queryClient }, params }) => {
-    await queryClient.prefetchQuery({
-      ...getProductOptions({
-        path: { productId: Number.parseInt(params.productId) },
-      }),
-    });
-  },
   component: ProductVulnerabilitiesComponent,
   pendingComponent: LoadingIndicator,
 });

--- a/ui/src/routes/organizations/$orgId/route.tsx
+++ b/ui/src/routes/organizations/$orgId/route.tsx
@@ -133,6 +133,7 @@ export const Route = createFileRoute('/organizations/$orgId')({
         ...getOrganizationOptions({
           path: { organizationId: organizationId },
         }),
+        revalidateIfStale: true,
       });
 
       const organizationPermissions = await fetchOrganizationPermissions(

--- a/ui/src/routes/organizations/$orgId/settings/index.tsx
+++ b/ui/src/routes/organizations/$orgId/settings/index.tsx
@@ -223,15 +223,5 @@ const OrganizationSettingsPage = () => {
 };
 
 export const Route = createFileRoute('/organizations/$orgId/settings/')({
-  loader: async ({ context: { queryClient }, params }) => {
-    const organizationId = Number.parseInt(params.orgId);
-    await queryClient.prefetchQuery({
-      ...getOrganizationOptions({
-        path: {
-          organizationId,
-        },
-      }),
-    });
-  },
   component: OrganizationSettingsPage,
 });

--- a/ui/src/routes/organizations/$orgId/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/vulnerabilities/index.tsx
@@ -33,7 +33,6 @@ import z from 'zod';
 
 import { VulnerabilityRating, VulnerabilityWithStats } from '@/api';
 import {
-  getOrganizationOptions,
   getOrganizationVulnerabilitiesOptions,
   getOrganizationVulnerabilityAdvisorsOptions,
 } from '@/api/@tanstack/react-query.gen';
@@ -575,13 +574,6 @@ export const Route = createFileRoute('/organizations/$orgId/vulnerabilities/')({
     ...externalIdSearchParameterSchema.shape,
     ...markedSearchParameterSchema.shape,
   }),
-  loader: async ({ context: { queryClient }, params }) => {
-    await queryClient.prefetchQuery({
-      ...getOrganizationOptions({
-        path: { organizationId: Number.parseInt(params.orgId) },
-      }),
-    });
-  },
   component: OrganizationVulnerabilitiesComponent,
   pendingComponent: LoadingIndicator,
 });

--- a/ui/src/routes/organizations/index.tsx
+++ b/ui/src/routes/organizations/index.tsx
@@ -54,9 +54,6 @@ import {
 } from '@/schemas';
 import { useTablePrefsStore } from '@/store/table-prefs.store';
 
-// Fetch the default page size to loader from the store.
-const defaultPageSize = useTablePrefsStore.getState().orgPageSize;
-
 const columnHelper = createColumnHelper<Organization>();
 
 export const OrganizationsPage = () => {
@@ -235,16 +232,37 @@ export const Route = createFileRoute('/organizations/')({
     ...paginationSearchParameterSchema.shape,
     ...filterByNameSearchParameterSchema.shape,
   }),
-  loaderDeps: ({ search: { page, pageSize } }) => ({ page, pageSize }),
-  loader: async ({ context: { queryClient }, deps: { page, pageSize } }) => {
-    queryClient.prefetchQuery({
-      ...getOrganizationsOptions({
-        query: {
-          limit: pageSize || defaultPageSize,
-          offset: page ? (page - 1) * (pageSize || defaultPageSize) : 0,
-        },
+  loaderDeps: ({ search: { page, pageSize, filter } }) => ({
+    page,
+    pageSize,
+    filter,
+  }),
+  loader: async ({
+    context: { queryClient },
+    deps: { page, pageSize, filter },
+  }) => {
+    // Read the default page size from the store at loader time so the
+    // prefetched query key matches the component, which reads the same
+    // (live) preference. A module-level snapshot would go stale after the
+    // user changes their page-size preference during the session.
+    const limit = pageSize || useTablePrefsStore.getState().orgPageSize;
+
+    await Promise.all([
+      queryClient.prefetchQuery({
+        ...getOrganizationsOptions({
+          query: {
+            limit,
+            offset: page ? (page - 1) * limit : 0,
+            filter: filter || undefined,
+          },
+        }),
       }),
-    });
+      queryClient.prefetchQuery({
+        ...getOrganizationsOptions({
+          query: { limit: 1 },
+        }),
+      }),
+    ]);
   },
   component: OrganizationsPage,
   pendingComponent: LoadingIndicator,

--- a/ui/src/routes/organizations/index.tsx
+++ b/ui/src/routes/organizations/index.tsx
@@ -47,6 +47,7 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { useIsSuperuser } from '@/hooks/use-authorization';
+import { routePrefetchStaleTime } from '@/lib/query-client';
 import { toastError } from '@/lib/toast';
 import {
   filterByNameSearchParameterSchema,
@@ -80,6 +81,7 @@ export const OrganizationsPage = () => {
     ...getOrganizationsOptions({
       query: { limit: 1 },
     }),
+    staleTime: routePrefetchStaleTime,
   });
 
   const {
@@ -95,6 +97,7 @@ export const OrganizationsPage = () => {
         filter: nameFilter,
       },
     }),
+    staleTime: routePrefetchStaleTime,
   });
 
   const columns = useMemo(
@@ -256,11 +259,13 @@ export const Route = createFileRoute('/organizations/')({
             filter: filter || undefined,
           },
         }),
+        staleTime: routePrefetchStaleTime,
       }),
       queryClient.prefetchQuery({
         ...getOrganizationsOptions({
           query: { limit: 1 },
         }),
+        staleTime: routePrefetchStaleTime,
       }),
     ]);
   },

--- a/ui/tests/unit/fixtures/loader-test-utils.ts
+++ b/ui/tests/unit/fixtures/loader-test-utils.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+type QueryKeyRequest = {
+  _id?: string;
+  path?: Record<string, unknown>;
+  query?: Record<string, unknown>;
+};
+
+type QueryOptionsWithQueryKey = {
+  queryKey: readonly [QueryKeyRequest, ...unknown[]];
+};
+
+export const getQueryKeyRequest = (options: unknown): QueryKeyRequest =>
+  (options as QueryOptionsWithQueryKey).queryKey[0];
+
+export const createDeferred = <T = void>() => {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+};

--- a/ui/tests/unit/routes/admin-loader-prefetch.test.ts
+++ b/ui/tests/unit/routes/admin-loader-prefetch.test.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { Route as AdminRunsRoute } from '@/routes/admin/runs/index';
+import { Route as AdminUsersRoute } from '@/routes/admin/users/index';
+import { createDeferred } from '../fixtures/loader-test-utils';
+
+const expectLoaderToAwaitPrefetch = async (
+  loader: (options: unknown) => Promise<void>,
+  options: unknown
+) => {
+  const prefetch = createDeferred<undefined>();
+  const prefetchQuery = vi.fn().mockReturnValue(prefetch.promise);
+  let resolved = false;
+
+  const loaderPromise = loader({
+    ...(options as object),
+    context: {
+      queryClient: { prefetchQuery },
+    },
+  }).then(() => {
+    resolved = true;
+  });
+
+  await Promise.resolve();
+
+  expect(prefetchQuery).toHaveBeenCalledTimes(1);
+  expect(resolved).toBe(false);
+
+  prefetch.resolve(undefined);
+  await loaderPromise;
+
+  expect(resolved).toBe(true);
+};
+
+describe('admin route loaders', () => {
+  it('awaits the runs prefetch before resolving', async () => {
+    const loader = AdminRunsRoute.options.loader as unknown as (
+      options: unknown
+    ) => Promise<void>;
+
+    await expectLoaderToAwaitPrefetch(loader, {
+      deps: {
+        page: 2,
+        pageSize: 25,
+        status: ['FINISHED'],
+      },
+      params: {},
+    });
+  });
+
+  it('awaits the users prefetch before resolving', async () => {
+    const loader = AdminUsersRoute.options.loader as unknown as (
+      options: unknown
+    ) => Promise<void>;
+
+    await expectLoaderToAwaitPrefetch(loader, {
+      deps: {},
+      params: {},
+    });
+  });
+});

--- a/ui/tests/unit/routes/admin-loader-prefetch.test.ts
+++ b/ui/tests/unit/routes/admin-loader-prefetch.test.ts
@@ -19,22 +19,24 @@
 
 import { describe, expect, it, vi } from 'vitest';
 
+import { Route as AdminPluginTemplatesRoute } from '@/routes/admin/plugins/$pluginType/$pluginId/index';
 import { Route as AdminRunsRoute } from '@/routes/admin/runs/index';
 import { Route as AdminUsersRoute } from '@/routes/admin/users/index';
 import { createDeferred } from '../fixtures/loader-test-utils';
 
-const expectLoaderToAwaitPrefetch = async (
+const expectLoaderToAwaitQuery = async (
   loader: (options: unknown) => Promise<void>,
+  queryMethod: 'ensureQueryData' | 'prefetchQuery',
   options: unknown
 ) => {
-  const prefetch = createDeferred<undefined>();
-  const prefetchQuery = vi.fn().mockReturnValue(prefetch.promise);
+  const deferredQuery = createDeferred<undefined>();
+  const queryFn = vi.fn().mockReturnValue(deferredQuery.promise);
   let resolved = false;
 
   const loaderPromise = loader({
     ...(options as object),
     context: {
-      queryClient: { prefetchQuery },
+      queryClient: { [queryMethod]: queryFn },
     },
   }).then(() => {
     resolved = true;
@@ -42,10 +44,10 @@ const expectLoaderToAwaitPrefetch = async (
 
   await Promise.resolve();
 
-  expect(prefetchQuery).toHaveBeenCalledTimes(1);
+  expect(queryFn).toHaveBeenCalledTimes(1);
   expect(resolved).toBe(false);
 
-  prefetch.resolve(undefined);
+  deferredQuery.resolve(undefined);
   await loaderPromise;
 
   expect(resolved).toBe(true);
@@ -57,7 +59,7 @@ describe('admin route loaders', () => {
       options: unknown
     ) => Promise<void>;
 
-    await expectLoaderToAwaitPrefetch(loader, {
+    await expectLoaderToAwaitQuery(loader, 'prefetchQuery', {
       deps: {
         page: 2,
         pageSize: 25,
@@ -67,14 +69,28 @@ describe('admin route loaders', () => {
     });
   });
 
-  it('awaits the users prefetch before resolving', async () => {
+  it('awaits the users query before resolving', async () => {
     const loader = AdminUsersRoute.options.loader as unknown as (
       options: unknown
     ) => Promise<void>;
 
-    await expectLoaderToAwaitPrefetch(loader, {
+    await expectLoaderToAwaitQuery(loader, 'ensureQueryData', {
       deps: {},
       params: {},
+    });
+  });
+
+  it('awaits the plugin templates query before resolving', async () => {
+    const loader = AdminPluginTemplatesRoute.options.loader as unknown as (
+      options: unknown
+    ) => Promise<void>;
+
+    await expectLoaderToAwaitQuery(loader, 'prefetchQuery', {
+      deps: {},
+      params: {
+        pluginType: 'scanner',
+        pluginId: 'ScanCode',
+      },
     });
   });
 });

--- a/ui/tests/unit/routes/admin-loader-prefetch.test.ts
+++ b/ui/tests/unit/routes/admin-loader-prefetch.test.ts
@@ -22,12 +22,16 @@ import { describe, expect, it, vi } from 'vitest';
 import { Route as AdminPluginTemplatesRoute } from '@/routes/admin/plugins/$pluginType/$pluginId/index';
 import { Route as AdminRunsRoute } from '@/routes/admin/runs/index';
 import { Route as AdminUsersRoute } from '@/routes/admin/users/index';
-import { createDeferred } from '../fixtures/loader-test-utils';
+import {
+  createDeferred,
+  getQueryKeyRequest,
+} from '../fixtures/loader-test-utils';
 
 const expectLoaderToAwaitQuery = async (
   loader: (options: unknown) => Promise<void>,
   queryMethod: 'ensureQueryData' | 'prefetchQuery',
-  options: unknown
+  options: unknown,
+  expectedQueryCalls = 1
 ) => {
   const deferredQuery = createDeferred<undefined>();
   const queryFn = vi.fn().mockReturnValue(deferredQuery.promise);
@@ -44,29 +48,48 @@ const expectLoaderToAwaitQuery = async (
 
   await Promise.resolve();
 
-  expect(queryFn).toHaveBeenCalledTimes(1);
+  expect(queryFn).toHaveBeenCalledTimes(expectedQueryCalls);
   expect(resolved).toBe(false);
 
   deferredQuery.resolve(undefined);
   await loaderPromise;
 
   expect(resolved).toBe(true);
+
+  return queryFn;
 };
 
 describe('admin route loaders', () => {
-  it('awaits the runs prefetch before resolving', async () => {
+  it('awaits the runs and total count prefetches before resolving', async () => {
     const loader = AdminRunsRoute.options.loader as unknown as (
       options: unknown
     ) => Promise<void>;
 
-    await expectLoaderToAwaitQuery(loader, 'prefetchQuery', {
-      deps: {
-        page: 2,
-        pageSize: 25,
-        status: ['FINISHED'],
+    const queryFn = await expectLoaderToAwaitQuery(
+      loader,
+      'prefetchQuery',
+      {
+        deps: {
+          page: 2,
+          pageSize: 25,
+          status: ['FINISHED'],
+        },
+        params: {},
       },
-      params: {},
+      2
+    );
+
+    const runsRequest = getQueryKeyRequest(queryFn.mock.calls[0]![0]);
+    expect(runsRequest._id).toBe('getRuns');
+    expect(runsRequest.query).toEqual({
+      limit: 25,
+      offset: 25,
+      status: 'FINISHED',
     });
+
+    const totalCountRequest = getQueryKeyRequest(queryFn.mock.calls[1]![0]);
+    expect(totalCountRequest._id).toBe('getRuns');
+    expect(totalCountRequest.query).toEqual({ limit: 1 });
   });
 
   it('awaits the users query before resolving', async () => {

--- a/ui/tests/unit/routes/organization-route-loader.test.ts
+++ b/ui/tests/unit/routes/organization-route-loader.test.ts
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { Route } from '@/routes/organizations/$orgId/route';
+import { getQueryKeyRequest } from '../fixtures/loader-test-utils';
+
+describe('/organizations/$orgId layout loader', () => {
+  it('revalidates stale organization data and updates route context', async () => {
+    const ensureQueryData = vi.fn().mockResolvedValue({
+      id: 1,
+      name: 'Acme',
+    });
+    const fetchQuery = vi.fn().mockImplementation((options: unknown) => {
+      const request = getQueryKeyRequest(options);
+
+      if (request._id === 'getSuperuser') return false;
+
+      return {
+        organizationPermissions: ['WRITE'],
+      };
+    });
+
+    const context: {
+      queryClient: {
+        ensureQueryData: typeof ensureQueryData;
+        fetchQuery: typeof fetchQuery;
+      };
+      breadcrumbs: { organization?: string };
+      permissions: {
+        organization?: { includes: (permission: string) => boolean };
+      };
+    } = {
+      queryClient: {
+        ensureQueryData,
+        fetchQuery,
+      },
+      breadcrumbs: {},
+      permissions: {},
+    };
+
+    const loader = Route.options.loader as unknown as (
+      options: unknown
+    ) => Promise<void>;
+
+    await loader({
+      context,
+      params: {
+        orgId: '1',
+      },
+    });
+
+    expect(ensureQueryData).toHaveBeenCalledTimes(1);
+
+    const organizationOptions = ensureQueryData.mock.calls[0]![0];
+    const organizationRequest = getQueryKeyRequest(organizationOptions);
+    expect(organizationRequest._id).toBe('getOrganization');
+    expect(organizationRequest.path).toEqual({ organizationId: 1 });
+    expect(organizationOptions).toMatchObject({ revalidateIfStale: true });
+
+    expect(context.breadcrumbs.organization).toBe('Acme');
+    expect(context.permissions.organization?.includes('WRITE')).toBe(true);
+    expect(context.permissions.organization?.includes('MANAGE_GROUPS')).toBe(
+      false
+    );
+  });
+});

--- a/ui/tests/unit/routes/organizations-index-loader.test.ts
+++ b/ui/tests/unit/routes/organizations-index-loader.test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { Route } from '@/routes/organizations/index';
+import { getQueryKeyRequest } from '../fixtures/loader-test-utils';
+
+describe('/organizations loader', () => {
+  it('includes the name filter in loader deps and the prefetched query key', async () => {
+    const deps = Route.options.loaderDeps?.({
+      search: {
+        page: 2,
+        pageSize: 25,
+        filter: 'acme',
+      },
+    } as never);
+
+    expect(deps).toEqual({
+      page: 2,
+      pageSize: 25,
+      filter: 'acme',
+    });
+
+    const prefetchQuery = vi.fn().mockResolvedValue(undefined);
+
+    const loader = Route.options.loader as unknown as (
+      options: unknown
+    ) => Promise<void>;
+
+    await loader({
+      context: {
+        queryClient: { prefetchQuery },
+      },
+      deps,
+      params: {},
+    });
+
+    expect(prefetchQuery).toHaveBeenCalledTimes(2);
+
+    const organizationsRequest = getQueryKeyRequest(
+      prefetchQuery.mock.calls[0]![0]
+    );
+    expect(organizationsRequest._id).toBe('getOrganizations');
+    expect(organizationsRequest.query).toMatchObject({
+      limit: 25,
+      offset: 25,
+      filter: 'acme',
+    });
+
+    const totalCountRequest = getQueryKeyRequest(
+      prefetchQuery.mock.calls[1]![0]
+    );
+    expect(totalCountRequest._id).toBe('getOrganizations');
+    expect(totalCountRequest.query).toEqual({ limit: 1 });
+  });
+});

--- a/ui/tests/unit/routes/run-subpage-loader-prefetch.test.ts
+++ b/ui/tests/unit/routes/run-subpage-loader-prefetch.test.ts
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { ALL_ITEMS } from '@/lib/constants';
+import { Route as DependenciesRoute } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/dependencies/index';
+import { Route as ProjectsRoute } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index';
+import { getQueryKeyRequest } from '../fixtures/loader-test-utils';
+
+const params = {
+  orgId: '1',
+  productId: '2',
+  repoId: '3',
+  runIndex: '7',
+};
+
+describe('run subpage loaders', () => {
+  it('prefetches dependency graph data for the resolved run', async () => {
+    const fetchQuery = vi.fn().mockResolvedValue({ id: 123, index: 7 });
+    const prefetchQuery = vi.fn().mockResolvedValue(undefined);
+
+    const loader = DependenciesRoute.options.loader as unknown as (
+      options: unknown
+    ) => Promise<void>;
+
+    await loader({
+      context: {
+        queryClient: { fetchQuery, prefetchQuery },
+      },
+      params,
+    });
+
+    const runRequest = getQueryKeyRequest(fetchQuery.mock.calls[0]![0]);
+    expect(runRequest._id).toBe('getRepositoryRun');
+    expect(runRequest.path).toEqual({
+      repositoryId: 3,
+      ortRunIndex: 7,
+    });
+
+    const dependencyGraphRequest = getQueryKeyRequest(
+      prefetchQuery.mock.calls[0]![0]
+    );
+    expect(dependencyGraphRequest._id).toBe('getRunDependencyGraph');
+    expect(dependencyGraphRequest.path).toEqual({ runId: 123 });
+  });
+
+  it('prefetches project data for the resolved run', async () => {
+    const ensureQueryData = vi.fn().mockResolvedValue({ id: 123, index: 7 });
+    const prefetchQuery = vi.fn().mockResolvedValue(undefined);
+
+    const loader = ProjectsRoute.options.loader as unknown as (
+      options: unknown
+    ) => Promise<void>;
+
+    await loader({
+      context: {
+        queryClient: { ensureQueryData, prefetchQuery },
+      },
+      params,
+    });
+
+    const runRequest = getQueryKeyRequest(ensureQueryData.mock.calls[0]![0]);
+    expect(runRequest._id).toBe('getRepositoryRun');
+    expect(runRequest.path).toEqual({
+      repositoryId: 3,
+      ortRunIndex: 7,
+    });
+
+    const projectsRequest = getQueryKeyRequest(prefetchQuery.mock.calls[0]![0]);
+    expect(projectsRequest._id).toBe('getRunProjects');
+    expect(projectsRequest.path).toEqual({ runId: 123 });
+    expect(projectsRequest.query).toEqual({ limit: ALL_ITEMS });
+  });
+});


### PR DESCRIPTION
This PR contains some technical fixes and improvements, mostly for the UI route loaders. 

For reviewers: the PR contains some very technical changes and explanations, so most commit messages try to assist in reviewing by providing references to the relevant TanStack Router and TanStack Query documentation.

The PR has been reviewed twice: once with GPT 5.5 and second time with Anthropic's new Fable 5.

Please see the commits for details.