### PR TITLE
fix(workers)!: Don't generate the NPM `always-auth` property anymore

### DIFF
--- a/workers/common/src/main/kotlin/env/NpmRcGenerator.kt
+++ b/workers/common/src/main/kotlin/env/NpmRcGenerator.kt
@@ -94,13 +94,6 @@ class NpmRcGenerator : EnvironmentConfigGenerator<NpmDefinition> {
                         GeneratorLogger.entryAdded(entry, NPMRC_FILE_NAME, definition.service)
                     }
                 }
-
-                if (definition.alwaysAuth) {
-                    "$uriFragment:always-auth=true".also { entry ->
-                        println(entry)
-                        GeneratorLogger.entryAdded(entry, NPMRC_FILE_NAME, definition.service)
-                    }
-                }
             }
 
             printProxySettings { proxyConfig ->

--- a/workers/common/src/main/kotlin/env/config/EnvironmentDefinitionFactory.kt
+++ b/workers/common/src/main/kotlin/env/config/EnvironmentDefinitionFactory.kt
@@ -163,8 +163,7 @@ class EnvironmentDefinitionFactory {
                 credentialsTypes = credentialsTypes(),
                 scope = getOptionalProperty("scope"),
                 email = getOptionalProperty("email"),
-                authMode = getEnumProperty("authMode", NpmAuthMode.PASSWORD),
-                alwaysAuth = getBooleanProperty("alwaysAuth", true)
+                authMode = getEnumProperty("authMode", NpmAuthMode.PASSWORD)
             )
         }
 

--- a/workers/common/src/main/kotlin/env/definition/NpmDefinition.kt
+++ b/workers/common/src/main/kotlin/env/definition/NpmDefinition.kt
@@ -86,11 +86,5 @@ class NpmDefinition(
     /**
      * Defines the way authentication should be handled for this private registry.
      */
-    val authMode: NpmAuthMode = NpmAuthMode.PASSWORD,
-
-    /**
-     * A flag to control the generation of the `always-auth` property for this registry. Via this flag, NPM can be
-     * instructed to always send authentication information.
-     */
-    val alwaysAuth: Boolean = true
+    val authMode: NpmAuthMode = NpmAuthMode.PASSWORD
 ) : EnvironmentServiceDefinition(service, credentialsTypes)

