### PR TITLE
ci(github): Skip decompressing when downloading artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -156,6 +156,7 @@ jobs:
     - name: Download Artifacts
       uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
+        skip-decompress: true
         path: artifacts/
 
     - name: Create checksums


### PR DESCRIPTION
This is a fixup for 9b8db27.