### PR TITLE
Extend the keep-alive mechanism to Analyzer phases

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
@@ -26,6 +26,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.AdvisorJob as ApiAdvisorJob
 import org.eclipse.apoapsis.ortserver.api.v1.model.AdvisorJobConfiguration as ApiAdvisorJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.AnalyzerJob as ApiAnalyzerJob
 import org.eclipse.apoapsis.ortserver.api.v1.model.AnalyzerJobConfiguration as ApiAnalyzerJobConfiguration
+import org.eclipse.apoapsis.ortserver.api.v1.model.AnalyzerPhase as ApiAnalyzerPhase
 import org.eclipse.apoapsis.ortserver.api.v1.model.ComparisonOperator as ApiComparisonOperator
 import org.eclipse.apoapsis.ortserver.api.v1.model.EcosystemStats as ApiEcosystemStats
 import org.eclipse.apoapsis.ortserver.api.v1.model.EnvironmentConfig as ApiEnvironmentConfig
@@ -87,6 +88,7 @@ import org.eclipse.apoapsis.ortserver.model.AdvisorJob
 import org.eclipse.apoapsis.ortserver.model.AdvisorJobConfiguration
 import org.eclipse.apoapsis.ortserver.model.AnalyzerJob
 import org.eclipse.apoapsis.ortserver.model.AnalyzerJobConfiguration
+import org.eclipse.apoapsis.ortserver.model.AnalyzerPhase
 import org.eclipse.apoapsis.ortserver.model.EcosystemStats
 import org.eclipse.apoapsis.ortserver.model.EnvironmentConfig
 import org.eclipse.apoapsis.ortserver.model.EnvironmentVariableDeclaration
@@ -222,7 +224,8 @@ fun AnalyzerJobConfiguration.mapToApi() =
         packageManagerOptions = packageManagerOptions?.mapValues { it.value.mapToApi() },
         repositoryConfigPath = repositoryConfigPath,
         skipExcluded = skipExcluded,
-        keepAliveWorker = keepAliveWorker
+        keepAliveWorker = keepAliveWorker,
+        keepAlivePhases = keepAlivePhases.mapTo(mutableSetOf()) { it.mapToApi() }
     )
 
 fun ApiAnalyzerJobConfiguration.mapToModel() =
@@ -236,7 +239,8 @@ fun ApiAnalyzerJobConfiguration.mapToModel() =
         packageManagerOptions = packageManagerOptions?.mapValues { it.value.mapToModel() },
         repositoryConfigPath = repositoryConfigPath,
         skipExcluded = skipExcluded,
-        keepAliveWorker = keepAliveWorker
+        keepAliveWorker = keepAliveWorker,
+        keepAlivePhases = keepAlivePhases.mapTo(mutableSetOf()) { it.mapToModel() }
     )
 
 fun EvaluatorJob.mapToApi() =
@@ -776,6 +780,20 @@ fun ApiSubmoduleFetchStrategy.mapToModel() = when (this) {
     ApiSubmoduleFetchStrategy.DISABLED -> SubmoduleFetchStrategy.DISABLED
     ApiSubmoduleFetchStrategy.TOP_LEVEL_ONLY -> SubmoduleFetchStrategy.TOP_LEVEL_ONLY
     ApiSubmoduleFetchStrategy.FULLY_RECURSIVE -> SubmoduleFetchStrategy.FULLY_RECURSIVE
+}
+
+fun AnalyzerPhase.mapToApi() = when (this) {
+    AnalyzerPhase.PREPARATION -> ApiAnalyzerPhase.PREPARATION
+    AnalyzerPhase.ANALYSIS -> ApiAnalyzerPhase.ANALYSIS
+    AnalyzerPhase.RESULT -> ApiAnalyzerPhase.RESULT
+    AnalyzerPhase.FULL -> ApiAnalyzerPhase.FULL
+}
+
+fun ApiAnalyzerPhase.mapToModel() = when (this) {
+    ApiAnalyzerPhase.PREPARATION -> AnalyzerPhase.PREPARATION
+    ApiAnalyzerPhase.ANALYSIS -> AnalyzerPhase.ANALYSIS
+    ApiAnalyzerPhase.RESULT -> AnalyzerPhase.RESULT
+    ApiAnalyzerPhase.FULL -> AnalyzerPhase.FULL
 }
 
 fun ShortestDependencyPath.mapToApi() = ApiShortestDependencyPath(

--- a/api/v1/model/src/commonMain/kotlin/JobConfigurations.kt
+++ b/api/v1/model/src/commonMain/kotlin/JobConfigurations.kt
@@ -111,7 +111,13 @@ data class AnalyzerJobConfiguration(
      * Keep the worker alive after it has finished. This is useful for manual problem analysis directly
      * within the pod's execution environment.
      */
-    val keepAliveWorker: Boolean = false
+    val keepAliveWorker: Boolean = false,
+
+    /**
+     * If [keepAliveWorker] is *true*, this property lists the phases in which the worker should be kept alive. If no
+     * phase is provided, the worker will wait after all steps are finished.
+     */
+    val keepAlivePhases: Set<AnalyzerPhase> = emptySet()
 )
 
 /**
@@ -283,4 +289,29 @@ enum class SubmoduleFetchStrategy {
      * Fetch all nested submodules recursively.
      */
     FULLY_RECURSIVE
+}
+
+/**
+ * An enumeration defining the different phases supported by the Analyzer worker.
+ */
+enum class AnalyzerPhase {
+    /**
+     * The preparation phase which clones the repository and sets up the environment for the analysis.
+     */
+    PREPARATION,
+
+    /**
+     * The analysis phase which invokes ORT's Analyzer to analyze the current repository.
+     */
+    ANALYSIS,
+
+    /**
+     * The result phase which gathers the results from the [ANALYSIS] phase and stores them in the database.
+     */
+    RESULT,
+
+    /**
+     * The full phase which is used to run the whole Analyzer process in a single shot.
+     */
+    FULL
 }

