### PR TITLE
Run Analyzer in multiple phases

### DIFF
--- a/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-kotlin-jvm-conventions.gradle.kts
@@ -65,6 +65,7 @@ tasks.withType<Test>().configureEach {
     // Required since Java 17, see: https://kotest.io/docs/next/extensions/system_extensions.html#system-environment
     if (javaVersion.isCompatibleWith(JavaVersion.VERSION_17)) {
         jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
+        jvmArgs("--add-opens=java.base/java.io=ALL-UNNAMED")
     }
 
     val testSystemProperties = mutableListOf("gradle.build.dir" to project.layout.buildDirectory.get().toString())

--- a/workers/analyzer/docker/Analyzer.Dockerfile
+++ b/workers/analyzer/docker/Analyzer.Dockerfile
@@ -576,3 +576,5 @@ COPY --from=gleam --chown=$USER:$USER $GLEAM_HOME $GLEAM_HOME
 
 # Make sure the user executing the container has access rights in the $CARGO_HOME directory.
 RUN sudo chgrp -R 0 $CARGO_HOME && sudo chmod -R g+rwX $CARGO_HOME
+
+COPY scripts/await.sh /etc/analyzer_scripts/await.sh

--- a/workers/analyzer/docker/scripts/await.sh
+++ b/workers/analyzer/docker/scripts/await.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+# A script to support the synchronization between different containers if the Analyzer runs in multiple phases.
+# The script expects the path to a file as single argument. It waits until this file is created and then returns.
+
+if [ -z "$1" ]; then
+    echo "Error: No target file path provided." >&2
+    echo "Usage: $0 <target_file>" >&2
+    exit 1
+fi
+
+TARGET_FILE=$1
+echo "Waiting for file $TARGET_FILE."
+
+while [ ! -f "$TARGET_FILE" ]; do
+    sleep 5
+done
+
+echo "File $TARGET_FILE detected."

--- a/workers/analyzer/src/main/kotlin/AnalyzerComponent.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerComponent.kt
@@ -45,23 +45,47 @@ import org.eclipse.apoapsis.ortserver.workers.common.ortRunServiceModule
 import org.koin.core.component.inject
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
+import org.koin.core.qualifier.named
 import org.koin.dsl.bind
 import org.koin.dsl.module
+
+/** The name of the preparation phase. */
+private const val PREPARATION_PHASE = "preparation"
+
+/** The name of the analysis phase. */
+private const val ANALYSIS_PHASE = "analysis"
+
+/** The name of the result phase. */
+private const val RESULT_PHASE = "result"
+
+/** The name of the full phase which includes all other phases. */
+private const val FULL_PHASE = "full"
+
+/** A set with the names of all supported phases. */
+private val VALID_PHASES = setOf(PREPARATION_PHASE, ANALYSIS_PHASE, RESULT_PHASE, FULL_PHASE)
 
 /**
  * The central entry point into the Analyzer service. The class processes messages to analyze repositories by
  * delegating to helper objects.
  */
-class AnalyzerComponent : EndpointComponent<AnalyzerRequest>(AnalyzerEndpoint) {
+class AnalyzerComponent(
+    /** The command line arguments passed to the Analyzer endpoint. */
+    private val args: Array<String>
+) : EndpointComponent<AnalyzerRequest>(AnalyzerEndpoint) {
     override val endpointHandler: EndpointHandler<AnalyzerRequest> = { message ->
         val analyzerWorker by inject<AnalyzerWorker>()
         val publisher by inject<MessagePublisher>()
-        // TODO: Obtain the current phase from the command line arguments.
-        val phase by inject<AnalyzerPhase>()
         val jobId = message.payload.analyzerJobId
 
         withMdcContext(AnalyzerEndpoint.jobMdcKey(jobId)) {
-            val response = when (val result = analyzerWorker.run(jobId, message.header.traceId, phase, emptyArray())) {
+            val result = analyzerWorker.run(
+                jobId,
+                message.header.traceId,
+                getPhase(),
+                args.drop(1).toTypedArray()
+            )
+
+            val response = when (result) {
                 is RunResult.Success -> {
                     logger.info("Analyzer job '$jobId' succeeded.")
                     Message(message.header, AnalyzerWorkerResult(jobId))
@@ -102,10 +126,26 @@ class AnalyzerComponent : EndpointComponent<AnalyzerRequest>(AnalyzerEndpoint) {
         singleOf(::AnalyzerDownloader)
         singleOf(::AnalyzerRunner)
         singleOf(::AnalyzerWorker)
-        singleOf(::FullPhase).bind(AnalyzerPhase::class)
+        singleOf(::FullPhase) { qualifier = named("full") }.bind(AnalyzerPhase::class)
+        singleOf(::PreparationPhase) { qualifier = named(PREPARATION_PHASE) }.bind(AnalyzerPhase::class)
+        singleOf(::AnalysisPhase) { qualifier = named(ANALYSIS_PHASE) }.bind(AnalyzerPhase::class)
+        singleOf(::ResultPhase) { qualifier = named(RESULT_PHASE) }.bind(AnalyzerPhase::class)
         single<AuthorizationService> { DbAuthorizationService(get()) }
         singleOf(::RepositoryService)
         singleOf(::IssueResolutionEventStore)
         singleOf(::IssueResolutionService)
+    }
+
+    /**
+     * Obtain the current phase for the Analyzer run from the dependency definitions based on the command line
+     * arguments. If no argument is specified, use the `FULL` phase.
+     */
+    private fun getPhase(): AnalyzerPhase {
+        val phase = args.firstOrNull()?.lowercase() ?: "full"
+        require(phase in VALID_PHASES) {
+            "Invalid phase '$phase'. Valid phases are: $VALID_PHASES (ignoring case)."
+        }
+
+        return getKoin().get(named(phase))
     }
 }

--- a/workers/analyzer/src/main/kotlin/AnalyzerComponent.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerComponent.kt
@@ -45,6 +45,7 @@ import org.eclipse.apoapsis.ortserver.workers.common.ortRunServiceModule
 import org.koin.core.component.inject
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.singleOf
+import org.koin.dsl.bind
 import org.koin.dsl.module
 
 /**
@@ -55,10 +56,12 @@ class AnalyzerComponent : EndpointComponent<AnalyzerRequest>(AnalyzerEndpoint) {
     override val endpointHandler: EndpointHandler<AnalyzerRequest> = { message ->
         val analyzerWorker by inject<AnalyzerWorker>()
         val publisher by inject<MessagePublisher>()
+        // TODO: Obtain the current phase from the command line arguments.
+        val phase by inject<AnalyzerPhase>()
         val jobId = message.payload.analyzerJobId
 
         withMdcContext(AnalyzerEndpoint.jobMdcKey(jobId)) {
-            val response = when (val result = analyzerWorker.run(jobId, message.header.traceId)) {
+            val response = when (val result = analyzerWorker.run(jobId, message.header.traceId, phase, emptyArray())) {
                 is RunResult.Success -> {
                     logger.info("Analyzer job '$jobId' succeeded.")
                     Message(message.header, AnalyzerWorkerResult(jobId))
@@ -99,6 +102,7 @@ class AnalyzerComponent : EndpointComponent<AnalyzerRequest>(AnalyzerEndpoint) {
         singleOf(::AnalyzerDownloader)
         singleOf(::AnalyzerRunner)
         singleOf(::AnalyzerWorker)
+        singleOf(::FullPhase).bind(AnalyzerPhase::class)
         single<AuthorizationService> { DbAuthorizationService(get()) }
         singleOf(::RepositoryService)
         singleOf(::IssueResolutionEventStore)

--- a/workers/analyzer/src/main/kotlin/AnalyzerPhase.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerPhase.kt
@@ -19,14 +19,39 @@
 
 package org.eclipse.apoapsis.ortserver.workers.analyzer
 
+import java.io.File
+
+import kotlinx.serialization.Serializable
+
 import org.eclipse.apoapsis.ortserver.components.resolutions.issues.IssueResolutionService
+import org.eclipse.apoapsis.ortserver.model.AnalyzerJobConfiguration
 import org.eclipse.apoapsis.ortserver.services.config.AdminConfigService
 import org.eclipse.apoapsis.ortserver.services.ortrun.OrtRunService
 import org.eclipse.apoapsis.ortserver.workers.common.RunResult
+import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContextFactory
+import org.eclipse.apoapsis.ortserver.workers.common.env.EnvironmentForkHelper
 import org.eclipse.apoapsis.ortserver.workers.common.env.EnvironmentService
 
 import org.jetbrains.exposed.v1.jdbc.Database
+
+import org.ossreviewtoolkit.model.writeValue
+
+import org.slf4j.LoggerFactory
+
+/** The prefix of folder names created for the data exchange between different phases. */
+internal const val JOB_DIR_PREFIX = "analyzer-job-"
+
+/** The name of the file to store authentication information. */
+internal const val AUTH_INFO_FILE = "auth-info.json"
+
+/** The name of the file with data from the preparation phase. */
+internal const val PREPARATION_EXCHANGE_FILE = "preparation-exchange.json"
+
+/** The name of the directory in which package manager configuration files are created. */
+internal const val CONFIG_DIR = "conf"
+
+private val logger = LoggerFactory.getLogger(AnalyzerPhase::class.java)
 
 /**
  * An interface representing a phase of the Analyzer execution.
@@ -82,9 +107,7 @@ internal class FullPhase(
     private val issueResolutionService: IssueResolutionService
 ) : AnalyzerPhase {
     override suspend fun run(worker: AnalyzerWorker, jobId: Long, args: Array<String>): RunResult {
-        require(args.isEmpty()) {
-            "Unexpected arguments passed to the 'FULL' phase: '${args.joinToString(" ")}'."
-        }
+        checkArgs(this, args, 0, 0)
 
         val job = ortRunService.getValidAnalyzerJob(jobId)
 
@@ -95,3 +118,127 @@ internal class FullPhase(
         }
     }
 }
+
+/**
+ * An implementation of [AnalyzerPhase] which performs the necessary preparation steps before the ORT Analyzer can be
+ * invoked. This phase is concerned with cloning the repository, creating the package manager configuration files based
+ * on the environment configuration, and resolving all secrets that need to be available during the analysis.
+ *
+ * The [run] function expects an argument pointing to the root path of a shared directory structure under which the
+ * results of this phase should be persisted. The class creates a subdirectory for the current job below this
+ * structure.
+ */
+internal class PreparationPhase(
+    /** The service to access and update information about the current run. */
+    private val ortRunService: OrtRunService,
+
+    /** The factory to create a worker context. */
+    private val contextFactory: WorkerContextFactory,
+
+    /** The service to set up the environment for the analysis. */
+    private val environmentService: EnvironmentService
+) : AnalyzerPhase {
+    override suspend fun run(
+        worker: AnalyzerWorker,
+        jobId: Long,
+        args: Array<String>
+    ): RunResult {
+        val exchangeDir = exchangeDirectory(jobId, checkArgs(this, args, 1, 1))
+        val job = ortRunService.getValidAnalyzerJob(jobId)
+
+        val prepareExchange = contextFactory.withContext(job.ortRunId) { context ->
+            val configDir = exchangeDir.resolve(CONFIG_DIR).apply { mkdirs() }
+            val prepareResult = worker.prepare(context, job, ortRunService, environmentService, exchangeDir, configDir)
+
+            val authInfoFile = exchangeDir.resolve(AUTH_INFO_FILE)
+            logger.info("Writing auth info file '{}'.", authInfoFile)
+            EnvironmentForkHelper.persistAuthenticationInfo(authInfoFile)
+
+            PreparationExchange(
+                environment = prepareResult.resolvedEnvironment,
+                runnerConfig = job.configuration.toRunnerConfig(context),
+                runId = job.ortRunId
+            )
+        }
+
+        writeExchangeFile(exchangeDir, PREPARATION_EXCHANGE_FILE, prepareExchange)
+
+        return RunResult.Ignored
+    }
+}
+
+/**
+ * A data class to hold results of the preparation phase that needs to be exchanged with later phases.
+ * [PreparationPhase] creates such an object and serializes it to a file on a shared volume. From there, it is picked
+ * up to start the analysis.
+ */
+@Serializable
+internal data class PreparationExchange(
+    /** A map with environment variables that need to be set for the analysis phase. */
+    val environment: Map<String, String>,
+
+    /** The resolved configuration for the [AnalyzerRunner]. */
+    val runnerConfig: AnalyzerRunnerConfig,
+
+    /** The ID of the run that is analyzed. */
+    val runId: Long
+)
+
+/**
+ * Return a directory to be used for exchanging information between the different phases for the Analyzer job with the
+ * given [jobId] based on the provided [args]. The root path of the volume to be used for this purpose is expected to
+ * be in the first argument. Throw an exception if no valid root path is specified here.
+ */
+private fun exchangeDirectory(jobId: Long, args: Array<String>): File {
+    require(args.isNotEmpty()) {
+        "Expected an argument for the exchange directory."
+    }
+
+    val exchangeRoot = File(args[0])
+    require(exchangeRoot.isDirectory) {
+        "Root directory for exchange files is not a valid directory: '${exchangeRoot.absolutePath}'."
+    }
+
+    return File(exchangeRoot, "$JOB_DIR_PREFIX$jobId").also { it.mkdirs() }
+}
+
+/**
+ * Check whether the number of arguments for [phase] in the given [args] is in the valid range of [minCount], and
+ * [maxCount]. Throw an exception with a meaningful message if this is not the case.
+ */
+private fun checkArgs(phase: AnalyzerPhase, args: Array<String>, minCount: Int, maxCount: Int): Array<String> {
+    require(args.size in minCount..maxCount) {
+        "Unexpected arguments passed to phase '${phase.javaClass.simpleName}': '${args.joinToString(" ")}'."
+    }
+
+    return args
+}
+
+/**
+ * Write a file with the given [name] and [data] in the [exchangeDir] for this [AnalyzerPhase]. Log this operation.
+ */
+private inline fun <reified T : Any> AnalyzerPhase.writeExchangeFile(
+    exchangeDir: File,
+    name: String,
+    data: T
+) {
+    val exchangeFile = exchangeDir.resolve(name)
+    logger.info("[{}]: Writing exchange file '{}'.", javaClass.simpleName, exchangeFile)
+
+    exchangeFile.writeValue(data)
+}
+
+/**
+ * Create an [AnalyzerRunnerConfig] from this [AnalyzerJobConfiguration] to be used to analyze the current project.
+ * Use the given [context] to resolve the secrets in the plugin configuration.
+ */
+private suspend fun AnalyzerJobConfiguration.toRunnerConfig(context: WorkerContext): AnalyzerRunnerConfig =
+    AnalyzerRunnerConfig(
+        skipExcluded = skipExcluded,
+        allowDynamicVersions = allowDynamicVersions,
+        enabledPackageManagers = enabledPackageManagers,
+        disabledPackageManagers = disabledPackageManagers,
+        packageManagerOptions = packageManagerOptions,
+        repositoryConfigPath = repositoryConfigPath,
+        packageCurationProviders = context.resolveProviderPluginConfigSecrets(packageCurationProviders)
+    )

--- a/workers/analyzer/src/main/kotlin/AnalyzerPhase.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerPhase.kt
@@ -39,6 +39,7 @@ import org.eclipse.apoapsis.ortserver.workers.common.env.EnvironmentService
 
 import org.jetbrains.exposed.v1.jdbc.Database
 
+import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.writeValue
 import org.ossreviewtoolkit.utils.common.Os
@@ -261,6 +262,52 @@ internal class AnalysisPhase : AnalyzerPhase {
             syncFile.parentFile?.mkdirs()
             logger.info("Writing sync file '{}'.", syncFile)
             syncFile.writeText("done")
+        }
+    }
+}
+
+/**
+ * An implementation of [AnalyzerPhase] that collects the results from the analysis and stores them in the database.
+ *
+ * The results, in form of a serialized ORT result, are expected to be found in a job-specific directory on an exchange
+ * volume whose root path is passed as single argument.
+ */
+internal class ResultPhase(
+    /** The database to access the job and store the results. */
+    private val db: Database,
+
+    /** The service to access and update information about the current run. */
+    private val ortRunService: OrtRunService,
+
+    /** The factory to create a worker context. */
+    private val contextFactory: WorkerContextFactory,
+
+    /** The service to access the global server configuration. */
+    private val adminConfigService: AdminConfigService,
+
+    /** The service to handle issues. */
+    private val issueResolutionService: IssueResolutionService
+) : AnalyzerPhase {
+    override suspend fun run(
+        worker: AnalyzerWorker,
+        jobId: Long,
+        args: Array<String>
+    ): RunResult {
+        val exchangeDir = exchangeDirectory(jobId, checkArgs(this, args, 1, 1))
+        val job = ortRunService.getValidAnalyzerJob(jobId)
+
+        val result: OrtResult = readExchangeFile(exchangeDir, ORT_RESULT_FILE)
+
+        return contextFactory.withContext(job.ortRunId) { context ->
+            worker.processResult(
+                context,
+                job,
+                result,
+                db,
+                ortRunService,
+                adminConfigService,
+                issueResolutionService
+            )
         }
     }
 }

--- a/workers/analyzer/src/main/kotlin/AnalyzerPhase.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerPhase.kt
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.analyzer
+
+import org.eclipse.apoapsis.ortserver.components.resolutions.issues.IssueResolutionService
+import org.eclipse.apoapsis.ortserver.services.config.AdminConfigService
+import org.eclipse.apoapsis.ortserver.services.ortrun.OrtRunService
+import org.eclipse.apoapsis.ortserver.workers.common.RunResult
+import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContextFactory
+import org.eclipse.apoapsis.ortserver.workers.common.env.EnvironmentService
+
+import org.jetbrains.exposed.v1.jdbc.Database
+
+/**
+ * An interface representing a phase of the Analyzer execution.
+ *
+ * The Analyzer can run in different phases with different configurations to reduce the impact of untrusted code it
+ * might be exposed to when analyzing build scripts. For instance, a preparation phase to set up the build environment
+ * needs access to the secret storage to generate the package manager configuration files according to the environment
+ * definition. In the actual analysis phase, this is no longer required.
+ *
+ * The idea behind this interface is that each implementation corresponds to a specific phase of an Analyzer run. The
+ * whole functionality of the run is implemented by [AnalyzerWorker]. A concrete phase implementation invokes the
+ * functions of the worker to execute the corresponding steps. It has access to the dependencies and services it needs
+ * for its specific task - and only to those. This allows for a clear separation between the single phases.
+ *
+ * The Analyzer endpoint determines the phase to be used based on command line arguments. It inspects the passed in
+ * command line and obtains the referenced [AnalyzerPhase] implementation. The command line may contain additional
+ * arguments to be interpreted by the current phase.
+ */
+internal sealed interface AnalyzerPhase {
+    /**
+     * Execute this phase for the Analyzer job with the given [jobId] by invoking the given [worker].
+     * Obtain relevant parameters from the given [command line arguments][args]. Return a [RunResult] the indicates to
+     * the Analyzer endpoint how to handle the result.
+     */
+    suspend fun run(worker: AnalyzerWorker, jobId: Long, args: Array<String>): RunResult
+}
+
+/**
+ * An implementation of [AnalyzerPhase] that executes the whole Analyzer run in a single shot. This is the most
+ * efficient way to analyze a repository, since there is no need to temporary store and exchange intermediate results.
+ * There is, however, no isolation between the single steps; the full infrastructure is accessible during the whole
+ * analysis.
+ *
+ * This implementation does not support any command line arguments.
+ */
+internal class FullPhase(
+    /** The database to access the job and store the results. */
+    private val db: Database,
+
+    /** The service to access and update information about the current run. */
+    private val ortRunService: OrtRunService,
+
+    /** The factory to create a worker context. */
+    private val contextFactory: WorkerContextFactory,
+
+    /** The service to set up the environment for the analysis. */
+    private val environmentService: EnvironmentService,
+
+    /** The service to access the global server configuration. */
+    private val adminConfigService: AdminConfigService,
+
+    /** The service to handle issues. */
+    private val issueResolutionService: IssueResolutionService
+) : AnalyzerPhase {
+    override suspend fun run(worker: AnalyzerWorker, jobId: Long, args: Array<String>): RunResult {
+        require(args.isEmpty()) {
+            "Unexpected arguments passed to the 'FULL' phase: '${args.joinToString(" ")}'."
+        }
+
+        val job = ortRunService.getValidAnalyzerJob(jobId)
+
+        return contextFactory.withContext(job.ortRunId) { context ->
+            val prepareResult = worker.prepare(context, job, ortRunService, environmentService)
+            val ortResult = worker.analyze(context, job, prepareResult)
+            worker.processResult(context, job, ortResult, db, ortRunService, adminConfigService, issueResolutionService)
+        }
+    }
+}

--- a/workers/analyzer/src/main/kotlin/AnalyzerPhase.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerPhase.kt
@@ -113,7 +113,7 @@ internal class FullPhase(
 
         return contextFactory.withContext(job.ortRunId) { context ->
             val prepareResult = worker.prepare(context, job, ortRunService, environmentService)
-            val ortResult = worker.analyze(context, job, prepareResult)
+            val ortResult = worker.analyze(prepareResult)
             worker.processResult(context, job, ortResult, db, ortRunService, adminConfigService, issueResolutionService)
         }
     }

--- a/workers/analyzer/src/main/kotlin/AnalyzerPhase.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerPhase.kt
@@ -19,23 +19,29 @@
 
 package org.eclipse.apoapsis.ortserver.workers.analyzer
 
+import com.typesafe.config.ConfigFactory
+
 import java.io.File
 
 import kotlinx.serialization.Serializable
 
 import org.eclipse.apoapsis.ortserver.components.resolutions.issues.IssueResolutionService
+import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.model.AnalyzerJobConfiguration
 import org.eclipse.apoapsis.ortserver.services.config.AdminConfigService
 import org.eclipse.apoapsis.ortserver.services.ortrun.OrtRunService
 import org.eclipse.apoapsis.ortserver.workers.common.RunResult
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContextFactory
+import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerOrtConfig
 import org.eclipse.apoapsis.ortserver.workers.common.env.EnvironmentForkHelper
 import org.eclipse.apoapsis.ortserver.workers.common.env.EnvironmentService
 
 import org.jetbrains.exposed.v1.jdbc.Database
 
+import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.writeValue
+import org.ossreviewtoolkit.utils.common.Os
 
 import org.slf4j.LoggerFactory
 
@@ -50,6 +56,8 @@ internal const val PREPARATION_EXCHANGE_FILE = "preparation-exchange.json"
 
 /** The name of the directory in which package manager configuration files are created. */
 internal const val CONFIG_DIR = "conf"
+
+internal const val ORT_RESULT_FILE = "ort-result.json"
 
 private val logger = LoggerFactory.getLogger(AnalyzerPhase::class.java)
 
@@ -168,6 +176,96 @@ internal class PreparationPhase(
 }
 
 /**
+ * An implementation of [AnalyzerPhase] that runs the ORT Analyzer in the environment prepared by [PreparationPhase].
+ *
+ * The [run] function expects the directory containing the results of the preparation phase as first argument. It reads
+ * the relevant files in this directory and delegates to [AnalyzerWorker] to perform the Analysis. It then writes the
+ * resulting ORT result in this directory as well.
+ *
+ * An optional second argument can point to a path of a file that should be created once the analysis is done. This can
+ * be used as a synchronization mechanism to signal the completion of the analysis phase.
+ */
+internal class AnalysisPhase : AnalyzerPhase {
+    override suspend fun run(
+        worker: AnalyzerWorker,
+        jobId: Long,
+        args: Array<String>
+    ): RunResult {
+        val exchangeDir = exchangeDirectory(jobId, checkArgs(this, args, 1, 2))
+
+        val prepareResult = createPrepareResult(exchangeDir, jobId)
+        copyConfigFiles(exchangeDir)
+        setUpEnvironment()
+
+        val result = worker.analyze(prepareResult)
+        writeExchangeFile(exchangeDir, ORT_RESULT_FILE, result)
+
+        writeSyncFile(args)
+        return RunResult.Ignored
+    }
+
+    /**
+     * Load the required data of the preparation phase from the given [exchangeDir] for the Analyzer job with the given
+     * [jobId] to create a [PrepareResult].
+     */
+    private fun createPrepareResult(
+        exchangeDir: File,
+        jobId: Long
+    ): PrepareResult {
+        val preparationExchange = readExchangeFile<PreparationExchange>(exchangeDir, PREPARATION_EXCHANGE_FILE)
+
+        // An empty config manager is sufficient here, since no infrastructure secrets are queried in this phase.
+        val configManager = ConfigManager.create(ConfigFactory.empty())
+        EnvironmentForkHelper.setupAuthentication(exchangeDir.resolve(AUTH_INFO_FILE), configManager)
+
+        val cloneDirectory = requireNotNull(
+            AnalyzerDownloader.findDownloadDir(exchangeDir, preparationExchange.runId)
+        ) {
+            "Could not find the directory with the cloned repository for Analyzer job $jobId."
+        }
+
+        return PrepareResult(
+            cloneDirectory = cloneDirectory,
+            resolvedEnvironment = preparationExchange.environment,
+            runnerConfig = preparationExchange.runnerConfig
+        )
+    }
+
+    /**
+     * Copy the package manager configuration files created during the preparation phase from the given [exchangeDir]
+     * to the user's home directory.
+     */
+    private fun copyConfigFiles(exchangeDir: File) {
+        val configDir = exchangeDir.resolve(CONFIG_DIR)
+        val userHomeDir = Os.userHomeDirectory
+        logger.info("Copying configuration files from '{}' to '{}'.", configDir, userHomeDir)
+
+        configDir.copyRecursively(target = userHomeDir, overwrite = true)
+    }
+
+    /**
+     * Set up the current environment, so that the ORT Analyzer can run. Because this phase does not use a
+     * [WorkerContext], some initialization steps have to be performed manually.
+     */
+    private fun setUpEnvironment() {
+        logger.info("Setting up the ORT environment for the analysis phase.")
+        WorkerOrtConfig.create().setUpOrtEnvironment()
+    }
+
+    /**
+     * Write the sync file to indicate that this phase is complete if configured in the given [args].
+     */
+    private fun writeSyncFile(args: Array<String>) {
+        if (args.size == 2) {
+            val syncFile = File(args[1])
+            syncFile.parentFile?.mkdirs()
+            logger.info("Writing sync file '{}'.", syncFile)
+            syncFile.writeText("done")
+        }
+    }
+}
+
+/**
  * A data class to hold results of the preparation phase that needs to be exchanged with later phases.
  * [PreparationPhase] creates such an object and serializes it to a file on a shared volume. From there, it is picked
  * up to start the analysis.
@@ -226,6 +324,17 @@ private inline fun <reified T : Any> AnalyzerPhase.writeExchangeFile(
     logger.info("[{}]: Writing exchange file '{}'.", javaClass.simpleName, exchangeFile)
 
     exchangeFile.writeValue(data)
+}
+
+/**
+ * Read a file with the given [name] in the [exchangeDir] for this [AnalyzerPhase]. Return the deserialized data.
+ * Log this operation.
+ */
+private inline fun <reified T : Any> AnalyzerPhase.readExchangeFile(exchangeDir: File, name: String): T {
+    val exchangeFile = exchangeDir.resolve(name)
+    logger.info("[{}]: Reading exchange file '{}'.", javaClass.simpleName, exchangeFile)
+
+    return exchangeFile.readValue()
 }
 
 /**

--- a/workers/analyzer/src/main/kotlin/AnalyzerRunner.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerRunner.kt
@@ -34,9 +34,6 @@ import org.eclipse.apoapsis.ortserver.utils.config.getInterpolatedStringOrDefaul
 import org.eclipse.apoapsis.ortserver.utils.config.getStringOrDefault
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
 import org.eclipse.apoapsis.ortserver.workers.common.env.EnvironmentForkHelper
-import org.eclipse.apoapsis.ortserver.workers.common.env.config.ResolvedEnvironmentConfig
-import org.eclipse.apoapsis.ortserver.workers.common.env.definition.SecretVariableDefinition
-import org.eclipse.apoapsis.ortserver.workers.common.env.definition.SimpleVariableDefinition
 
 import org.ossreviewtoolkit.analyzer.Analyzer
 import org.ossreviewtoolkit.analyzer.determineEnabledPackageManagers
@@ -135,23 +132,23 @@ class AnalyzerRunner(
 
     /**
      * Run the analyzer for the given [inputDir] using the provided [runnerConfig] and return the resulting
-     * [OrtResult]. Depending on the [environmentConfig], the analyzer is run in the same JVM or in a forked JVM with a
-     * customized environment.
+     * [OrtResult]. Depending on the [environmentVariables], the analyzer is run in the same JVM or in a forked JVM
+     * with a customized environment.
      */
     suspend fun run(
         context: WorkerContext,
         inputDir: File,
         runnerConfig: AnalyzerRunnerConfig,
-        environmentConfig: ResolvedEnvironmentConfig
-    ): OrtResult = if (environmentConfig.environmentVariables.isEmpty()) {
+        environmentVariables: Map<String, String>
+    ): OrtResult = if (environmentVariables.isEmpty()) {
         runInProcess(inputDir, runnerConfig)
     } else {
-        runForked(context, inputDir, runnerConfig, environmentConfig)
+        runForked(context, inputDir, runnerConfig, environmentVariables)
     }
 
     /**
      * Create a [ProcessBuilder] for running the [AnalyzerRunner] in a forked JVM with a customized environment.
-     * Use the given [context] to resolve secrets from the [environmentConfig] and set them as environment variables.
+     * Pass all variables from the given [environment] to the environment of the newly started process.
      * Generate the command line arguments for the forked process based on the configuration of the Analyzer worker
      * and the given [exchangeDir] and [inputDir]: The command and the arguments to launch a new JVM process can be
      * defined in the following configuration properties:
@@ -162,11 +159,10 @@ class AnalyzerRunner(
      *    - `${LAUNCH}`: Will be replaced by the fully qualified name of the main class to be executed and the
      *      arguments to be passed to it.
      */
-    internal suspend fun createProcessBuilder(
-        context: WorkerContext,
+    internal fun createProcessBuilder(
         exchangeDir: File,
         inputDir: File,
-        environmentConfig: ResolvedEnvironmentConfig
+        environment: Map<String, String>
     ): ProcessBuilder {
         val placeholders = mapOf(
             CLASSPATH_PLACEHOLDER to System.getProperty("java.class.path"),
@@ -179,23 +175,13 @@ class AnalyzerRunner(
             .redirectError(ProcessBuilder.Redirect.INHERIT)
             .redirectOutput(ProcessBuilder.Redirect.INHERIT)
 
-        val allSecrets = environmentConfig.environmentVariables
-            .filterIsInstance<SecretVariableDefinition>()
-            .map { it.valueSecret }
-        val resolvedSecrets = context.resolveSecrets(*allSecrets.toTypedArray())
-        val environment = processBuilder.environment()
-        environmentConfig.environmentVariables.forEach { variable ->
-            when (variable) {
-                is SecretVariableDefinition -> environment[variable.name] = resolvedSecrets[variable.valueSecret]
-                is SimpleVariableDefinition -> environment[variable.name] = variable.value
-            }
-        }
+        processBuilder.environment() += environment
 
         return processBuilder
     }
 
     /**
-     * Run the Analyzer in a forked JVM with a customized [environmentConfig] using the given [context],
+     * Run the Analyzer in a forked JVM with a customized [environment] using the given [context],
      * [project directory][inputDir], and [config]. This function is used if custom environment variables need to be
      * set.
      */
@@ -203,12 +189,12 @@ class AnalyzerRunner(
         context: WorkerContext,
         inputDir: File,
         config: AnalyzerRunnerConfig,
-        environmentConfig: ResolvedEnvironmentConfig
+        environment: Map<String, String>
     ): OrtResult {
         val exchangeDir = context.createTempDir()
         exchangeDir.resolve(ANALYZER_CONFIG_FILE).writeValue(config)
 
-        val processBuilder = createProcessBuilder(context, exchangeDir, inputDir, environmentConfig)
+        val processBuilder = createProcessBuilder(exchangeDir, inputDir, environment)
 
         logger.info("Starting forked AnalyzerRunner with command: ${processBuilder.command()}")
         withContext(Dispatchers.IO) {

--- a/workers/analyzer/src/main/kotlin/AnalyzerRunner.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerRunner.kt
@@ -32,7 +32,6 @@ import org.eclipse.apoapsis.ortserver.model.AnalyzerJobConfiguration
 import org.eclipse.apoapsis.ortserver.services.ortrun.mapToOrt
 import org.eclipse.apoapsis.ortserver.utils.config.getInterpolatedStringOrDefault
 import org.eclipse.apoapsis.ortserver.utils.config.getStringOrDefault
-import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
 import org.eclipse.apoapsis.ortserver.workers.common.env.EnvironmentForkHelper
 
 import org.ossreviewtoolkit.analyzer.Analyzer
@@ -46,7 +45,9 @@ import org.ossreviewtoolkit.model.readValueOrNull
 import org.ossreviewtoolkit.model.writeValue
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.PackageCurationProviderFactory
 import org.ossreviewtoolkit.plugins.packagecurationproviders.api.SimplePackageCurationProvider
+import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.ort.ORT_REPO_CONFIG_FILENAME
+import org.ossreviewtoolkit.utils.ort.createOrtTempDir
 
 import org.slf4j.LoggerFactory
 
@@ -136,14 +137,13 @@ class AnalyzerRunner(
      * with a customized environment.
      */
     suspend fun run(
-        context: WorkerContext,
         inputDir: File,
         runnerConfig: AnalyzerRunnerConfig,
         environmentVariables: Map<String, String>
     ): OrtResult = if (environmentVariables.isEmpty()) {
         runInProcess(inputDir, runnerConfig)
     } else {
-        runForked(context, inputDir, runnerConfig, environmentVariables)
+        runForked(inputDir, runnerConfig, environmentVariables)
     }
 
     /**
@@ -186,30 +186,33 @@ class AnalyzerRunner(
      * set.
      */
     internal suspend fun runForked(
-        context: WorkerContext,
         inputDir: File,
         config: AnalyzerRunnerConfig,
         environment: Map<String, String>
     ): OrtResult {
-        val exchangeDir = context.createTempDir()
-        exchangeDir.resolve(ANALYZER_CONFIG_FILE).writeValue(config)
+        val exchangeDir = createOrtTempDir()
+        try {
+            exchangeDir.resolve(ANALYZER_CONFIG_FILE).writeValue(config)
 
-        val processBuilder = createProcessBuilder(exchangeDir, inputDir, environment)
+            val processBuilder = createProcessBuilder(exchangeDir, inputDir, environment)
 
-        logger.info("Starting forked AnalyzerRunner with command: ${processBuilder.command()}")
-        withContext(Dispatchers.IO) {
-            val process = processBuilder.start()
-            process.outputStream.use { pipe ->
-                EnvironmentForkHelper.prepareFork(pipe)
+            logger.info("Starting forked AnalyzerRunner with command: ${processBuilder.command()}")
+            withContext(Dispatchers.IO) {
+                val process = processBuilder.start()
+                process.outputStream.use { pipe ->
+                    EnvironmentForkHelper.prepareFork(pipe)
+                }
+
+                val exitCode = process.waitFor()
+
+                logger.info("Forked AnalyzerRunner process finished with exit code $exitCode.")
             }
 
-            val exitCode = process.waitFor()
-
-            logger.info("Forked AnalyzerRunner process finished with exit code $exitCode.")
+            return exchangeDir.resolve(ANALYZER_RESULT_FILE).takeIf { it.isFile }?.readValue()
+                ?: handleForkError(exchangeDir)
+        } finally {
+            exchangeDir.safeDeleteRecursively()
         }
-
-        return exchangeDir.resolve(ANALYZER_RESULT_FILE).takeIf { it.isFile }?.readValue()
-            ?: handleForkError(exchangeDir)
     }
 
     /**

--- a/workers/analyzer/src/main/kotlin/AnalyzerRunnerConfig.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerRunnerConfig.kt
@@ -19,6 +19,8 @@
 
 package org.eclipse.apoapsis.ortserver.workers.analyzer
 
+import kotlinx.serialization.Serializable
+
 import org.eclipse.apoapsis.ortserver.model.AnalyzerJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.ProviderPluginConfiguration
 import org.eclipse.apoapsis.ortserver.model.runs.PackageManagerConfiguration
@@ -27,6 +29,7 @@ import org.eclipse.apoapsis.ortserver.model.runs.PackageManagerConfiguration
  * The configuration for the [AnalyzerRunner], containing the parts of [AnalyzerJobConfiguration] that are required to
  * execute the ORT analyzer.
  */
+@Serializable
 data class AnalyzerRunnerConfig(
     /** See [AnalyzerJobConfiguration.allowDynamicVersions]. */
     val allowDynamicVersions: Boolean,

--- a/workers/analyzer/src/main/kotlin/AnalyzerWorker.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerWorker.kt
@@ -93,13 +93,18 @@ internal class AnalyzerWorker(
     /**
      * Prepare the execution of the ORT Analyzer for the current [analyzerJob]. Use the given [context] and
      * [environmentService] to resolve required secrets and set up the environment for the analysis. Use the given
-     * [ortRunService] to read and update information about the current run.
+     * [ortRunService] to read and update information about the current run. Clone the repository into the given
+     * [downloadDir] if specified; otherwise, use a temporary directory for this purpose. Generate package manager
+     * configuration files in the given [configDir] if specified; otherwise, generate them directly in the user's
+     * home directory.
      */
     internal suspend fun prepare(
         context: WorkerContext,
         analyzerJob: AnalyzerJob,
         ortRunService: OrtRunService,
-        environmentService: EnvironmentService
+        environmentService: EnvironmentService,
+        downloadDir: File? = null,
+        configDir: File? = null
     ): PrepareResult {
         val ortRun = ortRunService.getOrtRun(analyzerJob.ortRunId)
             ?: throw IllegalArgumentException("The ORT run '${analyzerJob.ortRunId}' does not exist.")
@@ -132,7 +137,9 @@ internal class AnalyzerWorker(
             repository.url,
             ortRun.revision,
             ortRun.path.orEmpty(),
-            job.configuration.submoduleFetchStrategy
+            job.configuration.submoduleFetchStrategy,
+            targetDir = downloadDir,
+            runId = ortRun.id.takeUnless { downloadDir == null }
         )
 
         if (downloadResult.initRevision != ortRun.revision) {
@@ -148,7 +155,8 @@ internal class AnalyzerWorker(
             context,
             downloadResult.directory,
             envConfigFromJob,
-            repositoryServices
+            repositoryServices,
+            configDir
         )
         val environment = resolveEnvironmentVariables(context, resolvedEnvConfig)
 

--- a/workers/analyzer/src/main/kotlin/AnalyzerWorker.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerWorker.kt
@@ -160,18 +160,21 @@ internal class AnalyzerWorker(
         )
         val environment = resolveEnvironmentVariables(context, resolvedEnvConfig)
 
-        return PrepareResult(downloadResult.directory, environment)
+        return PrepareResult(
+            downloadResult.directory,
+            environment,
+            job.configuration.toRunnerConfig(context)
+        )
     }
 
     /**
-     * Invoke the [AnalyzerRunner] on the prepared environment for the current [job] using the given [context] and the
-     * [prepareResult] from the preparation phase. Return the [OrtResult] produced by the ORT Analyzer.
+     * Invoke the [AnalyzerRunner] on the prepared environment as defined by the [prepareResult] from the preparation
+     * phase. Return the [OrtResult] produced by the ORT Analyzer.
      */
-    internal suspend fun analyze(context: WorkerContext, job: AnalyzerJob, prepareResult: PrepareResult): OrtResult =
+    internal suspend fun analyze(prepareResult: PrepareResult): OrtResult =
         runner.run(
-            context,
             prepareResult.cloneDirectory,
-            job.configuration.toRunnerConfig(context),
+            prepareResult.runnerConfig,
             prepareResult.resolvedEnvironment
         )
 
@@ -293,7 +296,10 @@ internal data class PrepareResult(
     val cloneDirectory: File,
 
     /** The environment variables to be passed to a forked Analyzer process if any. */
-    val resolvedEnvironment: Map<String, String>
+    val resolvedEnvironment: Map<String, String>,
+
+    /** The configuration for the [AnalyzerRunner]. */
+    val runnerConfig: AnalyzerRunnerConfig
 )
 
 private class AnalyzerException(message: String) : Exception(message)

--- a/workers/analyzer/src/main/kotlin/AnalyzerWorker.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerWorker.kt
@@ -36,6 +36,9 @@ import org.eclipse.apoapsis.ortserver.workers.common.RunResult
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContextFactory
 import org.eclipse.apoapsis.ortserver.workers.common.env.EnvironmentService
+import org.eclipse.apoapsis.ortserver.workers.common.env.config.ResolvedEnvironmentConfig
+import org.eclipse.apoapsis.ortserver.workers.common.env.definition.SecretVariableDefinition
+import org.eclipse.apoapsis.ortserver.workers.common.env.definition.SimpleVariableDefinition
 import org.eclipse.apoapsis.ortserver.workers.common.resolutions.OrtServerResolutionProvider
 import org.eclipse.apoapsis.ortserver.workers.common.validateForProcessing
 
@@ -111,11 +114,12 @@ internal class AnalyzerWorker(
                 envConfigFromJob,
                 repositoryServices
             )
+            val environment = resolveEnvironmentVariables(context, resolvedEnvConfig)
             val ortResult = runner.run(
                 context,
                 downloadResult.directory,
                 job.configuration.toRunnerConfig(context),
-                resolvedEnvConfig
+                environment
             )
 
             ortRunService.storeRepositoryInformation(ortRun.id, ortResult.repository)
@@ -244,3 +248,28 @@ private suspend fun AnalyzerJobConfiguration.toRunnerConfig(context: WorkerConte
         repositoryConfigPath = repositoryConfigPath,
         packageCurationProviders = context.resolveProviderPluginConfigSecrets(packageCurationProviders)
     )
+
+/**
+ * Return a [Map] with all environment variables configured in the given [environmentConfig] with secrets resolved.
+ * Use the given [context] to resolve secret values.
+ */
+private suspend fun resolveEnvironmentVariables(
+    context: WorkerContext,
+    environmentConfig: ResolvedEnvironmentConfig
+): Map<String, String> {
+    val allSecrets = environmentConfig.environmentVariables
+        .filterIsInstance<SecretVariableDefinition>()
+        .map { it.valueSecret }
+    val resolvedSecrets = allSecrets.takeUnless { it.isEmpty() }?.let {
+        context.resolveSecrets(*allSecrets.toTypedArray())
+    }.orEmpty()
+    val environment = mutableMapOf<String, String>()
+    environmentConfig.environmentVariables.forEach { variable ->
+        when (variable) {
+            is SecretVariableDefinition -> environment[variable.name] = resolvedSecrets.getValue(variable.valueSecret)
+            is SimpleVariableDefinition -> environment[variable.name] = variable.value
+        }
+    }
+
+    return environment
+}

--- a/workers/analyzer/src/main/kotlin/AnalyzerWorker.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerWorker.kt
@@ -19,10 +19,14 @@
 
 package org.eclipse.apoapsis.ortserver.workers.analyzer
 
+import java.io.File
+
 import org.eclipse.apoapsis.ortserver.components.resolutions.issues.IssueResolutionService
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
+import org.eclipse.apoapsis.ortserver.model.AnalyzerJob
 import org.eclipse.apoapsis.ortserver.model.AnalyzerJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
+import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.RepositoryId
 import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.AppliedPackageCurationRef
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
@@ -34,7 +38,6 @@ import org.eclipse.apoapsis.ortserver.transport.EndpointComponent
 import org.eclipse.apoapsis.ortserver.workers.common.JobIgnoredException
 import org.eclipse.apoapsis.ortserver.workers.common.RunResult
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
-import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContextFactory
 import org.eclipse.apoapsis.ortserver.workers.common.env.EnvironmentService
 import org.eclipse.apoapsis.ortserver.workers.common.env.config.ResolvedEnvironmentConfig
 import org.eclipse.apoapsis.ortserver.workers.common.env.definition.SecretVariableDefinition
@@ -45,6 +48,7 @@ import org.eclipse.apoapsis.ortserver.workers.common.validateForProcessing
 import org.jetbrains.exposed.v1.jdbc.Database
 
 import org.ossreviewtoolkit.model.Identifier as OrtIdentifier
+import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.utils.ort.ORT_VERSION
 
@@ -53,166 +57,24 @@ import org.slf4j.LoggerFactory
 private val logger = LoggerFactory.getLogger(AnalyzerWorker::class.java)
 
 internal class AnalyzerWorker(
-    private val db: Database,
     private val downloader: AnalyzerDownloader,
-    private val runner: AnalyzerRunner,
-    private val ortRunService: OrtRunService,
-    private val contextFactory: WorkerContextFactory,
-    private val environmentService: EnvironmentService,
-    private val adminConfigService: AdminConfigService,
-    private val issueResolutionService: IssueResolutionService
+    private val runner: AnalyzerRunner
 ) {
-    suspend fun run(jobId: Long, traceId: String): RunResult = runCatching {
-        var job = getValidAnalyzerJob(jobId)
-        val ortRun = ortRunService.getOrtRun(job.ortRunId)
-            ?: throw IllegalArgumentException("The ORT run '${job.ortRunId}' does not exist.")
-        val repository = ortRunService.getHierarchyForOrtRun(ortRun.id)?.repository
-            ?: throw IllegalArgumentException("The repository '${ortRun.repositoryId}' does not exist.")
+    /**
+     * Execute an Analyzer run for the given [jobId] and [traceId] in the specified [phase] with the given [args] as
+     * additional parameters. Perform a double-dispatching with the provided [phase] to run only the required steps.
+     * Handle occurring exceptions and return a [RunResult] with the outcome of the operation.
+     */
+    suspend fun run(jobId: Long, traceId: String, phase: AnalyzerPhase, args: Array<String>): RunResult = runCatching {
+        logger.info(
+            "Starting {} for job {} with arguments {}.",
+            phase.javaClass.simpleName,
+            jobId,
+            args.contentToString()
+        )
 
-        job = ortRunService.startAnalyzerJob(job.id)
-            ?: throw IllegalArgumentException("The analyzer job with id '$jobId' could not be started.")
-        logger.debug("Analyzer job with id '{}' started at {}.", job.id, job.startedAt)
-        logger.info("Using ORT version {}.", ORT_VERSION)
-
-        contextFactory.withContext(job.ortRunId) { context ->
-            if (job.configuration.keepAliveWorker) {
-                EndpointComponent.generateKeepAliveFile()
-            }
-
-            val envConfigFromJob = job.configuration.environmentConfig
-            val repositoryServices =
-                environmentService.findInfrastructureServicesForRepository(context, envConfigFromJob)
-            if (repositoryServices.isNotEmpty()) {
-                logger.info(
-                    "Generating a .netrc file with credentials from infrastructure services '{}' to download the " +
-                            "repository.",
-                    repositoryServices.map(InfrastructureService::name)
-                )
-
-                environmentService.setupAuthentication(context, repositoryServices)
-            }
-
-            val downloadResult = downloader.downloadRepository(
-                repository.url,
-                ortRun.revision,
-                ortRun.path.orEmpty(),
-                job.configuration.submoduleFetchStrategy
-            )
-
-            if (downloadResult.initRevision != ortRun.revision) {
-                logger.info(
-                    "Updating revision of ORT run from '${ortRun.revision}' to '${downloadResult.initRevision}'."
-                )
-                ortRunService.updateRevision(ortRun.id, downloadResult.initRevision)
-            }
-
-            ortRunService.updateResolvedRevision(ortRun.id, downloadResult.resolvedRevision)
-
-            val resolvedEnvConfig = environmentService.setUpEnvironment(
-                context,
-                downloadResult.directory,
-                envConfigFromJob,
-                repositoryServices
-            )
-            val environment = resolveEnvironmentVariables(context, resolvedEnvConfig)
-            val ortResult = runner.run(
-                context,
-                downloadResult.directory,
-                job.configuration.toRunnerConfig(context),
-                environment
-            )
-
-            ortRunService.storeRepositoryInformation(ortRun.id, ortResult.repository)
-            ortRunService.storeResolvedPackageCurations(job.ortRunId, ortResult.resolvedConfiguration.packageCurations)
-
-            val analyzerRun = ortResult.analyzer
-                ?: throw AnalyzerException("ORT Analyzer failed to create a result.")
-
-            val excludedPackageIds = analyzerRun.result.packages
-                .filter { ortResult.isPackageExcluded(it.id) }
-                .mapTo(mutableSetOf()) { it.id.mapToModel() }
-
-            val excludedProjectIds = analyzerRun.result.projects
-                .filter { ortResult.isProjectExcluded(it.id) }
-                .mapTo(mutableSetOf()) { it.id.mapToModel() }
-
-            // IMPORTANT: Use getAnalyzerIssues() to get ONLY analyzer issues, not all issues.
-            val allIssues = ortResult.getAnalyzerIssues().mapValues { it.value.toList() }
-
-            val resolutionProvider = OrtServerResolutionProvider.create(
-                context,
-                adminConfigService,
-                ortResult.repository.config.resolutions,
-                RepositoryId(ortRun.repositoryId),
-                issueResolutionService
-            )
-
-            // Apply resolutions using the common function.
-            val resolvedItems = resolutionProvider.matchResolutions(
-                issuesByIdentifier = allIssues,
-                ruleViolations = emptyList(),
-                vulnerabilities = emptyList()
-            )
-
-            // Calculate unresolved issues for logging.
-            val unresolvedIssues = allIssues.flatMap { (ortIdentifier, issues) ->
-                val identifier = ortIdentifier.takeIf { it != OrtIdentifier.EMPTY }?.mapToModel()
-                issues.filter { it.mapToModel(identifier) !in resolvedItems.issues.keys }
-            }
-
-            logger.info(
-                "Analyzer job ${job.id} for repository ${repository.url} with revision ${ortRun.revision} " +
-                        "finished with ${allIssues.values.flatten().size} total issues " +
-                        "and ${unresolvedIssues.size} unresolved issues."
-            )
-
-            val shortestPathsByIdentifier = mutableMapOf<Identifier, MutableList<ShortestDependencyPath>>()
-
-            analyzerRun.result.projects.forEach { project ->
-                getIdentifierToShortestPathsMap(
-                    project.id.mapToModel(),
-                    ortResult.dependencyNavigator.getShortestPaths(project)
-                ).forEach { (identifier, path) ->
-                    shortestPathsByIdentifier.getOrPut(identifier) { mutableListOf() } += path
-                }
-            }
-
-            db.dbQuery {
-                getValidAnalyzerJob(jobId)
-                ortRunService.storeAnalyzerRun(
-                    analyzerRun.mapToModel(jobId),
-                    shortestPathsByIdentifier,
-                    excludedPackageIds,
-                    excludedProjectIds
-                )
-                ortRunService.storeResolvedItems(job.ortRunId, resolvedItems)
-            }
-
-            val packageIds = ortResult.getPackages().map { it.metadata.id }.toSet()
-
-            val packageCurationAssociations = packageIds.associate { pkgId ->
-                val refs = buildList {
-                    ortResult.resolvedConfiguration.packageCurations.forEach { resolvedPackageCurations ->
-                        resolvedPackageCurations.curations.forEachIndexed { rank, curation ->
-                            if (curation.isApplicable(pkgId)) {
-                                add(AppliedPackageCurationRef(resolvedPackageCurations.provider.id, rank))
-                            }
-                        }
-                    }
-                }
-
-                pkgId.mapToModel() to refs
-            }.filterValues { it.isNotEmpty() }
-
-            if (packageCurationAssociations.isNotEmpty()) {
-                ortRunService.storePackageCurationAssociations(job.ortRunId, packageCurationAssociations)
-            }
-
-            if (unresolvedIssues.any { it.severity >= Severity.WARNING }) {
-                RunResult.FinishedWithIssues
-            } else {
-                RunResult.Success
-            }
+        phase.run(this, jobId, args).also {
+            logger.info("{} for job {} completed.", phase.javaClass.simpleName, jobId)
         }
     }.getOrElse {
         when (it) {
@@ -228,11 +90,219 @@ internal class AnalyzerWorker(
         }
     }
 
-    private fun getValidAnalyzerJob(jobId: Long) =
-        ortRunService.getAnalyzerJob(jobId).validateForProcessing(jobId)
+    /**
+     * Prepare the execution of the ORT Analyzer for the current [analyzerJob]. Use the given [context] and
+     * [environmentService] to resolve required secrets and set up the environment for the analysis. Use the given
+     * [ortRunService] to read and update information about the current run.
+     */
+    internal suspend fun prepare(
+        context: WorkerContext,
+        analyzerJob: AnalyzerJob,
+        ortRunService: OrtRunService,
+        environmentService: EnvironmentService
+    ): PrepareResult {
+        val ortRun = ortRunService.getOrtRun(analyzerJob.ortRunId)
+            ?: throw IllegalArgumentException("The ORT run '${analyzerJob.ortRunId}' does not exist.")
+        val repository = ortRunService.getHierarchyForOrtRun(ortRun.id)?.repository
+            ?: throw IllegalArgumentException("The repository '${ortRun.repositoryId}' does not exist.")
+
+        val job = ortRunService.startAnalyzerJob(analyzerJob.id)
+            ?: throw IllegalArgumentException("The analyzer job with id '${analyzerJob.id}' could not be started.")
+        logger.debug("Analyzer job with id '{}' started at {}.", job.id, job.startedAt)
+        logger.info("Using ORT version {}.", ORT_VERSION)
+
+        if (job.configuration.keepAliveWorker) {
+            EndpointComponent.generateKeepAliveFile()
+        }
+
+        val envConfigFromJob = job.configuration.environmentConfig
+        val repositoryServices =
+            environmentService.findInfrastructureServicesForRepository(context, envConfigFromJob)
+        if (repositoryServices.isNotEmpty()) {
+            logger.info(
+                "Generating a .netrc file with credentials from infrastructure services '{}' to download the " +
+                        "repository.",
+                repositoryServices.map(InfrastructureService::name)
+            )
+
+            environmentService.setupAuthentication(context, repositoryServices)
+        }
+
+        val downloadResult = downloader.downloadRepository(
+            repository.url,
+            ortRun.revision,
+            ortRun.path.orEmpty(),
+            job.configuration.submoduleFetchStrategy
+        )
+
+        if (downloadResult.initRevision != ortRun.revision) {
+            logger.info(
+                "Updating revision of ORT run from '${ortRun.revision}' to '${downloadResult.initRevision}'."
+            )
+            ortRunService.updateRevision(ortRun.id, downloadResult.initRevision)
+        }
+
+        ortRunService.updateResolvedRevision(ortRun.id, downloadResult.resolvedRevision)
+
+        val resolvedEnvConfig = environmentService.setUpEnvironment(
+            context,
+            downloadResult.directory,
+            envConfigFromJob,
+            repositoryServices
+        )
+        val environment = resolveEnvironmentVariables(context, resolvedEnvConfig)
+
+        return PrepareResult(downloadResult.directory, environment)
+    }
+
+    /**
+     * Invoke the [AnalyzerRunner] on the prepared environment for the current [job] using the given [context] and the
+     * [prepareResult] from the preparation phase. Return the [OrtResult] produced by the ORT Analyzer.
+     */
+    internal suspend fun analyze(context: WorkerContext, job: AnalyzerJob, prepareResult: PrepareResult): OrtResult =
+        runner.run(
+            context,
+            prepareResult.cloneDirectory,
+            job.configuration.toRunnerConfig(context),
+            prepareResult.resolvedEnvironment
+        )
+
+    /**
+     * Process the [ortResult] created for the current Analyzer [job]. Store it in the [database][db] with the help of
+     * the given [ortRunService], [issueResolutionService], [adminConfigService], and [context]. Return a [RunResult]
+     * indicating the success of the whole Analyzer run.
+     */
+    internal suspend fun processResult(
+        context: WorkerContext,
+        job: AnalyzerJob,
+        ortResult: OrtResult,
+        db: Database,
+        ortRunService: OrtRunService,
+        adminConfigService: AdminConfigService,
+        issueResolutionService: IssueResolutionService
+    ): RunResult {
+        val ortRun = ortRunService.getValidOrtRun(job)
+        ortRunService.storeRepositoryInformation(job.ortRunId, ortResult.repository)
+        ortRunService.storeResolvedPackageCurations(job.ortRunId, ortResult.resolvedConfiguration.packageCurations)
+
+        val analyzerRun = ortResult.analyzer
+            ?: throw AnalyzerException("ORT Analyzer failed to create a result.")
+
+        val excludedPackageIds = analyzerRun.result.packages
+            .filter { ortResult.isPackageExcluded(it.id) }
+            .mapTo(mutableSetOf()) { it.id.mapToModel() }
+
+        val excludedProjectIds = analyzerRun.result.projects
+            .filter { ortResult.isProjectExcluded(it.id) }
+            .mapTo(mutableSetOf()) { it.id.mapToModel() }
+
+            // IMPORTANT: Use getAnalyzerIssues() to get ONLY analyzer issues, not all issues.
+            val allIssues = ortResult.getAnalyzerIssues().mapValues { it.value.toList() }
+
+        val resolutionProvider = OrtServerResolutionProvider.create(
+            context,
+            adminConfigService,
+            ortResult.repository.config.resolutions,
+            RepositoryId(ortRun.repositoryId),
+            issueResolutionService
+        )
+
+            // Apply resolutions using the common function.
+            val resolvedItems = resolutionProvider.matchResolutions(
+                issuesByIdentifier = allIssues,
+                ruleViolations = emptyList(),
+                vulnerabilities = emptyList()
+            )
+
+            // Calculate unresolved issues for logging.
+            val unresolvedIssues = allIssues.flatMap { (ortIdentifier, issues) ->
+                val identifier = ortIdentifier.takeIf { it != OrtIdentifier.EMPTY }?.mapToModel()
+                issues.filter { it.mapToModel(identifier) !in resolvedItems.issues.keys }
+            }
+
+            logger.info(
+                "Analyzer job ${job.id} for repository ${ortResult.repository.vcsProcessed.url} with revision " +
+                        "${ortRun.revision} finished with ${allIssues.values.flatten().size} total issues " +
+                        "and ${unresolvedIssues.size} unresolved issues."
+            )
+
+        val shortestPathsByIdentifier = mutableMapOf<Identifier, MutableList<ShortestDependencyPath>>()
+
+        analyzerRun.result.projects.forEach { project ->
+            getIdentifierToShortestPathsMap(
+                project.id.mapToModel(),
+                ortResult.dependencyNavigator.getShortestPaths(project)
+            ).forEach { (identifier, path) ->
+                shortestPathsByIdentifier.getOrPut(identifier) { mutableListOf() } += path
+            }
+        }
+
+        db.dbQuery {
+            ortRunService.getValidAnalyzerJob(job.id)
+            ortRunService.storeAnalyzerRun(
+                analyzerRun.mapToModel(job.id),
+                shortestPathsByIdentifier,
+                excludedPackageIds,
+                excludedProjectIds
+            )
+            ortRunService.storeResolvedItems(job.ortRunId, resolvedItems)
+        }
+
+        val packageIds = ortResult.getPackages().map { it.metadata.id }.toSet()
+
+        val packageCurationAssociations = packageIds.associate { pkgId ->
+            val refs = buildList {
+                ortResult.resolvedConfiguration.packageCurations.forEach { resolvedPackageCurations ->
+                    resolvedPackageCurations.curations.forEachIndexed { rank, curation ->
+                        if (curation.isApplicable(pkgId)) {
+                            add(AppliedPackageCurationRef(resolvedPackageCurations.provider.id, rank))
+                        }
+                    }
+                }
+            }
+
+            pkgId.mapToModel() to refs
+        }.filterValues { it.isNotEmpty() }
+
+        if (packageCurationAssociations.isNotEmpty()) {
+            ortRunService.storePackageCurationAssociations(job.ortRunId, packageCurationAssociations)
+        }
+
+        return if (unresolvedIssues.any { it.severity >= Severity.WARNING }) {
+            RunResult.FinishedWithIssues
+        } else {
+            RunResult.Success
+        }
+    }
 }
 
+/**
+ * A data class storing the result of the preparation phase. The data contained here is needed by the [AnalyzerRunner]
+ * to perform the actual analysis of the already checked out repository.
+ */
+internal data class PrepareResult(
+    /** The directory in which the source code of the repository to be analyzed has been cloned. */
+    val cloneDirectory: File,
+
+    /** The environment variables to be passed to a forked Analyzer process if any. */
+    val resolvedEnvironment: Map<String, String>
+)
+
 private class AnalyzerException(message: String) : Exception(message)
+
+/**
+ * Obtain the [AnalyzerJob] for the given [jobId] and make sure that it is valid. Throw an exception if no valid
+ * job can be obtained.
+ */
+internal fun OrtRunService.getValidAnalyzerJob(jobId: Long) =
+    getAnalyzerJob(jobId).validateForProcessing(jobId)
+
+/**
+ * Return the [OrtRun] referenced by the given [job] or throw an [IllegalArgumentException] if it does not exist.
+ */
+internal fun OrtRunService.getValidOrtRun(job: AnalyzerJob): OrtRun =
+    getOrtRun(job.ortRunId)
+        ?: throw IllegalArgumentException("The ORT run '${job.ortRunId}' does not exist.")
 
 /**
  * Create an [AnalyzerRunnerConfig] from this [AnalyzerJobConfiguration] to be used to analyze the current project.

--- a/workers/analyzer/src/main/kotlin/Entrypoint.kt
+++ b/workers/analyzer/src/main/kotlin/Entrypoint.kt
@@ -32,13 +32,22 @@ private val logger = LoggerFactory.getLogger(AnalyzerComponent::class.java)
 /**
  * This is the entry point of the Analyzer worker. It calls the Analyzer from ORT programmatically by
  * interfacing on its APIs.
+ *
+ * Per default, a whole analysis is performed. This can be changed via command line arguments. The first argument is
+ * interpreted as the name of the analyzer phase to execute; further arguments are then passed to the phase. The
+ * following phases are supported (names are case-insensitive):
+ * - _preparation_ for the preparation phase
+ * - _analysis_ for the analysis phase
+ * - _result_ for the result phase
+ * - The phase _full_ can be exlicitly specified to run the whole analysis. This has the same effect as providing no
+ *   argument at all.
  */
-suspend fun main() {
+suspend fun main(args: Array<String>) {
     withMdcContext(StandardMdcKeys.COMPONENT to "analyzer-worker") {
-        logger.info("Starting ORT-Server Analyzer endpoint.")
+        logger.info("Starting ORT-Server Analyzer endpoint with arguments {}.", args.contentToString())
 
         enableOrtStackTraces()
         Os.fixupUserHomeProperty()
-        AnalyzerComponent().start()
+        AnalyzerComponent(args).start()
     }
 }

--- a/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
@@ -204,7 +204,7 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
         "A message to analyze a project should be processed" {
             runEndpointTest {
                 declareMock<AnalyzerWorker> {
-                    coEvery { run(JOB_ID, TRACE_ID) } returns RunResult.Success
+                    coEvery { run(JOB_ID, TRACE_ID, any(), any()) } returns RunResult.Success
                 }
 
                 sendAnalyzerRequest()
@@ -218,7 +218,9 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
         "An error message should be sent back in case of a processing error" {
             runEndpointTest {
                 declareMock<AnalyzerWorker> {
-                    coEvery { run(JOB_ID, TRACE_ID) } returns RunResult.Failed(IllegalStateException("Test exception"))
+                    coEvery {
+                        run(JOB_ID, TRACE_ID, any(), any())
+                    } returns RunResult.Failed(IllegalStateException("Test exception"))
                 }
 
                 sendAnalyzerRequest()
@@ -232,7 +234,7 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
         "A 'run finished with issues' message should be sent when ORT issues are over the threshold" {
             runEndpointTest {
                 declareMock<AnalyzerWorker> {
-                    coEvery { run(JOB_ID, TRACE_ID) } returns RunResult.FinishedWithIssues
+                    coEvery { run(JOB_ID, TRACE_ID, any(), any()) } returns RunResult.FinishedWithIssues
                 }
 
                 sendAnalyzerRequest()
@@ -246,7 +248,7 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
         "No response should be sent if the request is ignored" {
             runEndpointTest {
                 declareMock<AnalyzerWorker> {
-                    coEvery { run(JOB_ID, TRACE_ID) } returns RunResult.Ignored
+                    coEvery { run(JOB_ID, TRACE_ID, any(), any()) } returns RunResult.Ignored
                 }
 
                 sendAnalyzerRequest()

--- a/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerEndpointTest.kt
@@ -21,6 +21,7 @@ package org.eclipse.apoapsis.ortserver.workers.analyzer
 
 import com.typesafe.config.Config
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.core.test.TestCase
 import io.kotest.engine.spec.tempdir
@@ -204,7 +205,7 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
         "A message to analyze a project should be processed" {
             runEndpointTest {
                 declareMock<AnalyzerWorker> {
-                    coEvery { run(JOB_ID, TRACE_ID, any(), any()) } returns RunResult.Success
+                    coEvery { run(JOB_ID, TRACE_ID, any<FullPhase>(), emptyArray()) } returns RunResult.Success
                 }
 
                 sendAnalyzerRequest()
@@ -256,6 +257,65 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
                 MessageSenderFactoryForTesting.expectNoMessage(OrchestratorEndpoint)
             }
         }
+
+        "The preparation phase should be run" {
+            val args = arrayOf("preparation", "/data/exchange")
+            runEndpointTest(args) {
+                declareMock<AnalyzerWorker> {
+                    coEvery {
+                        run(JOB_ID, TRACE_ID, any<PreparationPhase>(), arrayOf(args[1]))
+                    } returns RunResult.Ignored
+                }
+
+                sendAnalyzerRequest()
+
+                MessageSenderFactoryForTesting.expectNoMessage(OrchestratorEndpoint)
+            }
+        }
+
+        "The analysis phase should be run" {
+            val args = arrayOf("Analysis", "/data/exchange", "sync.sig")
+            runEndpointTest(args) {
+                declareMock<AnalyzerWorker> {
+                    coEvery {
+                        run(JOB_ID, TRACE_ID, any<AnalysisPhase>(), arrayOf(args[1], args[2]))
+                    } returns RunResult.Ignored
+                }
+
+                sendAnalyzerRequest()
+
+                MessageSenderFactoryForTesting.expectNoMessage(OrchestratorEndpoint)
+            }
+        }
+
+        "The result phase should be run" {
+            val args = arrayOf("RESULT", "/data/exchange")
+            runEndpointTest(args) {
+                declareMock<AnalyzerWorker> {
+                    coEvery {
+                        run(JOB_ID, TRACE_ID, any<ResultPhase>(), arrayOf(args[1]))
+                    } returns RunResult.Success
+                }
+
+                sendAnalyzerRequest()
+
+                val resultMessage = MessageSenderFactoryForTesting.expectMessage(OrchestratorEndpoint)
+                resultMessage.header shouldBe messageHeader
+                resultMessage.payload shouldBe AnalyzerWorkerResult(JOB_ID)
+            }
+        }
+
+        "An unsupported phase should be handled" {
+            val unsupportedPhase = "do-nothing"
+            val args = arrayOf(unsupportedPhase)
+            runEndpointTest(args) {
+                val exception = shouldThrow<IllegalArgumentException> {
+                    sendAnalyzerRequest()
+                }
+
+                exception.message shouldContain "'$unsupportedPhase'"
+            }
+        }
     }
 
     /**
@@ -269,10 +329,10 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
     }
 
     /**
-     * Run [block] as a test for the Analyzer endpoint. Start the endpoint with a configuration that selects the
-     * testing transport. Then execute the given [block].
+     * Run [block] as a test for the Analyzer endpoint with the given [args]. Start the endpoint with a configuration
+     * that selects the testing transport. Then execute the given [block].
      */
-    private suspend fun runEndpointTest(block: suspend () -> Unit) {
+    private suspend fun runEndpointTest(args: Array<String> = emptyArray(), block: suspend () -> Unit) {
         withMockDatabaseModule {
             val environment = mapOf(
                 "ANALYZER_RECEIVER_TRANSPORT_TYPE" to TEST_TRANSPORT_NAME,
@@ -282,7 +342,7 @@ class AnalyzerEndpointTest : KoinTest, StringSpec() {
             )
 
             withEnvironment(environment) {
-                main()
+                main(args)
 
                 MockProvider.register { mockkClass(it) }
 

--- a/workers/analyzer/src/test/kotlin/AnalyzerPhaseTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerPhaseTest.kt
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.workers.analyzer
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.WordSpec
+
+import io.mockk.mockk
+
+class AnalyzerPhaseTest : WordSpec({
+    "FullPhase" should {
+        "throw if unexpected arguments are passed" {
+            val phase = FullPhase(
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk(),
+                mockk()
+            )
+
+            shouldThrow<IllegalArgumentException> {
+                phase.run(mockk(), 42L, arrayOf("not-expected"))
+            }
+        }
+    }
+})

--- a/workers/analyzer/src/test/kotlin/AnalyzerPhaseTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerPhaseTest.kt
@@ -21,6 +21,8 @@ package org.eclipse.apoapsis.ortserver.workers.analyzer
 
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.engine.spec.tempdir
+import io.kotest.matchers.string.shouldContain
 
 import io.mockk.mockk
 
@@ -38,6 +40,50 @@ class AnalyzerPhaseTest : WordSpec({
 
             shouldThrow<IllegalArgumentException> {
                 phase.run(mockk(), 42L, arrayOf("not-expected"))
+            }
+        }
+    }
+
+    "PreparationPhase" should {
+        "throw if no exchange dir parameter is provided" {
+            val phase = PreparationPhase(
+                mockk(),
+                mockk(),
+                mockk()
+            )
+
+            shouldThrow<IllegalArgumentException> {
+                phase.run(mockk(), 42L, emptyArray())
+            }
+        }
+
+        "throw if an exchange dir parameter pointing to a non-existing directory is provided" {
+            val nonExistingDir = "non-existing-directory"
+
+            val phase = PreparationPhase(
+                mockk(),
+                mockk(),
+                mockk()
+            )
+
+            val exception = shouldThrow<IllegalArgumentException> {
+                phase.run(mockk(), 42L, arrayOf(nonExistingDir))
+            }
+
+            exception.message shouldContain nonExistingDir
+        }
+
+        "throw if too many arguments are provided" {
+            val exchangeDir = tempdir()
+
+            val phase = PreparationPhase(
+                mockk(),
+                mockk(),
+                mockk()
+            )
+
+            shouldThrow<IllegalArgumentException> {
+                phase.run(mockk(), 42L, arrayOf(exchangeDir.absolutePath, "extra-arg"))
             }
         }
     }

--- a/workers/analyzer/src/test/kotlin/AnalyzerPhaseTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerPhaseTest.kt
@@ -87,4 +87,16 @@ class AnalyzerPhaseTest : WordSpec({
             }
         }
     }
+
+    "AnalysisPhase" should {
+        "throw if too many arguments are provided" {
+            val exchangeDir = tempdir()
+
+            val phase = AnalysisPhase()
+
+            shouldThrow<IllegalArgumentException> {
+                phase.run(mockk(), 42L, arrayOf(exchangeDir.absolutePath, "sync", "extra-arg"))
+            }
+        }
+    }
 })

--- a/workers/analyzer/src/test/kotlin/AnalyzerPhaseTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerPhaseTest.kt
@@ -99,4 +99,16 @@ class AnalyzerPhaseTest : WordSpec({
             }
         }
     }
+
+    "ResultPhase" should {
+        "throw if too many arguments are provided" {
+            val exchangeDir = tempdir()
+
+            val phase = ResultPhase(mockk(), mockk(), mockk(), mockk(), mockk())
+
+            shouldThrow<IllegalArgumentException> {
+                phase.run(mockk(), 42L, arrayOf(exchangeDir.absolutePath, "sync", "extra-arg"))
+            }
+        }
+    }
 })

--- a/workers/analyzer/src/test/kotlin/AnalyzerRunnerTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerRunnerTest.kt
@@ -25,7 +25,6 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.collections.containExactly
-import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.maps.beEmpty
 import io.kotest.matchers.maps.shouldContainAll
@@ -54,14 +53,10 @@ import java.time.Instant
 import org.eclipse.apoapsis.ortserver.model.AnalyzerJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.ProviderPluginConfiguration
 import org.eclipse.apoapsis.ortserver.model.ResolvableProviderPluginConfig
-import org.eclipse.apoapsis.ortserver.model.Secret
 import org.eclipse.apoapsis.ortserver.model.runs.PackageManagerConfiguration
 import org.eclipse.apoapsis.ortserver.services.ortrun.mapToOrt
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
 import org.eclipse.apoapsis.ortserver.workers.common.env.EnvironmentForkHelper
-import org.eclipse.apoapsis.ortserver.workers.common.env.config.ResolvedEnvironmentConfig
-import org.eclipse.apoapsis.ortserver.workers.common.env.definition.SecretVariableDefinition
-import org.eclipse.apoapsis.ortserver.workers.common.env.definition.SimpleVariableDefinition
 
 import org.ossreviewtoolkit.model.AnalyzerResult
 import org.ossreviewtoolkit.model.AnalyzerRun
@@ -134,10 +129,10 @@ class AnalyzerRunnerTest : WordSpec({
         context: WorkerContext = createWorkerContext(),
         inputDir: File = projectDir,
         config: AnalyzerRunnerConfig = testRunnerConfig,
-        environmentConfig: ResolvedEnvironmentConfig = ResolvedEnvironmentConfig(),
+        environment: Map<String, String> = emptyMap(),
         runner: AnalyzerRunner = AnalyzerRunner(ConfigFactory.empty())
     ): OrtResult =
-        runner.run(context, inputDir, config, environmentConfig)
+        runner.run(context, inputDir, config, environment)
 
     afterSpec {
         unmockkAll()
@@ -289,13 +284,9 @@ class AnalyzerRunnerTest : WordSpec({
             val exchangeDir = tempdir()
             val inputDir = File("some/folder/to/analyze")
 
-            val secret1 = mockk<Secret>()
-            val secret2 = mockk<Secret>()
-            val environmentConfig = ResolvedEnvironmentConfig(
-                environmentVariables = setOf(
-                    SecretVariableDefinition("MY_ENV_VAR", secret1),
-                    SecretVariableDefinition("ANOTHER_ENV_VAR", secret2)
-                )
+            val environmentVariables = mapOf(
+                "MY_ENV_VAR" to "someValue",
+                "ANOTHER_ENV_VAR" to "someSecretValue"
             )
 
             val context = createWorkerContext(tempDir = exchangeDir)
@@ -335,13 +326,13 @@ class AnalyzerRunnerTest : WordSpec({
 
             val runner = spyk(AnalyzerRunner(ConfigFactory.empty()))
             coEvery {
-                runner.createProcessBuilder(context, exchangeDir, inputDir, environmentConfig)
+                runner.createProcessBuilder(exchangeDir, inputDir, environmentVariables)
             } returns processBuilder
 
             val result = run(
                 context,
                 config = runnerConfig,
-                environmentConfig = environmentConfig,
+                environment = environmentVariables,
                 inputDir = inputDir,
                 runner = runner
             )
@@ -372,18 +363,16 @@ class AnalyzerRunnerTest : WordSpec({
 
             val runner = spyk(AnalyzerRunner(ConfigFactory.empty()))
             coEvery {
-                runner.createProcessBuilder(any(), any(), any(), any())
+                runner.createProcessBuilder(any(), any(), any())
             } returns processBuilder
 
-            val environmentConfig = ResolvedEnvironmentConfig(
-                environmentVariables = setOf(SecretVariableDefinition("MY_ENV_VAR", mockk()))
-            )
+            val environmentVariables = mapOf("MY_ENV_VAR" to "someValue")
 
             val forkError = "test.ForkException: Something went terribly wrong."
             exchangeDir.resolve("analyzer-error.txt").writeText(forkError)
 
             val exception = shouldThrow<IOException> {
-                run(context, inputDir = inputDir, environmentConfig = environmentConfig, runner = runner)
+                run(context, inputDir = inputDir, environment = environmentVariables, runner = runner)
             }
 
             exception.message shouldContain forkError
@@ -403,15 +392,13 @@ class AnalyzerRunnerTest : WordSpec({
 
             val runner = spyk(AnalyzerRunner(ConfigFactory.empty()))
             coEvery {
-                runner.createProcessBuilder(any(), any(), any(), any())
+                runner.createProcessBuilder(any(), any(), any())
             } returns processBuilder
 
-            val environmentConfig = ResolvedEnvironmentConfig(
-                environmentVariables = setOf(SecretVariableDefinition("MY_ENV_VAR", mockk()))
-            )
+            val environmentVariables = mapOf("MY_ENV_VAR" to "someValue")
 
             val exception = shouldThrow<IOException> {
-                run(context, inputDir = inputDir, environmentConfig = environmentConfig, runner = runner)
+                run(context, inputDir = inputDir, environment = environmentVariables, runner = runner)
             }
 
             exception.message shouldContain "The forked process died"
@@ -420,26 +407,12 @@ class AnalyzerRunnerTest : WordSpec({
 
     "createProcessBuilder" should {
         "create a process builder with the correct environment" {
-            val secret1 = mockk<Secret>()
-            val secret2 = mockk<Secret>()
-            val environmentConfig = ResolvedEnvironmentConfig(
-                environmentVariables = setOf(
-                    SecretVariableDefinition("MY_ENV_VAR", secret1),
-                    SecretVariableDefinition("ANOTHER_ENV_VAR", secret2),
-                    SimpleVariableDefinition("SIMPLE_ENV_VAR", "simpleValue"),
-                    SimpleVariableDefinition("ANOTHER_SIMPLE_ENV_VAR", "anotherSimpleValue")
-                )
+            val environmentVariables = mapOf(
+                "MY_ENV_VAR" to "secret1",
+                "ANOTHER_ENV_VAR" to "secret2",
+                "SIMPLE_ENV_VAR" to "simpleValue",
+                "ANOTHER_SIMPLE_ENV_VAR" to "anotherSimpleValue"
             )
-
-            val secretsToResolve = mutableListOf<Secret>()
-            val context = mockk<WorkerContext> {
-                coEvery { resolveSecrets(*varargAll { secretsToResolve.add(it) }) } answers {
-                    mapOf(
-                        secret1 to "mySecret",
-                        secret2 to "anotherSecret"
-                    )
-                }
-            }
 
             val exchangeDir = File("exchangeDir")
             val inputDir = File("inputDir")
@@ -451,16 +424,9 @@ class AnalyzerRunnerTest : WordSpec({
                         "${exchangeDir.absolutePath} ${inputDir.absolutePath}"
             )
             val runner = AnalyzerRunner(ConfigFactory.empty())
-            val processBuilder = runner.createProcessBuilder(context, exchangeDir, inputDir, environmentConfig)
+            val processBuilder = runner.createProcessBuilder(exchangeDir, inputDir, environmentVariables)
 
-            secretsToResolve should containExactlyInAnyOrder(secret1, secret2)
-
-            processBuilder.environment() shouldContainAll mapOf(
-                "MY_ENV_VAR" to "mySecret",
-                "ANOTHER_ENV_VAR" to "anotherSecret",
-                "SIMPLE_ENV_VAR" to "simpleValue",
-                "ANOTHER_SIMPLE_ENV_VAR" to "anotherSimpleValue"
-            )
+            processBuilder.environment() shouldContainAll environmentVariables
 
             processBuilder.command() shouldContainExactly expectedCommands
         }
@@ -471,10 +437,6 @@ class AnalyzerRunnerTest : WordSpec({
                 "analyzer.forkCommandSeparator" to "*"
             )
             val config = ConfigFactory.parseMap(configMap)
-
-            val context = mockk<WorkerContext> {
-                coEvery { resolveSecrets(*anyVararg()) } returns emptyMap()
-            }
 
             val exchangeDir = File("exchangeDir")
             val inputDir = File("inputDir")
@@ -488,8 +450,7 @@ class AnalyzerRunnerTest : WordSpec({
             )
 
             val runner = AnalyzerRunner(config)
-            val processBuilder =
-                runner.createProcessBuilder(context, exchangeDir, inputDir, ResolvedEnvironmentConfig())
+            val processBuilder = runner.createProcessBuilder(exchangeDir, inputDir, emptyMap())
 
             processBuilder.command() shouldContainExactly expectedCommands
         }

--- a/workers/analyzer/src/test/kotlin/AnalyzerRunnerTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerRunnerTest.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.workers.analyzer
 import com.typesafe.config.ConfigFactory
 
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.TestConfiguration
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.collections.containExactly
@@ -39,6 +40,7 @@ import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkObject
+import io.mockk.mockkStatic
 import io.mockk.runs
 import io.mockk.spyk
 import io.mockk.unmockkAll
@@ -52,10 +54,8 @@ import java.time.Instant
 
 import org.eclipse.apoapsis.ortserver.model.AnalyzerJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.ProviderPluginConfiguration
-import org.eclipse.apoapsis.ortserver.model.ResolvableProviderPluginConfig
 import org.eclipse.apoapsis.ortserver.model.runs.PackageManagerConfiguration
 import org.eclipse.apoapsis.ortserver.services.ortrun.mapToOrt
-import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
 import org.eclipse.apoapsis.ortserver.workers.common.env.EnvironmentForkHelper
 
 import org.ossreviewtoolkit.model.AnalyzerResult
@@ -92,6 +92,7 @@ import org.ossreviewtoolkit.model.config.VulnerabilityResolution
 import org.ossreviewtoolkit.model.config.VulnerabilityResolutionReason
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.writeValue
+import org.ossreviewtoolkit.utils.common.safeDeleteRecursively
 import org.ossreviewtoolkit.utils.common.safeMkdirs
 import org.ossreviewtoolkit.utils.ort.Environment
 import org.ossreviewtoolkit.utils.ort.createOrtTempDir
@@ -115,24 +116,13 @@ private val testRunnerConfig = AnalyzerRunnerConfig(
 )
 
 class AnalyzerRunnerTest : WordSpec({
-    fun createWorkerContext(
-        providerPluginConfigs: List<ResolvableProviderPluginConfig> = emptyList(),
-        resolvedProviderPluginConfigs: List<ProviderPluginConfiguration> = emptyList(),
-        tempDir: File = tempdir()
-    ): WorkerContext =
-        mockk {
-            every { createTempDir() } returns tempDir
-            coEvery { resolveProviderPluginConfigSecrets(providerPluginConfigs) } returns resolvedProviderPluginConfigs
-        }
-
     suspend fun run(
-        context: WorkerContext = createWorkerContext(),
         inputDir: File = projectDir,
         config: AnalyzerRunnerConfig = testRunnerConfig,
         environment: Map<String, String> = emptyMap(),
         runner: AnalyzerRunner = AnalyzerRunner(ConfigFactory.empty())
     ): OrtResult =
-        runner.run(context, inputDir, config, environment)
+        runner.run(inputDir, config, environment)
 
     afterSpec {
         unmockkAll()
@@ -281,15 +271,13 @@ class AnalyzerRunnerTest : WordSpec({
         }
 
         "start a forked process if custom environment variables are provided" {
-            val exchangeDir = tempdir()
+            val exchangeDir = mockTempDir()
             val inputDir = File("some/folder/to/analyze")
 
             val environmentVariables = mapOf(
                 "MY_ENV_VAR" to "someValue",
                 "ANOTHER_ENV_VAR" to "someSecretValue"
             )
-
-            val context = createWorkerContext(tempDir = exchangeDir)
 
             val processStream = mockk<OutputStream> {
                 every { close() } just runs
@@ -328,9 +316,9 @@ class AnalyzerRunnerTest : WordSpec({
             coEvery {
                 runner.createProcessBuilder(exchangeDir, inputDir, environmentVariables)
             } returns processBuilder
+            every { runner.createOrtTempDir() } returns exchangeDir
 
             val result = run(
-                context,
                 config = runnerConfig,
                 environment = environmentVariables,
                 inputDir = inputDir,
@@ -346,14 +334,13 @@ class AnalyzerRunnerTest : WordSpec({
                 process.waitFor()
                 EnvironmentForkHelper.prepareFork(processStream)
                 processStream.close()
+                exchangeDir.safeDeleteRecursively()
             }
         }
 
         "handle errors from the forked process" {
-            val exchangeDir = tempdir()
+            val exchangeDir = mockTempDir()
             val inputDir = File("analyze/this/folder")
-
-            val context = createWorkerContext(tempDir = exchangeDir)
 
             val process = createProcessMock()
             val processBuilder = mockk<ProcessBuilder> {
@@ -365,6 +352,7 @@ class AnalyzerRunnerTest : WordSpec({
             coEvery {
                 runner.createProcessBuilder(any(), any(), any())
             } returns processBuilder
+            every { runner.createOrtTempDir() } returns exchangeDir
 
             val environmentVariables = mapOf("MY_ENV_VAR" to "someValue")
 
@@ -372,17 +360,14 @@ class AnalyzerRunnerTest : WordSpec({
             exchangeDir.resolve("analyzer-error.txt").writeText(forkError)
 
             val exception = shouldThrow<IOException> {
-                run(context, inputDir = inputDir, environment = environmentVariables, runner = runner)
+                run(inputDir = inputDir, environment = environmentVariables, runner = runner)
             }
 
             exception.message shouldContain forkError
         }
 
         "handle errors from the forked process when the error file does not exist" {
-            val exchangeDir = tempdir()
             val inputDir = File("analyze/this/folder")
-
-            val context = createWorkerContext(tempDir = exchangeDir)
 
             val process = createProcessMock()
             val processBuilder = mockk<ProcessBuilder> {
@@ -398,7 +383,7 @@ class AnalyzerRunnerTest : WordSpec({
             val environmentVariables = mapOf("MY_ENV_VAR" to "someValue")
 
             val exception = shouldThrow<IOException> {
-                run(context, inputDir = inputDir, environment = environmentVariables, runner = runner)
+                run(inputDir = inputDir, environment = environmentVariables, runner = runner)
             }
 
             exception.message shouldContain "The forked process died"
@@ -534,3 +519,17 @@ private fun createProcessMock(pipeStream: OutputStream = ByteArrayOutputStream()
         every { waitFor() } returns 0
         every { outputStream } returns pipeStream
     }
+
+/**
+ * Create a temporary directory and prevent that it gets deleted. This is a bit tricky: AnalyzerRunner creates a
+ * temporary directory for the communication with the forked Java process. The directory is then deleted afterward.
+ * The test needs to inspect the files written into this directory. Therefore, a known directory needs to be injected,
+ * and its deletion needs to be prevented.
+ */
+fun TestConfiguration.mockTempDir(): File {
+    mockkStatic(File::safeDeleteRecursively, Any::createOrtTempDir)
+    val dir = tempdir()
+    every { dir.safeDeleteRecursively() } just runs
+
+    return dir
+}

--- a/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
@@ -71,12 +71,14 @@ import org.eclipse.apoapsis.ortserver.model.Secret
 import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.AppliedPackageCurationRef
 import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.ResolvedItemsResult
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
+import org.eclipse.apoapsis.ortserver.model.runs.PackageManagerConfiguration
 import org.eclipse.apoapsis.ortserver.services.ortrun.OrtRunService
 import org.eclipse.apoapsis.ortserver.shared.orttestdata.OrtTestData
 import org.eclipse.apoapsis.ortserver.shared.orttestdata.OrtTestData.TIME_STAMP_SECONDS
 import org.eclipse.apoapsis.ortserver.workers.common.RunResult
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContextFactory
+import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerOrtConfig
 import org.eclipse.apoapsis.ortserver.workers.common.env.EnvironmentForkHelper
 import org.eclipse.apoapsis.ortserver.workers.common.env.EnvironmentService
 import org.eclipse.apoapsis.ortserver.workers.common.env.config.ResolvedEnvironmentConfig
@@ -85,12 +87,15 @@ import org.eclipse.apoapsis.ortserver.workers.common.env.definition.SimpleVariab
 
 import org.ossreviewtoolkit.model.Identifier as OrtIdentifier
 import org.ossreviewtoolkit.model.Issue
+import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.ResolvedPackageCurations
 import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.config.IssueResolution
 import org.ossreviewtoolkit.model.config.IssueResolutionReason
 import org.ossreviewtoolkit.model.config.Resolutions
 import org.ossreviewtoolkit.model.readValue
+import org.ossreviewtoolkit.model.writeValue
+import org.ossreviewtoolkit.utils.common.Os
 
 private const val JOB_ID = 1L
 private const val TRACE_ID = "42"
@@ -1259,6 +1264,127 @@ class AnalyzerWorkerTest : StringSpec({
             runnerConfig.enabledPackageManagers shouldContainExactlyInAnyOrder listOf("Maven")
 
             runId shouldBe ortRun.id
+        }
+    }
+
+    "The analysis phase should be executed" {
+        val exchangeDir = tempdir()
+        val jobDir = exchangeDir.resolve("$JOB_DIR_PREFIX${analyzerJob.id}")
+        val cloneDir = jobDir.resolve("analyzer-worker-${ortRun.id}-download").apply { mkdirs() }
+        val prepareResult = PrepareResult(
+            cloneDirectory = cloneDir,
+            resolvedEnvironment = mapOf("SOME_VARIABLE" to "someValue"),
+            runnerConfig = AnalyzerRunnerConfig(
+                allowDynamicVersions = true,
+                skipExcluded = false,
+                enabledPackageManagers = listOf("Maven"),
+                disabledPackageManagers = listOf("Gradle"),
+                packageManagerOptions = mapOf(
+                    "Maven" to PackageManagerConfiguration(
+                        options = mapOf("someOption" to "someValue")
+                    )
+                ),
+                packageCurationProviders = listOf(
+                    ProviderPluginConfiguration(
+                        type = "test-provider",
+                        options = mapOf("option1" to "value1", "option2" to "value2"),
+                        secrets = mapOf("password" to "secret-password")
+                    )
+            ),
+                repositoryConfigPath = "test/path"
+            )
+        )
+        val prepareExchange = PreparationExchange(
+            environment = prepareResult.resolvedEnvironment,
+            runnerConfig = prepareResult.runnerConfig,
+            runId = ortRun.id
+        )
+        val prepareFile = jobDir.resolve(PREPARATION_EXCHANGE_FILE)
+        prepareFile.writeValue(prepareExchange)
+
+        val userHomeDir = tempdir()
+        val configDir = jobDir.resolve(CONFIG_DIR)
+        val subConfigDir = configDir.resolve("sub-config").apply { mkdirs() }
+        configDir.resolve("settings.xml").writeText("Maven configuration")
+        subConfigDir.resolve("test.conf").writeText("Test configuration")
+
+        val ortResult = OrtTestData.result.copy(scanner = null, advisor = null)
+        val runner = mockk<AnalyzerRunner> {
+            coEvery {
+                run(prepareResult.cloneDirectory, prepareResult.runnerConfig, prepareResult.resolvedEnvironment)
+            } answers {
+                Os.userHomeDirectory.resolve("settings.xml").readText() shouldBe "Maven configuration"
+                Os.userHomeDirectory.resolve("sub-config/test.conf").readText() shouldBe "Test configuration"
+                ortResult
+            }
+        }
+
+        mockkObject(EnvironmentForkHelper, Os, WorkerOrtConfig) {
+            val workerOrtConfig = mockk<WorkerOrtConfig> {
+                every { setUpOrtEnvironment() } just runs
+            }
+            every { WorkerOrtConfig.create() } returns workerOrtConfig
+            every { EnvironmentForkHelper.setupAuthentication(any(), any()) } just runs
+            every { Os.userHomeDirectory } returns userHomeDir
+
+            val worker = AnalyzerWorker(mockk(), runner)
+            worker.testRun(AnalysisPhase(), arrayOf(exchangeDir.absolutePath)) shouldBe RunResult.Ignored
+
+            val analysisResult: OrtResult = jobDir.resolve(ORT_RESULT_FILE).readValue()
+            analysisResult shouldBe ortResult
+
+            verify {
+                EnvironmentForkHelper.setupAuthentication(jobDir.resolve(AUTH_INFO_FILE), any())
+                workerOrtConfig.setUpOrtEnvironment()
+            }
+        }
+    }
+
+    "The analysis phase should write a sync file when it is done" {
+        val exchangeDir = tempdir()
+        val jobDir = exchangeDir.resolve("$JOB_DIR_PREFIX${analyzerJob.id}")
+        val downloadDir = jobDir.resolve("analyzer-worker-${ortRun.id}-download")
+        downloadDir.mkdirs()
+        val syncFile = exchangeDir.resolve("some/sync/i-am-done.sync")
+        val prepareResult = PrepareResult(
+            cloneDirectory = tempdir(),
+            resolvedEnvironment = emptyMap(),
+            runnerConfig = AnalyzerRunnerConfig(
+                allowDynamicVersions = true,
+                skipExcluded = false,
+                enabledPackageManagers = null,
+                disabledPackageManagers = null,
+                packageManagerOptions = null,
+                packageCurationProviders = emptyList(),
+                repositoryConfigPath = null
+            )
+        )
+        val prepareExchange = PreparationExchange(
+            environment = prepareResult.resolvedEnvironment,
+            runnerConfig = prepareResult.runnerConfig,
+            runId = ortRun.id
+        )
+        val prepareFile = jobDir.resolve(PREPARATION_EXCHANGE_FILE)
+        prepareFile.writeValue(prepareExchange)
+        jobDir.resolve(CONFIG_DIR).mkdirs() // Config directory must exist.
+
+        val ortResult = OrtTestData.result.copy(scanner = null, advisor = null)
+        val runner = mockk<AnalyzerRunner> {
+            coEvery { run(any(), any(), any()) } returns ortResult
+        }
+
+        mockkObject(EnvironmentForkHelper, WorkerOrtConfig) {
+            every { WorkerOrtConfig.create() } returns mockk(relaxed = true)
+            every { EnvironmentForkHelper.setupAuthentication(any(), any()) } just runs
+
+            val worker = AnalyzerWorker(mockk(), runner)
+            val result = worker.testRun(
+                AnalysisPhase(),
+                arrayOf(exchangeDir.absolutePath, syncFile.absolutePath)
+            )
+            result shouldBe RunResult.Ignored
+
+            syncFile.isFile shouldBe true
         }
     }
 })

--- a/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
@@ -137,9 +137,10 @@ private val analyzerJob = AnalyzerJob(
 )
 
 /**
- * Helper function to invoke this worker with test parameters.
+ * Helper function to invoke this worker with the given [phase] and test parameters.
  */
-private suspend fun AnalyzerWorker.testRun(): RunResult = run(JOB_ID, TRACE_ID)
+private suspend fun AnalyzerWorker.testRun(phase: AnalyzerPhase): RunResult =
+    run(JOB_ID, TRACE_ID, phase, emptyArray())
 
 @Suppress("LargeClass")
 class AnalyzerWorkerTest : StringSpec({
@@ -177,19 +178,18 @@ class AnalyzerWorkerTest : StringSpec({
             } returns ResolvedEnvironmentConfig()
         }
 
-        val worker = AnalyzerWorker(
+        val phase = FullPhase(
             mockk(),
-            downloader,
-            AnalyzerRunner(ConfigFactory.empty()),
             ortRunService,
             contextFactory,
             envService,
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
+        val worker = AnalyzerWorker(downloader, AnalyzerRunner(ConfigFactory.empty()))
 
         mockkTransaction {
-            val result = worker.testRun()
+            val result = worker.testRun(phase)
 
             result shouldBe RunResult.Success
 
@@ -237,19 +237,18 @@ class AnalyzerWorkerTest : StringSpec({
             coEvery { setUpEnvironment(context, projectDir, null, emptyList()) } returns ResolvedEnvironmentConfig()
         }
 
-        val worker = AnalyzerWorker(
+        val phase = FullPhase(
             mockk(),
-            downloader,
-            AnalyzerRunner(ConfigFactory.empty()),
             ortRunService,
             contextFactory,
             envService,
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
+        val worker = AnalyzerWorker(downloader, AnalyzerRunner(ConfigFactory.empty()))
 
         mockkTransaction {
-            val result = worker.testRun()
+            val result = worker.testRun(phase)
 
             result shouldBe RunResult.Success
 
@@ -301,19 +300,18 @@ class AnalyzerWorkerTest : StringSpec({
             } returns ResolvedEnvironmentConfig()
         }
 
-        val worker = AnalyzerWorker(
+        val phase = FullPhase(
             mockk(),
-            downloader,
-            AnalyzerRunner(ConfigFactory.empty()),
             ortRunService,
             contextFactory,
             envService,
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
+        val worker = AnalyzerWorker(downloader, AnalyzerRunner(ConfigFactory.empty()))
 
         mockkTransaction {
-            val result = worker.testRun()
+            val result = worker.testRun(phase)
 
             result shouldBe RunResult.Success
 
@@ -375,19 +373,18 @@ class AnalyzerWorkerTest : StringSpec({
             coEvery { run(context, any(), runnerConfig, emptyMap()) } throws testException
         }
 
-        val worker = AnalyzerWorker(
+        val phase = FullPhase(
             mockk(),
-            downloader,
-            runner,
             ortRunService,
             contextFactory,
             envService,
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
+        val worker = AnalyzerWorker(downloader, runner)
 
         mockkTransaction {
-            when (val result = worker.testRun()) {
+            when (val result = worker.testRun(phase)) {
                 is RunResult.Failed -> result.error shouldBe testException
                 else -> AssertionErrorBuilder.fail("Unexpected result: $result")
             }
@@ -435,19 +432,18 @@ class AnalyzerWorkerTest : StringSpec({
             } throws testException
         }
 
-        val worker = AnalyzerWorker(
+        val phase = FullPhase(
             mockk(),
-            downloader,
-            runner,
             ortRunService,
             contextFactory,
             envService,
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
+        val worker = AnalyzerWorker(downloader, runner)
 
         mockkTransaction {
-            when (val result = worker.testRun()) {
+            when (val result = worker.testRun(phase)) {
                 is RunResult.Failed -> result.error shouldBe testException
                 else -> AssertionErrorBuilder.fail("Unexpected result: $result")
             }
@@ -526,19 +522,18 @@ class AnalyzerWorkerTest : StringSpec({
             coEvery { run(context, any(), runnerConfig, expectedEnvironmentVariables) } throws testException
         }
 
-        val worker = AnalyzerWorker(
+        val phase = FullPhase(
             mockk(),
-            downloader,
-            runner,
             ortRunService,
             contextFactory,
             envService,
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
+        val worker = AnalyzerWorker(downloader, runner)
 
         mockkTransaction {
-            when (val result = worker.testRun()) {
+            when (val result = worker.testRun(phase)) {
                 is RunResult.Failed -> result.error shouldBe testException
                 else -> AssertionErrorBuilder.fail("Unexpected result: $result")
             }
@@ -553,19 +548,18 @@ class AnalyzerWorkerTest : StringSpec({
             every { getAnalyzerJob(any()) } throws testException
         }
 
-        val worker = AnalyzerWorker(
+        val phase = FullPhase(
             mockk(),
-            mockk(),
-            AnalyzerRunner(ConfigFactory.empty()),
             ortRunService,
             mockk(),
             mockk(),
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
+        val worker = AnalyzerWorker(mockk(), AnalyzerRunner(ConfigFactory.empty()))
 
         mockkTransaction {
-            when (val result = worker.testRun()) {
+            when (val result = worker.testRun(phase)) {
                 is RunResult.Failed -> result.error shouldBe testException
                 else -> AssertionErrorBuilder.fail("Unexpected result: $result")
             }
@@ -578,19 +572,18 @@ class AnalyzerWorkerTest : StringSpec({
             every { getAnalyzerJob(any()) } returns invalidJob
         }
 
-        val worker = AnalyzerWorker(
+        val phase = FullPhase(
             mockk(),
-            mockk(),
-            AnalyzerRunner(ConfigFactory.empty()),
             ortRunService,
             mockk(),
             mockk(),
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
+        val worker = AnalyzerWorker(mockk(), AnalyzerRunner(ConfigFactory.empty()))
 
         mockkTransaction {
-            val result = worker.testRun()
+            val result = worker.testRun(phase)
 
             result shouldBe RunResult.Ignored
         }
@@ -674,19 +667,18 @@ class AnalyzerWorkerTest : StringSpec({
             coEvery { run(any(), any(), any(), any()) } answers { ortResult }
         }
 
-        val worker = AnalyzerWorker(
+        val phase = FullPhase(
             mockk(),
-            downloader,
-            runnerMock,
             ortRunService,
             contextFactory,
             envService,
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
+        val worker = AnalyzerWorker(downloader, runnerMock)
 
         mockkTransaction {
-            val result = worker.testRun()
+            val result = worker.testRun(phase)
 
             result shouldBe RunResult.Success
 
@@ -762,19 +754,18 @@ class AnalyzerWorkerTest : StringSpec({
             coEvery { run(any(), any(), any(), any()) } answers { ortResult }
         }
 
-        val worker = AnalyzerWorker(
+        val phase = FullPhase(
             mockk(),
-            downloader,
-            runnerMock,
             ortRunService,
             contextFactory,
             envService,
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
+        val worker = AnalyzerWorker(downloader, runnerMock)
 
         mockkTransaction {
-            val result = worker.testRun()
+            val result = worker.testRun(phase)
 
             result shouldBe RunResult.FinishedWithIssues
             resolvedItemsSlot.captured.issues should beEmpty()
@@ -815,19 +806,18 @@ class AnalyzerWorkerTest : StringSpec({
             coEvery { run(any(), any(), any(), any()) } returns OrtTestData.result
         }
 
-        val worker = AnalyzerWorker(
+        val phase = FullPhase(
             mockk(),
-            downloader,
-            runnerMock,
             ortRunService,
             contextFactory,
             envService,
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
+        val worker = AnalyzerWorker(downloader, runnerMock)
 
         mockkTransaction {
-            val result = worker.testRun()
+            val result = worker.testRun(phase)
 
             result shouldBe RunResult.Success
 
@@ -882,19 +872,18 @@ class AnalyzerWorkerTest : StringSpec({
             coEvery { run(any(), any(), any(), any()) } returns ortResultWithoutCurations
         }
 
-        val worker = AnalyzerWorker(
+        val phase = FullPhase(
             mockk(),
-            downloader,
-            runnerMock,
             ortRunService,
             contextFactory,
             envService,
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
+        val worker = AnalyzerWorker(downloader, runnerMock)
 
         mockkTransaction {
-            val result = worker.testRun()
+            val result = worker.testRun(phase)
 
             result shouldBe RunResult.Success
 
@@ -948,19 +937,18 @@ class AnalyzerWorkerTest : StringSpec({
             coEvery { run(any(), any(), any(), any()) } returns ortResultWithExcludedProject
         }
 
-        val worker = AnalyzerWorker(
+        val phase = FullPhase(
             mockk(),
-            downloader,
-            runnerMock,
             ortRunService,
             contextFactory,
             envService,
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
+        val worker = AnalyzerWorker(downloader, runnerMock)
 
         mockkTransaction {
-            val result = worker.testRun()
+            val result = worker.testRun(phase)
 
             result shouldBe RunResult.Success
 
@@ -1011,19 +999,18 @@ class AnalyzerWorkerTest : StringSpec({
             }
         }
 
-        val worker = AnalyzerWorker(
+        val phase = FullPhase(
             mockk(),
-            downloader,
-            runnerMock,
             ortRunService,
             contextFactory,
             envService,
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
+        val worker = AnalyzerWorker(downloader, runnerMock)
 
         mockkTransaction {
-            val result = worker.testRun()
+            val result = worker.testRun(phase)
 
             result shouldBe RunResult.FinishedWithIssues
         }
@@ -1087,19 +1074,18 @@ class AnalyzerWorkerTest : StringSpec({
             }
         }
 
-        val worker = AnalyzerWorker(
+        val phase = FullPhase(
             mockk(),
-            downloader,
-            runnerMock,
             ortRunService,
             contextFactory,
             envService,
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
+        val worker = AnalyzerWorker(downloader, runnerMock)
 
         mockkTransaction {
-            val result = worker.testRun()
+            val result = worker.testRun(phase)
 
             result shouldBe RunResult.Success
         }
@@ -1141,19 +1127,18 @@ class AnalyzerWorkerTest : StringSpec({
             }
         }
 
-        val worker = AnalyzerWorker(
+        val phase = FullPhase(
             mockk(),
-            downloader,
-            runnerMock,
             ortRunService,
             contextFactory,
             envService,
             mockk(relaxed = true),
             mockIssueResolutionService()
         )
+        val worker = AnalyzerWorker(downloader, runnerMock)
 
         mockkTransaction {
-            val result = worker.testRun()
+            val result = worker.testRun(phase)
 
             result shouldBe RunResult.Success
         }

--- a/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
@@ -25,7 +25,9 @@ import com.typesafe.config.ConfigFactory
 
 import io.kotest.assertions.AssertionErrorBuilder
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.maps.beEmpty
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -36,6 +38,7 @@ import io.mockk.coVerifyOrder
 import io.mockk.every
 import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkObject
 import io.mockk.runs
 import io.mockk.slot
 import io.mockk.spyk
@@ -43,6 +46,7 @@ import io.mockk.verify
 
 import java.io.ByteArrayInputStream
 import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
 
 import kotlin.time.Clock
 import kotlin.time.Instant
@@ -73,6 +77,7 @@ import org.eclipse.apoapsis.ortserver.shared.orttestdata.OrtTestData.TIME_STAMP_
 import org.eclipse.apoapsis.ortserver.workers.common.RunResult
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContextFactory
+import org.eclipse.apoapsis.ortserver.workers.common.env.EnvironmentForkHelper
 import org.eclipse.apoapsis.ortserver.workers.common.env.EnvironmentService
 import org.eclipse.apoapsis.ortserver.workers.common.env.config.ResolvedEnvironmentConfig
 import org.eclipse.apoapsis.ortserver.workers.common.env.definition.SecretVariableDefinition
@@ -85,6 +90,7 @@ import org.ossreviewtoolkit.model.Severity
 import org.ossreviewtoolkit.model.config.IssueResolution
 import org.ossreviewtoolkit.model.config.IssueResolutionReason
 import org.ossreviewtoolkit.model.config.Resolutions
+import org.ossreviewtoolkit.model.readValue
 
 private const val JOB_ID = 1L
 private const val TRACE_ID = "42"
@@ -102,7 +108,7 @@ private val repository = Repository(
 private val hierarchy = Hierarchy(repository, mockk(), mockk())
 
 private val ortRun = OrtRun(
-    id = 1L,
+    id = 12L,
     index = 1L,
     organizationId = 1L,
     productId = 1L,
@@ -127,7 +133,7 @@ private val ortRun = OrtRun(
 
 private val analyzerJob = AnalyzerJob(
     id = JOB_ID,
-    ortRunId = 12,
+    ortRunId = ortRun.id,
     createdAt = Clock.System.now(),
     startedAt = Clock.System.now(),
     finishedAt = null,
@@ -137,10 +143,10 @@ private val analyzerJob = AnalyzerJob(
 )
 
 /**
- * Helper function to invoke this worker with the given [phase] and test parameters.
+ * Helper function to invoke this worker with the given [phase], [args] and further test parameters.
  */
-private suspend fun AnalyzerWorker.testRun(phase: AnalyzerPhase): RunResult =
-    run(JOB_ID, TRACE_ID, phase, emptyArray())
+private suspend fun AnalyzerWorker.testRun(phase: AnalyzerPhase, args: Array<String> = emptyArray()): RunResult =
+    run(JOB_ID, TRACE_ID, phase, args)
 
 @Suppress("LargeClass")
 class AnalyzerWorkerTest : StringSpec({
@@ -1143,16 +1149,136 @@ class AnalyzerWorkerTest : StringSpec({
             result shouldBe RunResult.Success
         }
     }
+
+    "The preparation phase should be executed" {
+        val exchangeDir = tempdir()
+        val jobDir = exchangeDir.resolve("$JOB_DIR_PREFIX${analyzerJob.id}")
+
+        val jobConfig = AnalyzerJobConfiguration(
+            enabledPackageManagers = listOf("Maven"),
+            packageCurationProviders = listOf(mockk())
+        )
+        val job = analyzerJob.copy(configuration = jobConfig)
+
+        val ortRunService = mockk<OrtRunService> {
+            every { getAnalyzerJob(any()) } returns job
+            every { getHierarchyForOrtRun(any()) } returns hierarchy
+            every { getOrtRun(any()) } returns ortRun
+            every { startAnalyzerJob(any()) } returns job
+            every { updateResolvedRevision(any(), any()) } just runs
+        }
+
+        val downloader = mockk<AnalyzerDownloader> {
+            every {
+                downloadRepository(any(), any(), runId = ortRun.id, targetDir = jobDir)
+            } returns
+                    DownloadResult(projectDir, "main", "resolvedRevision")
+        }
+
+        val pluginConfigs = listOf(
+            ProviderPluginConfiguration(
+                type = "test-provider",
+                options = mapOf("option1" to "value1", "option2" to "value2"),
+                secrets = mapOf("password" to "secret-password")
+            )
+        )
+
+        val context = mockWorkerContext {
+            coEvery { resolveProviderPluginConfigSecrets(jobConfig.packageCurationProviders) } returns pluginConfigs
+        }
+
+        val refContextOpen = AtomicBoolean()
+        val contextFactory = mockContextFactory(context, refContextOpen)
+
+        val infrastructureServices = listOf<InfrastructureService>(mockk(relaxed = true), mockk(relaxed = true))
+        val envService = mockk<EnvironmentService> {
+            coEvery { findInfrastructureServicesForRepository(context, null) } returns infrastructureServices
+            coEvery { setupAuthentication(context, infrastructureServices) } just runs
+            coEvery {
+                setUpEnvironment(context, projectDir, null, infrastructureServices, any())
+            } returns ResolvedEnvironmentConfig(
+                environmentVariables = setOf(
+                    SimpleVariableDefinition("SIMPLE_ENV_VAR", "simpleValue")
+                )
+            )
+        }
+
+        mockkObject(EnvironmentForkHelper) {
+            every { EnvironmentForkHelper.persistAuthenticationInfo(any()) } answers {
+                refContextOpen.get() shouldBe true
+            }
+
+            val phase = PreparationPhase(
+                ortRunService,
+                contextFactory,
+                envService
+            )
+            val runner = mockk<AnalyzerRunner>()
+            val worker = AnalyzerWorker(downloader, runner)
+
+            mockkTransaction {
+                val result = worker.testRun(phase, arrayOf(exchangeDir.absolutePath))
+
+                result shouldBe RunResult.Ignored
+
+                verify(exactly = 1) {
+                    ortRunService.updateResolvedRevision(ortRun.id, "resolvedRevision")
+
+                    EnvironmentForkHelper.persistAuthenticationInfo(jobDir.resolve(AUTH_INFO_FILE))
+                }
+
+                coVerifyOrder {
+                    envService.setupAuthentication(context, infrastructureServices)
+                    downloader.downloadRepository(
+                        repository.url,
+                        ortRun.revision,
+                        targetDir = jobDir,
+                        runId = ortRun.id
+                    )
+                    envService.setUpEnvironment(
+                        context,
+                        projectDir,
+                        null,
+                        infrastructureServices,
+                        jobDir.resolve(CONFIG_DIR)
+                    )
+                }
+
+                coVerify(exactly = 0) {
+                    runner.run(any(), any(), any(), any())
+                }
+            }
+        }
+
+        val exchangeFile = jobDir.resolve(PREPARATION_EXCHANGE_FILE)
+        val preparationExchange = exchangeFile.readValue<PreparationExchange>()
+
+        with(preparationExchange) {
+            environment shouldBe mapOf("SIMPLE_ENV_VAR" to "simpleValue")
+
+            runnerConfig.packageCurationProviders shouldContainExactlyInAnyOrder pluginConfigs
+            runnerConfig.enabledPackageManagers shouldContainExactlyInAnyOrder listOf("Maven")
+
+            runId shouldBe ortRun.id
+        }
+    }
 })
 
 /**
- * Create a mock [WorkerContextFactory] and prepare it to return the given [context].
+ * Create a mock [WorkerContextFactory] and prepare it to return the given [context]. Use the given [refContextOpen] to
+ * track when the context is open.
  */
-private fun mockContextFactory(context: WorkerContext = mockk()): WorkerContextFactory {
-    val slot = slot<suspend (WorkerContext) -> RunResult>()
+private fun mockContextFactory(
+    context: WorkerContext = mockk(),
+    refContextOpen: AtomicBoolean = AtomicBoolean()
+): WorkerContextFactory {
+    val slot = slot<suspend (WorkerContext) -> Any>()
     return mockk {
         coEvery { withContext(analyzerJob.ortRunId, capture(slot)) } coAnswers {
-            slot.captured(context)
+            refContextOpen.set(true)
+            slot.captured(context).also {
+                refContextOpen.set(false)
+            }
         }
     }
 }

--- a/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
@@ -71,8 +71,10 @@ import org.eclipse.apoapsis.ortserver.model.Secret
 import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.AppliedPackageCurationRef
 import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.ResolvedItemsResult
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
+import org.eclipse.apoapsis.ortserver.model.runs.Package
 import org.eclipse.apoapsis.ortserver.model.runs.PackageManagerConfiguration
 import org.eclipse.apoapsis.ortserver.services.ortrun.OrtRunService
+import org.eclipse.apoapsis.ortserver.services.ortrun.mapToModel
 import org.eclipse.apoapsis.ortserver.shared.orttestdata.OrtTestData
 import org.eclipse.apoapsis.ortserver.shared.orttestdata.OrtTestData.TIME_STAMP_SECONDS
 import org.eclipse.apoapsis.ortserver.workers.common.RunResult
@@ -1385,6 +1387,72 @@ class AnalyzerWorkerTest : StringSpec({
             result shouldBe RunResult.Ignored
 
             syncFile.isFile shouldBe true
+        }
+    }
+
+    "The result phase should be executed" {
+        val exchangeDir = tempdir()
+        val jobDir = exchangeDir.resolve("$JOB_DIR_PREFIX${analyzerJob.id}")
+
+        val ortRunService = mockk<OrtRunService> {
+            every { getAnalyzerJob(any()) } returns analyzerJob
+            every { getHierarchyForOrtRun(any()) } returns hierarchy
+            every { getOrtRun(any()) } returns ortRun
+            every { storeAnalyzerRun(any(), any()) } just runs
+            every { storeRepositoryInformation(any(), any()) } just runs
+            every { storeResolvedPackageCurations(any(), any()) } just runs
+            every { storePackageCurationAssociations(any(), any()) } just runs
+            every { storeResolvedItems(any(), any()) } just runs
+        }
+
+        val context = mockWorkerContext()
+        val contextFactory = mockContextFactory(context)
+
+        val analyzerIssue = Issue(
+            timestamp = Instant.fromEpochSeconds(TIME_STAMP_SECONDS).toJavaInstant(),
+            source = "analyzer",
+            message = "Analyzer issue",
+            severity = Severity.ERROR
+        )
+        val ortResult = OrtTestData.result.copy(
+            analyzer = OrtTestData.result.analyzer?.copy(
+                result = OrtTestData.result.analyzer?.result!!.copy(
+                    issues = mapOf(OrtIdentifier("Maven:com.example:package:1.0") to listOf(analyzerIssue))
+                )
+            )
+        )
+
+        jobDir.resolve(ORT_RESULT_FILE).writeValue(ortResult)
+
+        val phase = ResultPhase(
+            mockk(),
+            ortRunService,
+            contextFactory,
+            mockk(relaxed = true),
+            mockIssueResolutionService()
+        )
+        val worker = AnalyzerWorker(mockk(), mockk())
+
+        mockkTransaction {
+            val result = worker.testRun(phase, arrayOf(exchangeDir.absolutePath))
+
+            result shouldBe RunResult.FinishedWithIssues
+
+            verify(exactly = 1) {
+                ortRunService.storeAnalyzerRun(
+                    withArg {
+                        // There is no exact match because of different orders of elements in sets.
+                        val expectedAnalyzerRun = ortResult.analyzer?.mapToModel(JOB_ID)
+                        it.analyzerJobId shouldBe JOB_ID
+                        it.config shouldBe expectedAnalyzerRun?.config
+                        it.environment shouldBe expectedAnalyzerRun?.environment
+                        it.packages.map(Package::identifier) shouldBe
+                                expectedAnalyzerRun?.packages?.map(Package::identifier)
+                    },
+                    any()
+                )
+                ortRunService.storeRepositoryInformation(ortRun.id, OrtTestData.result.repository)
+            }
         }
     }
 })

--- a/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
@@ -376,7 +376,7 @@ class AnalyzerWorkerTest : StringSpec({
         val runnerConfig = runnerConfig(jobConfig, packageCurationProvidersConfigs)
         val testException = IllegalStateException("AnalyzerRunner test exception")
         val runner = mockk<AnalyzerRunner> {
-            coEvery { run(context, any(), runnerConfig, emptyMap()) } throws testException
+            coEvery { run(any(), runnerConfig, emptyMap()) } throws testException
         }
 
         val phase = FullPhase(
@@ -430,7 +430,6 @@ class AnalyzerWorkerTest : StringSpec({
         val runner = mockk<AnalyzerRunner> {
             coEvery {
                 run(
-                    context,
                     any(),
                     runnerConfig(analyzerJob.configuration),
                     emptyMap()
@@ -525,7 +524,7 @@ class AnalyzerWorkerTest : StringSpec({
         val runnerConfig = runnerConfig(jobConfig, packageCurationProvidersConfigs)
         val testException = IllegalStateException("AnalyzerRunner test exception")
         val runner = mockk<AnalyzerRunner> {
-            coEvery { run(context, any(), runnerConfig, expectedEnvironmentVariables) } throws testException
+            coEvery { run(any(), runnerConfig, expectedEnvironmentVariables) } throws testException
         }
 
         val phase = FullPhase(
@@ -670,7 +669,7 @@ class AnalyzerWorkerTest : StringSpec({
         )
 
         val runnerMock = spyk(AnalyzerRunner(ConfigFactory.empty())) {
-            coEvery { run(any(), any(), any(), any()) } answers { ortResult }
+            coEvery { run(any(), any(), any()) } answers { ortResult }
         }
 
         val phase = FullPhase(
@@ -757,7 +756,7 @@ class AnalyzerWorkerTest : StringSpec({
         )
 
         val runnerMock = spyk(AnalyzerRunner(ConfigFactory.empty())) {
-            coEvery { run(any(), any(), any(), any()) } answers { ortResult }
+            coEvery { run(any(), any(), any()) } answers { ortResult }
         }
 
         val phase = FullPhase(
@@ -809,7 +808,7 @@ class AnalyzerWorkerTest : StringSpec({
         }
 
         val runnerMock = spyk(AnalyzerRunner(ConfigFactory.empty())) {
-            coEvery { run(any(), any(), any(), any()) } returns OrtTestData.result
+            coEvery { run(any(), any(), any()) } returns OrtTestData.result
         }
 
         val phase = FullPhase(
@@ -875,7 +874,7 @@ class AnalyzerWorkerTest : StringSpec({
         )
 
         val runnerMock = spyk(AnalyzerRunner(ConfigFactory.empty())) {
-            coEvery { run(any(), any(), any(), any()) } returns ortResultWithoutCurations
+            coEvery { run(any(), any(), any()) } returns ortResultWithoutCurations
         }
 
         val phase = FullPhase(
@@ -940,7 +939,7 @@ class AnalyzerWorkerTest : StringSpec({
         )
 
         val runnerMock = spyk(AnalyzerRunner(ConfigFactory.empty())) {
-            coEvery { run(any(), any(), any(), any()) } returns ortResultWithExcludedProject
+            coEvery { run(any(), any(), any()) } returns ortResultWithExcludedProject
         }
 
         val phase = FullPhase(
@@ -994,7 +993,7 @@ class AnalyzerWorkerTest : StringSpec({
         }
 
         val runnerMock = spyk(AnalyzerRunner(ConfigFactory.empty())) {
-            coEvery { run(any(), any(), any(), any()) } answers {
+            coEvery { run(any(), any(), any()) } answers {
                 OrtTestData.result.copy(
                     repository = OrtTestData.result.repository.copy(
                         config = OrtTestData.result.repository.config.copy(
@@ -1053,7 +1052,7 @@ class AnalyzerWorkerTest : StringSpec({
         }
 
         val runnerMock = spyk(AnalyzerRunner(ConfigFactory.empty())) {
-            coEvery { run(any(), any(), any(), any()) } answers {
+            coEvery { run(any(), any(), any()) } answers {
                 OrtTestData.result.copy(
                     resolvedConfiguration = OrtTestData.result.resolvedConfiguration.copy(
                         resolutions = OrtTestData.result.resolvedConfiguration.resolutions?.copy(
@@ -1128,7 +1127,7 @@ class AnalyzerWorkerTest : StringSpec({
         }
 
         val runnerMock = spyk(AnalyzerRunner(ConfigFactory.empty())) {
-            coEvery { run(any(), any(), any(), any()) } answers {
+            coEvery { run(any(), any(), any()) } answers {
                 OrtTestData.result
             }
         }
@@ -1245,7 +1244,7 @@ class AnalyzerWorkerTest : StringSpec({
                 }
 
                 coVerify(exactly = 0) {
-                    runner.run(any(), any(), any(), any())
+                    runner.run(any(), any(), any())
                 }
             }
         }

--- a/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
@@ -25,6 +25,7 @@ import com.typesafe.config.ConfigFactory
 
 import io.kotest.assertions.AssertionErrorBuilder
 import io.kotest.core.spec.style.StringSpec
+import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.maps.beEmpty
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -62,6 +63,7 @@ import org.eclipse.apoapsis.ortserver.model.OrtRunStatus
 import org.eclipse.apoapsis.ortserver.model.ProviderPluginConfiguration
 import org.eclipse.apoapsis.ortserver.model.Repository
 import org.eclipse.apoapsis.ortserver.model.RepositoryType
+import org.eclipse.apoapsis.ortserver.model.Secret
 import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.AppliedPackageCurationRef
 import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.ResolvedItemsResult
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
@@ -73,6 +75,8 @@ import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContextFactory
 import org.eclipse.apoapsis.ortserver.workers.common.env.EnvironmentService
 import org.eclipse.apoapsis.ortserver.workers.common.env.config.ResolvedEnvironmentConfig
+import org.eclipse.apoapsis.ortserver.workers.common.env.definition.SecretVariableDefinition
+import org.eclipse.apoapsis.ortserver.workers.common.env.definition.SimpleVariableDefinition
 
 import org.ossreviewtoolkit.model.Identifier as OrtIdentifier
 import org.ossreviewtoolkit.model.Issue
@@ -359,7 +363,7 @@ class AnalyzerWorkerTest : StringSpec({
 
         val contextFactory = mockContextFactory(context)
 
-        val resolvedEnvConfig = mockk<ResolvedEnvironmentConfig>()
+        val resolvedEnvConfig = ResolvedEnvironmentConfig()
         val envService = mockk<EnvironmentService> {
             coEvery { findInfrastructureServicesForRepository(context, envConfig) } returns emptyList()
             coEvery { setUpEnvironment(context, projectDir, envConfig, emptyList()) } returns resolvedEnvConfig
@@ -368,7 +372,7 @@ class AnalyzerWorkerTest : StringSpec({
         val runnerConfig = runnerConfig(jobConfig, packageCurationProvidersConfigs)
         val testException = IllegalStateException("AnalyzerRunner test exception")
         val runner = mockk<AnalyzerRunner> {
-            coEvery { run(context, any(), runnerConfig, resolvedEnvConfig) } throws testException
+            coEvery { run(context, any(), runnerConfig, emptyMap()) } throws testException
         }
 
         val worker = AnalyzerWorker(
@@ -413,7 +417,7 @@ class AnalyzerWorkerTest : StringSpec({
 
         val contextFactory = mockContextFactory(context)
 
-        val resolvedEnvConfig = mockk<ResolvedEnvironmentConfig>()
+        val resolvedEnvConfig = ResolvedEnvironmentConfig()
         val envService = mockk<EnvironmentService> {
             coEvery { findInfrastructureServicesForRepository(context, any()) } returns emptyList()
             coEvery { setUpEnvironment(context, projectDir, null, emptyList()) } returns resolvedEnvConfig
@@ -426,7 +430,7 @@ class AnalyzerWorkerTest : StringSpec({
                     context,
                     any(),
                     runnerConfig(analyzerJob.configuration),
-                    resolvedEnvConfig
+                    emptyMap()
                 )
             } throws testException
         }
@@ -448,6 +452,99 @@ class AnalyzerWorkerTest : StringSpec({
                 else -> AssertionErrorBuilder.fail("Unexpected result: $result")
             }
         }
+    }
+
+    "AnalyzerRunner should be invoked correctly with resolved environment variables" {
+        val envConfig = mockk<EnvironmentConfig>()
+        val jobConfig = AnalyzerJobConfiguration(
+            environmentConfig = envConfig,
+            enabledPackageManagers = listOf("Maven"),
+            packageCurationProviders = listOf(mockk())
+        )
+        val job = analyzerJob.copy(configuration = jobConfig)
+
+        val ortRunService = mockk<OrtRunService> {
+            every { getAnalyzerJob(any()) } returns job
+            every { getHierarchyForOrtRun(any()) } returns hierarchy
+            every { getOrtRun(any()) } returns ortRun
+            every { startAnalyzerJob(any()) } returns job
+            every { storeAnalyzerRun(any(), any()) } just runs
+            every { storeRepositoryInformation(any(), any()) } just runs
+            every { storeResolvedPackageCurations(any(), any()) } just runs
+            every { storePackageCurationAssociations(any(), any()) } just runs
+            every { storeResolvedItems(any(), any()) } just runs
+            every { updateResolvedRevision(any(), any()) } just runs
+        }
+
+        val downloader = mockk<AnalyzerDownloader> {
+            every { downloadRepository(any(), any()) } returns
+                    DownloadResult(projectDir, "main", "resolvedRevision")
+        }
+
+        val secret1 = mockk<Secret>()
+        val secret2 = mockk<Secret>()
+        val resolvedEnvConfig = ResolvedEnvironmentConfig(
+            environmentVariables = setOf(
+                SecretVariableDefinition("MY_ENV_VAR", secret1),
+                SecretVariableDefinition("ANOTHER_ENV_VAR", secret2),
+                SimpleVariableDefinition("SIMPLE_ENV_VAR", "simpleValue"),
+                SimpleVariableDefinition("ANOTHER_SIMPLE_ENV_VAR", "anotherSimpleValue")
+            )
+        )
+        val expectedEnvironmentVariables = mapOf(
+            "MY_ENV_VAR" to "mySecret",
+            "ANOTHER_ENV_VAR" to "anotherSecret",
+            "SIMPLE_ENV_VAR" to "simpleValue",
+            "ANOTHER_SIMPLE_ENV_VAR" to "anotherSimpleValue"
+        )
+
+        val secretsToResolve = mutableListOf<Secret>()
+        val packageCurationProvidersConfigs = listOf(mockk<ProviderPluginConfiguration>())
+        val context = mockWorkerContext {
+            coEvery {
+                resolveProviderPluginConfigSecrets(jobConfig.packageCurationProviders)
+            } returns packageCurationProvidersConfigs
+
+            coEvery { resolveSecrets(*varargAll { secretsToResolve.add(it) }) } answers {
+                mapOf(
+                    secret1 to "mySecret",
+                    secret2 to "anotherSecret"
+                )
+            }
+        }
+
+        val contextFactory = mockContextFactory(context)
+
+        val envService = mockk<EnvironmentService> {
+            coEvery { findInfrastructureServicesForRepository(context, envConfig) } returns emptyList()
+            coEvery { setUpEnvironment(context, projectDir, envConfig, emptyList()) } returns resolvedEnvConfig
+        }
+
+        val runnerConfig = runnerConfig(jobConfig, packageCurationProvidersConfigs)
+        val testException = IllegalStateException("AnalyzerRunner test exception")
+        val runner = mockk<AnalyzerRunner> {
+            coEvery { run(context, any(), runnerConfig, expectedEnvironmentVariables) } throws testException
+        }
+
+        val worker = AnalyzerWorker(
+            mockk(),
+            downloader,
+            runner,
+            ortRunService,
+            contextFactory,
+            envService,
+            mockk(relaxed = true),
+            mockIssueResolutionService()
+        )
+
+        mockkTransaction {
+            when (val result = worker.testRun()) {
+                is RunResult.Failed -> result.error shouldBe testException
+                else -> AssertionErrorBuilder.fail("Unexpected result: $result")
+            }
+        }
+
+        secretsToResolve should containExactlyInAnyOrder(secret1, secret2)
     }
 
     "A failure result should be returned in case of an error" {


### PR DESCRIPTION
This PR implements the logic to optionally split the Analyzer into three phases: preparation, analysis, and result. The phase to execute is passed as command line argument to the endpoint. If no argument is provided, all phases are run - which is the same behavior as before. Refer to the single commits for further information.

This PR depends on https://github.com/eclipse-apoapsis/ort-server/pull/5431.