### PR TITLE
ci(check-issue-links): Use the API to get the PR's commit messages

### DIFF
--- a/.github/workflows/check-issue-links.yml
+++ b/.github/workflows/check-issue-links.yml
@@ -11,17 +11,14 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-    - name: Check out repository
-      uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      with:
-        fetch-depth: 0
-        repository: ${{ github.event.pull_request.repo.full_name }}
-        ref: ${{ github.event.pull_request.head.sha }}
-
     - name: Extract commit messages
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        # Extract the commit messages of the commits in this PR.
-        git log --format='%B' HEAD~${{ github.event.pull_request.commits }}..HEAD > commit_messages.txt
+        # Fetch the PR's commit messages via the API to avoid checking out untrusted code.
+        gh api --paginate \
+          "repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/commits" \
+          --jq '.[].commit.message' > commit_messages.txt
         echo "Extracted commit messages:"
         cat commit_messages.txt
 


### PR DESCRIPTION
Since version 7.0.0 [1], the checkout action requires to set `allow-unsafe-pr-checkout: true` to checkout the PR's code when using the `pull_request_target` trigger. Instead of setting this option, use the GitHub API to fetch the PR's commit messages to completely avoid checking out the PR's code.

[1]: https://github.com/actions/checkout/releases/tag/v7.0.0