--- a/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
@@ -47,7 +47,6 @@ import io.ktor.client.request.setBody
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpMethod
 import io.ktor.http.HttpStatusCode
-import io.ktor.http.parameters
 
 import io.mockk.mockk
 
@@ -64,6 +63,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToApi
 import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToApiSummary
 import org.eclipse.apoapsis.ortserver.api.v1.model.AdvisorJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.AnalyzerJobConfiguration
+import org.eclipse.apoapsis.ortserver.api.v1.model.AnalyzerPhase
 import org.eclipse.apoapsis.ortserver.api.v1.model.EnvironmentConfig
 import org.eclipse.apoapsis.ortserver.api.v1.model.EnvironmentVariableDeclaration as ApiEnvironmentVariableDeclaration
 import org.eclipse.apoapsis.ortserver.api.v1.model.EvaluatorJobConfiguration
@@ -1116,7 +1116,12 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
 
         val keepAliveJobConfigs = ApiJobConfigurations().let {
             listOf(
-                it.copy(analyzer = AnalyzerJobConfiguration(keepAliveWorker = true)),
+                it.copy(
+                    analyzer = AnalyzerJobConfiguration(
+                        keepAliveWorker = true,
+                        keepAlivePhases = EnumSet.of(AnalyzerPhase.ANALYSIS, AnalyzerPhase.RESULT)
+                    )
+                ),
                 it.copy(advisor = AdvisorJobConfiguration(keepAliveWorker = true)),
                 it.copy(evaluator = EvaluatorJobConfiguration(keepAliveWorker = true)),
                 it.copy(notifier = NotifierJobConfiguration(keepAliveWorker = true)),
@@ -1156,6 +1161,16 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
                     }
 
                     response shouldHaveStatus HttpStatusCode.Created
+
+                    val run = response.body<OrtRun>()
+                    with(run.jobConfigs) {
+                        analyzer.keepAliveWorker shouldBe it.analyzer.keepAliveWorker
+                        analyzer.keepAlivePhases shouldBe it.analyzer.keepAlivePhases
+                        advisor?.keepAliveWorker shouldBe it.advisor?.keepAliveWorker
+                        scanner?.keepAliveWorker shouldBe it.scanner?.keepAliveWorker
+                        evaluator?.keepAliveWorker shouldBe it.evaluator?.keepAliveWorker
+                        reporter?.keepAliveWorker shouldBe it.reporter?.keepAliveWorker
+                    }
                 }
             }
         }

--- a/dao/src/testFixtures/kotlin/MockDatabaseModule.kt
+++ b/dao/src/testFixtures/kotlin/MockDatabaseModule.kt
@@ -58,7 +58,7 @@ private fun databaseModuleWithMockConnection() = module {
  */
 fun mockDatabaseModule() {
     mockkStatic(::databaseModule)
-    every { databaseModule() } returns databaseModuleWithMockConnection()
+    every { databaseModule(any()) } returns databaseModuleWithMockConnection()
 }
 
 /**

--- a/model/src/commonMain/kotlin/JobConfigurations.kt
+++ b/model/src/commonMain/kotlin/JobConfigurations.kt
@@ -120,7 +120,13 @@ data class AnalyzerJobConfiguration(
      * Keep the worker alive after it has finished. This is useful for manual problem analysis directly
      * within the pod's execution environment.
      */
-    val keepAliveWorker: Boolean = false
+    val keepAliveWorker: Boolean = false,
+
+    /**
+     * If [keepAliveWorker] is *true*, this property lists the phases in which the worker should be kept alive. If no
+     * phase is provided, the worker will wait after all steps are finished.
+     */
+    val keepAlivePhases: Set<AnalyzerPhase> = emptySet()
 )
 
 /**
@@ -286,4 +292,29 @@ enum class SubmoduleFetchStrategy {
      * Fetch all nested submodules recursively.
      */
     FULLY_RECURSIVE
+}
+
+/**
+ * An enumeration defining the different phases supported by the Analyzer worker.
+ */
+enum class AnalyzerPhase {
+    /**
+     * The preparation phase which clones the repository and sets up the environment for the analysis.
+     */
+    PREPARATION,
+
+    /**
+     * The analysis phase which invokes ORT's Analyzer to analyze the current repository.
+     */
+    ANALYSIS,
+
+    /**
+     * The result phase which gathers the results from the [ANALYSIS] phase and stores them in the database.
+     */
+    RESULT,
+
+    /**
+     * The full phase which is used to run the whole Analyzer process in a single shot.
+     */
+    FULL
 }

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
@@ -27,6 +27,8 @@ import {
   PreconfiguredPluginDescriptor,
   Secret,
 } from '@/api';
