### PR TITLE
fix(ui): Move "Fix available" badge to the last row

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
@@ -170,29 +170,29 @@ const VulnerabilityCard = ({
           {vulnerability.advisor.name}
         </div>
       </div>
-      {(vulnerability.firstFixedVersions?.length ?? 0) > 0 && (
-        <div className='flex items-center justify-end'>
+
+      <div className='flex items-center justify-between'>
+        <div className='flex gap-2'>
+          <Badge
+            className={`${getResolvedBackgroundColor(getResolvedStatus(vulnerability))}`}
+            variant='small'
+          >
+            {getResolvedStatus(vulnerability)}
+          </Badge>
+          <Badge
+            className={`${getVulnerabilityRatingBackgroundColor(
+              vulnerability.rating
+            )}`}
+            variant='small'
+          >
+            {vulnerability.rating}
+          </Badge>
+        </div>
+        {(vulnerability.firstFixedVersions?.length ?? 0) > 0 && (
           <Badge className='bg-green-300 whitespace-nowrap text-black'>
             Fix available
           </Badge>
-        </div>
-      )}
-
-      <div className='flex gap-2'>
-        <Badge
-          className={`${getResolvedBackgroundColor(getResolvedStatus(vulnerability))}`}
-          variant='small'
-        >
-          {getResolvedStatus(vulnerability)}
-        </Badge>
-        <Badge
-          className={`${getVulnerabilityRatingBackgroundColor(
-            vulnerability.rating
-          )}`}
-          variant='small'
-        >
-          {vulnerability.rating}
-        </Badge>
+        )}
       </div>
     </div>
   );


### PR DESCRIPTION
The badge is sitting on its own in a separate row, wasting vertical space in the table. Fix by moving it into the last row of `VulnerabilityCard`, which includes other status badges such as rating and status of the vulnerability.

<img width="1178" height="101" alt="Screenshot from 2026-07-30 08-44-06" src="https://github.com/user-attachments/assets/c1ec8323-fee7-483c-a433-d4aea57e480c" />
