### PR TITLE
ui: Unify aggregate statistics loading boundaries

### DIFF
--- a/ui/src/routes/organizations/$orgId/-components/organization-products-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-products-statistics-card.tsx
@@ -22,8 +22,6 @@ import { Link } from '@tanstack/react-router';
 import { Files, PlusIcon } from 'lucide-react';
 
 import { getOrganizationProductsOptions } from '@/api/@tanstack/react-query.gen';
-import { LoadingIndicator } from '@/components/loading-indicator';
-import { StatisticsCard } from '@/components/statistics-card';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -32,7 +30,6 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { useOrganizationPermission } from '@/hooks/use-authorization';
-import { toastError } from '@/lib/toast';
 
 type OrganizationProductsStatisticsCardProps = {
   orgId: string;
@@ -48,28 +45,12 @@ export const OrganizationProductsStatisticsCard = ({
     'CREATE_PRODUCT'
   );
 
-  const { data, isPending, isError, error } = useSuspenseQuery({
+  const { data } = useSuspenseQuery({
     ...getOrganizationProductsOptions({
       path: { organizationId: Number.parseInt(orgId) },
       query: { limit: 1 },
     }),
   });
-
-  if (isPending) {
-    return (
-      <StatisticsCard
-        title='Products'
-        icon={() => <Files className='h-4 w-4 text-orange-500' />}
-        value={<LoadingIndicator />}
-        className='hover:bg-muted/50 h-full'
-      />
-    );
-  }
-
-  if (isError) {
-    toastError('Unable to load data', error);
-    return;
-  }
 
   const total = data.pagination.totalCount;
 

--- a/ui/src/routes/organizations/$orgId/index.tsx
+++ b/ui/src/routes/organizations/$orgId/index.tsx
@@ -18,15 +18,15 @@
  */
 
 import { useQuery } from '@tanstack/react-query';
-import { CatchBoundary, createFileRoute, Link } from '@tanstack/react-router';
-import { Boxes, Bug, Scale, ShieldQuestion } from 'lucide-react';
-import { Suspense } from 'react';
+import { createFileRoute, Link } from '@tanstack/react-router';
+import { Boxes, Bug, Files, Scale, ShieldQuestion } from 'lucide-react';
+import type { ReactNode } from 'react';
 import z from 'zod';
 
 import { getOrganizationOptions } from '@/api/@tanstack/react-query.gen';
-import { ErrorComponent } from '@/components/error-component';
 import { OrganizationFavoriteButton } from '@/components/favorite-button';
 import { LoadingIndicator } from '@/components/loading-indicator';
+import { QueryBoundary, QueryErrorFallback } from '@/components/query-boundary';
 import { StatisticsCard } from '@/components/statistics-card';
 import {
   Card,
@@ -35,6 +35,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
 import { toastError } from '@/lib/toast';
 import {
   filterByNameSearchParameterSchema,
@@ -46,6 +47,57 @@ import { OrganizationProductTable } from './-components/organization-product-tab
 import { OrganizationProductsStatisticsCard } from './-components/organization-products-statistics-card';
 import { OrganizationViolationsStatisticsCard } from './-components/organization-violations-statistics-card';
 import { OrganizationVulnerabilitiesStatisticsCard } from './-components/organization-vulnerabilities-statistics-card';
+
+type StatisticsFallbackProps = {
+  value: ReactNode;
+};
+
+const OrganizationProductsStatisticsFallback = ({
+  value,
+}: StatisticsFallbackProps) => (
+  <Card className='col-span-2'>
+    <CardHeader>
+      <CardTitle>
+        <div className='flex items-center justify-between'>
+          <span className='text-sm font-semibold'>Products</span>
+          <Files className='h-4 w-4' />
+        </div>
+      </CardTitle>
+    </CardHeader>
+    <CardContent className='text-sm'>
+      <div className='flex min-h-8 items-center'>{value}</div>
+    </CardContent>
+  </Card>
+);
+
+const OrganizationStatisticsFallback = ({ value }: StatisticsFallbackProps) => (
+  <div className='grid grid-cols-4 gap-2'>
+    <StatisticsCard
+      title='Vulnerabilities'
+      icon={() => <ShieldQuestion className='h-4 w-4 text-orange-500' />}
+      value={value}
+      className='hover:bg-muted/50 h-full'
+    />
+    <StatisticsCard
+      title='Issues'
+      icon={() => <Bug className='h-4 w-4 text-orange-500' />}
+      value={value}
+      className='hover:bg-muted/50 h-full'
+    />
+    <StatisticsCard
+      title='Rule Violations'
+      icon={() => <Scale className='h-4 w-4 text-orange-500' />}
+      value={value}
+      className='hover:bg-muted/50 h-full'
+    />
+    <StatisticsCard
+      title='Packages'
+      icon={() => <Boxes className='h-4 w-4 text-orange-500' />}
+      value={value}
+      className='hover:bg-muted/50 h-full'
+    />
+  </div>
+);
 
 const OrganizationComponent = () => {
   const params = Route.useParams();
@@ -89,16 +141,37 @@ const OrganizationComponent = () => {
             </div>
           </CardHeader>
         </Card>
-        <OrganizationProductsStatisticsCard
-          className='col-span-2'
-          orgId={params.orgId}
-        />
+        <QueryBoundary
+          fallback={
+            <OrganizationProductsStatisticsFallback
+              value={<Skeleton className='h-8 w-12' />}
+            />
+          }
+          errorFallback={(props) => (
+            <OrganizationProductsStatisticsFallback
+              value={<QueryErrorFallback {...props} />}
+            />
+          )}
+          resetKey={`${organization.id}-products`}
+        >
+          <OrganizationProductsStatisticsCard
+            className='col-span-2'
+            orgId={params.orgId}
+          />
+        </QueryBoundary>
       </div>
-      <CatchBoundary
-        getResetKey={() => 'reset'}
-        errorComponent={(props) => (
-          <ErrorComponent {...props} title='Could not load statistics' />
+      <QueryBoundary
+        fallback={
+          <OrganizationStatisticsFallback
+            value={<Skeleton className='h-8 w-12' />}
+          />
+        }
+        errorFallback={(props) => (
+          <OrganizationStatisticsFallback
+            value={<QueryErrorFallback {...props} />}
+          />
         )}
+        resetKey={`${organization.id}-statistics`}
       >
         <div className='grid grid-cols-4 gap-2'>
           <Link
@@ -113,68 +186,20 @@ const OrganizationComponent = () => {
               ],
             }}
           >
-            <Suspense
-              fallback={
-                <StatisticsCard
-                  title='Vulnerabilities'
-                  icon={() => (
-                    <ShieldQuestion className='h-4 w-4 text-orange-500' />
-                  )}
-                  value={<LoadingIndicator />}
-                  className='hover:bg-muted/50 h-full'
-                />
-              }
-            >
-              <OrganizationVulnerabilitiesStatisticsCard
-                organizationId={organization.id}
-                className='hover:bg-muted/50'
-              />
-            </Suspense>
+            <OrganizationVulnerabilitiesStatisticsCard
+              organizationId={organization.id}
+              className='hover:bg-muted/50 h-full'
+            />
           </Link>
-          <Suspense
-            fallback={
-              <StatisticsCard
-                title='Issues'
-                icon={() => <Bug className='h-4 w-4 text-orange-500' />}
-                value={<LoadingIndicator />}
-                className='hover:bg-muted/50 h-full'
-              />
-            }
-          >
-            <OrganizationIssuesStatisticsCard
-              organizationId={organization.id}
-            />
-          </Suspense>
-          <Suspense
-            fallback={
-              <StatisticsCard
-                title='Rule Violations'
-                icon={() => <Scale className='h-4 w-4 text-orange-500' />}
-                value={<LoadingIndicator />}
-                className='hover:bg-muted/50 h-full'
-              />
-            }
-          >
-            <OrganizationViolationsStatisticsCard
-              organizationId={organization.id}
-            />
-          </Suspense>
-          <Suspense
-            fallback={
-              <StatisticsCard
-                title='Packages'
-                icon={() => <Boxes className='h-4 w-4 text-orange-500' />}
-                value={<LoadingIndicator />}
-                className='hover:bg-muted/50 h-full'
-              />
-            }
-          >
-            <OrganizationPackagesStatisticsCard
-              organizationId={organization.id}
-            />
-          </Suspense>
+          <OrganizationIssuesStatisticsCard organizationId={organization.id} />
+          <OrganizationViolationsStatisticsCard
+            organizationId={organization.id}
+          />
+          <OrganizationPackagesStatisticsCard
+            organizationId={organization.id}
+          />
         </div>
-      </CatchBoundary>
+      </QueryBoundary>
       <Card>
         <CardContent className='my-4'>
           <OrganizationProductTable />

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repositories-statistics-card.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repositories-statistics-card.tsx
@@ -17,13 +17,11 @@
  * License-Filename: LICENSE
  */
 
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import { Files, PlusIcon } from 'lucide-react';
 
 import { getProductRepositoriesOptions } from '@/api/@tanstack/react-query.gen';
-import { LoadingIndicator } from '@/components/loading-indicator';
-import { StatisticsCard } from '@/components/statistics-card';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -32,7 +30,6 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { useProductPermission } from '@/hooks/use-authorization';
-import { toastError } from '@/lib/toast';
 
 type ProductRepositoriesStatisticsCardProps = {
   orgId: string;
@@ -50,28 +47,12 @@ export const ProductRepositoriesStatisticsCard = ({
     'CREATE_REPOSITORY'
   );
 
-  const { data, isPending, isError, error } = useQuery({
+  const { data } = useSuspenseQuery({
     ...getProductRepositoriesOptions({
       path: { productId: Number.parseInt(productId) },
       query: { limit: 1 },
     }),
   });
-
-  if (isPending) {
-    return (
-      <StatisticsCard
-        title='Repositories'
-        icon={() => <Files className='h-4 w-4 text-orange-500' />}
-        value={<LoadingIndicator />}
-        className='hover:bg-muted/50 h-full'
-      />
-    );
-  }
-
-  if (isError) {
-    toastError('Unable to load data', error);
-    return;
-  }
 
   const repositoriesTotal = data.pagination.totalCount;
 

--- a/ui/src/routes/organizations/$orgId/products/$productId/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/index.tsx
@@ -19,13 +19,14 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { Boxes, Bug, Scale, ShieldQuestion } from 'lucide-react';
-import { Suspense } from 'react';
+import { Boxes, Bug, Files, Scale, ShieldQuestion } from 'lucide-react';
+import type { ReactNode } from 'react';
 import z from 'zod';
 
 import { getProductOptions } from '@/api/@tanstack/react-query.gen';
 import { ProductFavoriteButton } from '@/components/favorite-button';
 import { LoadingIndicator } from '@/components/loading-indicator';
+import { QueryBoundary, QueryErrorFallback } from '@/components/query-boundary';
 import { StatisticsCard } from '@/components/statistics-card';
 import {
   Card,
@@ -34,6 +35,7 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
 import { toastError } from '@/lib/toast';
 import {
   filterByNameSearchParameterSchema,
@@ -45,6 +47,57 @@ import { ProductRepositoriesStatisticsCard } from './-components/product-reposit
 import { ProductRepositoryTable } from './-components/product-repository-table';
 import { ProductViolationsStatisticsCard } from './-components/product-violations-statistics-card';
 import { ProductVulnerabilitiesStatisticsCard } from './-components/product-vulnerabilities-statistics-card';
+
+type StatisticsFallbackProps = {
+  value: ReactNode;
+};
+
+const ProductRepositoriesStatisticsFallback = ({
+  value,
+}: StatisticsFallbackProps) => (
+  <Card className='col-span-2'>
+    <CardHeader>
+      <CardTitle>
+        <div className='flex items-center justify-between'>
+          <span className='text-sm font-semibold'>Repositories</span>
+          <Files className='h-4 w-4' />
+        </div>
+      </CardTitle>
+    </CardHeader>
+    <CardContent className='text-sm'>
+      <div className='flex min-h-8 items-center'>{value}</div>
+    </CardContent>
+  </Card>
+);
+
+const ProductStatisticsFallback = ({ value }: StatisticsFallbackProps) => (
+  <div className='grid grid-cols-4 gap-2'>
+    <StatisticsCard
+      title='Vulnerabilities'
+      icon={() => <ShieldQuestion className='h-4 w-4 text-orange-500' />}
+      value={value}
+      className='hover:bg-muted/50 h-full'
+    />
+    <StatisticsCard
+      title='Issues'
+      icon={() => <Bug className='h-4 w-4 text-orange-500' />}
+      value={value}
+      className='hover:bg-muted/50 h-full'
+    />
+    <StatisticsCard
+      title='Rule Violations'
+      icon={() => <Scale className='h-4 w-4 text-orange-500' />}
+      value={value}
+      className='hover:bg-muted/50 h-full'
+    />
+    <StatisticsCard
+      title='Packages'
+      icon={() => <Boxes className='h-4 w-4 text-orange-500' />}
+      value={value}
+      className='hover:bg-muted/50 h-full'
+    />
+  </div>
+);
 
 const ProductComponent = () => {
   const params = Route.useParams();
@@ -89,81 +142,63 @@ const ProductComponent = () => {
             </div>
           </CardHeader>
         </Card>
-        <ProductRepositoriesStatisticsCard
-          className='col-span-2'
-          orgId={params.orgId}
-          productId={product.id.toString()}
-        />
-      </div>
-      <div className='grid grid-cols-4 gap-2'>
-        <Link
-          to='/organizations/$orgId/products/$productId/vulnerabilities'
-          params={{
-            orgId: params.orgId,
-            productId: params.productId,
-          }}
-          search={{
-            sortBy: [
-              { id: 'rating', desc: true },
-              { id: 'repositoriesCount', desc: true },
-            ],
-          }}
+        <QueryBoundary
+          fallback={
+            <ProductRepositoriesStatisticsFallback
+              value={<Skeleton className='h-8 w-12' />}
+            />
+          }
+          errorFallback={(props) => (
+            <ProductRepositoriesStatisticsFallback
+              value={<QueryErrorFallback {...props} />}
+            />
+          )}
+          resetKey={`${product.id}-repositories`}
         >
-          <Suspense
-            fallback={
-              <StatisticsCard
-                title='Vulnerabilities'
-                icon={() => (
-                  <ShieldQuestion className='h-4 w-4 text-orange-500' />
-                )}
-                value={<LoadingIndicator />}
-                className='hover:bg-muted/50 h-full'
-              />
-            }
+          <ProductRepositoriesStatisticsCard
+            className='col-span-2'
+            orgId={params.orgId}
+            productId={product.id.toString()}
+          />
+        </QueryBoundary>
+      </div>
+      <QueryBoundary
+        fallback={
+          <ProductStatisticsFallback
+            value={<Skeleton className='h-8 w-12' />}
+          />
+        }
+        errorFallback={(props) => (
+          <ProductStatisticsFallback
+            value={<QueryErrorFallback {...props} />}
+          />
+        )}
+        resetKey={`${product.id}-statistics`}
+      >
+        <div className='grid grid-cols-4 gap-2'>
+          <Link
+            to='/organizations/$orgId/products/$productId/vulnerabilities'
+            params={{
+              orgId: params.orgId,
+              productId: params.productId,
+            }}
+            search={{
+              sortBy: [
+                { id: 'rating', desc: true },
+                { id: 'repositoriesCount', desc: true },
+              ],
+            }}
           >
             <ProductVulnerabilitiesStatisticsCard
               productId={product.id}
-              className='hover:bg-muted/50'
-            />
-          </Suspense>
-        </Link>
-        <Suspense
-          fallback={
-            <StatisticsCard
-              title='Issues'
-              icon={() => <Bug className='h-4 w-4 text-orange-500' />}
-              value={<LoadingIndicator />}
               className='hover:bg-muted/50 h-full'
             />
-          }
-        >
+          </Link>
           <ProductIssuesStatisticsCard productId={product.id} />
-        </Suspense>
-        <Suspense
-          fallback={
-            <StatisticsCard
-              title='Rule Violations'
-              icon={() => <Scale className='h-4 w-4 text-orange-500' />}
-              value={<LoadingIndicator />}
-              className='hover:bg-muted/50 h-full'
-            />
-          }
-        >
           <ProductViolationsStatisticsCard productId={product.id} />
-        </Suspense>
-        <Suspense
-          fallback={
-            <StatisticsCard
-              title='Packages'
-              icon={() => <Boxes className='h-4 w-4 text-orange-500' />}
-              value={<LoadingIndicator />}
-              className='hover:bg-muted/50 h-full'
-            />
-          }
-        >
           <ProductPackagesStatisticsCard productId={product.id} />
-        </Suspense>
-      </div>
+        </div>
+      </QueryBoundary>
       <Card>
         <CardContent className='my-4'>
           <ProductRepositoryTable />

--- a/ui/tests/unit/components/organization-products-statistics-card.test.tsx
+++ b/ui/tests/unit/components/organization-products-statistics-card.test.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import type { ReactNode } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { OrganizationProductsStatisticsCard } from '@/routes/organizations/$orgId/-components/organization-products-statistics-card';
+
+const mocks = vi.hoisted(() => ({
+  canCreateProduct: true,
+  useOrganizationPermission: vi.fn(),
+  useSuspenseQuery: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>();
+
+  return {
+    ...actual,
+    useSuspenseQuery: mocks.useSuspenseQuery,
+  };
+});
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    children,
+    className,
+    disabled,
+    params,
+  }: {
+    children: ReactNode;
+    className?: string;
+    disabled?: boolean;
+    params: { orgId: string };
+  }) => (
+    <a
+      className={className}
+      href={`/organizations/${params.orgId}/create-product`}
+      aria-disabled={disabled}
+    >
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/hooks/use-authorization', () => ({
+  useOrganizationPermission: mocks.useOrganizationPermission,
+}));
+
+const renderCard = () =>
+  renderToStaticMarkup(
+    <OrganizationProductsStatisticsCard orgId='42' className='col-span-2' />
+  );
+
+describe('OrganizationProductsStatisticsCard', () => {
+  beforeEach(() => {
+    mocks.canCreateProduct = true;
+    mocks.useOrganizationPermission.mockReset();
+    mocks.useOrganizationPermission.mockImplementation(() => ({
+      isAllowed: mocks.canCreateProduct,
+    }));
+    mocks.useSuspenseQuery.mockReset();
+    mocks.useSuspenseQuery.mockReturnValue({
+      data: { pagination: { totalCount: 12 } },
+    });
+  });
+
+  it('renders the product total and add action', () => {
+    const markup = renderCard();
+
+    expect(markup).toContain('Products');
+    expect(markup).toContain('>12<');
+    expect(markup).toContain('Add product');
+    expect(markup).toContain('href="/organizations/42/create-product"');
+    expect(markup).toContain('col-span-2');
+    expect(mocks.useOrganizationPermission).toHaveBeenCalledWith(
+      42,
+      'CREATE_PRODUCT'
+    );
+  });
+
+  it('disables the add action without permission', () => {
+    mocks.canCreateProduct = false;
+
+    const markup = renderCard();
+
+    expect(markup).toContain('aria-disabled="true"');
+  });
+});

--- a/ui/tests/unit/components/product-repositories-statistics-card.test.tsx
+++ b/ui/tests/unit/components/product-repositories-statistics-card.test.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import type { ReactNode } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ProductRepositoriesStatisticsCard } from '@/routes/organizations/$orgId/products/$productId/-components/product-repositories-statistics-card';
+
+const mocks = vi.hoisted(() => ({
+  canCreateRepository: true,
+  useProductPermission: vi.fn(),
+  useSuspenseQuery: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-query')>();
+
+  return {
+    ...actual,
+    useSuspenseQuery: mocks.useSuspenseQuery,
+  };
+});
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    children,
+    className,
+    disabled,
+    params,
+  }: {
+    children: ReactNode;
+    className?: string;
+    disabled?: boolean;
+    params: { orgId: string; productId: string };
+  }) => (
+    <a
+      className={className}
+      href={`/organizations/${params.orgId}/products/${params.productId}/create-repository`}
+      aria-disabled={disabled}
+    >
+      {children}
+    </a>
+  ),
+}));
+
+vi.mock('@/hooks/use-authorization', () => ({
+  useProductPermission: mocks.useProductPermission,
+}));
+
+const renderCard = () =>
+  renderToStaticMarkup(
+    <ProductRepositoriesStatisticsCard
+      orgId='42'
+      productId='84'
+      className='col-span-2'
+    />
+  );
+
+describe('ProductRepositoriesStatisticsCard', () => {
+  beforeEach(() => {
+    mocks.canCreateRepository = true;
+    mocks.useProductPermission.mockReset();
+    mocks.useProductPermission.mockImplementation(() => ({
+      isAllowed: mocks.canCreateRepository,
+    }));
+    mocks.useSuspenseQuery.mockReset();
+    mocks.useSuspenseQuery.mockReturnValue({
+      data: { pagination: { totalCount: 12 } },
+    });
+  });
+
+  it('renders the repository total and add action', () => {
+    const markup = renderCard();
+
+    expect(markup).toContain('Repositories');
+    expect(markup).toContain('>12<');
+    expect(markup).toContain('Add repository');
+    expect(markup).toContain(
+      'href="/organizations/42/products/84/create-repository"'
+    );
+    expect(markup).toContain('col-span-2');
+    expect(mocks.useProductPermission).toHaveBeenCalledWith(
+      84,
+      'CREATE_REPOSITORY'
+    );
+  });
+
+  it('disables the add action without permission', () => {
+    mocks.canCreateRepository = false;
+
+    const markup = renderCard();
+
+    expect(markup).toContain('aria-disabled="true"');
+  });
+});


### PR DESCRIPTION
This PR implements loading state behavior for the organization and products data and statistics cards, related to #5578. A video demo from a product overview page shows all component loading states in this page in action:

https://github.com/user-attachments/assets/a97d5377-792f-4134-a42a-5b249bab4ea1

(Video was cut a bit short, but the status badges do render, eventually :smirk: )

Please see the commits for details.