### PR TITLE
ui: Complete item count badge loading states implementation

### DIFF
--- a/ui/src/routes/organizations/$orgId/-components/product-item-counts.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/product-item-counts.tsx
@@ -17,18 +17,25 @@
  * License-Filename: LICENSE
  */
 
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { getProductRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
-import { ItemCounts } from '@/components/item-counts';
+import { ItemCounts, ItemCountsSkeleton } from '@/components/item-counts';
+import { QueryBoundary } from '@/components/query-boundary';
 import { config } from '@/config';
 
 type ProductItemCountsProps = {
   productId: number;
 };
 
-export const ProductItemCounts = ({ productId }: ProductItemCountsProps) => {
-  const statistics = useQuery({
+export const ProductItemCounts = ({ productId }: ProductItemCountsProps) => (
+  <QueryBoundary fallback={<ItemCountsSkeleton />} resetKey={productId}>
+    <ProductItemCountsInner productId={productId} />
+  </QueryBoundary>
+);
+
+const ProductItemCountsInner = ({ productId }: ProductItemCountsProps) => {
+  const statistics = useSuspenseQuery({
     ...getProductRunStatisticsOptions({
       path: { productId },
     }),

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repository-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repository-table.tsx
@@ -39,8 +39,8 @@ import { toastError } from '@/lib/toast';
 import { useTablePrefsStore } from '@/store/table-prefs.store';
 import { LastJobStatus } from './last-job-status';
 import { LastRunDate } from './last-run-date';
-import { LastRunItemCounts } from './last-run-item-counts';
 import { LastRunStatus } from './last-run-status';
+import { RepositoryItemCounts } from './repository-item-counts';
 import { TotalRuns } from './total-runs';
 
 const columnHelper = createColumnHelper<Repository>();
@@ -193,7 +193,7 @@ export const ProductRepositoryTable = () => {
           <div className='flex flex-col gap-1'>
             <LastRunStatus repoId={row.original.id} />
             <div className='flex'>
-              <LastRunItemCounts repoId={row.original.id} />
+              <RepositoryItemCounts repoId={row.original.id} />
             </div>
           </div>
         ),

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/repository-item-counts.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/repository-item-counts.tsx
@@ -27,29 +27,33 @@ import { config } from '@/config';
 import { isJobFinished } from '@/helpers/job-helpers';
 import { useLatestRepositoryRun } from '@/hooks/use-latest-repository-run';
 
-type LastRunItemCountsProps = {
+type RepositoryItemCountsProps = {
   repoId: number;
 };
 
-export const LastRunItemCounts = ({ repoId }: LastRunItemCountsProps) => (
+export const RepositoryItemCounts = ({ repoId }: RepositoryItemCountsProps) => (
   <QueryBoundary fallback={<ItemCountsSkeleton />} resetKey={repoId}>
-    <LastRunItemCountsStage1 repoId={repoId} />
+    <RepositoryItemCountsStage1 repoId={repoId} />
   </QueryBoundary>
 );
 
-const LastRunItemCountsStage1 = ({ repoId }: { repoId: number }) => {
+const RepositoryItemCountsStage1 = ({ repoId }: { repoId: number }) => {
   const run = useLatestRepositoryRun(repoId);
 
   if (!run) return <div className='min-h-6' />;
 
-  return <LastRunItemCountsStage2 summary={run} />;
+  return <RepositoryItemCountsStage2 summary={run} />;
 };
 
 const showBadge = (jobSummary: JobSummary | null | undefined) => {
   return jobSummary != null && isJobFinished(jobSummary.status);
 };
 
-const LastRunItemCountsStage2 = ({ summary }: { summary: OrtRunSummary }) => {
+const RepositoryItemCountsStage2 = ({
+  summary,
+}: {
+  summary: OrtRunSummary;
+}) => {
   const statistics = useSuspenseQuery({
     ...getRunStatisticsOptions({
       path: { runId: summary.id },

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/index.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/index.ts
@@ -24,6 +24,7 @@ export * from './move-repository';
 export * from './notifier-fields';
 export * from './package-manager-field';
 export * from './reporter-fields';
+export * from './run-item-counts';
 export * from './repository-runs-table';
 export * from './run-configuration-diff-dialog';
 export * from './scanner-fields';

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/repository-runs-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/repository-runs-table.tsx
@@ -32,13 +32,7 @@ import {
 import { GitCompare, Repeat, View } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
-import {
-  JobSummary,
-  Organization,
-  OrtRunSummary,
-  Product,
-  Repository,
-} from '@/api';
+import { Organization, OrtRunSummary, Product, Repository } from '@/api';
 import {
   deleteRepositoryRunMutation,
   getOrganizationOptions,
@@ -47,13 +41,11 @@ import {
   getRepositoryRunOptions,
   getRepositoryRunsOptions,
   getRepositoryRunsQueryKey,
-  getRunStatisticsOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { DataTable } from '@/components/data-table/data-table';
 import { DeleteDialog } from '@/components/delete-dialog';
 import { DeleteIconButton } from '@/components/delete-icon-button';
 import { FavoriteButton } from '@/components/favorite-button';
-import { ItemCounts } from '@/components/item-counts';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import { OrtRunJobStatus } from '@/components/ort-run-job-status';
 import { RunDuration } from '@/components/run-duration';
@@ -76,7 +68,6 @@ import {
 import { config } from '@/config';
 import { diffResolvedJobConfigs } from '@/helpers/config-diff';
 import { getStatusBackgroundColor } from '@/helpers/get-status-class';
-import { isJobFinished } from '@/helpers/job-helpers';
 import { useRepositoryPermission } from '@/hooks/use-authorization';
 import { ApiError } from '@/lib/api-error';
 import { toast, toastError } from '@/lib/toast';
@@ -89,6 +80,7 @@ import {
   type RunComparisonSelection,
 } from './repository-runs-table-utils';
 import { RunConfigurationDiffDialog } from './run-configuration-diff-dialog';
+import { RunItemCounts } from './run-item-counts';
 
 type RepositoryTableProps = {
   orgId: string;
@@ -110,14 +102,6 @@ type RunComparisonContext = {
 const pollInterval = config.pollInterval;
 
 const columnHelper = createColumnHelper<OrtRunSummary>();
-
-const showBadge = (jobSummary: JobSummary | null | undefined) => {
-  return (
-    jobSummary !== undefined &&
-    jobSummary !== null &&
-    isJobFinished(jobSummary.status)
-  );
-};
 
 const SummaryCard = ({
   summary,
@@ -142,13 +126,6 @@ const SummaryCard = ({
 
   const hasLabels = summary.labels && Object.keys(summary.labels).length > 0;
 
-  const statistics = useQuery({
-    ...getRunStatisticsOptions({
-      path: { runId: summary.id },
-    }),
-    refetchInterval: pollInterval,
-  });
-
   return (
     <div className='grid grid-cols-12 gap-2'>
       {/* Left column - status, job status, duration */}
@@ -159,33 +136,7 @@ const SummaryCard = ({
           {summary.status}
         </Badge>
         <div className='col-span-2 flex flex-col items-start justify-center gap-2'>
-          <ItemCounts
-            statistics={statistics.data}
-            wide
-            showIssues={showBadge(summary.jobs.analyzer)}
-            showVulnerabilities={showBadge(summary.jobs.advisor)}
-            showRuleViolations={showBadge(summary.jobs.evaluator)}
-            link={{
-              params: {
-                orgId: summary.organizationId.toString(),
-                productId: summary.productId.toString(),
-                repoId: summary.repositoryId.toString(),
-                runIndex: summary.index.toString(),
-              },
-              issuesSearch: {
-                sortBy: [{ id: 'severity', desc: true }],
-                itemResolved: ['Unresolved'],
-              },
-              vulnerabilitiesSearch: {
-                sortBy: [{ id: 'rating', desc: true }],
-                itemResolved: ['Unresolved'],
-              },
-              ruleViolationsSearch: {
-                sortBy: [{ id: 'severity', desc: true }],
-                itemResolved: ['Unresolved'],
-              },
-            }}
-          />
+          <RunItemCounts summary={summary} />
         </div>
         <OrtRunJobStatus
           jobs={summary.jobs}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/run-item-counts.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/run-item-counts.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import type { JobSummary, OrtRunSummary } from '@/api';
+import { getRunStatisticsOptions } from '@/api/@tanstack/react-query.gen';
+import { ItemCounts, ItemCountsSkeleton } from '@/components/item-counts';
+import { QueryBoundary } from '@/components/query-boundary';
+import { config } from '@/config';
+import { isJobFinished } from '@/helpers/job-helpers';
+
+const showBadge = (jobSummary: JobSummary | null | undefined) => {
+  return jobSummary != null && isJobFinished(jobSummary.status);
+};
+
+export const RunItemCounts = ({ summary }: { summary: OrtRunSummary }) => (
+  <QueryBoundary fallback={<ItemCountsSkeleton wide />} resetKey={summary.id}>
+    <RunItemCountsInner summary={summary} />
+  </QueryBoundary>
+);
+
+const RunItemCountsInner = ({ summary }: { summary: OrtRunSummary }) => {
+  const statistics = useSuspenseQuery({
+    ...getRunStatisticsOptions({
+      path: { runId: summary.id },
+    }),
+    refetchInterval: config.pollInterval,
+  });
+
+  return (
+    <ItemCounts
+      statistics={statistics.data}
+      wide
+      showIssues={showBadge(summary.jobs.analyzer)}
+      showVulnerabilities={showBadge(summary.jobs.advisor)}
+      showRuleViolations={showBadge(summary.jobs.evaluator)}
+      link={{
+        params: {
+          orgId: summary.organizationId.toString(),
+          productId: summary.productId.toString(),
+          repoId: summary.repositoryId.toString(),
+          runIndex: summary.index.toString(),
+        },
+        issuesSearch: {
+          sortBy: [{ id: 'severity', desc: true }],
+          itemResolved: ['Unresolved'],
+        },
+        vulnerabilitiesSearch: {
+          sortBy: [{ id: 'rating', desc: true }],
+          itemResolved: ['Unresolved'],
+        },
+        ruleViolationsSearch: {
+          sortBy: [{ id: 'severity', desc: true }],
+          itemResolved: ['Unresolved'],
+        },
+      }}
+    />
+  );
+};

--- a/ui/tests/unit/components/product-item-counts.test.tsx
+++ b/ui/tests/unit/components/product-item-counts.test.tsx
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ProductItemCounts } from '@/routes/organizations/$orgId/-components/product-item-counts';
+
+type Statistics = {
+  issuesCount: number;
+  vulnerabilitiesCount: number;
+  ruleViolationsCount: number;
+};
+
+type ItemCountsProps = {
+  statistics: Statistics;
+  compact: boolean;
+  link?: unknown;
+  tooltip: (label: string, count: number) => string;
+};
+
+const mocks = vi.hoisted(() => ({
+  statistics: {
+    issuesCount: 3,
+    vulnerabilitiesCount: 5,
+    ruleViolationsCount: 7,
+  } as Statistics,
+  suspend: false,
+  itemCountsProps: undefined as ItemCountsProps | undefined,
+  pendingPromise: new Promise<never>(() => undefined),
+  useSuspenseQuery: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>();
+
+  return {
+    ...actual,
+    useSuspenseQuery: mocks.useSuspenseQuery,
+  };
+});
+
+vi.mock('@/components/item-counts', () => ({
+  ItemCounts: (props: ItemCountsProps) => {
+    mocks.itemCountsProps = props;
+    return <div>Item counts</div>;
+  },
+  ItemCountsSkeleton: () => <div data-slot='item-counts-skeleton' />,
+}));
+
+const renderItemCounts = () =>
+  renderToStaticMarkup(<ProductItemCounts productId={2} />);
+
+describe('ProductItemCounts', () => {
+  beforeEach(() => {
+    mocks.suspend = false;
+    mocks.itemCountsProps = undefined;
+    mocks.useSuspenseQuery.mockReset();
+    mocks.useSuspenseQuery.mockImplementation(() => {
+      if (mocks.suspend) throw mocks.pendingPromise;
+
+      return { data: mocks.statistics };
+    });
+  });
+
+  it('renders the product statistics without links', () => {
+    const markup = renderItemCounts();
+
+    expect(markup).toContain('Item counts');
+    expect(mocks.itemCountsProps).toMatchObject({
+      statistics: mocks.statistics,
+      compact: true,
+    });
+    expect(mocks.itemCountsProps?.link).toBeUndefined();
+    expect(mocks.itemCountsProps?.tooltip('issues', 3)).toBe(
+      '3 issues in total'
+    );
+  });
+
+  it('renders a skeleton while the statistics are loading', () => {
+    mocks.suspend = true;
+
+    const markup = renderItemCounts();
+
+    expect(markup).toContain('data-slot="item-counts-skeleton"');
+    expect(markup).toContain('Loading data...');
+    expect(mocks.itemCountsProps).toBeUndefined();
+  });
+});

--- a/ui/tests/unit/components/repository-item-counts.test.tsx
+++ b/ui/tests/unit/components/repository-item-counts.test.tsx
@@ -21,7 +21,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import type { OrtRunSummary } from '@/api';
-import { LastRunItemCounts } from '@/routes/organizations/$orgId/products/$productId/-components/last-run-item-counts';
+import { RepositoryItemCounts } from '@/routes/organizations/$orgId/products/$productId/-components/repository-item-counts';
 
 type Statistics = {
   issuesCount: number;
@@ -97,9 +97,9 @@ const runSummary = {
 } as OrtRunSummary;
 
 const renderItemCounts = () =>
-  renderToStaticMarkup(<LastRunItemCounts repoId={3} />);
+  renderToStaticMarkup(<RepositoryItemCounts repoId={3} />);
 
-describe('LastRunItemCounts', () => {
+describe('RepositoryItemCounts', () => {
   beforeEach(() => {
     mocks.latestRun = runSummary;
     mocks.latestRunSuspends = false;

--- a/ui/tests/unit/components/run-item-counts.test.tsx
+++ b/ui/tests/unit/components/run-item-counts.test.tsx
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { OrtRunSummary } from '@/api';
+import { RunItemCounts } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/run-item-counts';
+
+type Statistics = {
+  issuesCount: number;
+  vulnerabilitiesCount: number;
+  ruleViolationsCount: number;
+};
+
+type ItemCountsProps = {
+  statistics: Statistics;
+  showIssues: boolean;
+  showVulnerabilities: boolean;
+  showRuleViolations: boolean;
+  wide: boolean;
+  link: {
+    params: Record<string, string>;
+    issuesSearch: unknown;
+    vulnerabilitiesSearch: unknown;
+    ruleViolationsSearch: unknown;
+  };
+};
+
+const mocks = vi.hoisted(() => ({
+  statistics: {
+    issuesCount: 3,
+    vulnerabilitiesCount: 5,
+    ruleViolationsCount: 7,
+  } as Statistics,
+  suspend: false,
+  itemCountsProps: undefined as ItemCountsProps | undefined,
+  skeletonWide: undefined as boolean | undefined,
+  pendingPromise: new Promise<never>(() => undefined),
+  useSuspenseQuery: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>();
+
+  return {
+    ...actual,
+    useSuspenseQuery: mocks.useSuspenseQuery,
+  };
+});
+
+vi.mock('@/components/item-counts', () => ({
+  ItemCounts: (props: ItemCountsProps) => {
+    mocks.itemCountsProps = props;
+    return <div>Item counts</div>;
+  },
+  ItemCountsSkeleton: ({ wide }: { wide?: boolean }) => {
+    mocks.skeletonWide = wide;
+    return <div data-slot='item-counts-skeleton' />;
+  },
+}));
+
+const runSummary = {
+  id: 11,
+  index: 7,
+  organizationId: 1,
+  productId: 2,
+  repositoryId: 3,
+  jobs: {
+    analyzer: { status: 'FINISHED' },
+    advisor: { status: 'FINISHED' },
+    evaluator: { status: 'FINISHED' },
+  },
+} as OrtRunSummary;
+
+const renderItemCounts = (summary: OrtRunSummary = runSummary) =>
+  renderToStaticMarkup(<RunItemCounts summary={summary} />);
+
+describe('RunItemCounts', () => {
+  beforeEach(() => {
+    mocks.suspend = false;
+    mocks.itemCountsProps = undefined;
+    mocks.skeletonWide = undefined;
+    mocks.useSuspenseQuery.mockReset();
+    mocks.useSuspenseQuery.mockImplementation(() => {
+      if (mocks.suspend) throw mocks.pendingPromise;
+
+      return { data: mocks.statistics };
+    });
+  });
+
+  it('renders wide item-count badges linked to the run findings', () => {
+    const markup = renderItemCounts();
+
+    expect(markup).toContain('Item counts');
+    expect(mocks.itemCountsProps).toMatchObject({
+      statistics: mocks.statistics,
+      showIssues: true,
+      showVulnerabilities: true,
+      showRuleViolations: true,
+      wide: true,
+      link: {
+        params: {
+          orgId: '1',
+          productId: '2',
+          repoId: '3',
+          runIndex: '7',
+        },
+        issuesSearch: {
+          sortBy: [{ id: 'severity', desc: true }],
+          itemResolved: ['Unresolved'],
+        },
+        vulnerabilitiesSearch: {
+          sortBy: [{ id: 'rating', desc: true }],
+          itemResolved: ['Unresolved'],
+        },
+        ruleViolationsSearch: {
+          sortBy: [{ id: 'severity', desc: true }],
+          itemResolved: ['Unresolved'],
+        },
+      },
+    });
+  });
+
+  it('renders a wide skeleton while the statistics are loading', () => {
+    mocks.suspend = true;
+
+    const markup = renderItemCounts();
+
+    expect(markup).toContain('data-slot="item-counts-skeleton"');
+    expect(markup).toContain('Loading data...');
+    expect(mocks.skeletonWide).toBe(true);
+    expect(mocks.itemCountsProps).toBeUndefined();
+  });
+
+  it('hides badges for jobs that have not finished', () => {
+    renderItemCounts({
+      ...runSummary,
+      jobs: {
+        ...runSummary.jobs,
+        advisor: { ...runSummary.jobs.advisor!, status: 'RUNNING' },
+        evaluator: null,
+      },
+    });
+
+    expect(mocks.itemCountsProps).toMatchObject({
+      showIssues: true,
+      showVulnerabilities: false,
+      showRuleViolations: false,
+    });
+  });
+});


### PR DESCRIPTION
This PR completes the handling of loading states for the item count badges on all hierarchy levels, preventing them causing row jumping due to data loading, as mentioned in #5578.

#### Product item counts
https://github.com/user-attachments/assets/05f11236-edc5-4b5d-9e4f-498af8ee47db

#### Repository (latest run) item counts
https://github.com/user-attachments/assets/fbfab96a-40a4-4eae-9f5c-9a4dff71c673

#### Run item counts
https://github.com/user-attachments/assets/09e63ef5-66f2-434c-a4d2-ba902030e872

As you can see from the videos, all three badge skeletons are always shown, even if some badges will be missing in the end due to some jobs not included in the ORT run. This is deliberate, because the final badge visibility (especially on organization and product levels) depends on asynchronously loaded job and statistics data, and taking this into account would unnecessarily complicate the loading-state handling.