### PR TITLE
fix(ui): Categorize just 'deprecated' correctly

### DIFF
--- a/ui/src/helpers/get-issue-category.ts
+++ b/ui/src/helpers/get-issue-category.ts
@@ -22,7 +22,7 @@ import { IssueCategory } from '@/schemas';
 // A map where the key is the issue category and the value is an array of regular expressions.
 // Upon finding a new issue that is not categorized properly, please extend this map.
 const issueCategoryMap: Record<IssueCategory, RegExp[]> = {
-  Deprecation: [/^deprecated .*/],
+  Deprecation: [/^deprecated\b.*/],
   Infrastructure: [
     /The .* worker failed due to an unexpected error.*/,
     /ERROR: Timeout after .* seconds while scanning file '.*'\./,

--- a/ui/tests/unit/logic/get-issue-category.test.ts
+++ b/ui/tests/unit/logic/get-issue-category.test.ts
@@ -37,6 +37,7 @@ it('correctly categorizes deprecation issues', () => {
     'deprecated @npmcli/move-file@1.1.2: This functionality has been moved to @npmcli/fs',
     'deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported',
     'deprecated uuid@3.4.0: Please upgrade  to version 7 or higher.',
+    'deprecated',
   ];
 
   messages.forEach((message) => {


### PR DESCRIPTION
This shows up for `NPM::codeco-gui:0.1.0`.