### PR TITLE
ui: Show detected licenses and the corresponding findings for a package

### DIFF
--- a/components/license-findings/backend/src/main/kotlin/LicenseFindingService.kt
+++ b/components/license-findings/backend/src/main/kotlin/LicenseFindingService.kt
@@ -21,29 +21,26 @@ package org.eclipse.apoapsis.ortserver.components.licensefindings
 
 import org.eclipse.apoapsis.ortserver.dao.QueryParametersException
 import org.eclipse.apoapsis.ortserver.dao.blockingQuery
+import org.eclipse.apoapsis.ortserver.dao.queries.licensefindings.buildLicenseFindingsJoin
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerjob.AnalyzerJobsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.AnalyzerRunsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesAnalyzerRunsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.scannerjob.ScannerJobsTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsPackageProvenancesTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsScanResultsTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.LicenseFindingsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.PackageProvenancesTable
-import org.eclipse.apoapsis.ortserver.dao.tables.ScanResultPackageProvenancesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.ScanResultsTable
-import org.eclipse.apoapsis.ortserver.dao.tables.ScanSummariesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
+import org.eclipse.apoapsis.ortserver.dao.utils.applyFilter
 import org.eclipse.apoapsis.ortserver.dao.utils.applyILike
 import org.eclipse.apoapsis.ortserver.dao.utils.toSortOrder
+import org.eclipse.apoapsis.ortserver.model.util.FilterOperatorAndValue
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
 import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 
 import org.jetbrains.exposed.v1.core.Count
 import org.jetbrains.exposed.v1.core.CustomFunction
-import org.jetbrains.exposed.v1.core.Join
 import org.jetbrains.exposed.v1.core.JoinType
 import org.jetbrains.exposed.v1.core.Op
 import org.jetbrains.exposed.v1.core.ResultRow