--- a/workers/common/src/test/kotlin/env/NpmRcGeneratorTest.kt
+++ b/workers/common/src/test/kotlin/env/NpmRcGeneratorTest.kt
@@ -68,7 +68,6 @@ class NpmRcGeneratorTest : WordSpec({
             val expectedLines = """
                 $REGISTRY_URI_FRAGMENT:username=${MockConfigFileBuilder.testSecretRef(usernameSecret)}
                 $REGISTRY_URI_FRAGMENT:_password=${MockConfigFileBuilder.testSecretRef(passwordSecret)}
-                $REGISTRY_URI_FRAGMENT:always-auth=true
             """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
@@ -106,11 +105,9 @@ class NpmRcGeneratorTest : WordSpec({
             val expectedLines = """
                 $REGISTRY_URI_FRAGMENT:username=${MockConfigFileBuilder.testSecretRef(usernameSecret)}
                 $REGISTRY_URI_FRAGMENT:_password=${MockConfigFileBuilder.testSecretRef(passwordSecret1)}
-                $REGISTRY_URI_FRAGMENT:always-auth=true
 
                 $otherRegistryFragment:username=${MockConfigFileBuilder.testSecretRef(usernameSecret)}
                 $otherRegistryFragment:_password=${MockConfigFileBuilder.testSecretRef(passwordSecret2)}
-                $otherRegistryFragment:always-auth=true
             """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
@@ -152,7 +149,6 @@ class NpmRcGeneratorTest : WordSpec({
 
             val expectedLines = """
                 $REGISTRY_URI_FRAGMENT:_auth=${MockConfigFileBuilder.testSecretRef(passwordSecret)}
-                $REGISTRY_URI_FRAGMENT:always-auth=true
             """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
@@ -172,7 +168,6 @@ class NpmRcGeneratorTest : WordSpec({
 
             val expectedLines = """
                 $REGISTRY_URI_FRAGMENT:_authToken=${MockConfigFileBuilder.testSecretRef(passwordSecret)}
-                $REGISTRY_URI_FRAGMENT:always-auth=true
             """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
@@ -198,28 +193,9 @@ class NpmRcGeneratorTest : WordSpec({
 
             val expectedLines = """
                 $REGISTRY_URI_FRAGMENT:_auth=$authBase64
-                $REGISTRY_URI_FRAGMENT:always-auth=true
             """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
-        }
-
-        "skip the always-auth line if the flag is false" {
-            val passwordSecret = MockConfigFileBuilder.createSecret("registryPass")
-            val definition = NpmDefinition(
-                MockConfigFileBuilder.createInfrastructureService(NPM_REGISTRY_URI, passwordSecret = passwordSecret),
-                emptySet(),
-                authMode = NpmAuthMode.PASSWORD_AUTH,
-                alwaysAuth = false
-            )
-
-            val mockBuilder = MockConfigFileBuilder()
-
-            NpmRcGenerator().generate(mockBuilder.builder, listOf(definition))
-
-            val generated = mockBuilder.generatedText().trim()
-
-            generated shouldBe "$REGISTRY_URI_FRAGMENT:_auth=${MockConfigFileBuilder.testSecretRef(passwordSecret)}"
         }
 
         "print the email if it is present" {
@@ -239,7 +215,6 @@ class NpmRcGeneratorTest : WordSpec({
             val expectedLines = """
                 $REGISTRY_URI_FRAGMENT:_auth=${MockConfigFileBuilder.testSecretRef(passwordSecret)}
                 $REGISTRY_URI_FRAGMENT:email=$email
-                $REGISTRY_URI_FRAGMENT:always-auth=true
             """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
@@ -262,7 +237,6 @@ class NpmRcGeneratorTest : WordSpec({
             val expectedLines = """
                 @$scope:registry=$NPM_REGISTRY_URI
                 $REGISTRY_URI_FRAGMENT:_auth=${MockConfigFileBuilder.testSecretRef(passwordSecret)}
-                $REGISTRY_URI_FRAGMENT:always-auth=true
             """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines
@@ -288,7 +262,6 @@ class NpmRcGeneratorTest : WordSpec({
             val expectedLines = """
                 @$scope:registry=$NPM_REGISTRY_URI
                 $REGISTRY_URI_FRAGMENT:_auth=${MockConfigFileBuilder.testSecretRef(passwordSecret)}
-                $REGISTRY_URI_FRAGMENT:always-auth=true
             """.trimIndent().lines()
             val lines = mockBuilder.generatedLines()
             lines shouldContainExactly expectedLines

--- a/workers/common/src/test/kotlin/env/config/EnvironmentDefinitionFactoryTest.kt
+++ b/workers/common/src/test/kotlin/env/config/EnvironmentDefinitionFactoryTest.kt
@@ -219,8 +219,7 @@ class EnvironmentDefinitionFactoryTest : WordSpec() {
                 val properties = mapOf(
                     "scope" to scope,
                     "email" to email,
-                    "authMode" to authMode.name,
-                    "alwaysAuth" to "false"
+                    "authMode" to authMode.name
                 )
 
                 val definition = createSuccessful(EnvironmentDefinitionFactory.NPM_TYPE, properties)
@@ -229,7 +228,6 @@ class EnvironmentDefinitionFactoryTest : WordSpec() {
                 definition.scope shouldBe scope
                 definition.email shouldBe email
                 definition.authMode shouldBe authMode
-                definition.alwaysAuth shouldBe false
             }
 
             "be created with default values" {
@@ -241,7 +239,6 @@ class EnvironmentDefinitionFactoryTest : WordSpec() {
                 definition.scope should beNull()
                 definition.email should beNull()
                 definition.authMode shouldBe NpmAuthMode.PASSWORD
-                definition.alwaysAuth shouldBe true
             }
 
             "fail if there are unsupported properties" {
@@ -271,16 +268,6 @@ class EnvironmentDefinitionFactoryTest : WordSpec() {
 
                 exception.message shouldContain properties.getValue("authMode")
                 exception.message shouldContain NpmAuthMode.PASSWORD_AUTH.name
-            }
-
-            "fail for an invalid boolean value" {
-                val properties = mapOf("alwaysAuth" to "maybe")
-
-                val exception = createFailed(EnvironmentDefinitionFactory.NPM_TYPE, properties)
-
-                exception.message shouldContain properties.getValue("alwaysAuth")
-                exception.message shouldContain "TRUE"
-                exception.message shouldContain "FALSE"
             }
 
             "allow overriding the credentials types" {
@@ -402,11 +389,9 @@ class EnvironmentDefinitionFactoryTest : WordSpec() {
 
         "A Yarn definition" should {
             "be created with the provided values" {
-                val alwaysAuth = "false"
                 val authMode = YarnAuthMode.AUTH_IDENT
 
                 val properties = mapOf(
-                    "alwaysAuth" to alwaysAuth,
                     "authMode" to authMode.name
                 )
 
@@ -414,7 +399,6 @@ class EnvironmentDefinitionFactoryTest : WordSpec() {
 
                 definition.shouldBeInstanceOf<YarnDefinition>()
                 definition.authMode shouldBe authMode
-                definition.alwaysAuth shouldBe false
             }
 
             "be created with default values" {
@@ -424,7 +408,6 @@ class EnvironmentDefinitionFactoryTest : WordSpec() {
 
                 definition.shouldBeInstanceOf<YarnDefinition>()
                 definition.authMode shouldBe YarnAuthMode.AUTH_TOKEN
-                definition.alwaysAuth shouldBe true
             }
 
             "fail if there are unsupported properties" {
@@ -459,16 +442,6 @@ class EnvironmentDefinitionFactoryTest : WordSpec() {
                 exception.message shouldContain properties.getValue("authMode")
                 exception.message shouldContain YarnAuthMode.AUTH_TOKEN.name
                 exception.message shouldContain YarnAuthMode.AUTH_IDENT.name
-            }
-
-            "fail for an invalid boolean value" {
-                val properties = mapOf("alwaysAuth" to "maybe")
-
-                val exception = createFailed(EnvironmentDefinitionFactory.YARN_TYPE, properties)
-
-                exception.message shouldContain properties.getValue("alwaysAuth")
-                exception.message shouldContain "TRUE"
-                exception.message shouldContain "FALSE"
             }
 
             "allow overriding the credentials types" {


### PR DESCRIPTION
The .npmrc option always-auth is a configuration setting that has historically played an important role in how the npm CLI interacts with package registries. By default, npm only sends authentication details when performing write operations (like npm publish or npm deprecate) or when accessing explicit private endpoints. However, many private registry managers (such as JFrog Artifactory, Azure Artifacts, AWS CodeArtifact, or Sonatype Nexus) are configured behind strict security firewalls where even read-only requests (like looking up metadata during npm install) require authentication. Enabling always-auth=true ensured that npm would actively present its credentials for these read operations.
The always-auth option has a multi-stage history of deprecation and final removal [1]:
* It was functionally deprecated with npm v7
* Starting with npm v11, a CLI warning is now outputed: "npm warn Unknown user config "always-auth". This will stop working in the next major version of npm."

This commit removes the property from the environment generator.
This is a breaking change as the environment definition has changed.

[1]: https://github.com/actions/setup-node/issues/1305