### PR TITLE
ci(github): Generate (and submit) the dependency graph only once

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,6 @@ jobs:
 
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-      with:
-        dependency-graph: generate-and-submit
 
     - name: Generate Release Notes
       run: ./gradlew -q printChangeLog > RELEASE_NOTES.md
@@ -119,8 +117,6 @@ jobs:
 
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@3f131e8634966bd73d06cc69884922b02e6faf92 # v6.2.0
-      with:
-        dependency-graph: generate-and-submit
 
     - name: Build CLI
       run: ./gradlew --stacktrace ${{ matrix.target.task }}


### PR DESCRIPTION
Only do this for the publishing job. The default is 'disabled' [1].

[1]: https://github.com/gradle/gradle-build-action/blob/093dfe9d598ec5a42246855d09b49dc76803c005/action.yml#L76