@@ -65,24 +62,26 @@ class LicenseFindingService(private val db: Database) {
      * Return the detected licenses for the ORT run with the given [ortRunId].
      *
      * The result contains one entry per detected license together with the number of distinct packages that contain the
-     * license. The result can be filtered by [licenseFilter] and paged and sorted according to [parameters].
+     * license. The result can be filtered by [licenseFilter], and paged and sorted according to [parameters].
      */
     fun getDetectedLicensesForRun(
         ortRunId: Long,
         parameters: ListQueryParameters,
-        licenseFilter: String?
+        licenseFilter: FilterOperatorAndValue<String>?
     ): ListQueryResult<DetectedLicense> = db.blockingQuery {
-        val ctx = buildQueryContext()
+        val licenseFindingsJoin = buildLicenseFindingsJoin()
         val packageCount = Count(IdentifiersTable.id, distinct = true)
         // Window function gives the total group count in the same query, avoiding running the query twice.
         val totalCount = Count(LicenseFindingsTable.license).over()
 
-        val query = ctx.join
+        val query = licenseFindingsJoin
             .select(LicenseFindingsTable.license, packageCount, totalCount)
             .where { ScannerJobsTable.ortRunId eq ortRunId }
             .groupBy(LicenseFindingsTable.license)
 
-        licenseFilter?.let { query.andWhere { LicenseFindingsTable.license.applyILike(it) } }
+        licenseFilter?.let {
+            query.andWhere { LicenseFindingsTable.license.applyFilter(it.operator, it.value) }
+        }
 
         parameters.sortFields.forEach { orderField ->
             val sortOrder = orderField.direction.toSortOrder()
@@ -113,17 +112,16 @@ class LicenseFindingService(private val db: Database) {
     /**
      * Return the packages in the ORT run with the given [ortRunId] that contain the provided [license].
      *
-     * The result can be filtered by [identifierFilter] and [purlFilter], and paged and sorted according to
-     * [parameters].
+     * The result can be filtered by [identifierFilter] and [purlFilter], and paged and sorted according to [parameters].
      */
     fun getPackagesWithDetectedLicenseForRun(
         ortRunId: Long,
         license: String,
         parameters: ListQueryParameters,
-        identifierFilter: String?,
+        identifierFilter: FilterOperatorAndValue<String>?,
         purlFilter: String?
     ): ListQueryResult<PackageIdentifier> = db.blockingQuery {
-        val ctx = buildQueryContext()
+        val licenseFindingsJoin = buildLicenseFindingsJoin()
 
         // Lateral subquery: fetch one purl per identifier for the current ORT run. Each ORT run has at most one
         // analyzer run, so LIMIT 1 is a safety net rather than a meaningful filter.
@@ -139,7 +137,7 @@ class LicenseFindingService(private val db: Database) {
             .limit(1)
             .alias("purl_sub")
 
-        val join = ctx.join.join(purlSubquery, JoinType.LEFT, lateral = true) { Op.TRUE }
+        val join = licenseFindingsJoin.join(purlSubquery, JoinType.LEFT, lateral = true) { Op.TRUE }
         val purl = purlSubquery[PackagesTable.purl].min().alias("purl")
         val totalCount = Count(IdentifiersTable.type).over()
 
@@ -163,7 +161,9 @@ class LicenseFindingService(private val db: Database) {
                 IdentifiersTable.version
             )
 
-        identifierFilter?.let { query.andWhere { identifierExpression().applyILike(it) } }
+        identifierFilter?.let {
+            query.andWhere { identifierExpression().applyFilter(it.operator, it.value) }
+        }
         purlFilter?.let { query.andWhere { purlSubquery[PackagesTable.purl].applyILike(it) } }
 
         parameters.sortFields.forEach { orderField ->
@@ -200,6 +200,21 @@ class LicenseFindingService(private val db: Database) {
     }
 
     /**
+     * Return the distinct detected license expressions for the given [identifier] in the ORT run with the given
+     * [ortRunId], sorted by their raw string values.
+     */
+    fun getDetectedLicensesForIdentifier(ortRunId: Long, identifier: String): List<String> = db.blockingQuery {
+        buildLicenseFindingsJoin()
+            .select(LicenseFindingsTable.license)
+            .where {
+                (ScannerJobsTable.ortRunId eq ortRunId) and (identifierExpression() eq identifier)
+            }
+            .withDistinct()
+            .orderBy(LicenseFindingsTable.license)
+            .map { it[LicenseFindingsTable.license] }
+    }
+
+    /**
      * Return the file-level license findings for the given [license] and package [identifier] in the ORT run with the
      * given [ortRunId].
      *
@@ -211,10 +226,10 @@ class LicenseFindingService(private val db: Database) {
         identifier: String,
         parameters: ListQueryParameters
     ): ListQueryResult<LicenseFinding> = db.blockingQuery {
-        val ctx = buildQueryContext()
+        val licenseFindingsJoin = buildLicenseFindingsJoin()
         val totalCount = Count(LicenseFindingsTable.path).over()
 
-        val query = ctx.join
+        val query = licenseFindingsJoin
             .select(
                 LicenseFindingsTable.path,
                 LicenseFindingsTable.startLine,
@@ -268,42 +283,6 @@ class LicenseFindingService(private val db: Database) {
             totalCount = rows.firstOrNull()?.get(totalCount) ?: 0L
         )
     }
-}
-
-private class QueryContext(val join: Join)
-
-/**
- * Build the common query context for license findings queries. Joins through the
- * [ScanResultPackageProvenancesTable] junction table to guarantee correct provenance matching at the
- * DB level.
- */
-private fun buildQueryContext(): QueryContext {
-    val join = LicenseFindingsTable
-        .innerJoin(ScanSummariesTable)
-        .join(ScanResultsTable, JoinType.INNER, ScanSummariesTable.id, ScanResultsTable.scanSummaryId)
-        .join(
-            ScanResultPackageProvenancesTable, JoinType.INNER,
-            ScanResultsTable.id, ScanResultPackageProvenancesTable.scanResultId
-        )
-        .join(
-            PackageProvenancesTable, JoinType.INNER,
-            ScanResultPackageProvenancesTable.packageProvenanceId, PackageProvenancesTable.id
-        )
-        .join(
-            ScannerRunsPackageProvenancesTable, JoinType.INNER,
-            PackageProvenancesTable.id, ScannerRunsPackageProvenancesTable.packageProvenanceId
-        )
-        .join(ScannerRunsTable, JoinType.INNER, ScannerRunsPackageProvenancesTable.scannerRunId, ScannerRunsTable.id)
-        .join(ScannerJobsTable, JoinType.INNER, ScannerRunsTable.scannerJobId, ScannerJobsTable.id)
-        // Ensures only scan results explicitly associated with the matched scanner run are returned,
-        // preventing results from a different scanner run that shares the same package provenance from leaking in.
-        .join(
-            ScannerRunsScanResultsTable, JoinType.INNER,
-            ScanResultsTable.id, ScannerRunsScanResultsTable.scanResultId
-        ) { ScannerRunsScanResultsTable.scannerRunId eq ScannerRunsTable.id }
-        .join(IdentifiersTable, JoinType.INNER, PackageProvenancesTable.identifierId, IdentifiersTable.id)
-
-    return QueryContext(join)
 }
 
 private fun identifierExpression() = CustomFunction<String>(

--- a/components/license-findings/backend/src/routes/kotlin/Routing.kt
+++ b/components/license-findings/backend/src/routes/kotlin/Routing.kt
@@ -23,11 +23,13 @@ import io.ktor.server.routing.Route
 
 import org.eclipse.apoapsis.ortserver.components.licensefindings.routes.getRunDetectedLicenseFindings
 import org.eclipse.apoapsis.ortserver.components.licensefindings.routes.getRunDetectedLicenses
+import org.eclipse.apoapsis.ortserver.components.licensefindings.routes.getRunDetectedLicensesForIdentifier
 import org.eclipse.apoapsis.ortserver.components.licensefindings.routes.getRunPackagesWithDetectedLicense
 import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
 
 fun Route.licenseFindingRoutes(service: LicenseFindingService, ortRunRepository: OrtRunRepository) {
     getRunDetectedLicenses(service, ortRunRepository)
+    getRunDetectedLicensesForIdentifier(service, ortRunRepository)
     getRunDetectedLicenseFindings(service, ortRunRepository)
     getRunPackagesWithDetectedLicense(service, ortRunRepository)
 }

--- a/components/license-findings/backend/src/routes/kotlin/routes/GetRunDetectedLicenses.kt
+++ b/components/license-findings/backend/src/routes/kotlin/routes/GetRunDetectedLicenses.kt
@@ -54,7 +54,11 @@ internal fun Route.getRunDetectedLicenses(
                 description = "The ID of the ORT run."
             }
             queryParameter<String>("license") {
-                description = "Filter by license using a case-insensitive substring match."
+                description = "Filter by license. Uses a case-insensitive substring match by default."
+            }
+            queryParameter<String>("licenseMatchType") {
+                description = "How to match the license filter: 'substring' performs a case-insensitive substring " +
+                    "match (the default), while 'exact' performs case-sensitive equality."
             }
             standardListQueryParameters()
         }
@@ -79,14 +83,29 @@ internal fun Route.getRunDetectedLicenses(
                     }
                 }
             }
+            HttpStatusCode.BadRequest to {
+                description = "If 'licenseMatchType' has an unsupported value."
+            }
         }
     }, requireRunReadPermission(ortRunRepository)) {
         val runId = call.requireIdParameter("runId")
 
         ortRunRepository.get(runId) ?: return@get call.respond(HttpStatusCode.NotFound)
 
-        val licenseFilter = call.parameters["license"]?.let {
-            FilterOperatorAndValue(ComparisonOperator.ILIKE, it)
+        val licenseFilter = call.parameters["license"]?.let { value ->
+            val matchType = call.parameters["licenseMatchType"] ?: "substring"
+            val operator = when (matchType) {
+                "substring" -> ComparisonOperator.ILIKE
+
+                "exact" -> ComparisonOperator.EQUALS
+
+                else -> return@get call.respond(
+                    HttpStatusCode.BadRequest,
+                    "Unsupported 'licenseMatchType' value '$matchType'. Supported values are 'substring' and 'exact'."
+                )
+            }
+
+            FilterOperatorAndValue(operator, value)
         }
 
         val result = service.getDetectedLicensesForRun(

--- a/components/license-findings/backend/src/routes/kotlin/routes/GetRunDetectedLicenses.kt
+++ b/components/license-findings/backend/src/routes/kotlin/routes/GetRunDetectedLicenses.kt
@@ -27,6 +27,8 @@ import org.eclipse.apoapsis.ortserver.components.authorization.routes.get
 import org.eclipse.apoapsis.ortserver.components.licensefindings.DetectedLicense
 import org.eclipse.apoapsis.ortserver.components.licensefindings.LicenseFindingService
 import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
+import org.eclipse.apoapsis.ortserver.model.util.ComparisonOperator
+import org.eclipse.apoapsis.ortserver.model.util.FilterOperatorAndValue
 import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToApi
 import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToModel
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse
@@ -83,10 +85,14 @@ internal fun Route.getRunDetectedLicenses(
 
         ortRunRepository.get(runId) ?: return@get call.respond(HttpStatusCode.NotFound)
 
+        val licenseFilter = call.parameters["license"]?.let {
+            FilterOperatorAndValue(ComparisonOperator.ILIKE, it)
+        }
+
         val result = service.getDetectedLicensesForRun(
             ortRunId = runId,
             parameters = call.pagingOptions(SortProperty("license", SortDirection.ASCENDING)).mapToModel(),
-            licenseFilter = call.parameters["license"]
+            licenseFilter = licenseFilter
         )
 
         call.respond(HttpStatusCode.OK, result.mapToApi { it })

--- a/components/license-findings/backend/src/routes/kotlin/routes/GetRunDetectedLicensesForIdentifier.kt
+++ b/components/license-findings/backend/src/routes/kotlin/routes/GetRunDetectedLicensesForIdentifier.kt
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.components.licensefindings.routes
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+
+import org.eclipse.apoapsis.ortserver.components.authorization.routes.get
+import org.eclipse.apoapsis.ortserver.components.licensefindings.LicenseFindingService
+import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
+import org.eclipse.apoapsis.ortserver.shared.ktorutils.jsonBody
+import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireIdParameter
+
+internal fun Route.getRunDetectedLicensesForIdentifier(
+    service: LicenseFindingService,
+    ortRunRepository: OrtRunRepository
+): Route =
+    get("runs/{runId}/detected-licenses/identifiers/{identifier}", {
+        operationId = "getRunDetectedLicensesForIdentifier"
+        summary = "Get detected licenses for an identifier in an ORT run"
+        tags = listOf("Runs")
+
+        request {
+            pathParameter<Long>("runId") {
+                description = "The ID of the ORT run."
+            }
+            pathParameter<String>("identifier") {
+                description = "The URL-encoded ORT identifier (e.g. Maven%3Acom.example%3Alib%3A1.0)."
+            }
+        }
+
+        response {
+            HttpStatusCode.OK to {
+                description = "Success."
+                jsonBody<List<String>> {
+                    example("Get detected licenses for an identifier") {
+                        value = listOf("Apache-2.0", "MIT")
+                    }
+                }
+            }
+        }
+    }, requireRunReadPermission(ortRunRepository)) {
+        val runId = call.requireIdParameter("runId")
+
+        ortRunRepository.get(runId) ?: return@get call.respond(HttpStatusCode.NotFound)
+
+        val licenses = service.getDetectedLicensesForIdentifier(
+            ortRunId = runId,
+            identifier = call.parameters["identifier"].orEmpty()
+        )
+
+        call.respond(HttpStatusCode.OK, licenses)
+    }

--- a/components/license-findings/backend/src/routes/kotlin/routes/GetRunPackagesWithDetectedLicense.kt
+++ b/components/license-findings/backend/src/routes/kotlin/routes/GetRunPackagesWithDetectedLicense.kt
@@ -27,6 +27,8 @@ import org.eclipse.apoapsis.ortserver.components.authorization.routes.get
 import org.eclipse.apoapsis.ortserver.components.licensefindings.LicenseFindingService
 import org.eclipse.apoapsis.ortserver.components.licensefindings.PackageIdentifier
 import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
+import org.eclipse.apoapsis.ortserver.model.util.ComparisonOperator
+import org.eclipse.apoapsis.ortserver.model.util.FilterOperatorAndValue
 import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToApi
 import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToModel
 import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
@@ -88,11 +90,15 @@ internal fun Route.getRunPackagesWithDetectedLicense(
             }
         }
     }, requireRunReadPermission(ortRunRepository)) {
+        val identifierFilter = call.parameters["identifier"]?.let {
+            FilterOperatorAndValue(ComparisonOperator.ILIKE, it)
+        }
+
         val result = service.getPackagesWithDetectedLicenseForRun(
             ortRunId = call.requireIdParameter("runId"),
             license = call.parameters["license"].orEmpty(),
             parameters = call.pagingOptions(SortProperty("identifier", SortDirection.ASCENDING)).mapToModel(),
-            identifierFilter = call.parameters["identifier"],
+            identifierFilter = identifierFilter,
             purlFilter = call.parameters["purl"]
         )
 

--- a/components/license-findings/backend/src/routes/kotlin/routes/GetRunPackagesWithDetectedLicense.kt
+++ b/components/license-findings/backend/src/routes/kotlin/routes/GetRunPackagesWithDetectedLicense.kt
@@ -58,7 +58,11 @@ internal fun Route.getRunPackagesWithDetectedLicense(
                 description = "The URL-encoded SPDX license identifier (e.g. Apache-2.0, GPL-2.0-or-later)."
             }
             queryParameter<String>("identifier") {
-                description = "Filter by ORT identifier using a case-insensitive substring match."
+                description = "Filter by ORT identifier. Uses a case-insensitive substring match by default."
+            }
+            queryParameter<String>("identifierMatchType") {
+                description = "How to match the identifier filter: 'substring' performs a case-insensitive substring " +
+                    "match (the default), while 'exact' performs case-sensitive equality."
             }
             queryParameter<String>("purl") {
                 description = "Filter by PURL using a case-insensitive substring match."
@@ -88,10 +92,26 @@ internal fun Route.getRunPackagesWithDetectedLicense(
                     }
                 }
             }
+            HttpStatusCode.BadRequest to {
+                description = "If 'identifierMatchType' has an unsupported value."
+            }
         }
     }, requireRunReadPermission(ortRunRepository)) {
-        val identifierFilter = call.parameters["identifier"]?.let {
-            FilterOperatorAndValue(ComparisonOperator.ILIKE, it)
+        val identifierFilter = call.parameters["identifier"]?.let { value ->
+            val matchType = call.parameters["identifierMatchType"] ?: "substring"
+            val operator = when (matchType) {
+                "substring" -> ComparisonOperator.ILIKE
+
+                "exact" -> ComparisonOperator.EQUALS
+
+                else -> return@get call.respond(
+                    HttpStatusCode.BadRequest,
+                    "Unsupported 'identifierMatchType' value '$matchType'. Supported values are 'substring' and " +
+                        "'exact'."
+                )
+            }
+
+            FilterOperatorAndValue(operator, value)
         }
 
         val result = service.getPackagesWithDetectedLicenseForRun(

--- a/components/license-findings/backend/src/test/kotlin/LicenseFindingServiceTest.kt
+++ b/components/license-findings/backend/src/test/kotlin/LicenseFindingServiceTest.kt
@@ -717,7 +717,7 @@ internal fun seedCrossRunData(fixtures: Fixtures, db: Database): CrossRunSeedRes
     return CrossRunSeedResult(ortRun1.id, ortRun2.id, identifier)
 }
 
-private fun addLicenseFindings(
+internal fun addLicenseFindings(
     db: Database,
     scannerRunId: Long,
     identifier: Identifier,

--- a/components/license-findings/backend/src/test/kotlin/LicenseFindingServiceTest.kt
+++ b/components/license-findings/backend/src/test/kotlin/LicenseFindingServiceTest.kt
@@ -44,6 +44,8 @@ import org.eclipse.apoapsis.ortserver.model.RepositoryType
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.runs.RemoteArtifact
 import org.eclipse.apoapsis.ortserver.model.runs.VcsInfo
+import org.eclipse.apoapsis.ortserver.model.util.ComparisonOperator
+import org.eclipse.apoapsis.ortserver.model.util.FilterOperatorAndValue
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
 import org.eclipse.apoapsis.ortserver.model.util.OrderField
@@ -103,7 +105,7 @@ class LicenseFindingServiceTest : WordSpec() {
                 val result = service.getDetectedLicensesForRun(
                     seed.ortRunId,
                     ListQueryParameters(sortFields = listOf(OrderField("license", OrderDirection.ASCENDING))),
-                    "apache"
+                    FilterOperatorAndValue(ComparisonOperator.ILIKE, "apache")
                 )
 
                 result.totalCount shouldBe 1
@@ -120,6 +122,23 @@ class LicenseFindingServiceTest : WordSpec() {
                 )
 
                 result.data.map { it.license } should containExactly("MIT")
+            }
+
+            "apply an EQUALS licenseFilter" {
+                addLicenseFindings(
+                    db,
+                    seed.scannerRunId,
+                    Identifier("Maven", "com.example", "mit-or-apache", "1.0"),
+                    listOf("MIT OR Apache-2.0")
+                )
+
+                val result = service.getDetectedLicensesForRun(
+                    seed.ortRunId,
+                    ListQueryParameters(sortFields = listOf(OrderField("license", OrderDirection.ASCENDING))),
+                    FilterOperatorAndValue(ComparisonOperator.EQUALS, "MIT")
+                )
+
+                result.data should containExactly(DetectedLicense("MIT", 1))
             }
 
             "sort by packageCount descending without throwing" {
@@ -221,7 +240,7 @@ class LicenseFindingServiceTest : WordSpec() {
                     seed.ortRunId,
                     "Apache-2.0",
                     ListQueryParameters(sortFields = listOf(OrderField("identifier", OrderDirection.ASCENDING))),
-                    "ARTIFACT-package",
+                    FilterOperatorAndValue(ComparisonOperator.ILIKE, "ARTIFACT-package"),
                     null
                 )
 
@@ -236,12 +255,32 @@ class LicenseFindingServiceTest : WordSpec() {
                     seed.ortRunId,
                     "Apache-2.0",
                     ListQueryParameters(sortFields = listOf(OrderField("identifier", OrderDirection.ASCENDING))),
-                    "does-not-exist",
+                    FilterOperatorAndValue(ComparisonOperator.ILIKE, "does-not-exist"),
                     null
                 )
 
                 result.totalCount shouldBe 0
                 result.data.shouldBeEmpty()
+            }
+
+            "apply an EQUALS identifierFilter" {
+                val similarIdentifier = seed.artifactIdentifier.copy(name = "artifact-package-extra")
+                addLicenseFindings(db, seed.scannerRunId, similarIdentifier, listOf("Apache-2.0"))
+
+                val result = service.getPackagesWithDetectedLicenseForRun(
+                    seed.ortRunId,
+                    "Apache-2.0",
+                    ListQueryParameters(sortFields = listOf(OrderField("identifier", OrderDirection.ASCENDING))),
+                    FilterOperatorAndValue(
+                        ComparisonOperator.EQUALS,
+                        seed.artifactIdentifier.toCoordinates()
+                    ),
+                    null
+                )
+
+                result.data should containExactly(
+                    PackageIdentifier(seed.artifactIdentifier.mapToApi(), seed.artifactPurl)
+                )
             }
 
             "respect limit and offset" {
@@ -307,6 +346,65 @@ class LicenseFindingServiceTest : WordSpec() {
                     PackageIdentifier(seed.vcsIdentifier.mapToApi(), seed.vcsPurl),
                     PackageIdentifier(seed.artifactIdentifier.mapToApi(), seed.artifactPurl)
                 )
+            }
+        }
+
+        "getDetectedLicensesForIdentifier" should {
+            "return one compound expression unchanged" {
+                val identifier = Identifier("Maven", "com.example", "single-license", "1.0")
+                addLicenseFindings(db, seed.scannerRunId, identifier, listOf("MIT OR Apache-2.0"))
+
+                service.getDetectedLicensesForIdentifier(
+                    seed.ortRunId,
+                    identifier.toCoordinates()
+                ) should containExactly("MIT OR Apache-2.0")
+            }
+
+            "return distinct raw expressions sorted alphabetically" {
+                val identifier = Identifier("Maven", "com.example", "multiple-licenses", "1.0")
+                addLicenseFindings(
+                    db,
+                    seed.scannerRunId,
+                    identifier,
+                    listOf(
+                        "MIT OR Apache-2.0",
+                        "MIT AND Apache-2.0",
+                        "Apache-2.0 AND MIT",
+                        "Apache-2.0 AND MIT"
+                    )
+                )
+
+                service.getDetectedLicensesForIdentifier(
+                    seed.ortRunId,
+                    identifier.toCoordinates()
+                ) should containExactly(
+                    "Apache-2.0 AND MIT",
+                    "MIT AND Apache-2.0",
+                    "MIT OR Apache-2.0"
+                )
+            }
+
+            "return an empty list for an unknown identifier" {
+                service.getDetectedLicensesForIdentifier(
+                    seed.ortRunId,
+                    "Maven:com.example:unknown:1.0"
+                ).shouldBeEmpty()
+            }
+
+            "not return findings from another ORT run" {
+                service.getDetectedLicensesForIdentifier(
+                    seed.ortRunId,
+                    seed.otherIdentifier.toCoordinates()
+                ).shouldBeEmpty()
+            }
+
+            "return findings for a scanned project" {
+                addLicenseFindings(db, seed.scannerRunId, seed.projectIdentifier, listOf("Apache-2.0"))
+
+                service.getDetectedLicensesForIdentifier(
+                    seed.ortRunId,
+                    seed.projectIdentifier.toCoordinates()
+                ) should containExactly("Apache-2.0")
             }
         }
 
@@ -417,9 +515,11 @@ class LicenseFindingServiceTest : WordSpec() {
 internal data class SeedResult(
     val ortRunId: Long,
     val otherOrtRunId: Long,
+    val scannerRunId: Long,
     val artifactIdentifier: Identifier,
     val vcsIdentifier: Identifier,
     val otherIdentifier: Identifier,
+    val projectIdentifier: Identifier,
     val artifactPurl: String,
     val vcsPurl: String,
     val otherPurl: String
@@ -432,6 +532,7 @@ internal fun seedData(fixtures: Fixtures, db: Database, duplicatePackageEntries:
     val artifactIdentifier = Identifier("Maven", "com.example", "artifact-package", "1.0")
     val vcsIdentifier = Identifier("Maven", "com.example", "vcs-package", "2.0")
     val otherIdentifier = Identifier("NPM", "", "other-package", "3.0")
+    val projectIdentifier = Identifier("Gradle", "com.example", "project", "1.0")
 
     val artifactPurl = "pkg:maven/com.example/artifact-package@1.0"
     val artifactDuplicatePurl = "pkg:maven/com.example/artifact-package@1.0?classifier=duplicate"
@@ -447,6 +548,7 @@ internal fun seedData(fixtures: Fixtures, db: Database, duplicatePackageEntries:
     val analyzerJob = fixtures.createAnalyzerJob(ortRun.id)
     fixtures.createAnalyzerRun(
         analyzerJobId = analyzerJob.id,
+        projects = setOf(fixtures.getProject(projectIdentifier)),
         packages = buildSet {
             add(artifactPackage)
             add(vcsPackage)
@@ -478,9 +580,12 @@ internal fun seedData(fixtures: Fixtures, db: Database, duplicatePackageEntries:
         path = ""
     )
 
+    var scannerRunId = 0L
+
     db.blockingQuery {
         val scannerJob = fixtures.createScannerJob(ortRun.id)
         val scannerRun = fixtures.scannerRunRepository.create(scannerJob.id)
+        scannerRunId = scannerRun.id
 
         val otherScannerJob = fixtures.createScannerJob(otherOrtRun.id)
         val otherScannerRun = fixtures.scannerRunRepository.create(otherScannerJob.id)
@@ -522,9 +627,11 @@ internal fun seedData(fixtures: Fixtures, db: Database, duplicatePackageEntries:
     return SeedResult(
         ortRunId = ortRun.id,
         otherOrtRunId = otherOrtRun.id,
+        scannerRunId = scannerRunId,
         artifactIdentifier = artifactIdentifier,
         vcsIdentifier = vcsIdentifier,
         otherIdentifier = otherIdentifier,
+        projectIdentifier = projectIdentifier,
         artifactPurl = artifactPurl,
         vcsPurl = vcsPurl,
         otherPurl = otherPurl
@@ -608,6 +715,29 @@ internal fun seedCrossRunData(fixtures: Fixtures, db: Database): CrossRunSeedRes
     }
 
     return CrossRunSeedResult(ortRun1.id, ortRun2.id, identifier)
+}
+
+private fun addLicenseFindings(
+    db: Database,
+    scannerRunId: Long,
+    identifier: Identifier,
+    licenses: List<String>
+) {
+    val vcs = VcsInfo(
+        type = RepositoryType.GIT,
+        url = "https://example.com/scm/${identifier.name}.git",
+        revision = "revision-${identifier.name}",
+        path = ""
+    )
+
+    db.blockingQuery {
+        val packageProvenance = createPackageProvenance(scannerRunId, identifier, vcs = vcs)
+        val findings = licenses.mapIndexed { index, license ->
+            FindingSeed(license, "file-$index", index + 1, index + 1, 100f)
+        }
+
+        createVcsScanResult(scannerRunId, vcs, packageProvenance.id.value, findings)
+    }
 }
 
 private data class FindingSeed(

--- a/components/license-findings/backend/src/test/kotlin/routes/GetRunDetectedLicensesForIdentifierIntegrationTest.kt
+++ b/components/license-findings/backend/src/test/kotlin/routes/GetRunDetectedLicensesForIdentifierIntegrationTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.components.licensefindings.routes
+
+import io.kotest.matchers.collections.containExactly
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+
+import java.net.URLEncoder
+import java.nio.charset.StandardCharsets
+
+import org.eclipse.apoapsis.ortserver.components.licensefindings.LicenseFindingIntegrationTest
+import org.eclipse.apoapsis.ortserver.components.licensefindings.SeedResult
+import org.eclipse.apoapsis.ortserver.components.licensefindings.addLicenseFindings
+import org.eclipse.apoapsis.ortserver.components.licensefindings.seedData
+
+class GetRunDetectedLicensesForIdentifierIntegrationTest : LicenseFindingIntegrationTest({
+    lateinit var seeded: SeedResult
+
+    beforeEach {
+        seeded = seedData(dbExtension.fixtures, dbExtension.db)
+    }
+
+    "GetRunDetectedLicensesForIdentifier" should {
+        "return the detected licenses for a URL-encoded package identifier" {
+            val identifier = URLEncoder.encode(
+                seeded.artifactIdentifier.toCoordinates(),
+                StandardCharsets.UTF_8
+            )
+
+            licenseFindingTestApplication { client ->
+                val response = client.get(
+                    "/runs/${seeded.ortRunId}/detected-licenses/identifiers/$identifier"
+                )
+
+                response.status shouldBe HttpStatusCode.OK
+                response.body<List<String>>() should containExactly("Apache-2.0", "BSD-3-Clause")
+            }
+        }
+
+        "return the detected licenses for a project identifier" {
+            addLicenseFindings(
+                dbExtension.db,
+                seeded.scannerRunId,
+                seeded.projectIdentifier,
+                listOf("MIT")
+            )
+            val identifier = URLEncoder.encode(
+                seeded.projectIdentifier.toCoordinates(),
+                StandardCharsets.UTF_8
+            )
+
+            licenseFindingTestApplication { client ->
+                val response = client.get(
+                    "/runs/${seeded.ortRunId}/detected-licenses/identifiers/$identifier"
+                )
+
+                response.status shouldBe HttpStatusCode.OK
+                response.body<List<String>>() should containExactly("MIT")
+            }
+        }
+
+        "return an empty list for an identifier without findings" {
+            val identifier = URLEncoder.encode(
+                seeded.projectIdentifier.toCoordinates(),
+                StandardCharsets.UTF_8
+            )
+
+            licenseFindingTestApplication { client ->
+                val response = client.get(
+                    "/runs/${seeded.ortRunId}/detected-licenses/identifiers/$identifier"
+                )
+
+                response.status shouldBe HttpStatusCode.OK
+                response.body<List<String>>().shouldBeEmpty()
+            }
+        }
+
+        "return 404 for an unknown run" {
+            val identifier = URLEncoder.encode(
+                seeded.artifactIdentifier.toCoordinates(),
+                StandardCharsets.UTF_8
+            )
+
+            licenseFindingTestApplication { client ->
+                val response = client.get("/runs/999999/detected-licenses/identifiers/$identifier")
+
+                response.status shouldBe HttpStatusCode.NotFound
+            }
+        }
+    }
+})

--- a/components/license-findings/backend/src/test/kotlin/routes/GetRunDetectedLicensesIntegrationTest.kt
+++ b/components/license-findings/backend/src/test/kotlin/routes/GetRunDetectedLicensesIntegrationTest.kt
@@ -25,11 +25,15 @@ import io.kotest.matchers.shouldBe
 
 import io.ktor.client.call.body
 import io.ktor.client.request.get
+import io.ktor.client.request.parameter
 import io.ktor.http.HttpStatusCode
 
 import org.eclipse.apoapsis.ortserver.components.licensefindings.DetectedLicense
 import org.eclipse.apoapsis.ortserver.components.licensefindings.LicenseFindingIntegrationTest
+import org.eclipse.apoapsis.ortserver.components.licensefindings.SeedResult
+import org.eclipse.apoapsis.ortserver.components.licensefindings.addLicenseFindings
 import org.eclipse.apoapsis.ortserver.components.licensefindings.seedData
+import org.eclipse.apoapsis.ortserver.model.runs.Identifier
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters.Companion.DEFAULT_LIMIT
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagingData
@@ -37,16 +41,16 @@ import org.eclipse.apoapsis.ortserver.shared.apimodel.SortDirection
 import org.eclipse.apoapsis.ortserver.shared.apimodel.SortProperty
 
 class GetRunDetectedLicensesIntegrationTest : LicenseFindingIntegrationTest({
-    var ortRunId = -1L
+    lateinit var seeded: SeedResult
 
     beforeEach {
-        ortRunId = seedData(dbExtension.fixtures, dbExtension.db).ortRunId
+        seeded = seedData(dbExtension.fixtures, dbExtension.db)
     }
 
     "GetRunDetectedLicenses" should {
         "return 200 with all licenses and package counts sorted by license" {
             licenseFindingTestApplication { client ->
-                val response = client.get("/runs/$ortRunId/detected-licenses")
+                val response = client.get("/runs/${seeded.ortRunId}/detected-licenses")
 
                 response.status shouldBe HttpStatusCode.OK
                 response.body<PagedResponse<DetectedLicense>>() shouldBe PagedResponse(
@@ -65,14 +69,84 @@ class GetRunDetectedLicensesIntegrationTest : LicenseFindingIntegrationTest({
             }
         }
 
-        "filter by the license query parameter case-insensitively" {
+        "use substring matching by default for the license query parameter" {
+            addLicenseFindings(
+                dbExtension.db,
+                seeded.scannerRunId,
+                Identifier("Maven", "com.example", "mit-or-apache", "1.0"),
+                listOf("MIT OR Apache-2.0")
+            )
+
             licenseFindingTestApplication { client ->
-                val response = client.get("/runs/$ortRunId/detected-licenses?license=apache")
+                val response = client.get("/runs/${seeded.ortRunId}/detected-licenses") {
+                    parameter("license", "mit")
+                }
+
+                response.status shouldBe HttpStatusCode.OK
+                val body = response.body<PagedResponse<DetectedLicense>>()
+                body.pagination.totalCount shouldBe 2
+                body.data should containExactly(
+                    DetectedLicense("MIT", 1),
+                    DetectedLicense("MIT OR Apache-2.0", 1)
+                )
+            }
+        }
+
+        "support explicit substring matching for the license query parameter" {
+            addLicenseFindings(
+                dbExtension.db,
+                seeded.scannerRunId,
+                Identifier("Maven", "com.example", "mit-or-apache", "1.0"),
+                listOf("MIT OR Apache-2.0")
+            )
+
+            licenseFindingTestApplication { client ->
+                val response = client.get("/runs/${seeded.ortRunId}/detected-licenses") {
+                    parameter("license", "mit")
+                    parameter("licenseMatchType", "substring")
+                }
+
+                response.status shouldBe HttpStatusCode.OK
+                val body = response.body<PagedResponse<DetectedLicense>>()
+                body.pagination.totalCount shouldBe 2
+                body.data should containExactly(
+                    DetectedLicense("MIT", 1),
+                    DetectedLicense("MIT OR Apache-2.0", 1)
+                )
+            }
+        }
+
+        "support exact matching for the license query parameter" {
+            addLicenseFindings(
+                dbExtension.db,
+                seeded.scannerRunId,
+                Identifier("Maven", "com.example", "mit-or-apache", "1.0"),
+                listOf("MIT OR Apache-2.0")
+            )
+
+            licenseFindingTestApplication { client ->
+                val response = client.get("/runs/${seeded.ortRunId}/detected-licenses") {
+                    parameter("license", "MIT")
+                    parameter("licenseMatchType", "exact")
+                }
 
                 response.status shouldBe HttpStatusCode.OK
                 val body = response.body<PagedResponse<DetectedLicense>>()
                 body.pagination.totalCount shouldBe 1
-                body.data should containExactly(DetectedLicense("Apache-2.0", 2))
+                body.data should containExactly(DetectedLicense("MIT", 1))
+            }
+        }
+
+        "return 400 for an unsupported license match type" {
+            licenseFindingTestApplication { client ->
+                val response = client.get("/runs/${seeded.ortRunId}/detected-licenses") {
+                    parameter("license", "MIT")
+                    parameter("licenseMatchType", "unsupported")
+                }
+
+                response.status shouldBe HttpStatusCode.BadRequest
+                response.body<String>() shouldBe
+                    "Unsupported 'licenseMatchType' value 'unsupported'. Supported values are 'substring' and 'exact'."
             }
         }
 

--- a/components/license-findings/backend/src/test/kotlin/routes/GetRunPackagesWithDetectedLicenseIntegrationTest.kt
+++ b/components/license-findings/backend/src/test/kotlin/routes/GetRunPackagesWithDetectedLicenseIntegrationTest.kt
@@ -25,11 +25,13 @@ import io.kotest.matchers.shouldBe
 
 import io.ktor.client.call.body
 import io.ktor.client.request.get
+import io.ktor.client.request.parameter
 import io.ktor.http.HttpStatusCode
 
 import org.eclipse.apoapsis.ortserver.components.licensefindings.LicenseFindingIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.licensefindings.PackageIdentifier
 import org.eclipse.apoapsis.ortserver.components.licensefindings.SeedResult
+import org.eclipse.apoapsis.ortserver.components.licensefindings.addLicenseFindings
 import org.eclipse.apoapsis.ortserver.components.licensefindings.seedData
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters.Companion.DEFAULT_LIMIT
 import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToApi
@@ -70,10 +72,10 @@ class GetRunPackagesWithDetectedLicenseIntegrationTest : LicenseFindingIntegrati
             }
         }
 
-        "filter by the identifier query parameter" {
+        "use substring matching by default for the identifier query parameter" {
             licenseFindingTestApplication { client ->
                 val response = client.get(
-                    "/runs/${seeded.ortRunId}/detected-licenses/Apache-2.0/packages?identifier=vcs"
+                    "/runs/${seeded.ortRunId}/detected-licenses/Apache-2.0/packages?identifier=VCS"
                 )
 
                 response.status shouldBe HttpStatusCode.OK
@@ -85,6 +87,75 @@ class GetRunPackagesWithDetectedLicenseIntegrationTest : LicenseFindingIntegrati
                         seeded.vcsPurl
                     )
                 )
+            }
+        }
+
+        "support explicit substring matching for the identifier query parameter" {
+            addLicenseFindings(
+                dbExtension.db,
+                seeded.scannerRunId,
+                seeded.artifactIdentifier.copy(name = "artifact-package-extra"),
+                listOf("Apache-2.0")
+            )
+
+            licenseFindingTestApplication { client ->
+                val response = client.get(
+                    "/runs/${seeded.ortRunId}/detected-licenses/Apache-2.0/packages"
+                ) {
+                    parameter("identifier", "artifact-package")
+                    parameter("identifierMatchType", "substring")
+                }
+
+                response.status shouldBe HttpStatusCode.OK
+                val body = response.body<PagedResponse<PackageIdentifier>>()
+                body.pagination.totalCount shouldBe 2
+                body.data.map { it.identifier.name } should containExactly(
+                    "artifact-package",
+                    "artifact-package-extra"
+                )
+            }
+        }
+
+        "support exact matching for the identifier query parameter" {
+            addLicenseFindings(
+                dbExtension.db,
+                seeded.scannerRunId,
+                seeded.artifactIdentifier.copy(name = "artifact-package-extra"),
+                listOf("Apache-2.0")
+            )
+
+            licenseFindingTestApplication { client ->
+                val response = client.get(
+                    "/runs/${seeded.ortRunId}/detected-licenses/Apache-2.0/packages"
+                ) {
+                    parameter("identifier", seeded.artifactIdentifier.toCoordinates())
+                    parameter("identifierMatchType", "exact")
+                }
+
+                response.status shouldBe HttpStatusCode.OK
+                val body = response.body<PagedResponse<PackageIdentifier>>()
+                body.pagination.totalCount shouldBe 1
+                body.data should containExactly(
+                    PackageIdentifier(
+                        seeded.artifactIdentifier.mapToApi(),
+                        seeded.artifactPurl
+                    )
+                )
+            }
+        }
+
+        "return 400 for an unsupported identifier match type" {
+            licenseFindingTestApplication { client ->
+                val response = client.get(
+                    "/runs/${seeded.ortRunId}/detected-licenses/Apache-2.0/packages"
+                ) {
+                    parameter("identifier", "artifact-package")
+                    parameter("identifierMatchType", "unsupported")
+                }
+
+                response.status shouldBe HttpStatusCode.BadRequest
+                response.body<String>() shouldBe "Unsupported 'identifierMatchType' value 'unsupported'. " +
+                    "Supported values are 'substring' and 'exact'."
             }
         }
 

--- a/components/license-findings/backend/src/test/kotlin/routes/LicenseFindingAuthorizationTest.kt
+++ b/components/license-findings/backend/src/test/kotlin/routes/LicenseFindingAuthorizationTest.kt
@@ -72,6 +72,22 @@ class LicenseFindingAuthorizationTest : AbstractAuthorizationTest({
         }
     }
 
+    "GetRunDetectedLicensesForIdentifier" should {
+        "require RepositoryPermission.READ_ORT_RUNS" {
+            val encodedIdentifier = URLEncoder.encode(artifactIdentifier, StandardCharsets.UTF_8)
+
+            requestShouldRequireRole(
+                routes = {
+                    licenseFindingRoutes(service, ortRunRepository)
+                },
+                role = RepositoryRole.READER,
+                hierarchyId = hierarchyId
+            ) {
+                get("/runs/$ortRunId/detected-licenses/identifiers/$encodedIdentifier")
+            }
+        }
+    }
+
     "GetRunPackagesWithDetectedLicense" should {
         "require RepositoryPermission.READ_ORT_RUNS" {
             requestShouldRequireRole(

--- a/dao/src/main/kotlin/queries/licensefindings/LicenseFindingsQuery.kt
+++ b/dao/src/main/kotlin/queries/licensefindings/LicenseFindingsQuery.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.dao.queries.licensefindings
+
+import org.eclipse.apoapsis.ortserver.dao.repositories.scannerjob.ScannerJobsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsPackageProvenancesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsScanResultsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsTable
+import org.eclipse.apoapsis.ortserver.dao.tables.LicenseFindingsTable
+import org.eclipse.apoapsis.ortserver.dao.tables.PackageProvenancesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.ScanResultPackageProvenancesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.ScanResultsTable
+import org.eclipse.apoapsis.ortserver.dao.tables.ScanSummariesTable
+import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
+
+import org.jetbrains.exposed.v1.core.Join
+import org.jetbrains.exposed.v1.core.JoinType
+import org.jetbrains.exposed.v1.core.eq
+
+/**
+ * Build the common join for license finding queries.
+ *
+ * The join uses both scan result association tables to ensure that a result belongs to the matched package provenance
+ * and scanner run. Callers must additionally restrict [ScannerJobsTable.ortRunId] to the requested ORT run.
+ */
+fun buildLicenseFindingsJoin(): Join =
+    LicenseFindingsTable
+        .innerJoin(ScanSummariesTable)
+        .join(ScanResultsTable, JoinType.INNER, ScanSummariesTable.id, ScanResultsTable.scanSummaryId)
+        .join(
+            ScanResultPackageProvenancesTable,
+            JoinType.INNER,
+            ScanResultsTable.id,
+            ScanResultPackageProvenancesTable.scanResultId
+        )
+        .join(
+            PackageProvenancesTable,
+            JoinType.INNER,
+            ScanResultPackageProvenancesTable.packageProvenanceId,
+            PackageProvenancesTable.id
+        )
+        .join(
+            ScannerRunsPackageProvenancesTable,
+            JoinType.INNER,
+            PackageProvenancesTable.id,
+            ScannerRunsPackageProvenancesTable.packageProvenanceId
+        )
+        .join(
+            ScannerRunsTable,
+            JoinType.INNER,
+            ScannerRunsPackageProvenancesTable.scannerRunId,
+            ScannerRunsTable.id
+        )
+        .join(ScannerJobsTable, JoinType.INNER, ScannerRunsTable.scannerJobId, ScannerJobsTable.id)
+        .join(
+            ScannerRunsScanResultsTable,
+            JoinType.INNER,
+            ScanResultsTable.id,
+            ScannerRunsScanResultsTable.scanResultId
+        ) { ScannerRunsScanResultsTable.scannerRunId eq ScannerRunsTable.id }
+        .join(IdentifiersTable, JoinType.INNER, PackageProvenancesTable.identifierId, IdentifiersTable.id)

--- a/dao/src/main/kotlin/utils/Extensions.kt
+++ b/dao/src/main/kotlin/utils/Extensions.kt
@@ -38,6 +38,7 @@ import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
 import org.jetbrains.exposed.v1.core.AbstractQuery
 import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.ComparisonOp
+import org.jetbrains.exposed.v1.core.EqOp
 import org.jetbrains.exposed.v1.core.Expression
 import org.jetbrains.exposed.v1.core.Op
 import org.jetbrains.exposed.v1.core.QueryParameter
@@ -207,6 +208,16 @@ class InsensitiveRegexOp(expr1: Expression<*>, expr2: Expression<*>) : Compariso
  */
 fun Expression<String>.applyILike(value: String): Op<Boolean> =
     InsensitiveLikeOp(this, QueryParameter("%$value%", TextColumnType()))
+
+/**
+ * Apply the given [operator] and filter [value] to filter this expression by.
+ */
+fun Expression<String>.applyFilter(operator: ComparisonOperator, value: String): Op<Boolean> =
+    when (operator) {
+        ComparisonOperator.EQUALS -> EqOp(this, QueryParameter(value, TextColumnType()))
+        ComparisonOperator.ILIKE -> this.applyILike(value)
+        else -> throw IllegalArgumentException("Unsupported operator.")
+    }
 
 /**
  * Apply the given [value] to filter this column by using the ~* operator.

--- a/ui/src/components/licenses/index.ts
+++ b/ui/src/components/licenses/index.ts
@@ -17,4 +17,5 @@
  * License-Filename: LICENSE
  */
 
+export { LicensesAccordion } from '@/components/licenses/licenses-accordion';
 export { SpdxExpressionBadgeGroup } from '@/components/licenses/spdx-expression-badge-group';

--- a/ui/src/components/licenses/licenses-accordion.tsx
+++ b/ui/src/components/licenses/licenses-accordion.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import { getRouteApi, Link } from '@tanstack/react-router';
+
+import { Identifier } from '@/api';
+import { getRunDetectedLicensesForIdentifierOptions } from '@/api/@tanstack/react-query.gen';
+import { LoadingIndicator } from '@/components/loading-indicator';
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from '@/components/ui/accordion';
+import { identifierToString } from '@/helpers/identifier-conversion';
+import { SpdxExpressionBadgeGroup } from './spdx-expression-badge-group';
+
+const routeApi = getRouteApi(
+  '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex'
+);
+
+export type LicensesAccordionProps = {
+  runId: number;
+  identifier: Identifier;
+  declaredLicenses: string[];
+};
+
+export const LicensesAccordion = ({
+  runId,
+  identifier,
+  declaredLicenses,
+}: LicensesAccordionProps) => {
+  const params = routeApi.useParams();
+  const identifierString = identifierToString(identifier);
+  const { data: licenses, isPending } = useQuery({
+    ...getRunDetectedLicensesForIdentifierOptions({
+      path: { runId, identifier: identifierString },
+    }),
+  });
+
+  return (
+    <Accordion type='multiple' className='w-full'>
+      <AccordionItem value='licenses'>
+        <AccordionTrigger className='py-0 font-bold'>Licenses</AccordionTrigger>
+        <AccordionContent>
+          <div className='grid grid-cols-[auto_minmax(0,1fr)] items-baseline gap-x-2 gap-y-2 pt-2 pl-2 text-sm'>
+            <div className='font-semibold'>Declared:</div>
+            {declaredLicenses.length ? (
+              <div className='flex flex-wrap gap-1'>
+                {declaredLicenses.map((license, index) => (
+                  <SpdxExpressionBadgeGroup
+                    key={`${license}-${index}`}
+                    expression={license}
+                    suffix={
+                      index < declaredLicenses.length - 1 ? ',' : undefined
+                    }
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className='text-muted-foreground italic'>
+                No declared licenses.
+              </div>
+            )}
+
+            <div className='font-semibold'>Detected:</div>
+            {isPending ? (
+              <LoadingIndicator />
+            ) : licenses?.length ? (
+              <div className='flex flex-wrap gap-1'>
+                {licenses.map((license, index) => (
+                  <Link
+                    key={`${license}-${index}`}
+                    className='hover:opacity-80'
+                    to='/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings'
+                    params={params}
+                    search={{
+                      detectedLicense: [license],
+                      marked: license,
+                      packageMarked: identifierString,
+                      page: 1,
+                      packagePage: 1,
+                      findingsPage: 1,
+                    }}
+                  >
+                    <SpdxExpressionBadgeGroup
+                      expression={license}
+                      suffix={index < licenses.length - 1 ? ',' : undefined}
+                    />
+                  </Link>
+                ))}
+              </div>
+            ) : (
+              <div className='text-muted-foreground italic'>
+                No licenses detected.
+              </div>
+            )}
+          </div>
+        </AccordionContent>
+      </AccordionItem>
+    </Accordion>
+  );
+};

--- a/ui/src/components/licenses/spdx-expression-badge-group.tsx
+++ b/ui/src/components/licenses/spdx-expression-badge-group.tsx
@@ -30,6 +30,7 @@ import { cn } from '@/lib/utils';
 
 type SpdxExpressionBadgeGroupProps = React.ComponentProps<'span'> & {
   expression: string | null | undefined;
+  suffix?: React.ReactNode;
 };
 
 const expressionWrapperClassName =
@@ -47,41 +48,59 @@ function licenseNodeToString(node: SpdxLicenseNode): string {
     : node.license;
 }
 
-function needsParentheses(
-  parent: SpdxConjunctionNode,
-  child: SpdxExpressionNode
-): boolean {
-  return (
-    child.kind === 'conjunction' &&
-    parent.conjunction === 'and' &&
-    child.conjunction === 'or'
-  );
+function needsParentheses(child: SpdxExpressionNode): boolean {
+  return child.kind === 'conjunction';
 }
 
 function renderExpressionNode(
   node: SpdxExpressionNode,
-  parent?: SpdxConjunctionNode
+  expressionTitle: string,
+  parent?: SpdxConjunctionNode,
+  suffix?: React.ReactNode
 ): React.ReactNode {
   if (node.kind !== 'conjunction') {
-    return <LicenseBadge license={licenseNodeToString(node)} />;
+    const badge = (
+      <LicenseBadge
+        license={licenseNodeToString(node)}
+        title={expressionTitle}
+      />
+    );
+
+    return suffix ? (
+      <span className='inline-flex items-center'>
+        {badge}
+        {suffix}
+      </span>
+    ) : (
+      badge
+    );
   }
 
+  const parenthesized = Boolean(parent) && needsParentheses(node);
   const renderedGroup = (
     <>
-      {renderExpressionNode(node.left, node)}
+      {renderExpressionNode(node.left, expressionTitle, node)}
       <span className='text-muted-foreground text-xs font-medium uppercase'>
         {node.conjunction}
       </span>
-      {renderExpressionNode(node.right, node)}
+      {renderExpressionNode(
+        node.right,
+        expressionTitle,
+        node,
+        parenthesized ? undefined : suffix
+      )}
     </>
   );
 
-  if (parent && needsParentheses(parent, node)) {
+  if (parenthesized) {
     return (
       <>
         <span className='text-muted-foreground text-xs font-medium'>(</span>
         {renderedGroup}
-        <span className='text-muted-foreground text-xs font-medium'>)</span>
+        <span className='inline-flex items-center'>
+          <span className='text-muted-foreground text-xs font-medium'>)</span>
+          {suffix}
+        </span>
       </>
     );
   }
@@ -93,6 +112,7 @@ export function SpdxExpressionBadgeGroup({
   expression,
   className,
   title,
+  suffix,
   ...props
 }: SpdxExpressionBadgeGroupProps) {
   if (!expression?.trim()) {
@@ -104,7 +124,10 @@ export function SpdxExpressionBadgeGroup({
   if (parsedExpression.kind === 'invalid') {
     return (
       <span className={cn(expressionWrapperClassName, className)}>
-        <LicenseBadge license={parsedExpression.rawExpression.trim()} />
+        <span className='inline-flex items-center'>
+          <LicenseBadge license={parsedExpression.rawExpression.trim()} />
+          {suffix}
+        </span>
       </span>
     );
   }
@@ -112,22 +135,34 @@ export function SpdxExpressionBadgeGroup({
   if (parsedExpression.kind === 'atomic') {
     return (
       <span className={cn(expressionWrapperClassName, className)}>
-        <LicenseBadge
-          license={licenseNodeToString(parsedExpression.node)}
-          title={title ?? parsedExpression.normalizedExpression}
-          {...props}
-        />
+        <span className='inline-flex items-center'>
+          <LicenseBadge
+            license={licenseNodeToString(parsedExpression.node)}
+            title={title ?? parsedExpression.normalizedExpression}
+            {...props}
+          />
+          {suffix}
+        </span>
       </span>
     );
   }
 
+  const normalizedParsedExpression = parseLicenseExpression(
+    parsedExpression.normalizedExpression
+  );
+  const expressionNode =
+    normalizedParsedExpression.kind === 'compound'
+      ? normalizedParsedExpression.node
+      : parsedExpression.node;
+  const expressionTitle = title ?? parsedExpression.normalizedExpression;
+
   return (
     <span
       className={cn(expressionWrapperClassName, className)}
-      title={title ?? parsedExpression.normalizedExpression}
+      title={expressionTitle}
       {...props}
     >
-      {renderExpressionNode(parsedExpression.node)}
+      {renderExpressionNode(expressionNode, expressionTitle, undefined, suffix)}
     </span>
   );
 }

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/detected-license-packages-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/detected-license-packages-table.tsx
@@ -28,7 +28,7 @@ import {
   useReactTable,
 } from '@tanstack/react-table';
 import { ChevronDown, ChevronUp } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { DetectedLicense, PackageIdentifier } from '@/api';
 import { getRunPackagesWithDetectedLicenseOptions } from '@/api/@tanstack/react-query.gen';
@@ -47,6 +47,11 @@ import { toastError } from '@/lib/toast';
 import { PackageIdType } from '@/schemas';
 import { useUserSettingsStore } from '@/store/user-settings.store';
 import { DetectedLicenseFindingsTable } from './detected-license-findings-table';
+import {
+  clearPackageMarker,
+  getMarkerExpandedState,
+  getPackageIdentifierQueryFilter,
+} from './license-findings-state';
 
 const packageColumnHelper = createColumnHelper<PackageIdentifier>();
 const defaultPageSize = 10;
@@ -90,7 +95,10 @@ export const DetectedLicensePackagesTable = ({
   const packageIdFilter = search.packageId;
   const packageSortBy = search.packageSortBy;
   const packageColumnId = packageIdType === 'PURL' ? 'purl' : 'identifier';
-  const [packageExpanded, setPackageExpanded] = useState<ExpandedState>({});
+  const preserveManualExpansion = useRef(false);
+  const [packageExpanded, setPackageExpanded] = useState<ExpandedState>(
+    getMarkerExpandedState(search.packageMarked)
+  );
 
   const {
     data: packages,
@@ -107,9 +115,11 @@ export const DetectedLicensePackagesTable = ({
         limit: packagePageSize,
         offset: packagePageIndex * packagePageSize,
         sort: convertToBackendSorting(packageSortBy),
-        ...(packageIdType === 'PURL'
-          ? { purl: packageIdFilter }
-          : { identifier: packageIdFilter }),
+        ...getPackageIdentifierQueryFilter(
+          search.packageMarked,
+          packageIdType,
+          packageIdFilter
+        ),
       },
     }),
   });
@@ -127,17 +137,16 @@ export const DetectedLicensePackagesTable = ({
             onClick={() => {
               const isOpening = !packageRow.getIsExpanded();
 
-              packageRow.toggleExpanded();
-
-              if (isOpening) {
-                navigate({
-                  search: {
-                    ...search,
-                    findingsPage: 1,
-                  },
-                  replace: true,
-                });
-              }
+              setPackageExpanded(isOpening ? { [packageRow.id]: true } : {});
+              preserveManualExpansion.current =
+                search.packageMarked !== undefined;
+              navigate({
+                search: clearPackageMarker({
+                  ...search,
+                  findingsPage: 1,
+                }),
+                replace: true,
+              });
             }}
             style={{ cursor: 'pointer' }}
           >
@@ -166,11 +175,11 @@ export const DetectedLicensePackagesTable = ({
             filterVariant: 'text',
             setFilterValue: (value: string | undefined) => {
               navigate({
-                search: {
+                search: clearPackageMarker({
                   ...search,
                   packagePage: 1,
                   packageId: value,
-                },
+                }),
               });
             },
           },
@@ -198,8 +207,18 @@ export const DetectedLicensePackagesTable = ({
     getCoreRowModel: getCoreRowModel(),
     getExpandedRowModel: getExpandedRowModel(),
     getRowCanExpand: () => true,
+    getRowId: (row) => identifierToString(row.identifier),
     manualPagination: true,
   });
+
+  useEffect(() => {
+    if (preserveManualExpansion.current) {
+      preserveManualExpansion.current = false;
+      return;
+    }
+
+    setPackageExpanded(getMarkerExpandedState(search.packageMarked));
+  }, [search.packageMarked]);
 
   if (isPending) {
     return <LoadingIndicator />;
@@ -235,20 +254,20 @@ export const DetectedLicensePackagesTable = ({
         setCurrentPageOptions={(currentPage) => {
           return {
             to: '.',
-            search: {
+            search: clearPackageMarker({
               ...search,
               packagePage: currentPage,
-            },
+            }),
           };
         }}
         setPageSizeOptions={(size) => {
           return {
             to: '.',
-            search: {
+            search: clearPackageMarker({
               ...search,
               packagePage: 1,
               packagePageSize: size,
-            },
+            }),
           };
         }}
         setSortingOptions={(sortBy) => {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/license-findings-state.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/license-findings-state.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { ExpandedState } from '@tanstack/react-table';
+
+import { PackageIdType } from '@/schemas';
+
+export const getMarkerExpandedState = (marker?: string): ExpandedState =>
+  marker ? { [marker]: true } : {};
+
+export const getDetectedLicenseQueryFilter = (
+  marked: string | undefined,
+  license: string | undefined
+) => (marked ? { license: marked, licenseMatchType: 'exact' } : { license });
+
+export const getPackageIdentifierQueryFilter = (
+  packageMarked: string | undefined,
+  packageIdType: PackageIdType,
+  packageId: string | undefined
+) => {
+  if (packageMarked) {
+    return {
+      identifier: packageMarked,
+      identifierMatchType: 'exact',
+    };
+  }
+
+  return packageIdType === 'PURL'
+    ? { purl: packageId }
+    : { identifier: packageId };
+};
+
+export const clearDetectedLicenseMarkers = <T extends object>(search: T) => ({
+  ...search,
+  marked: undefined,
+  packageMarked: undefined,
+});
+
+export const clearPackageMarker = <T extends object>(search: T) => ({
+  ...search,
+  packageMarked: undefined,
+});

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/license-findings-view.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/license-findings-view.tsx
@@ -53,6 +53,12 @@ import {
 import { toastError } from '@/lib/toast';
 import { useUserSettingsStore } from '@/store/user-settings.store';
 import { DetectedLicensePackagesTable } from './detected-license-packages-table';
+import {
+  clearDetectedLicenseMarkers,
+  clearPackageMarker,
+  getDetectedLicenseQueryFilter,
+  getMarkerExpandedState,
+} from './license-findings-state';
 
 const licenseColumnHelper = createColumnHelper<DetectedLicense>();
 const defaultPageSize = 10;
@@ -80,6 +86,10 @@ export const LicenseFindingsView = () => {
       : undefined;
   const packageIdType = useUserSettingsStore((state) => state.packageIdType);
   const previousPackageIdType = useRef(packageIdType);
+  const preserveManualExpansion = useRef(false);
+  const [expanded, setExpanded] = useState<ExpandedState>(
+    getMarkerExpandedState(search.marked)
+  );
 
   const { data: ortRun } = useSuspenseQuery({
     ...getRepositoryRunOptions({
@@ -118,7 +128,7 @@ export const LicenseFindingsView = () => {
         limit: pageSize,
         offset: pageIndex * pageSize,
         sort: convertToBackendSorting(search.sortBy),
-        license: detectedLicenseFilter,
+        ...getDetectedLicenseQueryFilter(search.marked, detectedLicenseFilter),
       },
     }),
   });
@@ -139,14 +149,15 @@ export const LicenseFindingsView = () => {
               const isOpening = !row.getIsExpanded();
 
               setExpanded(isOpening ? { [row.id]: true } : {});
+              preserveManualExpansion.current = search.marked !== undefined;
               navigate({
-                search: {
+                search: clearDetectedLicenseMarkers({
                   ...search,
                   packagePage: 1,
                   packageId: undefined,
                   packageSortBy: undefined,
                   findingsPage: 1,
-                },
+                }),
                 replace: true,
               });
             }}
@@ -178,11 +189,11 @@ export const LicenseFindingsView = () => {
           })),
           setSelected: (licenses: string[]) => {
             navigate({
-              search: {
+              search: clearDetectedLicenseMarkers({
                 ...search,
                 page: 1,
                 detectedLicense: licenses.length === 0 ? undefined : licenses,
-              },
+              }),
             });
           },
         },
@@ -196,8 +207,6 @@ export const LicenseFindingsView = () => {
       },
     }),
   ];
-
-  const [expanded, setExpanded] = useState<ExpandedState>({});
 
   const table = useReactTable({
     data: detectedLicenseFindings?.data || [],
@@ -217,8 +226,18 @@ export const LicenseFindingsView = () => {
     getCoreRowModel: getCoreRowModel(),
     getExpandedRowModel: getExpandedRowModel(),
     getRowCanExpand: () => true,
+    getRowId: (row) => row.license,
     manualPagination: true,
   });
+
+  useEffect(() => {
+    if (preserveManualExpansion.current) {
+      preserveManualExpansion.current = false;
+      return;
+    }
+
+    setExpanded(getMarkerExpandedState(search.marked));
+  }, [search.marked]);
 
   useEffect(() => {
     if (previousPackageIdType.current === packageIdType) {
@@ -227,12 +246,12 @@ export const LicenseFindingsView = () => {
 
     previousPackageIdType.current = packageIdType;
     navigate({
-      search: {
+      search: clearPackageMarker({
         ...search,
         packagePage: 1,
         packageId: undefined,
         packageSortBy: undefined,
-      },
+      }),
       replace: true,
     });
     // Identifier mode changes invalidate the nested package query inputs.
@@ -282,13 +301,20 @@ export const LicenseFindingsView = () => {
           setCurrentPageOptions={(currentPage) => {
             return {
               to: '.',
-              search: { ...search, page: currentPage },
+              search: clearDetectedLicenseMarkers({
+                ...search,
+                page: currentPage,
+              }),
             };
           }}
           setPageSizeOptions={(size) => {
             return {
               to: '.',
-              search: { ...search, page: 1, pageSize: size },
+              search: clearDetectedLicenseMarkers({
+                ...search,
+                page: 1,
+                pageSize: size,
+              }),
             };
           }}
           setSortingOptions={(sortBy) => {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/index.tsx
@@ -24,7 +24,9 @@ import { LoadingIndicator } from '@/components/loading-indicator';
 import {
   detectedLicenseSearchParameterSchema,
   findingsPaginationSearchParameterSchema,
+  markedSearchParameterSchema,
   packageIdSearchParameterSchema,
+  packageMarkedSearchParameterSchema,
   packagePaginationSearchParameterSchema,
   packageSortingSearchParameterSchema,
   paginationSearchParameterSchema,
@@ -40,6 +42,8 @@ const licenseFindingsSearchSchema = z.object({
   ...findingsPaginationSearchParameterSchema.shape,
   ...packageSortingSearchParameterSchema.shape,
   ...packageIdSearchParameterSchema.shape,
+  ...markedSearchParameterSchema.shape,
+  ...packageMarkedSearchParameterSchema.shape,
 });
 
 export const Route = createFileRoute(

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
@@ -42,7 +42,10 @@ import { CopyToClipboard } from '@/components/copy-to-clipboard';
 import { DataTableCards } from '@/components/data-table-cards/data-table-cards';
 import { MarkItems } from '@/components/data-table/mark-items';
 import { DependencyPaths } from '@/components/dependency-paths';
-import { SpdxExpressionBadgeGroup } from '@/components/licenses';
+import {
+  LicensesAccordion,
+  SpdxExpressionBadgeGroup,
+} from '@/components/licenses';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { PackageCuration } from '@/components/package-curation';
 import { RenderProperty } from '@/components/render-property';
@@ -199,9 +202,11 @@ const PackageCard = ({ pkg }: { pkg: Package }) => {
 const renderSubComponent = ({
   row,
   packageIdType,
+  runId,
 }: {
   row: Row<Package>;
   packageIdType?: PackageIdType;
+  runId: number;
 }) => {
   const pkg = row.original;
   const hasCurations = pkg.curations.length > 0;
@@ -213,6 +218,16 @@ const renderSubComponent = ({
         label='Description'
         value={pkg.description}
         type='textblock'
+      />
+      <LicensesAccordion
+        runId={runId}
+        identifier={pkg.identifier}
+        declaredLicenses={[
+          ...(pkg.processedDeclaredLicense.spdxExpression
+            ? [pkg.processedDeclaredLicense.spdxExpression]
+            : []),
+          ...(pkg.processedDeclaredLicense.unmappedLicenses ?? []),
+        ]}
       />
       <RenderProperty label='CPE' value={pkg.cpe} />
       <RenderProperty
@@ -583,7 +598,7 @@ const PackagesComponent = () => {
         <DataTableCards
           table={table}
           renderSubComponent={({ row }) =>
-            renderSubComponent({ row, packageIdType })
+            renderSubComponent({ row, packageIdType, runId: ortRun.id })
           }
           setCurrentPageOptions={(currentPage) => {
             return {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
@@ -42,7 +42,10 @@ import {
 import { BreakableString } from '@/components/breakable-string';
 import { DataTableCards } from '@/components/data-table-cards/data-table-cards';
 import { MarkItems } from '@/components/data-table/mark-items';
-import { SpdxExpressionBadgeGroup } from '@/components/licenses';
+import {
+  LicensesAccordion,
+  SpdxExpressionBadgeGroup,
+} from '@/components/licenses';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { RenderProperty } from '@/components/render-property';
 import { Button } from '@/components/ui/button';
@@ -128,7 +131,13 @@ const ProjectCard = ({ project }: { project: Project }) => {
   );
 };
 
-const renderSubComponent = ({ row }: { row: Row<Project> }) => {
+const renderSubComponent = ({
+  row,
+  runId,
+}: {
+  row: Row<Project>;
+  runId: number;
+}) => {
   const project = row.original;
 
   return (
@@ -138,6 +147,16 @@ const renderSubComponent = ({ row }: { row: Row<Project> }) => {
         label='Description'
         value={project.description}
         type='textblock'
+      />
+      <LicensesAccordion
+        runId={runId}
+        identifier={project.identifier}
+        declaredLicenses={[
+          ...(project.processedDeclaredLicense.spdxExpression
+            ? [project.processedDeclaredLicense.spdxExpression]
+            : []),
+          ...(project.processedDeclaredLicense.unmappedLicenses ?? []),
+        ]}
       />
       <RenderProperty label='Homepage' value={project.homepageUrl} type='url' />
       <RenderProperty label='CPE' value={project.cpe} />
@@ -461,7 +480,9 @@ const ProjectsComponent = () => {
       <CardContent>
         <DataTableCards
           table={table}
-          renderSubComponent={renderSubComponent}
+          renderSubComponent={({ row }) =>
+            renderSubComponent({ row, runId: ortRun.id })
+          }
           setCurrentPageOptions={(currentPage) => {
             return {
               to: Route.to,

--- a/ui/src/schemas/index.ts
+++ b/ui/src/schemas/index.ts
@@ -202,6 +202,10 @@ export const markedSearchParameterSchema = z.object({
   marked: z.string().optional(),
 });
 
+export const packageMarkedSearchParameterSchema = z.object({
+  packageMarked: z.string().optional(),
+});
+
 // This schema is used to validate the filter parameter when filtering
 // organizations, products, or repositories with regexp.
 export const filterByNameSearchParameterSchema = z.object({

--- a/ui/tests/unit/components/licenses-accordion.test.tsx
+++ b/ui/tests/unit/components/licenses-accordion.test.tsx
@@ -1,0 +1,221 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { ReactNode } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Identifier } from '@/api';
+import { LicensesAccordion } from '@/components/licenses/licenses-accordion';
+
+const mocks = vi.hoisted(() => ({
+  queryState: {
+    data: undefined as string[] | undefined,
+    isPending: false,
+  },
+  links: [] as Array<{
+    search: Record<string, string | string[] | number>;
+  }>,
+  getOptions: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQuery: () => mocks.queryState,
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  getRouteApi: () => ({
+    useParams: () => ({
+      orgId: '1',
+      productId: '2',
+      repoId: '3',
+      runIndex: '4',
+    }),
+  }),
+  Link: ({
+    children,
+    search,
+  }: {
+    children: ReactNode;
+    search: Record<string, string | string[] | number>;
+  }) => {
+    mocks.links.push({ search });
+    return <a>{children}</a>;
+  },
+}));
+
+vi.mock('@/api/@tanstack/react-query.gen', () => ({
+  getRunDetectedLicensesForIdentifierOptions: mocks.getOptions,
+}));
+
+vi.mock('@/components/ui/accordion', () => ({
+  Accordion: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  AccordionItem: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AccordionTrigger: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+  AccordionContent: ({ children }: { children: ReactNode }) => (
+    <div>{children}</div>
+  ),
+}));
+
+vi.mock('@/components/licenses', () => ({
+  SpdxExpressionBadgeGroup: ({
+    expression,
+    suffix,
+  }: {
+    expression: string;
+    suffix?: ReactNode;
+  }) => (
+    <span>
+      {expression}
+      {suffix}
+    </span>
+  ),
+}));
+
+vi.mock('@/components/loading-indicator', () => ({
+  LoadingIndicator: () => <span>Loading data...</span>,
+}));
+
+const identifier: Identifier = {
+  type: 'Maven',
+  namespace: 'com.example',
+  name: 'some library',
+  version: '1.0/rc%1',
+};
+
+const renderAccordion = (
+  accordionIdentifier = identifier,
+  runId = 42,
+  declaredLicenses: string[] = []
+) =>
+  renderToStaticMarkup(
+    <LicensesAccordion
+      runId={runId}
+      identifier={accordionIdentifier}
+      declaredLicenses={declaredLicenses}
+    />
+  );
+
+describe('LicensesAccordion', () => {
+  beforeEach(() => {
+    mocks.queryState.data = undefined;
+    mocks.queryState.isPending = false;
+    mocks.links.length = 0;
+    mocks.getOptions.mockReset();
+    mocks.getOptions.mockReturnValue({});
+  });
+
+  it('shows a loading indicator while licenses are loading', () => {
+    mocks.queryState.isPending = true;
+
+    expect(renderAccordion()).toContain('Loading data...');
+  });
+
+  it('shows messages when no licenses were declared or detected', () => {
+    mocks.queryState.data = [];
+
+    const markup = renderAccordion();
+
+    expect(markup).toContain('No declared licenses.');
+    expect(markup).toContain('No licenses detected.');
+  });
+
+  it('renders comma-separated declared and detected licenses in labeled rows', () => {
+    mocks.queryState.data = ['Apache-2.0', 'GPL-2.0-only'];
+
+    const markup = renderAccordion(identifier, 42, ['MIT', 'BSD-3-Clause']);
+
+    expect(markup).toContain('Declared:');
+    expect(markup).toMatch(/MIT.*?,.*?BSD-3-Clause/);
+    expect(markup).toContain('Detected:');
+    expect(markup).toMatch(/Apache-2\.0.*?,.*?GPL-2\.0-only/);
+  });
+
+  it('passes the raw identifier to the generated client for URL encoding', () => {
+    mocks.queryState.data = ['MIT'];
+
+    renderAccordion();
+
+    expect(mocks.getOptions).toHaveBeenCalledWith({
+      path: {
+        runId: 42,
+        identifier: 'Maven:com.example:some library:1.0/rc%1',
+      },
+    });
+  });
+
+  it('renders one link for a detected license', () => {
+    mocks.queryState.data = ['Apache-2.0'];
+
+    const markup = renderAccordion();
+
+    expect(markup).toContain('Apache-2.0');
+    expect(mocks.links).toHaveLength(1);
+  });
+
+  it('uses a project ORT identifier in the query and deep link', () => {
+    const projectIdentifier: Identifier = {
+      type: 'Gradle',
+      namespace: '',
+      name: 'example-project',
+      version: '',
+    };
+    mocks.queryState.data = ['MIT'];
+
+    renderAccordion(projectIdentifier, 84);
+
+    expect(mocks.getOptions).toHaveBeenCalledWith({
+      path: {
+        runId: 84,
+        identifier: 'Gradle::example-project:',
+      },
+    });
+    expect(mocks.links[0]?.search.packageMarked).toBe(
+      'Gradle::example-project:'
+    );
+  });
+
+  it('keeps multiple expressions in independent exact links', () => {
+    mocks.queryState.data = ['MIT', 'MIT AND Apache-2.0'];
+
+    renderAccordion();
+
+    expect(mocks.links).toHaveLength(2);
+    expect(mocks.links[0]?.search).toEqual({
+      detectedLicense: ['MIT'],
+      marked: 'MIT',
+      packageMarked: 'Maven:com.example:some library:1.0/rc%1',
+      page: 1,
+      packagePage: 1,
+      findingsPage: 1,
+    });
+    expect(mocks.links[1]?.search).toEqual({
+      detectedLicense: ['MIT AND Apache-2.0'],
+      marked: 'MIT AND Apache-2.0',
+      packageMarked: 'Maven:com.example:some library:1.0/rc%1',
+      page: 1,
+      packagePage: 1,
+      findingsPage: 1,
+    });
+  });
+});

--- a/ui/tests/unit/components/spdx-expression-badge-group.test.tsx
+++ b/ui/tests/unit/components/spdx-expression-badge-group.test.tsx
@@ -54,6 +54,14 @@ describe('SpdxExpressionBadgeGroup', () => {
     expect(markup.match(/data-slot="badge"/g)?.length).toBe(2);
   });
 
+  it('renders a suffix as part of the wrapping expression', () => {
+    const markup = renderToStaticMarkup(
+      <SpdxExpressionBadgeGroup expression='MIT AND Apache-2.0' suffix=',' />
+    );
+
+    expect(markup).toMatch(/MIT<\/span>,<\/span>/);
+  });
+
   it('renders deprecated GPL plus syntax as its normalized atomic badge', () => {
     const markup = renderToStaticMarkup(
       <SpdxExpressionBadgeGroup expression='GPL-2.0+' />
@@ -74,6 +82,20 @@ describe('SpdxExpressionBadgeGroup', () => {
     expect(markup).toContain('Apache-2.0');
     expect(markup).toContain('BSD-3-Clause');
     expect(markup.match(/data-slot="badge"/g)?.length).toBe(3);
+  });
+
+  it('renders the same normalized order and grouping as the tooltip', () => {
+    const markup = renderToStaticMarkup(
+      <SpdxExpressionBadgeGroup expression='EPL-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR BSD-3-Clause' />
+    );
+
+    const expressionTitle =
+      'title="EPL-2.0 OR (BSD-3-Clause OR GPL-2.0-only WITH Classpath-exception-2.0)"';
+
+    expect(markup.split(expressionTitle)).toHaveLength(5);
+    expect(markup.replace(/<[^>]*>/g, '')).toBe(
+      'EPL-2.0or(BSD-3-ClauseorGPL-2.0-only WITH Classpath-exception-2.0)'
+    );
   });
 
   it('renders WITH expressions as a single badge', () => {

--- a/ui/tests/unit/logic/license-findings-state.test.ts
+++ b/ui/tests/unit/logic/license-findings-state.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  clearDetectedLicenseMarkers,
+  clearPackageMarker,
+  getDetectedLicenseQueryFilter,
+  getMarkerExpandedState,
+  getPackageIdentifierQueryFilter,
+} from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/license-findings-state';
+
+describe('license findings deep-link state', () => {
+  it('uses an exact license filter for a marked license', () => {
+    expect(
+      getDetectedLicenseQueryFilter('MIT', 'MIT,MIT AND Apache-2.0')
+    ).toEqual({ license: 'MIT', licenseMatchType: 'exact' });
+  });
+
+  it('keeps normal license filters when no license is marked', () => {
+    expect(getDetectedLicenseQueryFilter(undefined, 'MIT,Apache-2.0')).toEqual({
+      license: 'MIT,Apache-2.0',
+    });
+  });
+
+  it('uses stable marker values as expanded row IDs', () => {
+    expect(getMarkerExpandedState('MIT AND Apache-2.0')).toEqual({
+      'MIT AND Apache-2.0': true,
+    });
+
+    expect(getMarkerExpandedState('Maven:com.example:library:1.0')).toEqual({
+      'Maven:com.example:library:1.0': true,
+    });
+  });
+
+  it('uses the exact ORT identifier in PURL mode', () => {
+    const identifier = 'Maven:com.example:library:1.0';
+
+    expect(
+      getPackageIdentifierQueryFilter(identifier, 'PURL', 'pkg:maven/example')
+    ).toEqual({ identifier, identifierMatchType: 'exact' });
+  });
+
+  it('uses the exact project identifier even when it has no PURL', () => {
+    const identifier = 'Gradle:com.example:project:1.0';
+
+    expect(
+      getPackageIdentifierQueryFilter(identifier, 'PURL', undefined)
+    ).toEqual({ identifier, identifierMatchType: 'exact' });
+  });
+
+  it('updates expansion when a marker changes and collapses without one', () => {
+    expect(getMarkerExpandedState('Apache-2.0')).toEqual({
+      'Apache-2.0': true,
+    });
+    expect(getMarkerExpandedState('MIT')).toEqual({ MIT: true });
+    expect(getMarkerExpandedState()).toEqual({});
+  });
+
+  it('clears both markers for top-level interactions', () => {
+    expect(
+      clearDetectedLicenseMarkers({
+        detectedLicense: ['MIT'],
+        marked: 'MIT',
+        packageMarked: 'Maven:com.example:library:1.0',
+        page: 2,
+      })
+    ).toEqual({
+      detectedLicense: ['MIT'],
+      marked: undefined,
+      packageMarked: undefined,
+      page: 2,
+    });
+  });
+
+  it('clears only the package marker for nested interactions', () => {
+    expect(
+      clearPackageMarker({
+        marked: 'MIT',
+        packageMarked: 'Maven:com.example:library:1.0',
+        packagePage: 2,
+      })
+    ).toEqual({
+      marked: 'MIT',
+      packageMarked: undefined,
+      packagePage: 2,
+    });
+  });
+
+  it('keeps normal identifier filters when no package is marked', () => {
+    expect(
+      getPackageIdentifierQueryFilter(undefined, 'PURL', 'pkg:maven/example')
+    ).toEqual({ purl: 'pkg:maven/example' });
+    expect(
+      getPackageIdentifierQueryFilter(undefined, 'ORT_ID', 'Maven:example')
+    ).toEqual({ identifier: 'Maven:example' });
+  });
+});


### PR DESCRIPTION
#### New licenses section in Packages table / package details

<img width="1174" height="447" alt="Screenshot from 2026-07-30 08-11-24" src="https://github.com/user-attachments/assets/8f7c3ef1-b90d-4d9c-8ab0-835aa4f95c7c" />

#### Clicking a detected license SPDX expression takes the user to the corresponding findings in the Detected Licenses table

<img width="1174" height="638" alt="Screenshot from 2026-07-29 13-07-32" src="https://github.com/user-attachments/assets/4f84dd95-4eb2-41af-a89b-cf247c2706a6" />
