### PR TITLE
ui: Lay the foundation for more advanced component loading

### DIFF
--- a/ui/src/components/item-counts.tsx
+++ b/ui/src/components/item-counts.tsx
@@ -21,6 +21,7 @@ import { Link, LinkProps } from '@tanstack/react-router';
 import { Bug, Scale, ShieldQuestion } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
 import {
   Tooltip,
   TooltipContent,
@@ -72,7 +73,7 @@ export const ItemCounts = ({
   tooltip,
 }: ItemCountsProps) => {
   return (
-    <div className='grid grid-cols-3 gap-1'>
+    <div className='grid min-h-6 grid-cols-3 gap-1'>
       {showIssues && (
         <CountBadge
           count={statistics?.issuesCount}
@@ -130,6 +131,17 @@ export const ItemCounts = ({
     </div>
   );
 };
+
+export const ItemCountsSkeleton = ({ wide = false }: { wide?: boolean }) => (
+  <div className='grid min-h-6 grid-cols-3 gap-1'>
+    {[0, 1, 2].map((index) => (
+      <Skeleton
+        key={index}
+        className={cn('h-6 rounded-md', wide ? 'w-14' : 'w-12')}
+      />
+    ))}
+  </div>
+);
 
 type CountBadgeLinkProps = {
   params: LinkProps['params'];

--- a/ui/src/components/query-boundary.tsx
+++ b/ui/src/components/query-boundary.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { QueryErrorResetBoundary } from '@tanstack/react-query';
+import {
+  CatchBoundary,
+  type ErrorComponentProps,
+} from '@tanstack/react-router';
+import { TriangleAlert } from 'lucide-react';
+import { Suspense, type ReactNode } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+type QueryBoundaryProps = {
+  children: ReactNode;
+  fallback: ReactNode;
+  errorFallback?: (props: ErrorComponentProps) => ReactNode;
+  resetKey?: string | number;
+  loadingLabel?: string;
+};
+
+export const QueryErrorFallback = ({ error, reset }: ErrorComponentProps) => {
+  const retryLabel = `Could not load data: ${error.message}. Click to retry.`;
+
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <Button
+          type='button'
+          variant='ghost'
+          size='xs'
+          aria-label={retryLabel}
+          onClick={reset}
+        >
+          <TriangleAlert className='text-traffic-light-red size-4' />
+          Retry
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{retryLabel}</TooltipContent>
+    </Tooltip>
+  );
+};
+
+export const QueryBoundary = ({
+  children,
+  fallback,
+  errorFallback,
+  resetKey = 'reset',
+  loadingLabel = 'Loading data...',
+}: QueryBoundaryProps) => (
+  <QueryErrorResetBoundary>
+    {({ reset: resetQueries }) => (
+      <CatchBoundary
+        getResetKey={() => resetKey}
+        errorComponent={({ error, reset }) => {
+          const fallbackProps = {
+            error,
+            reset: () => {
+              resetQueries();
+              reset();
+            },
+          };
+
+          return errorFallback ? (
+            errorFallback(fallbackProps)
+          ) : (
+            <QueryErrorFallback {...fallbackProps} />
+          );
+        }}
+      >
+        <Suspense
+          fallback={
+            <>
+              <span className='sr-only' role='status'>
+                {loadingLabel}
+              </span>
+              {fallback}
+            </>
+          }
+        >
+          {children}
+        </Suspense>
+      </CatchBoundary>
+    )}
+  </QueryErrorResetBoundary>
+);

--- a/ui/src/components/ui/skeleton.tsx
+++ b/ui/src/components/ui/skeleton.tsx
@@ -1,0 +1,25 @@
+/*
+ * The component is originally a part of the shadcn/ui library at https://github.com/shadcn-ui/ui.
+ * The library is licensed as set out below:
+ *
+ * Copyright (c) 2023 shadcn
+ *
+ * SPDX-License-Identifier: MIT
+ */
+
+import { cn } from '@/lib/utils';
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      data-slot='skeleton'
+      className={cn('bg-primary/10 animate-pulse rounded-md', className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/ui/src/hooks/use-latest-repository-run.ts
+++ b/ui/src/hooks/use-latest-repository-run.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import type { OrtRunSummary } from '@/api';
+import { getRepositoryRunsOptions } from '@/api/@tanstack/react-query.gen';
+import { config } from '@/config';
+
+export const useLatestRepositoryRun = (
+  repoId: number
+): OrtRunSummary | undefined => {
+  const { data: runs } = useSuspenseQuery({
+    ...getRepositoryRunsOptions({
+      path: { repositoryId: repoId },
+      query: { limit: 1, sort: '-index' },
+    }),
+    refetchInterval: (query) => {
+      const latestRun = query.state.data?.data[0];
+      if (latestRun?.finishedAt) return undefined;
+
+      return config.pollInterval;
+    },
+  });
+
+  return runs.data[0];
+};

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/last-run-item-counts.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/last-run-item-counts.tsx
@@ -17,67 +17,40 @@
  * License-Filename: LICENSE
  */
 
-import { useQuery } from '@tanstack/react-query';
-import { Loader2 } from 'lucide-react';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
-import { JobSummary, OrtRunSummary } from '@/api';
-import {
-  getRepositoryRunsOptions,
-  getRunStatisticsOptions,
-} from '@/api/@tanstack/react-query.gen';
-import { ItemCounts } from '@/components/item-counts';
+import type { JobSummary, OrtRunSummary } from '@/api';
+import { getRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
+import { ItemCounts, ItemCountsSkeleton } from '@/components/item-counts';
+import { QueryBoundary } from '@/components/query-boundary';
 import { config } from '@/config';
 import { isJobFinished } from '@/helpers/job-helpers';
+import { useLatestRepositoryRun } from '@/hooks/use-latest-repository-run';
 
 type LastRunItemCountsProps = {
   repoId: number;
 };
 
-export const LastRunItemCounts = ({ repoId }: LastRunItemCountsProps) => {
-  const {
-    data: runs,
-    isPending: runsIsPending,
-    isError: runsIsError,
-  } = useQuery({
-    ...getRepositoryRunsOptions({
-      path: { repositoryId: repoId },
-      query: { limit: 1, sort: '-index' },
-    }),
-    refetchInterval: (query) => {
-      const curData = query.state.data?.data;
-      if (curData && curData[0] && curData[0].finishedAt) {
-        return undefined;
-      }
-      return config.pollInterval;
-    },
-  });
+export const LastRunItemCounts = ({ repoId }: LastRunItemCountsProps) => (
+  <QueryBoundary fallback={<ItemCountsSkeleton />} resetKey={repoId}>
+    <LastRunItemCountsStage1 repoId={repoId} />
+  </QueryBoundary>
+);
 
-  if (runsIsPending) {
-    return (
-      <>
-        <span className='sr-only'>Loading...</span>
-        <Loader2 size={16} className='mx-3 animate-spin' />
-      </>
-    );
-  }
+const LastRunItemCountsStage1 = ({ repoId }: { repoId: number }) => {
+  const run = useLatestRepositoryRun(repoId);
 
-  if (runsIsError) {
-    return <span>Error loading run.</span>;
-  }
+  if (!run) return <div className='min-h-6' />;
 
-  if (!runs.data[0]) return null;
-
-  const run = runs.data[0];
-
-  return <LastRunItemCountsInner summary={run} />;
+  return <LastRunItemCountsStage2 summary={run} />;
 };
 
 const showBadge = (jobSummary: JobSummary | null | undefined) => {
   return jobSummary != null && isJobFinished(jobSummary.status);
 };
 
-const LastRunItemCountsInner = ({ summary }: { summary: OrtRunSummary }) => {
-  const statistics = useQuery({
+const LastRunItemCountsStage2 = ({ summary }: { summary: OrtRunSummary }) => {
+  const statistics = useSuspenseQuery({
     ...getRunStatisticsOptions({
       path: { runId: summary.id },
     }),

--- a/ui/tests/unit/components/item-counts.test.tsx
+++ b/ui/tests/unit/components/item-counts.test.tsx
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { ItemCounts, ItemCountsSkeleton } from '@/components/item-counts';
+
+const getSkeletonClasses = (markup: string) =>
+  Array.from(
+    markup.matchAll(/data-slot="skeleton" class="([^"]+)"/g),
+    (match) => match[1]?.split(' ') ?? []
+  );
+
+describe('ItemCountsSkeleton', () => {
+  it('renders three standard-width skeletons', () => {
+    const skeletonClasses = getSkeletonClasses(
+      renderToStaticMarkup(<ItemCountsSkeleton />)
+    );
+
+    expect(skeletonClasses).toHaveLength(3);
+    skeletonClasses.forEach((classes) => expect(classes).toContain('w-12'));
+  });
+
+  it('renders three wide skeletons', () => {
+    const skeletonClasses = getSkeletonClasses(
+      renderToStaticMarkup(<ItemCountsSkeleton wide />)
+    );
+
+    expect(skeletonClasses).toHaveLength(3);
+    skeletonClasses.forEach((classes) => expect(classes).toContain('w-14'));
+  });
+});
+
+describe('ItemCounts', () => {
+  it('reserves space when all badges are hidden', () => {
+    const markup = renderToStaticMarkup(
+      <ItemCounts
+        statistics={undefined}
+        showIssues={false}
+        showVulnerabilities={false}
+        showRuleViolations={false}
+      />
+    );
+
+    expect(markup).toContain('min-h-6');
+  });
+});

--- a/ui/tests/unit/components/last-run-item-counts.test.tsx
+++ b/ui/tests/unit/components/last-run-item-counts.test.tsx
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { OrtRunSummary } from '@/api';
+import { LastRunItemCounts } from '@/routes/organizations/$orgId/products/$productId/-components/last-run-item-counts';
+
+type Statistics = {
+  issuesCount: number;
+  vulnerabilitiesCount: number;
+  ruleViolationsCount: number;
+};
+
+type ItemCountsProps = {
+  statistics: Statistics;
+  showIssues: boolean;
+  showVulnerabilities: boolean;
+  showRuleViolations: boolean;
+  compact: boolean;
+  link: {
+    params: Record<string, string>;
+    issuesSearch: unknown;
+    vulnerabilitiesSearch: unknown;
+    ruleViolationsSearch: unknown;
+  };
+  tooltip: (label: string, count: number) => string;
+};
+
+const mocks = vi.hoisted(() => ({
+  latestRun: undefined as OrtRunSummary | undefined,
+  latestRunSuspends: false,
+  statistics: {
+    issuesCount: 3,
+    vulnerabilitiesCount: 5,
+    ruleViolationsCount: 7,
+  } as Statistics,
+  statisticsSuspend: false,
+  itemCountsProps: undefined as ItemCountsProps | undefined,
+  pendingPromise: new Promise<never>(() => undefined),
+  useSuspenseQuery: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>();
+
+  return {
+    ...actual,
+    useSuspenseQuery: mocks.useSuspenseQuery,
+  };
+});
+
+vi.mock('@/hooks/use-latest-repository-run', () => ({
+  useLatestRepositoryRun: () => {
+    if (mocks.latestRunSuspends) throw mocks.pendingPromise;
+
+    return mocks.latestRun;
+  },
+}));
+
+vi.mock('@/components/item-counts', () => ({
+  ItemCounts: (props: ItemCountsProps) => {
+    mocks.itemCountsProps = props;
+    return <div>Item counts</div>;
+  },
+  ItemCountsSkeleton: () => <div data-slot='item-counts-skeleton' />,
+}));
+
+const runSummary = {
+  id: 11,
+  index: 7,
+  organizationId: 1,
+  productId: 2,
+  repositoryId: 3,
+  jobs: {
+    analyzer: { status: 'FINISHED' },
+    advisor: { status: 'RUNNING' },
+    evaluator: { status: 'FAILED' },
+  },
+} as OrtRunSummary;
+
+const renderItemCounts = () =>
+  renderToStaticMarkup(<LastRunItemCounts repoId={3} />);
+
+describe('LastRunItemCounts', () => {
+  beforeEach(() => {
+    mocks.latestRun = runSummary;
+    mocks.latestRunSuspends = false;
+    mocks.statisticsSuspend = false;
+    mocks.itemCountsProps = undefined;
+    mocks.useSuspenseQuery.mockReset();
+    mocks.useSuspenseQuery.mockImplementation(() => {
+      if (mocks.statisticsSuspend) throw mocks.pendingPromise;
+
+      return { data: mocks.statistics };
+    });
+  });
+
+  it('renders item counts for jobs that have finished', () => {
+    const markup = renderItemCounts();
+
+    expect(markup).toContain('Item counts');
+    expect(mocks.itemCountsProps).toMatchObject({
+      statistics: mocks.statistics,
+      showIssues: true,
+      showVulnerabilities: false,
+      showRuleViolations: true,
+      compact: true,
+      link: {
+        params: {
+          orgId: '1',
+          productId: '2',
+          repoId: '3',
+          runIndex: '7',
+        },
+        issuesSearch: {
+          sortBy: [{ id: 'severity', desc: true }],
+          itemResolved: ['Unresolved'],
+        },
+        vulnerabilitiesSearch: {
+          sortBy: [{ id: 'rating', desc: true }],
+          itemResolved: ['Unresolved'],
+        },
+        ruleViolationsSearch: {
+          sortBy: [{ id: 'severity', desc: true }],
+          itemResolved: ['Unresolved'],
+        },
+      },
+    });
+    expect(mocks.itemCountsProps?.tooltip('issues', 99)).toBe(
+      'View issues of run 7'
+    );
+    expect(mocks.itemCountsProps?.tooltip('issues', 100)).toBe(
+      'View all 100 issues of run 7'
+    );
+  });
+
+  it('renders a skeleton while the latest run is loading', () => {
+    mocks.latestRunSuspends = true;
+
+    const markup = renderItemCounts();
+
+    expect(markup).toContain('data-slot="item-counts-skeleton"');
+    expect(markup).toContain('Loading data...');
+    expect(mocks.itemCountsProps).toBeUndefined();
+  });
+
+  it('renders a skeleton while the run statistics are loading', () => {
+    mocks.statisticsSuspend = true;
+
+    const markup = renderItemCounts();
+
+    expect(markup).toContain('data-slot="item-counts-skeleton"');
+    expect(markup).toContain('Loading data...');
+    expect(mocks.itemCountsProps).toBeUndefined();
+  });
+
+  it('reserves space when the repository has no runs', () => {
+    mocks.latestRun = undefined;
+
+    const markup = renderItemCounts();
+
+    expect(markup).toContain('class="min-h-6"');
+    expect(markup).not.toContain('item-counts-skeleton');
+    expect(mocks.useSuspenseQuery).not.toHaveBeenCalled();
+    expect(mocks.itemCountsProps).toBeUndefined();
+  });
+});

--- a/ui/tests/unit/components/query-boundary.test.tsx
+++ b/ui/tests/unit/components/query-boundary.test.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+
+import { QueryBoundary, QueryErrorFallback } from '@/components/query-boundary';
+
+const SuspendedChild = () => {
+  throw new Promise(() => undefined);
+};
+
+describe('QueryBoundary', () => {
+  it('renders its children when they do not suspend', () => {
+    const markup = renderToStaticMarkup(
+      <QueryBoundary fallback={<div>Loading fallback</div>}>
+        <div>Loaded content</div>
+      </QueryBoundary>
+    );
+
+    expect(markup).toContain('Loaded content');
+    expect(markup).not.toContain('Loading fallback');
+    expect(markup).not.toContain('Loading data...');
+  });
+
+  it('renders its fallback and accessible label when a child suspends', () => {
+    const markup = renderToStaticMarkup(
+      <QueryBoundary
+        fallback={<div>Loading fallback</div>}
+        loadingLabel='Loading statistics...'
+      >
+        <div>
+          <SuspendedChild />
+          Suspended content
+        </div>
+      </QueryBoundary>
+    );
+
+    expect(markup).toContain('Loading fallback');
+    expect(markup).toContain('Loading statistics...');
+    expect(markup).toContain('role="status"');
+    expect(markup).not.toContain('Suspended content');
+  });
+});
+
+describe('QueryErrorFallback', () => {
+  it('renders an accessible retry button with the error message', () => {
+    const markup = renderToStaticMarkup(
+      <QueryErrorFallback error={new Error('Request failed')} reset={vi.fn()} />
+    );
+
+    expect(markup).toContain('lucide-triangle-alert');
+    expect(markup).toContain('Retry');
+    expect(markup).toContain(
+      'aria-label="Could not load data: Request failed. Click to retry."'
+    );
+  });
+});

--- a/ui/tests/unit/logic/use-latest-repository-run.test.ts
+++ b/ui/tests/unit/logic/use-latest-repository-run.test.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { OrtRunSummary } from '@/api';
+import { config } from '@/config';
+import { useLatestRepositoryRun } from '@/hooks/use-latest-repository-run';
+
+type RefetchInterval = (query: {
+  state: {
+    data?: {
+      data: Array<{ finishedAt?: string | null }>;
+    };
+  };
+}) => number | undefined;
+
+const mocks = vi.hoisted(() => ({
+  runs: [] as OrtRunSummary[],
+  queryOptions: undefined as unknown,
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  queryOptions: (queryOptions: unknown) => queryOptions,
+  useSuspenseQuery: (queryOptions: unknown) => {
+    mocks.queryOptions = queryOptions;
+    return { data: { data: mocks.runs } };
+  },
+}));
+
+const getRefetchInterval = () => {
+  const refetchInterval = (
+    mocks.queryOptions as { refetchInterval?: RefetchInterval }
+  ).refetchInterval;
+
+  expect(refetchInterval).toBeTypeOf('function');
+
+  return refetchInterval as RefetchInterval;
+};
+
+const runSummary = (finishedAt?: string | null) =>
+  ({ id: 1, finishedAt }) as OrtRunSummary;
+
+describe('useLatestRepositoryRun', () => {
+  beforeEach(() => {
+    mocks.runs = [];
+    mocks.queryOptions = undefined;
+  });
+
+  it('returns the latest run', () => {
+    const run = runSummary();
+    mocks.runs = [run];
+
+    expect(useLatestRepositoryRun(42)).toBe(run);
+  });
+
+  it('returns undefined when the repository has no runs', () => {
+    expect(useLatestRepositoryRun(42)).toBeUndefined();
+  });
+
+  it('polls while the latest run is unfinished', () => {
+    useLatestRepositoryRun(42);
+
+    expect(
+      getRefetchInterval()({ state: { data: { data: [runSummary()] } } })
+    ).toBe(config.pollInterval);
+  });
+
+  it('stops polling after the latest run finishes', () => {
+    useLatestRepositoryRun(42);
+
+    expect(
+      getRefetchInterval()({
+        state: { data: { data: [runSummary('2026-01-01T00:00:00Z')] } },
+      })
+    ).toBeUndefined();
+  });
+});


### PR DESCRIPTION
https://github.com/user-attachments/assets/bd6b38b7-6f5e-4a25-b251-2114d025ba62

This PR starts resolving a more general problem described in #5578 by laying the foundation for more advanced component rendering while fetching data. It uses a combination of React Suspense, query and error boundaries and shadcn-ui Skeleton component, to be able to render a skeleton of a component (which reserves the same horizontal and vertical space from the UI as after data loaded), while its data is loading.

As a demo of this behavior, the item count badges of the product repository table use this foundation. The video demostrates the behavior - no "row jumping" anymore in the table, once the data is loaded.

This PR will be followed by subsequent PRs using the foundation and tackling similar problems elsewhere in the UI.