+import { zAnalyzerPhase } from '@/api/zod.gen';
+import { MultiSelectField } from '@/components/form/multi-select-field.tsx';
 import { PluginMultiSelectField } from '@/components/form/plugin-multi-select-field.tsx';
 import { InlineCode } from '@/components/typography.tsx';
 import {
@@ -393,28 +395,49 @@ export const AnalyzerFields = ({
             showSelectedPluginsFirst={isRerun}
           />
           {isSuperuser && (
-            <FormField
-              control={form.control}
-              name='jobConfigs.analyzer.keepAliveWorker'
-              render={({ field }) => (
-                <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
-                  <div className='space-y-0.5'>
-                    <FormLabel>Keep worker alive</FormLabel>
-                    <FormDescription>
-                      A flag to control whether the worker is kept alive for
-                      debugging purposes. This flag only has an effect if the
-                      ORT Server is deployed on Kubernetes.
-                    </FormDescription>
-                  </div>
-                  <FormControl>
-                    <Switch
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                    />
-                  </FormControl>
-                </FormItem>
+            <div className='flex flex-col gap-4'>
+              <FormField
+                control={form.control}
+                name='jobConfigs.analyzer.keepAliveWorker'
+                render={({ field }) => (
+                  <FormItem className='flex flex-row items-center justify-between rounded-lg border p-4'>
+                    <div className='space-y-0.5'>
+                      <FormLabel>Keep worker alive</FormLabel>
+                      <FormDescription>
+                        A flag to control whether the worker is kept alive for
+                        debugging purposes. This flag only has an effect if the
+                        ORT Server is deployed on Kubernetes.
+                      </FormDescription>
+                    </div>
+                    <FormControl>
+                      <Switch
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                      />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+              {form.watch('jobConfigs.analyzer.keepAliveWorker') && (
+                <MultiSelectField
+                  form={form}
+                  name='jobConfigs.analyzer.keepAlivePhases'
+                  label='Keep-alive phases'
+                  description={
+                    <>
+                      The phases in which the worker should be kept alive. If
+                      none are selected, the worker is kept alive in the{' '}
+                      <InlineCode>full</InlineCode> and{' '}
+                      <InlineCode>analysis</InlineCode> phases.
+                    </>
+                  }
+                  options={zAnalyzerPhase.options.map((phase) => ({
+                    id: phase,
+                    label: capitalize(phase),
+                  }))}
+                />
               )}
-            />
+            </div>
           )}
         </AccordionContent>
       </AccordionItem>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/default-values.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/default-values.ts
@@ -122,7 +122,7 @@ export function defaultValues(
         allowDynamicVersions: true,
         skipExcluded: true,
         keepAliveWorker: false,
-        environmentDefinitions: undefined,
+        keepAlivePhases: [],
         infrastructureServices: [],
         packageCurationProviders: [],
         packageCurationProviderConfig:
@@ -261,6 +261,12 @@ export function defaultValues(
             keepAliveWorker:
               (ortRun.jobConfigs.analyzer?.keepAliveWorker && isSuperuser) ||
               baseDefaults.jobConfigs.analyzer.keepAliveWorker,
+            keepAlivePhases:
+              ortRun.jobConfigs.analyzer?.keepAliveWorker &&
+              isSuperuser &&
+              ortRun.jobConfigs.analyzer?.keepAlivePhases?.length
+                ? ortRun.jobConfigs.analyzer.keepAlivePhases
+                : baseDefaults.jobConfigs.analyzer.keepAlivePhases,
           },
           advisor: {
             enabled:

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/payload.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/payload.ts
@@ -155,6 +155,11 @@ export function formValuesToPayload(
       values.jobConfigs.analyzer.packageCurationProviders
     ),
     keepAliveWorker: values.jobConfigs.analyzer.keepAliveWorker || undefined,
+    keepAlivePhases:
+      values.jobConfigs.analyzer.keepAliveWorker &&
+      values.jobConfigs.analyzer.keepAlivePhases?.length
+        ? values.jobConfigs.analyzer.keepAlivePhases
+        : undefined,
   };
 
   //

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/run-schema.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/run-schema.ts
@@ -21,7 +21,7 @@ import { FieldErrors } from 'react-hook-form';
 import { z } from 'zod';
 
 import { PreconfiguredPluginDescriptor } from '@/api';
-import { zInfrastructureService } from '@/api/zod.gen';
+import { zAnalyzerPhase, zInfrastructureService } from '@/api/zod.gen';
 import { environmentDefinitionsSchema } from '@/lib/types';
 import {
   environmentVariableSchema,
@@ -78,6 +78,7 @@ export const createRunFormSchema = (
             environmentVariables: z.array(environmentVariableSchema).optional(),
             infrastructureServices: z.array(zInfrastructureService).optional(),
             keepAliveWorker: z.boolean(),
+            keepAlivePhases: z.array(zAnalyzerPhase).optional(),
             packageCurationProviders: z.array(z.string()),
             packageCurationProviderConfig: z
               .object(packageCurationProviderConfigSchema)

--- a/workers/analyzer/src/main/kotlin/AnalyzerComponent.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerComponent.kt
@@ -116,7 +116,7 @@ class AnalyzerComponent(
 
     override fun customModules(): List<Module> = listOf(
         analyzerModule(),
-        databaseModule(),
+        databaseModule(startEager = false), // Start services lazily, they are not required for all phases.
         ortRunServiceModule(),
         workerContextModule(),
         buildEnvironmentModule(includePackageManagerGenerators = true)

--- a/workers/analyzer/src/main/kotlin/AnalyzerPhase.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerPhase.kt
@@ -22,14 +22,17 @@ package org.eclipse.apoapsis.ortserver.workers.analyzer
 import com.typesafe.config.ConfigFactory
 
 import java.io.File
+import java.util.EnumSet
 
 import kotlinx.serialization.Serializable
 
 import org.eclipse.apoapsis.ortserver.components.resolutions.issues.IssueResolutionService
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.model.AnalyzerJobConfiguration
+import org.eclipse.apoapsis.ortserver.model.AnalyzerPhase as AnalyzerPhaseEnum
 import org.eclipse.apoapsis.ortserver.services.config.AdminConfigService
 import org.eclipse.apoapsis.ortserver.services.ortrun.OrtRunService
+import org.eclipse.apoapsis.ortserver.transport.EndpointComponent
 import org.eclipse.apoapsis.ortserver.workers.common.RunResult
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContextFactory
@@ -86,6 +89,34 @@ internal sealed interface AnalyzerPhase {
      * the Analyzer endpoint how to handle the result.
      */
     suspend fun run(worker: AnalyzerWorker, jobId: Long, args: Array<String>): RunResult
+
+    /**
+     * Evaluate the keep-alive settings for this [AnalysisPhase] and [config]. If necessary, write a file that keeps
+     * the worker alive.
+     */
+    suspend fun handleKeepAlive(config: AnalyzerJobConfiguration) {
+        handleKeepAlive(config.keepAliveWorker, config.keepAlivePhases)
+    }
+
+    /**
+     * Evaluate the given [keepAliveWorker] flag and the [keepAlivePhases]. If necessary, write a file that keeps the
+     * worker alive.
+     */
+    suspend fun handleKeepAlive(keepAliveWorker: Boolean, keepAlivePhases: Set<AnalyzerPhaseEnum>) {
+        if (!keepAliveWorker) return
+
+        val phases = keepAlivePhases.takeUnless { it.isEmpty() } ?: DEFAULT_KEEP_ALIVE_PHASES
+        val phaseName = AnalyzerPhaseEnum.valueOf(javaClass.simpleName.removeSuffix("Phase").uppercase())
+        if (phaseName in phases) {
+            EndpointComponent.generateKeepAliveFile()
+        } else {
+            logger.info(
+                "Not generating a keep-alive file. Current phase is '{}', requested phases are {}.",
+                phaseName,
+                phases
+            )
+        }
+    }
 }
 
 /**
@@ -119,6 +150,7 @@ internal class FullPhase(
         checkArgs(this, args, 0, 0)
 
         val job = ortRunService.getValidAnalyzerJob(jobId)
+        handleKeepAlive(job.configuration)
 
         return contextFactory.withContext(job.ortRunId) { context ->
             val prepareResult = worker.prepare(context, job, ortRunService, environmentService)
@@ -154,6 +186,7 @@ internal class PreparationPhase(
     ): RunResult {
         val exchangeDir = exchangeDirectory(jobId, checkArgs(this, args, 1, 1))
         val job = ortRunService.getValidAnalyzerJob(jobId)
+        handleKeepAlive(job.configuration)
 
         val prepareExchange = contextFactory.withContext(job.ortRunId) { context ->
             val configDir = exchangeDir.resolve(CONFIG_DIR).apply { mkdirs() }
@@ -195,6 +228,7 @@ internal class AnalysisPhase : AnalyzerPhase {
         val exchangeDir = exchangeDirectory(jobId, checkArgs(this, args, 1, 2))
 
         val prepareResult = createPrepareResult(exchangeDir, jobId)
+        handleKeepAlive(prepareResult.runnerConfig.keepAliveWorker, prepareResult.runnerConfig.keepAlivePhases)
         copyConfigFiles(exchangeDir)
         setUpEnvironment()
 
@@ -295,6 +329,7 @@ internal class ResultPhase(
     ): RunResult {
         val exchangeDir = exchangeDirectory(jobId, checkArgs(this, args, 1, 1))
         val job = ortRunService.getValidAnalyzerJob(jobId)
+        handleKeepAlive(job.configuration)
 
         val result: OrtResult = readExchangeFile(exchangeDir, ORT_RESULT_FILE)
 
@@ -328,6 +363,9 @@ internal data class PreparationExchange(
     /** The ID of the run that is analyzed. */
     val runId: Long
 )
+
+/** The phases for which the worker should be kept alive if no specific phases are provided. */
+private val DEFAULT_KEEP_ALIVE_PHASES = EnumSet.of(AnalyzerPhaseEnum.ANALYSIS, AnalyzerPhaseEnum.FULL)
 
 /**
  * Return a directory to be used for exchanging information between the different phases for the Analyzer job with the
@@ -396,5 +434,7 @@ private suspend fun AnalyzerJobConfiguration.toRunnerConfig(context: WorkerConte
         disabledPackageManagers = disabledPackageManagers,
         packageManagerOptions = packageManagerOptions,
         repositoryConfigPath = repositoryConfigPath,
-        packageCurationProviders = context.resolveProviderPluginConfigSecrets(packageCurationProviders)
+        packageCurationProviders = context.resolveProviderPluginConfigSecrets(packageCurationProviders),
+        keepAliveWorker = keepAliveWorker,
+        keepAlivePhases = keepAlivePhases
     )

--- a/workers/analyzer/src/main/kotlin/AnalyzerPhase.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerPhase.kt
@@ -198,7 +198,7 @@ internal class PreparationPhase(
 
             PreparationExchange(
                 environment = prepareResult.resolvedEnvironment,
-                runnerConfig = job.configuration.toRunnerConfig(context),
+                runnerConfig = prepareResult.runnerConfig,
                 runId = job.ortRunId
             )
         }
@@ -421,20 +421,3 @@ private inline fun <reified T : Any> AnalyzerPhase.readExchangeFile(exchangeDir:
 
     return exchangeFile.readValue()
 }
-
-/**
- * Create an [AnalyzerRunnerConfig] from this [AnalyzerJobConfiguration] to be used to analyze the current project.
- * Use the given [context] to resolve the secrets in the plugin configuration.
- */
-private suspend fun AnalyzerJobConfiguration.toRunnerConfig(context: WorkerContext): AnalyzerRunnerConfig =
-    AnalyzerRunnerConfig(
-        skipExcluded = skipExcluded,
-        allowDynamicVersions = allowDynamicVersions,
-        enabledPackageManagers = enabledPackageManagers,
-        disabledPackageManagers = disabledPackageManagers,
-        packageManagerOptions = packageManagerOptions,
-        repositoryConfigPath = repositoryConfigPath,
-        packageCurationProviders = context.resolveProviderPluginConfigSecrets(packageCurationProviders),
-        keepAliveWorker = keepAliveWorker,
-        keepAlivePhases = keepAlivePhases
-    )

--- a/workers/analyzer/src/main/kotlin/AnalyzerRunnerConfig.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerRunnerConfig.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.workers.analyzer
 import kotlinx.serialization.Serializable
 
 import org.eclipse.apoapsis.ortserver.model.AnalyzerJobConfiguration
+import org.eclipse.apoapsis.ortserver.model.AnalyzerPhase
 import org.eclipse.apoapsis.ortserver.model.ProviderPluginConfiguration
 import org.eclipse.apoapsis.ortserver.model.runs.PackageManagerConfiguration
 
@@ -50,5 +51,11 @@ data class AnalyzerRunnerConfig(
     val repositoryConfigPath: String?,
 
     /** See [AnalyzerJobConfiguration.skipExcluded]. */
-    val skipExcluded: Boolean?
+    val skipExcluded: Boolean?,
+
+    /** See [AnalyzerJobConfiguration.keepAliveWorker]. */
+    val keepAliveWorker: Boolean,
+
+    /** See [AnalyzerJobConfiguration.keepAlivePhases]. */
+    val keepAlivePhases: Set<AnalyzerPhase>
 )

--- a/workers/analyzer/src/main/kotlin/AnalyzerWorker.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerWorker.kt
@@ -34,7 +34,6 @@ import org.eclipse.apoapsis.ortserver.model.runs.ShortestDependencyPath
 import org.eclipse.apoapsis.ortserver.services.config.AdminConfigService
 import org.eclipse.apoapsis.ortserver.services.ortrun.OrtRunService
 import org.eclipse.apoapsis.ortserver.services.ortrun.mapToModel
-import org.eclipse.apoapsis.ortserver.transport.EndpointComponent
 import org.eclipse.apoapsis.ortserver.workers.common.JobIgnoredException
 import org.eclipse.apoapsis.ortserver.workers.common.RunResult
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
@@ -115,10 +114,6 @@ internal class AnalyzerWorker(
             ?: throw IllegalArgumentException("The analyzer job with id '${analyzerJob.id}' could not be started.")
         logger.debug("Analyzer job with id '{}' started at {}.", job.id, job.startedAt)
         logger.info("Using ORT version {}.", ORT_VERSION)
-
-        if (job.configuration.keepAliveWorker) {
-            EndpointComponent.generateKeepAliveFile()
-        }
 
         val envConfigFromJob = job.configuration.environmentConfig
         val repositoryServices =
@@ -330,7 +325,9 @@ private suspend fun AnalyzerJobConfiguration.toRunnerConfig(context: WorkerConte
         disabledPackageManagers = disabledPackageManagers,
         packageManagerOptions = packageManagerOptions,
         repositoryConfigPath = repositoryConfigPath,
-        packageCurationProviders = context.resolveProviderPluginConfigSecrets(packageCurationProviders)
+        packageCurationProviders = context.resolveProviderPluginConfigSecrets(packageCurationProviders),
+        keepAliveWorker = keepAliveWorker,
+        keepAlivePhases = keepAlivePhases
     )
 
 /**

--- a/workers/analyzer/src/test/kotlin/AnalyzerPhaseTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerPhaseTest.kt
@@ -24,7 +24,18 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.string.shouldContain
 
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.just
 import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.runs
+
+import java.util.EnumSet
+
+import org.eclipse.apoapsis.ortserver.model.AnalyzerJobConfiguration
+import org.eclipse.apoapsis.ortserver.model.AnalyzerPhase
+import org.eclipse.apoapsis.ortserver.transport.EndpointComponent
 
 class AnalyzerPhaseTest : WordSpec({
     "FullPhase" should {
@@ -108,6 +119,90 @@ class AnalyzerPhaseTest : WordSpec({
 
             shouldThrow<IllegalArgumentException> {
                 phase.run(mockk(), 42L, arrayOf(exchangeDir.absolutePath, "sync", "extra-arg"))
+            }
+        }
+    }
+
+    "handleKeepAlive()" should {
+        "write a keep-alive file if the phase matches" {
+            val config = AnalyzerJobConfiguration(
+                keepAliveWorker = true,
+                keepAlivePhases = EnumSet.of(AnalyzerPhase.PREPARATION, AnalyzerPhase.ANALYSIS)
+            )
+            val phase = AnalysisPhase()
+
+            mockkObject(EndpointComponent) {
+                coEvery { EndpointComponent.generateKeepAliveFile() } just runs
+
+                phase.handleKeepAlive(config)
+
+                coVerify { EndpointComponent.generateKeepAliveFile() }
+            }
+        }
+
+        "not write a keep-alive file if the phase does not match" {
+            val config = AnalyzerJobConfiguration(
+                keepAliveWorker = true,
+                keepAlivePhases = EnumSet.of(AnalyzerPhase.PREPARATION, AnalyzerPhase.RESULT)
+            )
+            val phase = AnalysisPhase()
+
+            mockkObject(EndpointComponent) {
+                phase.handleKeepAlive(config)
+
+                coVerify(exactly = 0) { EndpointComponent.generateKeepAliveFile() }
+            }
+        }
+
+        "not write a keep-alive file if the keep-alive flag is not set" {
+            val config = AnalyzerJobConfiguration(
+                keepAliveWorker = false,
+                keepAlivePhases = EnumSet.of(AnalyzerPhase.ANALYSIS)
+            )
+            val phase = AnalysisPhase()
+
+            mockkObject(EndpointComponent) {
+                phase.handleKeepAlive(config)
+
+                coVerify(exactly = 0) { EndpointComponent.generateKeepAliveFile() }
+            }
+        }
+
+        "write a keep-alive file per default for the full phase" {
+            val config = AnalyzerJobConfiguration(
+                keepAliveWorker = true
+            )
+            val phase = FullPhase(
+                db = mockk(),
+                ortRunService = mockk(),
+                contextFactory = mockk(),
+                environmentService = mockk(),
+                adminConfigService = mockk(),
+                issueResolutionService = mockk()
+            )
+
+            mockkObject(EndpointComponent) {
+                coEvery { EndpointComponent.generateKeepAliveFile() } just runs
+
+                phase.handleKeepAlive(config)
+
+                coVerify { EndpointComponent.generateKeepAliveFile() }
+            }
+        }
+
+        "write a keep-alive file per default for the analysis phase" {
+            val config = AnalyzerJobConfiguration(
+                keepAliveWorker = true,
+                keepAlivePhases = emptySet()
+            )
+            val phase = AnalysisPhase()
+
+            mockkObject(EndpointComponent) {
+                coEvery { EndpointComponent.generateKeepAliveFile() } just runs
+
+                phase.handleKeepAlive(config)
+
+                coVerify { EndpointComponent.generateKeepAliveFile() }
             }
         }
     }

--- a/workers/analyzer/src/test/kotlin/AnalyzerRunnerTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerRunnerTest.kt
@@ -112,7 +112,9 @@ private val testRunnerConfig = AnalyzerRunnerConfig(
             options = mapOf("foo" to "bar")
         )
     ),
-    repositoryConfigPath = null
+    repositoryConfigPath = null,
+    keepAliveWorker = false,
+    keepAlivePhases = emptySet()
 )
 
 class AnalyzerRunnerTest : WordSpec({
@@ -458,7 +460,9 @@ class AnalyzerRunnerTest : WordSpec({
                 packageCurationProviders = listOf(ProviderPluginConfiguration(type = "OrtConfig")),
                 packageManagerOptions = packageManagerOptions,
                 repositoryConfigPath = null,
-                skipExcluded = true
+                skipExcluded = true,
+                keepAliveWorker = false,
+                keepAlivePhases = emptySet()
             )
 
             val configFile = exchangeDir.resolve("analyzer-config.json")
@@ -488,7 +492,9 @@ class AnalyzerRunnerTest : WordSpec({
                     packageCurationProviders = emptyList(),
                     packageManagerOptions = null,
                     repositoryConfigPath = null,
-                    skipExcluded = null
+                    skipExcluded = null,
+                    keepAliveWorker = false,
+                    keepAlivePhases = emptySet()
                 )
             )
 

--- a/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerWorkerTest.kt
@@ -28,6 +28,7 @@ import io.kotest.core.spec.style.StringSpec
 import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldContainOnly
 import io.kotest.matchers.maps.beEmpty
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
@@ -42,10 +43,12 @@ import io.mockk.mockkObject
 import io.mockk.runs
 import io.mockk.slot
 import io.mockk.spyk
+import io.mockk.unmockkAll
 import io.mockk.verify
 
 import java.io.ByteArrayInputStream
 import java.io.File
+import java.util.EnumSet
 import java.util.concurrent.atomic.AtomicBoolean
 
 import kotlin.time.Clock
@@ -57,6 +60,7 @@ import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.dao.test.mockkTransaction
 import org.eclipse.apoapsis.ortserver.model.AnalyzerJob
 import org.eclipse.apoapsis.ortserver.model.AnalyzerJobConfiguration
+import org.eclipse.apoapsis.ortserver.model.AnalyzerPhase as AnalyzerPhaseEnum
 import org.eclipse.apoapsis.ortserver.model.EnvironmentConfig
 import org.eclipse.apoapsis.ortserver.model.Hierarchy
 import org.eclipse.apoapsis.ortserver.model.InfrastructureService
@@ -77,6 +81,7 @@ import org.eclipse.apoapsis.ortserver.services.ortrun.OrtRunService
 import org.eclipse.apoapsis.ortserver.services.ortrun.mapToModel
 import org.eclipse.apoapsis.ortserver.shared.orttestdata.OrtTestData
 import org.eclipse.apoapsis.ortserver.shared.orttestdata.OrtTestData.TIME_STAMP_SECONDS
+import org.eclipse.apoapsis.ortserver.transport.EndpointComponent
 import org.eclipse.apoapsis.ortserver.workers.common.RunResult
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContext
 import org.eclipse.apoapsis.ortserver.workers.common.context.WorkerContextFactory
@@ -157,9 +162,26 @@ private suspend fun AnalyzerWorker.testRun(phase: AnalyzerPhase, args: Array<Str
 
 @Suppress("LargeClass")
 class AnalyzerWorkerTest : StringSpec({
+    beforeEach {
+        mockkObject(EndpointComponent)
+        coEvery { EndpointComponent.generateKeepAliveFile() } just runs
+    }
+
+    afterEach {
+        unmockkAll()
+    }
+
     "A private repository should be analyzed successfully" {
+        val jobConfig = AnalyzerJobConfiguration(
+            enabledPackageManagers = listOf("Maven"),
+            packageCurationProviders = listOf(mockk()),
+            keepAliveWorker = true,
+            keepAlivePhases = EnumSet.of(AnalyzerPhaseEnum.ANALYSIS)
+        )
+        val job = analyzerJob.copy(configuration = jobConfig)
+
         val ortRunService = mockk<OrtRunService> {
-            every { getAnalyzerJob(any()) } returns analyzerJob
+            every { getAnalyzerJob(any()) } returns job
             every { getHierarchyForOrtRun(any()) } returns hierarchy
             every { getOrtRun(any()) } returns ortRun
             every { startAnalyzerJob(any()) } returns analyzerJob
@@ -191,13 +213,15 @@ class AnalyzerWorkerTest : StringSpec({
             } returns ResolvedEnvironmentConfig()
         }
 
-        val phase = FullPhase(
-            mockk(),
-            ortRunService,
-            contextFactory,
-            envService,
-            mockk(relaxed = true),
-            mockIssueResolutionService()
+        val phase = spyk(
+            FullPhase(
+                mockk(),
+                ortRunService,
+                contextFactory,
+                envService,
+                mockk(relaxed = true),
+                mockIssueResolutionService()
+            )
         )
         val worker = AnalyzerWorker(downloader, AnalyzerRunner(ConfigFactory.empty()))
 
@@ -216,6 +240,10 @@ class AnalyzerWorkerTest : StringSpec({
                 envService.setupAuthentication(context, infrastructureServices)
                 downloader.downloadRepository(repository.url, ortRun.revision)
                 envService.setUpEnvironment(context, projectDir, null, infrastructureServices)
+            }
+
+            coVerify {
+                phase.handleKeepAlive(jobConfig)
             }
         }
     }
@@ -1162,7 +1190,9 @@ class AnalyzerWorkerTest : StringSpec({
 
         val jobConfig = AnalyzerJobConfiguration(
             enabledPackageManagers = listOf("Maven"),
-            packageCurationProviders = listOf(mockk())
+            packageCurationProviders = listOf(mockk()),
+            keepAliveWorker = true,
+            keepAlivePhases = EnumSet.of(AnalyzerPhaseEnum.ANALYSIS)
         )
         val job = analyzerJob.copy(configuration = jobConfig)
 
@@ -1214,10 +1244,12 @@ class AnalyzerWorkerTest : StringSpec({
                 refContextOpen.get() shouldBe true
             }
 
-            val phase = PreparationPhase(
-                ortRunService,
-                contextFactory,
-                envService
+            val phase = spyk(
+                PreparationPhase(
+                    ortRunService,
+                    contextFactory,
+                    envService
+                )
             )
             val runner = mockk<AnalyzerRunner>()
             val worker = AnalyzerWorker(downloader, runner)
@@ -1250,6 +1282,8 @@ class AnalyzerWorkerTest : StringSpec({
                     )
                 }
 
+                coVerify { phase.handleKeepAlive(jobConfig) }
+
                 coVerify(exactly = 0) {
                     runner.run(any(), any(), any())
                 }
@@ -1264,6 +1298,8 @@ class AnalyzerWorkerTest : StringSpec({
 
             runnerConfig.packageCurationProviders shouldContainExactlyInAnyOrder pluginConfigs
             runnerConfig.enabledPackageManagers shouldContainExactlyInAnyOrder listOf("Maven")
+            runnerConfig.keepAliveWorker shouldBe true
+            runnerConfig.keepAlivePhases shouldContainOnly EnumSet.of(AnalyzerPhaseEnum.ANALYSIS)
 
             runId shouldBe ortRun.id
         }
@@ -1293,7 +1329,9 @@ class AnalyzerWorkerTest : StringSpec({
                         secrets = mapOf("password" to "secret-password")
                     )
             ),
-                repositoryConfigPath = "test/path"
+                repositoryConfigPath = "test/path",
+                keepAliveWorker = true,
+                keepAlivePhases = EnumSet.of(AnalyzerPhaseEnum.RESULT)
             )
         )
         val prepareExchange = PreparationExchange(
@@ -1330,7 +1368,8 @@ class AnalyzerWorkerTest : StringSpec({
             every { Os.userHomeDirectory } returns userHomeDir
 
             val worker = AnalyzerWorker(mockk(), runner)
-            worker.testRun(AnalysisPhase(), arrayOf(exchangeDir.absolutePath)) shouldBe RunResult.Ignored
+            val phase = spyk(AnalysisPhase())
+            worker.testRun(phase, arrayOf(exchangeDir.absolutePath)) shouldBe RunResult.Ignored
 
             val analysisResult: OrtResult = jobDir.resolve(ORT_RESULT_FILE).readValue()
             analysisResult shouldBe ortResult
@@ -1338,6 +1377,10 @@ class AnalyzerWorkerTest : StringSpec({
             verify {
                 EnvironmentForkHelper.setupAuthentication(jobDir.resolve(AUTH_INFO_FILE), any())
                 workerOrtConfig.setUpOrtEnvironment()
+            }
+
+            coVerify {
+                phase.handleKeepAlive(true, EnumSet.of(AnalyzerPhaseEnum.RESULT))
             }
         }
     }
@@ -1358,7 +1401,9 @@ class AnalyzerWorkerTest : StringSpec({
                 disabledPackageManagers = null,
                 packageManagerOptions = null,
                 packageCurationProviders = emptyList(),
-                repositoryConfigPath = null
+                repositoryConfigPath = null,
+                keepAliveWorker = false,
+                keepAlivePhases = emptySet()
             )
         )
         val prepareExchange = PreparationExchange(
@@ -1424,12 +1469,14 @@ class AnalyzerWorkerTest : StringSpec({
 
         jobDir.resolve(ORT_RESULT_FILE).writeValue(ortResult)
 
-        val phase = ResultPhase(
-            mockk(),
-            ortRunService,
-            contextFactory,
-            mockk(relaxed = true),
-            mockIssueResolutionService()
+        val phase = spyk(
+            ResultPhase(
+                mockk(),
+                ortRunService,
+                contextFactory,
+                mockk(relaxed = true),
+                mockIssueResolutionService()
+            )
         )
         val worker = AnalyzerWorker(mockk(), mockk())
 
@@ -1452,6 +1499,10 @@ class AnalyzerWorkerTest : StringSpec({
                     any()
                 )
                 ortRunService.storeRepositoryInformation(ortRun.id, OrtTestData.result.repository)
+            }
+
+            coVerify {
+                phase.handleKeepAlive(analyzerJob.configuration)
             }
         }
     }
@@ -1499,7 +1550,9 @@ private fun runnerConfig(
         disabledPackageManagers = jobConfig.disabledPackageManagers,
         packageManagerOptions = jobConfig.packageManagerOptions,
         repositoryConfigPath = jobConfig.repositoryConfigPath,
-        packageCurationProviders = packageCurationProviderConfigs.orEmpty()
+        packageCurationProviders = packageCurationProviderConfigs.orEmpty(),
+        keepAliveWorker = jobConfig.keepAliveWorker,
+        keepAlivePhases = jobConfig.keepAlivePhases
     )
 
 /**


### PR DESCRIPTION
Introduce a new property to the Analyzer job configuration that allows
specifying the phase(s) after which execution should wait. This enables
debugging of single phases.