### PR TITLE
ci(renovate): Configure automatic tool upgrades for the scanner Dockerfile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,15 @@
   "extends": [
     "github>eclipse-apoapsis/renovate"
   ],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/workers/scanner/docker/Scanner\\.Dockerfile$/"],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s*\\nARG \\w+_VERSION=(?<currentValue>\\S+)"
+      ]
+    }
+  ],
   "packageRules": [
     {
       "matchDatasources": ["npm"],

--- a/workers/scanner/docker/Scanner.Dockerfile
+++ b/workers/scanner/docker/Scanner.Dockerfile
@@ -63,7 +63,7 @@ ARG RUBY_VERSION=3.4.4
 ARG SCANCODE_VERSION=32.5.0
 
 # Install Askalono.
-RUN curl -LOs https://github.com/amzn/askalono/releases/download/$ASKALONO_VERSION/askalono-Linux.zip && \
+RUN curl -LOs https://github.com/jpeddicord/askalono/releases/download/$ASKALONO_VERSION/askalono-Linux.zip && \
     mkdir /opt/askalono && \
     unzip askalono-Linux.zip -d /opt/askalono && \
     rm askalono-Linux.zip

--- a/workers/scanner/docker/Scanner.Dockerfile
+++ b/workers/scanner/docker/Scanner.Dockerfile
@@ -56,10 +56,15 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     zlib1g \
     zlib1g-dev
 
+# renovate: datasource=github-releases depName=jpeddicord/askalono
 ARG ASKALONO_VERSION=0.5.0
+# renovate: datasource=rubygems depName=licensee
 ARG LICENSEE_VERSION=9.18.0
+# renovate: datasource=github-releases depName=getprovenant/provenant extractVersion=^v(?<version>.*)$
 ARG PROVENANT_VERSION=0.2.5
+# renovate: datasource=ruby-version depName=ruby
 ARG RUBY_VERSION=3.4.4
+# renovate: datasource=pypi depName=scancode-toolkit
 ARG SCANCODE_VERSION=32.5.0
 
 # Install Askalono.


### PR DESCRIPTION
Add a Renovate custom regex manager [1] to automate updating the tool versions in the `Scanner.Dockerfile`. To simplify matching the version args, use inline `# renovate:` annotations.

These annotations allow to specify the datasource and package name Renovate should use for the update, and optionally a custom regex to extract the version.

This is only implemented for the `Scanner.Dockerfile` to test how well the approach works before applying it to other Dockerfiles as well.

[1]: https://docs.renovatebot.com/modules/manager/regex/