### PR TITLE
fix(ui): Use strict matching in multi-select filters

### DIFF
--- a/ui/src/components/data-table/filter-multi-select.tsx
+++ b/ui/src/components/data-table/filter-multi-select.tsx
@@ -81,6 +81,7 @@ export function FilterMultiSelect<TValue>({
     return (
       <CommandItem
         key={String(option.value)}
+        value={option.label}
         onSelect={() => {
           if (isSelected) {
             setSelected(selected.filter((value) => value !== option.value));
@@ -121,7 +122,26 @@ export function FilterMultiSelect<TValue>({
         </Button>
       </PopoverTrigger>
       <PopoverContent className='w-[200px] p-0' align={align}>
-        <Command>
+        <Command
+          filter={(value, search) => {
+            const normalizedValue = value.toLowerCase();
+            const normalizedSearch = search.trim().toLowerCase();
+
+            if (!normalizedValue.includes(normalizedSearch)) {
+              return 0;
+            }
+
+            if (normalizedValue === normalizedSearch) {
+              return 1;
+            }
+
+            if (normalizedValue.startsWith(normalizedSearch)) {
+              return 0.9;
+            }
+
+            return 0.8;
+          }}
+        >
           {options.length > 5 && <CommandInput placeholder={title} />}
           <CommandList>
             <CommandEmpty>No results found.</CommandEmpty>


### PR DESCRIPTION
Match multi-select filter options by their label with strict substring matching instead of cmdk's default fuzzy matching. This avoids unrelated license options showing up for searches.

Keep exact and prefix matches ranked higher than other substring matches so the most relevant options stay at the top of the filtered list.

Resolves #5467.