### PR TITLE
chore(ui): Use a more generic base URL for releases

### DIFF
--- a/ui/src/lib/constants.ts
+++ b/ui/src/lib/constants.ts
@@ -26,7 +26,7 @@
 export const ALL_ITEMS = 100000;
 
 // The base download URL for the downloadable assets of the latest ORT Server release.
-export const GITHUB_LATEST_RELEASE_DOWNLOAD_URL =
-  'https://github.com/eclipse-apoapsis/ort-server/releases/latest/download';
+export const ORT_SERVER_GITHUB_RELEASES_BASE_URL =
+  'https://github.com/eclipse-apoapsis/ort-server/releases';
 
 export const ACTION_COLUMN_SIZE = 20;

--- a/ui/src/routes/about/index.tsx
+++ b/ui/src/routes/about/index.tsx
@@ -24,7 +24,7 @@ import { Fragment } from 'react';
 import { getVersionsOptions } from '@/api/@tanstack/react-query.gen';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Separator } from '@/components/ui/separator';
-import { GITHUB_LATEST_RELEASE_DOWNLOAD_URL } from '@/lib/constants';
+import { ORT_SERVER_GITHUB_RELEASES_BASE_URL } from '@/lib/constants';
 
 export const About = () => {
   const { data: versionData } = useSuspenseQuery({
@@ -38,11 +38,8 @@ export const About = () => {
   const ortServerVersion = versionData['ORT Server'];
   const isVersionCandidate = ortServerVersion?.includes('-RC.');
   const baseUrl = isVersionCandidate
-    ? GITHUB_LATEST_RELEASE_DOWNLOAD_URL
-    : GITHUB_LATEST_RELEASE_DOWNLOAD_URL.replace(
-        'latest/download',
-        `download/${ortServerVersion}`
-      );
+    ? `${ORT_SERVER_GITHUB_RELEASES_BASE_URL}/latest/download`
+    : `${ORT_SERVER_GITHUB_RELEASES_BASE_URL}/download/${ortServerVersion}`;
 
   return (
     <Card className='mx-auto w-full max-w-4xl'>


### PR DESCRIPTION
This prepares for using the base URL also to construct other URLs.