### PR TITLE
fix(workers): Resolved issues should contain an identifier

### DIFF
--- a/workers/advisor/src/main/kotlin/AdvisorWorker.kt
+++ b/workers/advisor/src/main/kotlin/AdvisorWorker.kt
@@ -36,6 +36,7 @@ import org.eclipse.apoapsis.ortserver.workers.common.validateForProcessing
 
 import org.jetbrains.exposed.v1.jdbc.Database
 
+import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.utils.ort.ORT_VERSION
 
@@ -84,9 +85,11 @@ internal class AdvisorWorker(
                 ).advisor
             ) { "ORT Adviser failed to create a result." }
 
-            val allIssues = buildList {
-                addAll(advisorRun.results.values.flatten().flatMap { it.summary.issues })
-                addAll(advisorRun.providerIssues)
+            val allIssues = buildMap {
+                advisorRun.results.forEach { (identifier, results) ->
+                    put(identifier, results.flatMap { it.summary.issues })
+                }
+                put(Identifier.EMPTY, advisorRun.providerIssues.toList())
             }
 
             val allVulnerabilities = advisorRun.results.values.flatten().flatMap { it.vulnerabilities }
@@ -102,7 +105,7 @@ internal class AdvisorWorker(
 
             // Apply resolutions using the common function for both issues AND vulnerabilities.
             val resolvedItems = resolutionProvider.matchResolutions(
-                issues = allIssues,
+                issuesByIdentifier = allIssues,
                 ruleViolations = emptyList(),
                 vulnerabilities = allVulnerabilities
             )
@@ -114,8 +117,9 @@ internal class AdvisorWorker(
             }
 
             // Calculate unresolved issues for logging.
-            val unresolvedIssues = allIssues.filter { issue ->
-                issue.mapToModel() !in resolvedItems.issues.keys
+            val unresolvedIssues = allIssues.flatMap { (ortIdentifier, issues) ->
+                val identifier = ortIdentifier.takeIf { it != Identifier.EMPTY }?.mapToModel()
+                issues.filter { it.mapToModel(identifier) !in resolvedItems.issues.keys }
             }
 
             // Calculate unresolved vulnerabilities for logging.
@@ -124,7 +128,7 @@ internal class AdvisorWorker(
             }
 
             logger.info(
-                "Advisor job ${job.id} finished with ${allIssues.size} total issues " +
+                "Advisor job ${job.id} finished with ${allIssues.values.flatten().size} total issues " +
                         "and ${unresolvedIssues.size} unresolved issues, " +
                         "${allVulnerabilities.size} total vulnerabilities " +
                         "and ${unresolvedVulnerabilities.size} unresolved vulnerabilities."

--- a/workers/analyzer/src/main/kotlin/AnalyzerWorker.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerWorker.kt
@@ -41,6 +41,7 @@ import org.eclipse.apoapsis.ortserver.workers.common.validateForProcessing
 
 import org.jetbrains.exposed.v1.jdbc.Database
 
+import org.ossreviewtoolkit.model.Identifier as OrtIdentifier
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.utils.ort.ORT_VERSION
 
@@ -132,7 +133,7 @@ internal class AnalyzerWorker(
                 .mapTo(mutableSetOf()) { it.id.mapToModel() }
 
             // IMPORTANT: Use getAnalyzerIssues() to get ONLY analyzer issues, not all issues.
-            val allIssues = ortResult.getAnalyzerIssues().values.flatten()
+            val allIssues = ortResult.getAnalyzerIssues().mapValues { it.value.toList() }
 
             val resolutionProvider = OrtServerResolutionProvider.create(
                 context,
@@ -144,19 +145,20 @@ internal class AnalyzerWorker(
 
             // Apply resolutions using the common function.
             val resolvedItems = resolutionProvider.matchResolutions(
-                issues = allIssues,
+                issuesByIdentifier = allIssues,
                 ruleViolations = emptyList(),
                 vulnerabilities = emptyList()
             )
 
             // Calculate unresolved issues for logging.
-            val unresolvedIssues = allIssues.filter { issue ->
-                issue.mapToModel() !in resolvedItems.issues.keys
+            val unresolvedIssues = allIssues.flatMap { (ortIdentifier, issues) ->
+                val identifier = ortIdentifier.takeIf { it != OrtIdentifier.EMPTY }?.mapToModel()
+                issues.filter { it.mapToModel(identifier) !in resolvedItems.issues.keys }
             }
 
             logger.info(
                 "Analyzer job ${job.id} for repository ${repository.url} with revision ${ortRun.revision} " +
-                        "finished with ${allIssues.size} total issues " +
+                        "finished with ${allIssues.values.flatten().size} total issues " +
                         "and ${unresolvedIssues.size} unresolved issues."
             )
 

--- a/workers/common/src/main/kotlin/resolutions/OrtServerResolutionProvider.kt
+++ b/workers/common/src/main/kotlin/resolutions/OrtServerResolutionProvider.kt
@@ -27,6 +27,7 @@ import org.eclipse.apoapsis.ortserver.components.resolutions.vulnerabilities.Vul
 import org.eclipse.apoapsis.ortserver.dao.utils.calculateResolutionMessageHash
 import org.eclipse.apoapsis.ortserver.model.RepositoryId
 import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.ResolvedItemsResult
+import org.eclipse.apoapsis.ortserver.model.runs.Issue as ServerIssue
 import org.eclipse.apoapsis.ortserver.model.runs.repository.IssueResolution as ServerIssueResolution
 import org.eclipse.apoapsis.ortserver.model.runs.repository.ResolutionSource
 import org.eclipse.apoapsis.ortserver.model.runs.repository.RuleViolationResolution as ServerRuleViolationResolution
@@ -38,6 +39,7 @@ import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
 import org.eclipse.apoapsis.ortserver.workers.common.readConfigFileValueWithDefault
 import org.eclipse.apoapsis.ortserver.workers.common.resolvedConfigurationContext
 
+import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.config.Resolutions
@@ -145,35 +147,44 @@ class OrtServerResolutionProvider(
         allVulnerabilityResolutions.filter { it.matches(vulnerability) }
 
     /**
-     * Return a [ResolvedItemsResult] that maps the provided [issues], [ruleViolations], and [vulnerabilities] to their
-     * matching resolutions from this provider. This is similar to ORT's `ConfigurationResolver.resolveResolutions()`,
-     * but returns the full mappings instead of just the distinct resolutions.
+     * Return a [ResolvedItemsResult] that maps the provided [issuesByIdentifier], [ruleViolations], and
+     * [vulnerabilities] to their matching resolutions from this provider. This is similar to ORT's
+     * `ConfigurationResolver.resolveResolutions()`, but returns the full mappings instead of just the distinct
+     * resolutions.
      */
     fun matchResolutions(
-        issues: List<Issue>,
+        issuesByIdentifier: Map<Identifier, List<Issue>>,
         ruleViolations: List<RuleViolation>,
         vulnerabilities: List<Vulnerability>
     ): ResolvedItemsResult {
-        val issueResolutions = issues.associateWith { issue ->
-            buildList {
-                addAll(
-                    globalResolutions.issues
-                        .filter { it.matches(issue) }
-                        .map { it.mapToModel(ResolutionSource.GLOBAL_FILE) }
-                )
-                addAll(
-                    repositoryConfigurationResolutions.issues
-                        .filter { it.matches(issue) }
-                        .map { it.mapToModel(ResolutionSource.REPOSITORY_FILE) }
-                )
-                addAll(
-                    managedIssueResolutions.filter { resolution ->
-                        checkNotNull(resolution.messageHash) == calculateResolutionMessageHash(issue.message)
+        val issueResolutions = mutableMapOf<ServerIssue, List<ServerIssueResolution>>()
+
+        issuesByIdentifier.forEach { (identifier, issues) ->
+            issueResolutions.putAll(
+                issues.associateWith { issue ->
+                    buildList {
+                        addAll(
+                            globalResolutions.issues
+                                .filter { it.matches(issue) }
+                                .map { it.mapToModel(ResolutionSource.GLOBAL_FILE) }
+                        )
+                        addAll(
+                            repositoryConfigurationResolutions.issues
+                                .filter { it.matches(issue) }
+                                .map { it.mapToModel(ResolutionSource.REPOSITORY_FILE) }
+                        )
+                        addAll(
+                            managedIssueResolutions.filter { resolution ->
+                                checkNotNull(resolution.messageHash) == calculateResolutionMessageHash(issue.message)
+                            }
+                                .map { it.copy(source = ResolutionSource.SERVER) }
+                        )
                     }
-                        .map { it.copy(source = ResolutionSource.SERVER) }
-                )
-            }
-        }.filterValues { it.isNotEmpty() }.mapKeys { it.key.mapToModel() }
+                }.filterValues { it.isNotEmpty() }.mapKeys {
+                    it.key.mapToModel(identifier.takeIf { ident -> ident != Identifier.EMPTY }?.mapToModel())
+                }
+            )
+        }
 
         val ruleViolationResolutions = ruleViolations.associateWith { violation ->
             buildList {

--- a/workers/common/src/test/kotlin/resolutions/MatchResolutionsIdentifierRegressionTest.kt
+++ b/workers/common/src/test/kotlin/resolutions/MatchResolutionsIdentifierRegressionTest.kt
@@ -1,0 +1,264 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.common.resolutions
+
+import com.github.michaelbull.result.Ok
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.nulls.beNull
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+import io.mockk.every
+import io.mockk.mockk
+
+import org.eclipse.apoapsis.ortserver.components.resolutions.issues.IssueResolutionService
+import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
+import org.eclipse.apoapsis.ortserver.dao.test.Fixtures
+import org.eclipse.apoapsis.ortserver.model.runs.IssueFilter
+import org.eclipse.apoapsis.ortserver.model.runs.repository.IssueResolution as ServerIssueResolution
+import org.eclipse.apoapsis.ortserver.model.runs.repository.IssueResolutionReason as ServerIssueResolutionReason
+import org.eclipse.apoapsis.ortserver.model.runs.repository.ResolutionSource
+import org.eclipse.apoapsis.ortserver.services.ortrun.IssueService
+import org.eclipse.apoapsis.ortserver.services.ortrun.OrtRunService
+import org.eclipse.apoapsis.ortserver.services.ortrun.mapToModel
+
+import org.jetbrains.exposed.v1.jdbc.Database
+
+import org.ossreviewtoolkit.model.Identifier as OrtIdentifier
+import org.ossreviewtoolkit.model.Issue as OrtIssue
+import org.ossreviewtoolkit.model.Severity as OrtSeverity
+import org.ossreviewtoolkit.model.config.IssueResolution
+import org.ossreviewtoolkit.model.config.IssueResolutionReason
+import org.ossreviewtoolkit.model.config.Resolutions
+
+/**
+ * A regression test for the https://github.com/eclipse-apoapsis/ort-server/issues/5271.
+ *
+ * Before that fix, [OrtServerResolutionProvider.matchResolutions] mapped resolved issues to keys that never carried
+ * an [org.eclipse.apoapsis.ortserver.model.runs.Identifier], no matter which [org.ossreviewtoolkit.model.Identifier]
+ * they were associated with. As `DaoResolvedConfigurationRepository.findOrtRunIssueId` (used by
+ * [OrtRunService.storeResolvedItems]) matches stored issues by identifier as well, this caused resolutions for
+ * issues that do have an identifier to not be attached to the correct issue, so that they kept appearing as
+ * unresolved in the UI despite having a matching resolution.
+ */
+class MatchResolutionsIdentifierRegressionTest : WordSpec({
+    val dbExtension = extension(DatabaseTestExtension())
+
+    lateinit var db: Database
+    lateinit var fixtures: Fixtures
+    lateinit var ortRunService: OrtRunService
+    lateinit var issueService: IssueService
+
+    var ortRunId = -1L
+
+    beforeEach {
+        db = dbExtension.db
+        fixtures = dbExtension.fixtures
+        ortRunId = fixtures.ortRun.id
+
+        ortRunService = OrtRunService(
+            db,
+            fixtures.advisorJobRepository,
+            fixtures.advisorRunRepository,
+            fixtures.analyzerJobRepository,
+            fixtures.analyzerRunRepository,
+            fixtures.evaluatorJobRepository,
+            fixtures.evaluatorRunRepository,
+            fixtures.ortRunRepository,
+            fixtures.reporterJobRepository,
+            fixtures.reporterRunRepository,
+            fixtures.notifierJobRepository,
+            fixtures.notifierRunRepository,
+            fixtures.repositoryConfigurationRepository,
+            fixtures.repositoryRepository,
+            fixtures.resolvedConfigurationRepository,
+            fixtures.scannerJobRepository,
+            fixtures.scannerRunRepository,
+            mockk(),
+            mockk()
+        )
+
+        // No resolutions managed by the server are used in these tests, so the resolution service can just return
+        // an empty list.
+        val issueResolutionService = mockk<IssueResolutionService> {
+            every { getResolutionsForRepository(any()) } returns Ok(emptyList())
+        }
+        issueService = IssueService(db, ortRunService, issueResolutionService)
+    }
+
+    val resolutionMessage = "resolvable issue message"
+
+    val provider = OrtServerResolutionProvider(
+        globalResolutions = Resolutions(
+            issues = listOf(
+                IssueResolution(
+                    message = resolutionMessage,
+                    reason = IssueResolutionReason.CANT_FIX_ISSUE,
+                    comment = "matching global issue resolution"
+                )
+            )
+        ),
+        repositoryConfigurationResolutions = Resolutions(),
+        managedIssueResolutions = emptyList(),
+        managedRuleViolationResolutions = emptyList(),
+        managedVulnerabilityResolutions = emptyList()
+    )
+
+    val expectedResolution = ServerIssueResolution(
+        message = resolutionMessage,
+        reason = ServerIssueResolutionReason.CANT_FIX_ISSUE,
+        comment = "matching global issue resolution",
+        source = ResolutionSource.GLOBAL_FILE
+    )
+
+    "matchResolutions combined with storeResolvedItems" should {
+        "resolve an issue that has no identifier" {
+            val issue = OrtIssue(
+                source = "Analyzer",
+                message = resolutionMessage,
+                severity = OrtSeverity.WARNING
+            )
+
+            fixtures.createAnalyzerRun(
+                analyzerJobId = fixtures.analyzerJob.id,
+                issues = listOf(issue.mapToModel())
+            )
+
+            val resolvedItems = provider.matchResolutions(
+                issuesByIdentifier = mapOf(OrtIdentifier.EMPTY to listOf(issue)),
+                ruleViolations = emptyList(),
+                vulnerabilities = emptyList()
+            )
+
+            resolvedItems.issues.keys shouldHaveSize 1
+            resolvedItems.issues.keys.single().identifier should beNull()
+
+            ortRunService.storeResolvedItems(ortRunId, resolvedItems)
+
+            // Verify that the unique resolution was stored in the resolved configuration.
+            val resolvedConfiguration = fixtures.resolvedConfigurationRepository.getForOrtRun(ortRunId)
+            resolvedConfiguration.shouldNotBeNull()
+            resolvedConfiguration.resolutions.issues should containExactly(expectedResolution)
+
+            // Verify that the issue itself is now reported as resolved (as it would show up in the UI).
+            val resolvedIssues = issueService.listForOrtRunId(ortRunId, issuesFilter = IssueFilter(resolved = true))
+            resolvedIssues.data shouldHaveSize 1
+            with(resolvedIssues.data.single()) {
+                message shouldBe resolutionMessage
+                identifier should beNull()
+            }
+        }
+
+        "resolve an issue that has an identifier" {
+            val identifier = OrtIdentifier("Maven", "com.example", "package-with-id", "1.0")
+            val issue = OrtIssue(
+                source = "Analyzer",
+                message = resolutionMessage,
+                severity = OrtSeverity.WARNING
+            )
+
+            fixtures.createAnalyzerRun(
+                analyzerJobId = fixtures.analyzerJob.id,
+                issues = listOf(issue.mapToModel(identifier = identifier.mapToModel()))
+            )
+
+            val resolvedItems = provider.matchResolutions(
+                issuesByIdentifier = mapOf(identifier to listOf(issue)),
+                ruleViolations = emptyList(),
+                vulnerabilities = emptyList()
+            )
+
+            resolvedItems.issues.keys shouldHaveSize 1
+            resolvedItems.issues.keys.single().identifier shouldBe identifier.mapToModel()
+
+            ortRunService.storeResolvedItems(ortRunId, resolvedItems)
+
+            // Verify that the unique resolution was stored in the resolved configuration.
+            val resolvedConfiguration = fixtures.resolvedConfigurationRepository.getForOrtRun(ortRunId)
+            resolvedConfiguration.shouldNotBeNull()
+            resolvedConfiguration.resolutions.issues should containExactly(expectedResolution)
+
+            // Without the fix, the resolved issue's key does not carry an identifier, so
+            // DaoResolvedConfigurationRepository.findOrtRunIssueId() fails to find the stored issue (which does
+            // have an identifier), and the issue keeps appearing as unresolved.
+            val resolvedIssues = issueService.listForOrtRunId(ortRunId, issuesFilter = IssueFilter(resolved = true))
+            resolvedIssues.data shouldHaveSize 1
+            with(resolvedIssues.data.single()) {
+                message shouldBe resolutionMessage
+                this.identifier shouldBe identifier.mapToModel()
+            }
+        }
+
+        "resolve issues with and without an identifier that share the same message" {
+            val identifier = OrtIdentifier("Maven", "com.example", "package-with-id", "1.0")
+
+            // Both issues use the very same message, source, severity and timestamp so that, without the fix, they
+            // would be mapped to the very same key by matchResolutions() and only one of them would be resolved.
+            val issueWithIdentifier = OrtIssue(
+                source = "Analyzer",
+                message = resolutionMessage,
+                severity = OrtSeverity.WARNING
+            )
+            val issueWithoutIdentifier = issueWithIdentifier.copy()
+
+            fixtures.createAnalyzerRun(
+                analyzerJobId = fixtures.analyzerJob.id,
+                issues = listOf(
+                    issueWithIdentifier.mapToModel(identifier = identifier.mapToModel()),
+                    issueWithoutIdentifier.mapToModel()
+                )
+            )
+
+            val resolvedItems = provider.matchResolutions(
+                issuesByIdentifier = mapOf(
+                    identifier to listOf(issueWithIdentifier),
+                    OrtIdentifier.EMPTY to listOf(issueWithoutIdentifier)
+                ),
+                ruleViolations = emptyList(),
+                vulnerabilities = emptyList()
+            )
+
+            // Both issues must be present as distinct keys in the resolved items result, distinguished by their
+            // identifier.
+            resolvedItems.issues.keys shouldHaveSize 2
+            resolvedItems.issues.keys.mapNotNull { it.identifier } shouldHaveSize 1
+            resolvedItems.issues.keys.mapNotNull { it.identifier }.single() shouldBe identifier.mapToModel()
+
+            ortRunService.storeResolvedItems(ortRunId, resolvedItems)
+
+            // Verify that the unique resolution was stored only once in the resolved configuration, even though it
+            // applies to both issues.
+            val resolvedConfiguration = fixtures.resolvedConfigurationRepository.getForOrtRun(ortRunId)
+            resolvedConfiguration.shouldNotBeNull()
+            resolvedConfiguration.resolutions.issues should containExactly(expectedResolution)
+
+            // Both issues (the one with and the one without an identifier) must have been resolved.
+            val resolvedIssues = issueService.listForOrtRunId(ortRunId, issuesFilter = IssueFilter(resolved = true))
+            resolvedIssues.data shouldHaveSize 2
+            resolvedIssues.data.mapNotNull { it.identifier } shouldHaveSize 1
+            resolvedIssues.data.mapNotNull { it.identifier }.single() shouldBe identifier.mapToModel()
+            resolvedIssues.data.map { it.message } shouldBe listOf(resolutionMessage, resolutionMessage)
+        }
+    }
+})

--- a/workers/common/src/test/kotlin/resolutions/OrtServerResolutionProviderTest.kt
+++ b/workers/common/src/test/kotlin/resolutions/OrtServerResolutionProviderTest.kt
@@ -50,6 +50,7 @@ import org.eclipse.apoapsis.ortserver.services.config.AdminConfigService
 import org.eclipse.apoapsis.ortserver.services.ortrun.mapToModel
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
 
+import org.ossreviewtoolkit.model.Identifier
 import org.ossreviewtoolkit.model.Issue
 import org.ossreviewtoolkit.model.RuleViolation
 import org.ossreviewtoolkit.model.Severity
@@ -683,7 +684,11 @@ class OrtServerResolutionProviderTest : WordSpec({
                 )
             )
 
-            val matchResult = provider.matchResolutions(listOf(issue1, issue2), emptyList(), emptyList())
+            val matchResult = provider.matchResolutions(
+                mapOf(Identifier.EMPTY to listOf(issue1, issue2)),
+                emptyList(),
+                emptyList()
+            )
 
             matchResult.issues should containExactly(
                 issue1.mapToModel() to expectedResolutionsForIssue1,
@@ -790,7 +795,7 @@ class OrtServerResolutionProviderTest : WordSpec({
             )
 
             val matchResult =
-                provider.matchResolutions(emptyList(), listOf(ruleViolation1, ruleViolation2), emptyList())
+                provider.matchResolutions(emptyMap(), listOf(ruleViolation1, ruleViolation2), emptyList())
 
             matchResult.ruleViolations should containExactly(
                 ruleViolation1.mapToModel() to expectedResolutionsForRuleViolation1,
@@ -875,7 +880,7 @@ class OrtServerResolutionProviderTest : WordSpec({
             )
 
             val matchResult =
-                provider.matchResolutions(emptyList(), emptyList(), listOf(vulnerability1, vulnerability2))
+                provider.matchResolutions(emptyMap(), emptyList(), listOf(vulnerability1, vulnerability2))
 
             matchResult.vulnerabilities should containExactly(
                 vulnerability1.mapToModel() to expectedResolutionsForVulnerability1,
@@ -905,7 +910,11 @@ class OrtServerResolutionProviderTest : WordSpec({
             val vulnerability = Vulnerability(id = "no match", references = emptyList())
 
             val matchResult =
-                provider.matchResolutions(listOf(issue), listOf(ruleViolation), listOf(vulnerability))
+                provider.matchResolutions(
+                    mapOf(Identifier.EMPTY to listOf(issue)),
+                    listOf(ruleViolation),
+                    listOf(vulnerability)
+                )
 
             matchResult.issues should beEmpty()
             matchResult.ruleViolations should beEmpty()

--- a/workers/evaluator/src/main/kotlin/EvaluatorRunner.kt
+++ b/workers/evaluator/src/main/kotlin/EvaluatorRunner.kt
@@ -147,7 +147,7 @@ class EvaluatorRunner(
         val evaluatorRun = evaluator.runScript(script)
 
         val resolvedItems = resolutionProvider.matchResolutions(
-            issues = emptyList(),
+            issuesByIdentifier = emptyMap(),
             ruleViolations = evaluatorRun.violations,
             vulnerabilities = emptyList()
         )

--- a/workers/reporter/src/main/kotlin/ReporterWorker.kt
+++ b/workers/reporter/src/main/kotlin/ReporterWorker.kt
@@ -122,7 +122,11 @@ internal class ReporterWorker(
             )
 
             val allIssues = reporterRunnerResult.issues
-            val reporterIssuesAsOrt = allIssues.map { it.mapToOrt() }
+            val reporterIssuesAsOrt = allIssues.groupBy({ issue ->
+                issue.identifier?.mapToOrt() ?: org.ossreviewtoolkit.model.Identifier.EMPTY
+            }) { issue ->
+                issue.mapToOrt()
+            }
 
             val resolutionProvider = OrtServerResolutionProvider.create(
                 context,
@@ -133,7 +137,7 @@ internal class ReporterWorker(
             )
 
             val resolvedReporterItems = resolutionProvider.matchResolutions(
-                issues = reporterIssuesAsOrt,
+                issuesByIdentifier = reporterIssuesAsOrt,
                 ruleViolations = emptyList(),
                 vulnerabilities = emptyList()
             )
@@ -152,8 +156,10 @@ internal class ReporterWorker(
                 ortRunService.storeResolvedItems(ortRun.id, resolvedReporterItems)
             }
 
-            val unresolvedIssues = reporterIssuesAsOrt.filter { issue ->
-                resolutionProvider.getResolutionsFor(issue).isEmpty()
+            val unresolvedIssues = reporterIssuesAsOrt.flatMap { entry ->
+                entry.value.filter { issue ->
+                    resolutionProvider.getResolutionsFor(issue).isEmpty()
+                }
             }
 
             logger.info(

--- a/workers/scanner/src/main/kotlin/ScannerWorker.kt
+++ b/workers/scanner/src/main/kotlin/ScannerWorker.kt
@@ -38,6 +38,7 @@ import org.eclipse.apoapsis.ortserver.workers.common.validateForProcessing
 
 import org.jetbrains.exposed.v1.jdbc.Database
 
+import org.ossreviewtoolkit.model.Identifier as OrtIdentifier
 import org.ossreviewtoolkit.model.Issue as OrtIssue
 import org.ossreviewtoolkit.model.Provenance
 import org.ossreviewtoolkit.model.ProvenanceResolutionResult
@@ -107,9 +108,14 @@ class ScannerWorker(
             )
 
             // Apply resolutions using the common function.
-            val allOrtIssues = allIssues.map { it.mapToOrt() }
+            val allOrtIssues = allIssues.groupBy({ issue ->
+                issue.identifier?.mapToOrt() ?: org.ossreviewtoolkit.model.Identifier.EMPTY
+            }) { issue ->
+                issue.mapToOrt()
+            }
+
             val resolvedItems = resolutionProvider.matchResolutions(
-                issues = allOrtIssues,
+                issuesByIdentifier = allOrtIssues,
                 ruleViolations = emptyList(),
                 vulnerabilities = emptyList()
             )
@@ -124,8 +130,9 @@ class ScannerWorker(
             }
 
             // Calculate unresolved issues for logging.
-            val unresolvedIssues = allOrtIssues.filter { issue ->
-                issue.mapToModel() !in resolvedItems.issues.keys
+            val unresolvedIssues = allOrtIssues.flatMap { (ortIdentifier, issues) ->
+                val identifier = ortIdentifier.takeIf { it != OrtIdentifier.EMPTY }?.mapToModel()
+                issues.filter { it.mapToModel(identifier) !in resolvedItems.issues.keys }
             }
 
             logger.info(


### PR DESCRIPTION
The commit b1fdb637d01bb62a4b4bef69dccfe075db812311 added an identifier check when matching issues while storing resolutions. This pull request makes sure that resolved issues contain an identifier, so that the aforementioned check returns the correct issues.

This fixes a bug that issues were appearing unresolved in the UI despite existing resolutions.

Fixes #5271.