### PR TITLE
ui: Complete product repository table's loading states

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/last-job-status.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/last-job-status.tsx
@@ -17,56 +17,40 @@
  * License-Filename: LICENSE
  */
 
-import { useQuery } from '@tanstack/react-query';
-import { Loader2 } from 'lucide-react';
-
-import { getRepositoryRunsOptions } from '@/api/@tanstack/react-query.gen';
 import { OrtRunJobStatus } from '@/components/ort-run-job-status';
-import { config } from '@/config';
+import { QueryBoundary } from '@/components/query-boundary';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useLatestRepositoryRun } from '@/hooks/use-latest-repository-run';
 
-export const LastJobStatus = ({ repoId }: { repoId: number }) => {
-  const {
-    data: runs,
-    isPending: runsIsPending,
-    isError: runsIsError,
-  } = useQuery({
-    ...getRepositoryRunsOptions({
-      path: { repositoryId: repoId },
-      query: { limit: 1, sort: '-index' },
-    }),
-    refetchInterval: (query) => {
-      const curData = query.state.data?.data;
-      if (curData && curData[0] && curData[0].finishedAt) {
-        return undefined;
-      }
-      return config.pollInterval;
-    },
-  });
+export const LastJobStatus = ({ repoId }: { repoId: number }) => (
+  <QueryBoundary
+    fallback={
+      <div className='flex min-h-3 items-center space-x-1'>
+        {Array.from({ length: 5 }).map((_, index) => (
+          <Skeleton key={index} className='h-3 w-3 rounded-full' />
+        ))}
+      </div>
+    }
+    resetKey={repoId}
+  >
+    <LastJobStatusInner repoId={repoId} />
+  </QueryBoundary>
+);
 
-  if (runsIsPending) {
-    return (
-      <>
-        <span className='sr-only'>Loading...</span>
-        <Loader2 size={16} className='mx-3 animate-spin' />
-      </>
-    );
-  }
+const LastJobStatusInner = ({ repoId }: { repoId: number }) => {
+  const run = useLatestRepositoryRun(repoId);
 
-  if (runsIsError) {
-    return <span>Error loading run.</span>;
-  }
-
-  if (!runs.data[0]) return null;
-
-  const run = runs.data[0];
+  if (!run) return <div className='min-h-3' />;
 
   return (
-    <OrtRunJobStatus
-      jobs={run.jobs}
-      orgId={run.organizationId.toString()}
-      productId={run.productId.toString()}
-      repoId={run.repositoryId.toString()}
-      runIndex={run.index.toString()}
-    />
+    <div className='min-h-3'>
+      <OrtRunJobStatus
+        jobs={run.jobs}
+        orgId={run.organizationId.toString()}
+        productId={run.productId.toString()}
+        repoId={run.repositoryId.toString()}
+        runIndex={run.index.toString()}
+      />
+    </div>
   );
 };

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/last-run-date.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/last-run-date.tsx
@@ -17,54 +17,37 @@
  * License-Filename: LICENSE
  */
 
-import { useQuery } from '@tanstack/react-query';
-import { Loader2 } from 'lucide-react';
-
-import { getRepositoryRunsOptions } from '@/api/@tanstack/react-query.gen';
+import { QueryBoundary } from '@/components/query-boundary';
 import { TimestampWithUTC } from '@/components/timestamp-with-utc';
+import { Skeleton } from '@/components/ui/skeleton';
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { config } from '@/config';
+import { useLatestRepositoryRun } from '@/hooks/use-latest-repository-run';
 
-export const LastRunDate = ({ repoId }: { repoId: number }) => {
-  const {
-    data: runs,
-    isPending: runsIsPending,
-    isError: runsIsError,
-  } = useQuery({
-    ...getRepositoryRunsOptions({
-      path: { repositoryId: repoId },
-      query: { limit: 1, sort: '-index' },
-    }),
-    refetchInterval: (query) => {
-      const curData = query.state.data?.data;
-      if (curData && curData[0] && curData[0].finishedAt) {
-        return undefined;
-      }
-      return config.pollInterval;
-    },
-  });
+export const LastRunDate = ({ repoId }: { repoId: number }) => (
+  <QueryBoundary
+    fallback={
+      <div className='flex min-h-10 flex-col gap-1'>
+        <Skeleton className='h-4 w-32' />
+        <Skeleton className='h-4 w-20' />
+      </div>
+    }
+    resetKey={repoId}
+  >
+    <LastRunDateInner repoId={repoId} />
+  </QueryBoundary>
+);
 
-  if (runsIsPending) {
-    return (
-      <>
-        <span className='sr-only'>Loading...</span>
-        <Loader2 size={16} className='mx-3 animate-spin' />
-      </>
-    );
-  }
+const LastRunDateInner = ({ repoId }: { repoId: number }) => {
+  const run = useLatestRepositoryRun(repoId);
 
-  if (runsIsError) return <span>Error loading run.</span>;
-
-  if (!runs.data[0]) return null;
-
-  const run = runs.data[0];
+  if (!run) return <div className='min-h-10' />;
 
   return (
-    <div className='flex flex-col items-start'>
+    <div className='flex min-h-10 flex-col items-start'>
       {run.finishedAt ? (
         <TimestampWithUTC timestamp={run.finishedAt} />
       ) : (

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/last-run-status.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/last-run-status.tsx
@@ -17,49 +17,25 @@
  * License-Filename: LICENSE
  */
 
-import { useQuery } from '@tanstack/react-query';
-import { Loader2 } from 'lucide-react';
-
-import { getRepositoryRunsOptions } from '@/api/@tanstack/react-query.gen';
+import { QueryBoundary } from '@/components/query-boundary';
 import { Badge } from '@/components/ui/badge';
-import { config } from '@/config';
+import { Skeleton } from '@/components/ui/skeleton';
 import { getStatusBackgroundColor } from '@/helpers/get-status-class';
+import { useLatestRepositoryRun } from '@/hooks/use-latest-repository-run';
 
-export const LastRunStatus = ({ repoId }: { repoId: number }) => {
-  const {
-    data: runs,
-    isPending: runsIsPending,
-    isError: runsIsError,
-  } = useQuery({
-    ...getRepositoryRunsOptions({
-      path: { repositoryId: repoId },
-      query: { limit: 1, sort: '-index' },
-    }),
-    refetchInterval: (query) => {
-      const curData = query.state.data?.data;
-      if (curData && curData[0] && curData[0].finishedAt) {
-        return undefined;
-      }
-      return config.pollInterval;
-    },
-  });
+export const LastRunStatus = ({ repoId }: { repoId: number }) => (
+  <QueryBoundary
+    fallback={<Skeleton className='h-5 w-16 rounded-md' />}
+    resetKey={repoId}
+  >
+    <LastRunStatusInner repoId={repoId} />
+  </QueryBoundary>
+);
 
-  if (runsIsPending) {
-    return (
-      <>
-        <span className='sr-only'>Loading...</span>
-        <Loader2 size={16} className='mx-3 animate-spin' />
-      </>
-    );
-  }
+const LastRunStatusInner = ({ repoId }: { repoId: number }) => {
+  const run = useLatestRepositoryRun(repoId);
 
-  if (runsIsError) {
-    return <span>Error loading run.</span>;
-  }
-
-  if (!runs.data[0]) return null;
-
-  const run = runs.data[0];
+  if (!run) return <div className='min-h-5' />;
 
   return (
     <Badge className={`border ${getStatusBackgroundColor(run.status)}`}>

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/total-runs.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/total-runs.tsx
@@ -17,43 +17,32 @@
  * License-Filename: LICENSE
  */
 
-import { useQuery } from '@tanstack/react-query';
-import { Loader2 } from 'lucide-react';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 import { getRepositoryRunsOptions } from '@/api/@tanstack/react-query.gen';
+import { QueryBoundary } from '@/components/query-boundary';
+import { Skeleton } from '@/components/ui/skeleton';
 import { config } from '@/config';
 
-export const TotalRuns = ({ repoId }: { repoId: number }) => {
-  const {
-    data: runs,
-    isPending: runsIsPending,
-    isError: runsIsError,
-  } = useQuery({
+export const TotalRuns = ({ repoId }: { repoId: number }) => (
+  <QueryBoundary fallback={<Skeleton className='h-5 w-6' />} resetKey={repoId}>
+    <TotalRunsInner repoId={repoId} />
+  </QueryBoundary>
+);
+
+const TotalRunsInner = ({ repoId }: { repoId: number }) => {
+  const { data: runs } = useSuspenseQuery({
     ...getRepositoryRunsOptions({
       path: { repositoryId: repoId },
       query: { limit: 1, sort: '-index' },
     }),
     refetchInterval: (query) => {
-      const curData = query.state.data?.data;
-      if (curData && curData[0] && curData[0].finishedAt) {
-        return undefined;
-      }
+      const latestRun = query.state.data?.data[0];
+      if (latestRun?.finishedAt) return undefined;
+
       return config.pollInterval;
     },
   });
 
-  if (runsIsPending) {
-    return (
-      <>
-        <span className='sr-only'>Loading...</span>
-        <Loader2 size={16} className='mx-3 animate-spin' />
-      </>
-    );
-  }
-
-  if (runsIsError) {
-    return <span>Error loading run.</span>;
-  }
-
-  return <div>{runs.pagination.totalCount}</div>;
+  return <div className='min-h-5'>{runs.pagination.totalCount}</div>;
 };

--- a/ui/tests/unit/components/last-job-status.test.tsx
+++ b/ui/tests/unit/components/last-job-status.test.tsx
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { OrtRunSummary } from '@/api';
+import { LastJobStatus } from '@/routes/organizations/$orgId/products/$productId/-components/last-job-status';
+
+type OrtRunJobStatusProps = {
+  jobs: OrtRunSummary['jobs'];
+  orgId: string;
+  productId: string;
+  repoId: string;
+  runIndex: string;
+};
+
+const mocks = vi.hoisted(() => ({
+  latestRun: undefined as OrtRunSummary | undefined,
+  suspend: false,
+  jobStatusProps: undefined as OrtRunJobStatusProps | undefined,
+  pendingPromise: new Promise<never>(() => undefined),
+}));
+
+vi.mock('@/hooks/use-latest-repository-run', () => ({
+  useLatestRepositoryRun: () => {
+    if (mocks.suspend) throw mocks.pendingPromise;
+
+    return mocks.latestRun;
+  },
+}));
+
+vi.mock('@/components/ort-run-job-status', () => ({
+  OrtRunJobStatus: (props: OrtRunJobStatusProps) => {
+    mocks.jobStatusProps = props;
+    return <div data-slot='job-status' />;
+  },
+}));
+
+const renderLastJobStatus = () =>
+  renderToStaticMarkup(<LastJobStatus repoId={42} />);
+
+describe('LastJobStatus', () => {
+  beforeEach(() => {
+    mocks.latestRun = undefined;
+    mocks.suspend = false;
+    mocks.jobStatusProps = undefined;
+  });
+
+  it('renders the latest run job statuses and links', () => {
+    const jobs = {
+      analyzer: { status: 'FINISHED' },
+      advisor: { status: 'RUNNING' },
+    } as OrtRunSummary['jobs'];
+
+    mocks.latestRun = {
+      jobs,
+      organizationId: 1,
+      productId: 2,
+      repositoryId: 3,
+      index: 7,
+    } as OrtRunSummary;
+
+    const markup = renderLastJobStatus();
+
+    expect(markup).toContain('class="min-h-3"');
+    expect(markup).toContain('data-slot="job-status"');
+    expect(mocks.jobStatusProps).toEqual({
+      jobs,
+      orgId: '1',
+      productId: '2',
+      repoId: '3',
+      runIndex: '7',
+    });
+  });
+
+  it('renders five skeleton dots while the latest run is loading', () => {
+    mocks.suspend = true;
+
+    const markup = renderLastJobStatus();
+
+    expect(markup).toContain('flex min-h-3 items-center space-x-1');
+    expect(markup.match(/data-slot="skeleton"/g)).toHaveLength(5);
+    expect(markup.match(/h-3 w-3 rounded-full/g)).toHaveLength(5);
+    expect(markup).toContain('Loading data...');
+    expect(mocks.jobStatusProps).toBeUndefined();
+  });
+
+  it('reserves space when the repository has no runs', () => {
+    const markup = renderLastJobStatus();
+
+    expect(markup).toContain('class="min-h-3"');
+    expect(markup).not.toContain('data-slot="job-status"');
+    expect(markup).not.toContain('data-slot="skeleton"');
+    expect(mocks.jobStatusProps).toBeUndefined();
+  });
+});

--- a/ui/tests/unit/components/last-run-date.test.tsx
+++ b/ui/tests/unit/components/last-run-date.test.tsx
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { OrtRunSummary } from '@/api';
+import { LastRunDate } from '@/routes/organizations/$orgId/products/$productId/-components/last-run-date';
+
+const mocks = vi.hoisted(() => ({
+  latestRun: undefined as OrtRunSummary | undefined,
+  suspend: false,
+  pendingPromise: new Promise<never>(() => undefined),
+}));
+
+vi.mock('@/hooks/use-latest-repository-run', () => ({
+  useLatestRepositoryRun: () => {
+    if (mocks.suspend) throw mocks.pendingPromise;
+
+    return mocks.latestRun;
+  },
+}));
+
+vi.mock('@/components/timestamp-with-utc', () => ({
+  TimestampWithUTC: ({
+    timestamp,
+    className,
+  }: {
+    timestamp: string;
+    className?: string;
+  }) => <span className={className}>{timestamp}</span>,
+}));
+
+const renderLastRunDate = () =>
+  renderToStaticMarkup(<LastRunDate repoId={42} />);
+
+describe('LastRunDate', () => {
+  beforeEach(() => {
+    mocks.latestRun = undefined;
+    mocks.suspend = false;
+  });
+
+  it('renders the finish date and user in a stable-height container', () => {
+    mocks.latestRun = {
+      finishedAt: '2026-07-31T08:00:00Z',
+      createdAt: '2026-07-31T07:00:00Z',
+      userDisplayName: {
+        fullName: 'Example User',
+        username: 'example',
+      },
+    } as OrtRunSummary;
+
+    const markup = renderLastRunDate();
+
+    expect(markup).toContain('flex min-h-10 flex-col items-start');
+    expect(markup).toContain('2026-07-31T08:00:00Z');
+    expect(markup).toContain('Example User');
+  });
+
+  it('reserves two lines when the run has no user', () => {
+    mocks.latestRun = {
+      finishedAt: null,
+      createdAt: '2026-07-31T07:00:00Z',
+    } as OrtRunSummary;
+
+    const markup = renderLastRunDate();
+
+    expect(markup).toContain('flex min-h-10 flex-col items-start');
+    expect(markup).toContain('class="italic"');
+    expect(markup).toContain('2026-07-31T07:00:00Z');
+  });
+
+  it('renders two skeleton lines while the latest run is loading', () => {
+    mocks.suspend = true;
+
+    const markup = renderLastRunDate();
+
+    expect(markup).toContain('flex min-h-10 flex-col gap-1');
+    expect(markup.match(/data-slot="skeleton"/g)).toHaveLength(2);
+    expect(markup).toContain('h-4 w-32');
+    expect(markup).toContain('h-4 w-20');
+    expect(markup).toContain('Loading data...');
+  });
+
+  it('reserves space when the repository has no runs', () => {
+    const markup = renderLastRunDate();
+
+    expect(markup).toContain('class="min-h-10"');
+    expect(markup).not.toContain('data-slot="skeleton"');
+  });
+});

--- a/ui/tests/unit/components/last-run-status.test.tsx
+++ b/ui/tests/unit/components/last-run-status.test.tsx
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { OrtRunSummary } from '@/api';
+import { LastRunStatus } from '@/routes/organizations/$orgId/products/$productId/-components/last-run-status';
+
+const mocks = vi.hoisted(() => ({
+  latestRun: undefined as OrtRunSummary | undefined,
+  suspend: false,
+  pendingPromise: new Promise<never>(() => undefined),
+}));
+
+vi.mock('@/hooks/use-latest-repository-run', () => ({
+  useLatestRepositoryRun: () => {
+    if (mocks.suspend) throw mocks.pendingPromise;
+
+    return mocks.latestRun;
+  },
+}));
+
+const renderLastRunStatus = () =>
+  renderToStaticMarkup(<LastRunStatus repoId={42} />);
+
+describe('LastRunStatus', () => {
+  beforeEach(() => {
+    mocks.latestRun = undefined;
+    mocks.suspend = false;
+  });
+
+  it('renders the latest run status', () => {
+    mocks.latestRun = { status: 'FINISHED' } as OrtRunSummary;
+
+    const markup = renderLastRunStatus();
+
+    expect(markup).toContain('data-slot="badge"');
+    expect(markup).toContain('FINISHED');
+  });
+
+  it('renders a skeleton while the latest run is loading', () => {
+    mocks.suspend = true;
+
+    const markup = renderLastRunStatus();
+
+    expect(markup).toContain('data-slot="skeleton"');
+    expect(markup).toContain('h-5 w-16 rounded-md');
+    expect(markup).toContain('Loading data...');
+    expect(markup).not.toContain('data-slot="badge"');
+  });
+
+  it('reserves space when the repository has no runs', () => {
+    const markup = renderLastRunStatus();
+
+    expect(markup).toContain('class="min-h-5"');
+    expect(markup).not.toContain('data-slot="badge"');
+    expect(markup).not.toContain('data-slot="skeleton"');
+  });
+});

--- a/ui/tests/unit/components/total-runs.test.tsx
+++ b/ui/tests/unit/components/total-runs.test.tsx
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { TotalRuns } from '@/routes/organizations/$orgId/products/$productId/-components/total-runs';
+
+const mocks = vi.hoisted(() => ({
+  suspend: false,
+  pendingPromise: new Promise<never>(() => undefined),
+  useSuspenseQuery: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>();
+
+  return {
+    ...actual,
+    useSuspenseQuery: mocks.useSuspenseQuery,
+  };
+});
+
+const renderTotalRuns = () => renderToStaticMarkup(<TotalRuns repoId={42} />);
+
+describe('TotalRuns', () => {
+  beforeEach(() => {
+    mocks.suspend = false;
+    mocks.useSuspenseQuery.mockReset();
+    mocks.useSuspenseQuery.mockImplementation(() => {
+      if (mocks.suspend) throw mocks.pendingPromise;
+
+      return { data: { pagination: { totalCount: 17 } } };
+    });
+  });
+
+  it('renders the total run count in a stable-height container', () => {
+    const markup = renderTotalRuns();
+
+    expect(markup).toContain('class="min-h-5"');
+    expect(markup).toContain('>17</div>');
+  });
+
+  it('renders a skeleton while the runs are loading', () => {
+    mocks.suspend = true;
+
+    const markup = renderTotalRuns();
+
+    expect(markup).toContain('data-slot="skeleton"');
+    expect(markup).toContain('h-5 w-6');
+    expect(markup).toContain('Loading data...');
+    expect(markup).not.toContain('>17</div>');
+  });
+});


### PR DESCRIPTION
This PR continues solving #5578 by finalizing all component loading states implementation for the product repositories table.

The video probably tells more than a hundred words:

https://github.com/user-attachments/assets/a4ea1f0a-839e-4377-a110-25845495b0d6

Please see the commits for details.