### PR TITLE
ui: Fix some problems with the home screen

### DIFF
--- a/ui/src/providers/home-data/local-home-data-provider.ts
+++ b/ui/src/providers/home-data/local-home-data-provider.ts
@@ -127,6 +127,9 @@ export const createLocalHomeDataProvider = (
     const recordRecentRun = useRecentRunsStore(
       (state) => state.recordRecentRun
     );
+    const setRecentRunUnavailable = useRecentRunsStore(
+      (state) => state.setRecentRunUnavailable
+    );
     const removeRecentRun = useRecentRunsStore(
       (state) => state.removeRecentRun
     );
@@ -141,6 +144,14 @@ export const createLocalHomeDataProvider = (
             recordRecentRun(currentUserId, recentRun);
           }
         },
+        setRecentRunUnavailable: (
+          recentRunId: string,
+          unavailable: boolean
+        ) => {
+          if (isHomeDataUserAvailable(currentUserId)) {
+            setRecentRunUnavailable(currentUserId, recentRunId, unavailable);
+          }
+        },
         removeRecentRun: (recentRunId: string) => {
           if (isHomeDataUserAvailable(currentUserId)) {
             removeRecentRun(currentUserId, recentRunId);
@@ -152,7 +163,13 @@ export const createLocalHomeDataProvider = (
           }
         },
       }),
-      [clearRecentRuns, currentUserId, recordRecentRun, removeRecentRun]
+      [
+        clearRecentRuns,
+        currentUserId,
+        recordRecentRun,
+        removeRecentRun,
+        setRecentRunUnavailable,
+      ]
     );
   };
 

--- a/ui/src/providers/home-data/persisted-state.ts
+++ b/ui/src/providers/home-data/persisted-state.ts
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { z } from 'zod';
+
+import { zOrtRunStatus } from '@/api/zod.gen';
+import {
+  DEFAULT_FAVORITE_GROUP_ORDER,
+  normalizeFavoriteGroupOrder,
+} from './favorites';
+import { buildRecentRunId } from './recent-runs';
+import type { FavoriteItem, FavoriteType, RecentRunItem } from './types';
+
+/*
+ * Migration of the persisted home data stores.
+ *
+ * Zustand keeps persisted state only when the stored version matches the configured one,
+ * unless a migration is given. Without one it drops the whole payload, which would lose
+ * the recent runs and favorites of every user on each version bump. The shapes used before
+ * the current version were never released, so the migrations here do not convert between
+ * known shapes. They validate the payload against the current shape and keep everything
+ * that still fits, which also covers a payload written by a newer deployment, because
+ * zustand migrates on any version mismatch, in both directions.
+ *
+ * The schemas are deliberately permissive. They require only the fields that cannot be
+ * reconstructed, backfill everything else, drop unusable optional values instead of the
+ * whole entry, and pass unknown fields through so that a newer shape survives a downgrade.
+ */
+
+export type PersistedRecentRunsState = {
+  recentRunsByUser: Record<string, RecentRunItem[]>;
+};
+
+export type PersistedFavoritesState = {
+  favoritesByUser: Record<string, FavoriteItem[]>;
+  favoriteGroupOrderByUser: Record<string, FavoriteType[]>;
+};
+
+/** Timestamp for entries stored before the timestamp fields existed. */
+const FALLBACK_TIMESTAMP = new Date(0).toISOString();
+
+const RUN_ROUTE =
+  '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex';
+
+const optionalText = z.string().min(1).optional().catch(undefined);
+
+const routeParamsSchema = z.record(z.string(), z.string());
+
+const favoriteTypeSchema = z.custom<FavoriteType>((value) =>
+  DEFAULT_FAVORITE_GROUP_ORDER.some((favoriteType) => favoriteType === value)
+);
+
+/**
+ * A recent run is kept as long as it identifies a run within the hierarchy, because the
+ * route and its parameters can be rebuilt from those identifiers.
+ */
+const recentRunItemSchema = z
+  .looseObject({
+    id: optionalText,
+    runId: z.number(),
+    runIndex: z.number(),
+    organizationId: z.number(),
+    organizationName: z.string().catch(''),
+    productId: z.number(),
+    productName: z.string().catch(''),
+    repositoryId: z.number(),
+    repositoryName: z.string().catch(''),
+    revision: optionalText,
+    path: optionalText,
+    status: zOrtRunStatus.optional().catch(undefined),
+    to: optionalText,
+    params: routeParamsSchema.optional().catch(undefined),
+    createdAt: optionalText,
+    recordedAt: optionalText,
+  })
+  .transform((item): RecentRunItem => ({
+    ...item,
+    id: item.id ?? buildRecentRunId(item.runId),
+    to: item.to ?? RUN_ROUTE,
+    params: item.params ?? {
+      orgId: item.organizationId.toString(),
+      productId: item.productId.toString(),
+      repoId: item.repositoryId.toString(),
+      runIndex: item.runIndex.toString(),
+    },
+    recordedAt: item.recordedAt ?? item.createdAt ?? FALLBACK_TIMESTAMP,
+  }));
+
+/** A favorite is kept as long as it has an identity, a label and a link target. */
+const favoriteItemSchema = z
+  .looseObject({
+    id: z.string().min(1),
+    type: favoriteTypeSchema,
+    name: z.string().min(1),
+    breadcrumbs: z.array(z.string()).optional().catch(undefined),
+    to: z.string().min(1),
+    params: routeParamsSchema.optional().catch(undefined),
+    starredAt: optionalText,
+  })
+  .transform((item): FavoriteItem => ({
+    ...item,
+    breadcrumbs: item.breadcrumbs ?? [item.name],
+    starredAt: item.starredAt ?? FALLBACK_TIMESTAMP,
+  }));
+
+const itemsByUserSchema = <T extends z.ZodType>(itemSchema: T) =>
+  z
+    .record(
+      z.string(),
+      z
+        .array(z.unknown())
+        .catch([])
+        .transform((items) =>
+          items.flatMap((item) => {
+            const parsedItem = itemSchema.safeParse(item);
+
+            return parsedItem.success ? [parsedItem.data as z.output<T>] : [];
+          })
+        )
+    )
+    .catch({});
+
+const favoriteGroupOrderByUserSchema = z
+  .record(
+    z.string(),
+    z
+      .array(z.unknown())
+      .catch([])
+      .transform((favoriteGroupOrder) =>
+        normalizeFavoriteGroupOrder(
+          favoriteGroupOrder.filter(
+            (favoriteType) => favoriteTypeSchema.safeParse(favoriteType).success
+          ) as FavoriteType[]
+        )
+      )
+  )
+  .catch({});
+
+const persistedRecentRunsStateSchema = z.looseObject({
+  recentRunsByUser: itemsByUserSchema(recentRunItemSchema),
+});
+
+const persistedFavoritesStateSchema = z.looseObject({
+  favoritesByUser: itemsByUserSchema(favoriteItemSchema),
+  favoriteGroupOrderByUser: favoriteGroupOrderByUserSchema,
+});
+
+/** Drop user entries that did not survive the migration. */
+const withoutEmptyUsers = <T>(
+  itemsByUser: Record<string, T[]>
+): Record<string, T[]> =>
+  Object.fromEntries(
+    Object.entries(itemsByUser).filter(([, items]) => items.length > 0)
+  );
+
+/** Migrate a persisted recent runs payload of an unknown version to the current shape. */
+export const migrateRecentRunsState = (
+  persistedState: unknown
+): PersistedRecentRunsState => {
+  const state = persistedRecentRunsStateSchema.safeParse(persistedState);
+
+  return {
+    recentRunsByUser: withoutEmptyUsers(
+      state.success ? state.data.recentRunsByUser : {}
+    ),
+  };
+};
+
+/** Migrate a persisted favorites payload of an unknown version to the current shape. */
+export const migrateFavoritesState = (
+  persistedState: unknown
+): PersistedFavoritesState => {
+  const state = persistedFavoritesStateSchema.safeParse(persistedState);
+
+  return {
+    favoritesByUser: withoutEmptyUsers(
+      state.success ? state.data.favoritesByUser : {}
+    ),
+    favoriteGroupOrderByUser: state.success
+      ? state.data.favoriteGroupOrderByUser
+      : {},
+  };
+};

--- a/ui/src/providers/home-data/recent-runs.ts
+++ b/ui/src/providers/home-data/recent-runs.ts
@@ -34,6 +34,32 @@ export const createRecentRunItem = (
 });
 
 /**
+ * Trim the list to the configured number of entries.
+ *
+ * Runs that can no longer be loaded go first, oldest ones before newer ones, so that they
+ * do not take the place of runs that are still there. This is the only case in which such
+ * a run disappears without the user removing it.
+ */
+const pruneRecentRunItems = (
+  recentRuns: RecentRunItem[],
+  maxItems: number
+): RecentRunItem[] => {
+  if (recentRuns.length <= maxItems) return recentRuns;
+
+  const excessItems = recentRuns.length - maxItems;
+  const evictedItems = new Set(
+    recentRuns
+      .filter((recentRun) => recentRun.unavailable)
+      .slice(-excessItems)
+      .map((recentRun) => recentRun.id)
+  );
+
+  return recentRuns
+    .filter((recentRun) => !evictedItems.has(recentRun.id))
+    .slice(0, maxItems);
+};
+
+/**
  * Add a run to the front of the recent-runs list.
  *
  * If the run is already in the list, replace the old entry and keep only the
@@ -47,10 +73,33 @@ export const addRecentRunItem = (
 ): RecentRunItem[] => {
   const item = createRecentRunItem(recentRun, now);
 
-  return [
-    item,
-    ...recentRuns.filter((existing) => existing.id !== item.id),
-  ].slice(0, maxItems);
+  return pruneRecentRunItems(
+    [item, ...recentRuns.filter((existing) => existing.id !== item.id)],
+    maxItems
+  );
+};
+
+/**
+ * Mark a run whose details can no longer be loaded, or clear that mark once they can be
+ * loaded again.
+ *
+ * The list is returned unchanged when the run is already in the wanted state, so that
+ * consumers do not re-render for nothing.
+ */
+export const setRecentRunItemUnavailable = (
+  recentRuns: RecentRunItem[],
+  recentRunId: string,
+  unavailable: boolean
+): RecentRunItem[] => {
+  const recentRun = recentRuns.find((item) => item.id === recentRunId);
+
+  if (!recentRun || Boolean(recentRun.unavailable) === unavailable) {
+    return recentRuns;
+  }
+
+  return recentRuns.map((item) =>
+    item.id === recentRunId ? { ...item, unavailable } : item
+  );
 };
 
 export const removeRecentRunItem = (

--- a/ui/src/providers/home-data/types.ts
+++ b/ui/src/providers/home-data/types.ts
@@ -56,6 +56,8 @@ export type RecentRunItem = {
   params: RecentRunRouteParams;
   createdAt?: string;
   recordedAt: string;
+  /** Whether the run details can no longer be loaded, for example after a deletion. */
+  unavailable?: boolean;
 };
 
 export type RecentRunItemInput = Omit<RecentRunItem, 'recordedAt'> & {
@@ -72,6 +74,7 @@ export type HomeFavoriteActions = {
 
 export type HomeRecentRunActions = {
   recordRecentRun: (recentRun: RecentRunItemInput) => void;
+  setRecentRunUnavailable: (recentRunId: string, unavailable: boolean) => void;
   removeRecentRun: (recentRunId: string) => void;
   clearRecentRuns: () => void;
 };

--- a/ui/src/routes/-components/home-recent-runs-section.tsx
+++ b/ui/src/routes/-components/home-recent-runs-section.tsx
@@ -20,7 +20,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { Link, type LinkProps } from '@tanstack/react-router';
 import { AxiosError } from 'axios';
-import { PlayCircle } from 'lucide-react';
+import { PlayCircle, X } from 'lucide-react';
 import { useEffect } from 'react';
 
 import { OrtRunStatus } from '@/api';
@@ -33,6 +33,7 @@ import { OrtRunJobStatus } from '@/components/ort-run-job-status';
 import { RunDuration } from '@/components/run-duration';
 import { TimestampWithUTC } from '@/components/timestamp-with-utc';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import {
   Card,
   CardContent,
@@ -57,9 +58,10 @@ const isRunFinished = (status: OrtRunStatus | undefined) =>
   status === 'FINISHED_WITH_ISSUES' ||
   status === 'FAILED';
 
-/** Render a recent run and remove it from the list if the run is deleted. */
+/** Render a recent run and mark it if the run can no longer be loaded. */
 const RecentRunListItem = ({ recentRun }: { recentRun: RecentRunItem }) => {
-  const { removeRecentRun } = useHomeRecentRunActions();
+  const { removeRecentRun, setRecentRunUnavailable } =
+    useHomeRecentRunActions();
   const runQuery = useQuery({
     ...getRepositoryRunOptions({
       path: {
@@ -67,23 +69,41 @@ const RecentRunListItem = ({ recentRun }: { recentRun: RecentRunItem }) => {
         ortRunIndex: recentRun.runIndex,
       },
     }),
+    // Stop asking for a run that is gone, but keep retrying a single failed request, which
+    // can also happen for a run that is still there.
     refetchInterval: (query) =>
-      isRunFinished(query.state.data?.status) ? false : config.pollInterval,
-    retry: (failureCount, error) => !isNotFoundError(error) && failureCount < 3,
+      isRunFinished(query.state.data?.status) ||
+      isNotFoundError(query.state.error)
+        ? false
+        : config.pollInterval,
+    retry: (failureCount) => failureCount < 3,
   });
 
+  const isMissing = isNotFoundError(runQuery.error);
+  const isUnavailable = isMissing || Boolean(recentRun.unavailable);
+
   useEffect(() => {
-    if (isNotFoundError(runQuery.error)) {
-      removeRecentRun(recentRun.id);
+    // Only a confirmed answer changes the mark, so that a run keeps its state while it is
+    // loading or while the server cannot be reached at all.
+    if (isMissing && !recentRun.unavailable) {
+      setRecentRunUnavailable(recentRun.id, true);
+    } else if (runQuery.isSuccess && recentRun.unavailable) {
+      setRecentRunUnavailable(recentRun.id, false);
     }
-  }, [recentRun.id, removeRecentRun, runQuery.error]);
+  }, [
+    isMissing,
+    recentRun.id,
+    recentRun.unavailable,
+    runQuery.isSuccess,
+    setRecentRunUnavailable,
+  ]);
 
   const run = runQuery.data;
   const statistics = useQuery({
     ...getRunStatisticsOptions({
       path: { runId: run?.id ?? recentRun.runId },
     }),
-    enabled: Boolean(run?.jobs) && !isNotFoundError(runQuery.error),
+    enabled: Boolean(run?.jobs) && !isMissing,
     refetchInterval: isRunFinished(run?.status) ? false : config.pollInterval,
   });
 
@@ -97,7 +117,11 @@ const RecentRunListItem = ({ recentRun }: { recentRun: RecentRunItem }) => {
   };
 
   return (
-    <li className='space-y-1 rounded-lg border px-3 py-2 text-sm'>
+    <li
+      className={`space-y-1 rounded-lg border px-3 py-2 text-sm ${
+        isUnavailable ? 'opacity-60' : ''
+      }`}
+    >
       <div className='flex items-start justify-between gap-3'>
         <Link
           to={recentRun.to as LinkProps['to']}
@@ -111,20 +135,45 @@ const RecentRunListItem = ({ recentRun }: { recentRun: RecentRunItem }) => {
             {recentRun.repositoryName}
           </span>
         </Link>
-        {status && (
-          <Badge
-            className={`shrink-0 border ${getStatusBackgroundColor(status)}`}
-          >
-            {status}
-          </Badge>
-        )}
+        <div className='flex shrink-0 items-center gap-1'>
+          {isUnavailable ? (
+            <Badge variant='outline'>Unavailable</Badge>
+          ) : (
+            status && (
+              <Badge className={`border ${getStatusBackgroundColor(status)}`}>
+                {status}
+              </Badge>
+            )
+          )}
+          {isUnavailable && (
+            <Button
+              type='button'
+              variant='ghost'
+              size='icon'
+              className='h-5 w-5'
+              aria-label='Remove run from the list'
+              onClick={() => removeRecentRun(recentRun.id)}
+            >
+              <X className='h-3 w-3' />
+            </Button>
+          )}
+        </div>
       </div>
+
+      {isUnavailable && (
+        <div className='text-muted-foreground'>
+          This run can no longer be loaded. It may have been deleted, or you may
+          no longer have access to it.
+        </div>
+      )}
 
       <div className='flex items-center justify-between gap-3'>
         <div className='flex min-w-0 flex-wrap items-center gap-1'>
           <span className='text-muted-foreground'>Created at</span>
           {createdAt && <TimestampWithUTC timestamp={createdAt} />}
-          {createdAt && (
+          {createdAt && !isUnavailable && (
+            // A run without a finishing time keeps counting, which must not happen for a
+            // run that is not there anymore.
             <div className='flex items-center'>
               {'('}
               <RunDuration

--- a/ui/src/store/cross-tab-sync.ts
+++ b/ui/src/store/cross-tab-sync.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+/*
+ * Cross-tab synchronization for persisted stores.
+ *
+ * A persisted store reads its local storage entry once while the page loads and then
+ * writes its complete state back on every change. Without synchronization, a tab keeps
+ * serving whatever it read at load time, so the state a second tab wrote in the meantime
+ * is overwritten as soon as the first tab changes anything.
+ *
+ * Browsers fire a storage event in all other tabs of the same origin whenever one of them
+ * writes to local storage. Re-reading the persisted state when that happens keeps the tabs
+ * close enough to each other that they stop overwriting one another. Two tabs writing
+ * within the same tick can still lose one change, which is accepted for stores that a
+ * backend-backed provider is meant to replace.
+ */
+
+/** The part of a storage event needed to decide whether a store has to be re-read. */
+type PersistedStorageEvent = Pick<StorageEvent, 'key' | 'storageArea'>;
+
+/**
+ * Create a storage event handler that re-reads the persisted state of the store using the
+ * given storage entry.
+ */
+export const createCrossTabSyncHandler =
+  (storageName: string, rehydrate: () => void) =>
+  (event: PersistedStorageEvent) => {
+    // Events of other storage areas, for example the session storage, are none of this
+    // store's business.
+    if (
+      event.storageArea != null &&
+      event.storageArea !== window.localStorage
+    ) {
+      return;
+    }
+
+    // A missing key means that the whole storage was cleared, which affects every store.
+    if (event.key !== null && event.key !== storageName) return;
+
+    rehydrate();
+  };
+
+/**
+ * Re-read the persisted state of a store whenever another tab writes to its storage entry.
+ *
+ * The listener is registered for the lifetime of the page because the stores are created
+ * once per page and live as long as it does.
+ */
+export const syncPersistedStoreAcrossTabs = (
+  storageName: string,
+  rehydrate: () => void
+) => {
+  if (typeof window === 'undefined') return;
+
+  window.addEventListener(
+    'storage',
+    createCrossTabSyncHandler(storageName, rehydrate)
+  );
+};

--- a/ui/src/store/favorites.store.ts
+++ b/ui/src/store/favorites.store.ts
@@ -27,6 +27,7 @@ import {
   toggleFavoriteItem,
   updateFavoriteItem,
 } from '@/providers/home-data/favorites';
+import { migrateFavoritesState } from '@/providers/home-data/persisted-state';
 import type {
   FavoriteItem,
   FavoriteItemInput,
@@ -122,6 +123,9 @@ export const useFavoritesStore = create<State & Actions>()(
         favoriteGroupOrderByUser: state.favoriteGroupOrderByUser,
       }),
       version: 2,
+      // Keep what is still usable instead of letting zustand drop the whole payload on a
+      // version mismatch, which would wipe the favorites of every user.
+      migrate: (persistedState) => migrateFavoritesState(persistedState),
     }
   )
 );

--- a/ui/src/store/favorites.store.ts
+++ b/ui/src/store/favorites.store.ts
@@ -33,6 +33,7 @@ import type {
   FavoriteItemInput,
   FavoriteType,
 } from '@/providers/home-data/types';
+import { syncPersistedStoreAcrossTabs } from './cross-tab-sync';
 
 type State = {
   favoritesByUser: Record<string, FavoriteItem[]>;
@@ -129,3 +130,7 @@ export const useFavoritesStore = create<State & Actions>()(
     }
   )
 );
+
+syncPersistedStoreAcrossTabs(FAVORITES_STORAGE_NAME, () => {
+  void useFavoritesStore.persist.rehydrate();
+});

--- a/ui/src/store/recent-runs.store.ts
+++ b/ui/src/store/recent-runs.store.ts
@@ -26,6 +26,7 @@ import {
   clearRecentRunItems,
   DEFAULT_MAX_RECENT_RUNS,
   removeRecentRunItem,
+  setRecentRunItemUnavailable,
 } from '@/providers/home-data/recent-runs';
 import type {
   RecentRunItem,
@@ -39,6 +40,11 @@ type State = {
 
 type Actions = {
   recordRecentRun: (userId: string, recentRun: RecentRunItemInput) => void;
+  setRecentRunUnavailable: (
+    userId: string,
+    recentRunId: string,
+    unavailable: boolean
+  ) => void;
   removeRecentRun: (userId: string, recentRunId: string) => void;
   clearRecentRuns: (userId: string) => void;
 };
@@ -64,6 +70,17 @@ export const useRecentRunsStore = create<State & Actions>()(
               getUserRecentRuns(state, userId),
               recentRun,
               DEFAULT_MAX_RECENT_RUNS
+            ),
+          },
+        })),
+      setRecentRunUnavailable: (userId, recentRunId, unavailable) =>
+        set((state) => ({
+          recentRunsByUser: {
+            ...state.recentRunsByUser,
+            [userId]: setRecentRunItemUnavailable(
+              getUserRecentRuns(state, userId),
+              recentRunId,
+              unavailable
             ),
           },
         })),

--- a/ui/src/store/recent-runs.store.ts
+++ b/ui/src/store/recent-runs.store.ts
@@ -31,6 +31,7 @@ import type {
   RecentRunItem,
   RecentRunItemInput,
 } from '@/providers/home-data/types';
+import { syncPersistedStoreAcrossTabs } from './cross-tab-sync';
 
 type State = {
   recentRunsByUser: Record<string, RecentRunItem[]>;
@@ -49,7 +50,8 @@ const getUserRecentRuns = (state: State, userId: string) =>
 
 // The local store intentionally only tracks runs started from this browser UI.
 // Runs started via CLI, API, or another browser are outside this temporary
-// local-storage implementation until a backend-backed provider exists.
+// local-storage implementation until a backend-backed provider exists. Tabs of
+// this browser share the store, see the cross-tab synchronization below.
 export const useRecentRunsStore = create<State & Actions>()(
   persist(
     (set) => ({
@@ -93,3 +95,7 @@ export const useRecentRunsStore = create<State & Actions>()(
     }
   )
 );
+
+syncPersistedStoreAcrossTabs(RECENT_RUNS_STORAGE_NAME, () => {
+  void useRecentRunsStore.persist.rehydrate();
+});

--- a/ui/src/store/recent-runs.store.ts
+++ b/ui/src/store/recent-runs.store.ts
@@ -20,6 +20,7 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
+import { migrateRecentRunsState } from '@/providers/home-data/persisted-state';
 import {
   addRecentRunItem,
   clearRecentRunItems,
@@ -86,6 +87,9 @@ export const useRecentRunsStore = create<State & Actions>()(
       name: RECENT_RUNS_STORAGE_NAME,
       partialize: (state) => ({ recentRunsByUser: state.recentRunsByUser }),
       version: 2,
+      // Keep what is still usable instead of letting zustand drop the whole payload on a
+      // version mismatch, which would wipe the recent runs of every user.
+      migrate: (persistedState) => migrateRecentRunsState(persistedState),
     }
   )
 );

--- a/ui/tests/unit/logic/cross-tab-sync.test.ts
+++ b/ui/tests/unit/logic/cross-tab-sync.test.ts
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { beforeEach, expect, it, vi } from 'vitest';
+
+import { createCrossTabSyncHandler } from '@/store/cross-tab-sync';
+
+const localStorage = {} as Storage;
+const sessionStorage = {} as Storage;
+
+vi.stubGlobal('window', { localStorage });
+
+const STORAGE_NAME = 'home-recent-runs-storage';
+
+const rehydrate = vi.fn();
+const handleStorageEvent = createCrossTabSyncHandler(STORAGE_NAME, rehydrate);
+
+beforeEach(() => {
+  rehydrate.mockClear();
+});
+
+it('re-reads the state when another tab writes the storage entry', () => {
+  handleStorageEvent({ key: STORAGE_NAME, storageArea: localStorage });
+
+  expect(rehydrate).toHaveBeenCalledOnce();
+});
+
+it('re-reads the state when the whole storage was cleared', () => {
+  handleStorageEvent({ key: null, storageArea: localStorage });
+
+  expect(rehydrate).toHaveBeenCalledOnce();
+});
+
+it('ignores writes to the storage entry of another store', () => {
+  handleStorageEvent({
+    key: 'home-favorites-storage',
+    storageArea: localStorage,
+  });
+
+  expect(rehydrate).not.toHaveBeenCalled();
+});
+
+it('ignores writes to another storage area', () => {
+  handleStorageEvent({ key: STORAGE_NAME, storageArea: sessionStorage });
+
+  expect(rehydrate).not.toHaveBeenCalled();
+});
+
+it('re-reads the state when the storage area is unknown', () => {
+  handleStorageEvent({ key: STORAGE_NAME, storageArea: null });
+
+  expect(rehydrate).toHaveBeenCalledOnce();
+});

--- a/ui/tests/unit/logic/home-store-cross-tab.test.ts
+++ b/ui/tests/unit/logic/home-store-cross-tab.test.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { beforeEach, expect, it, vi } from 'vitest';
+
+import type { RecentRunItemInput } from '@/providers/home-data/types';
+
+/*
+ * Simulate two browser tabs by loading the store module twice against one shared local
+ * storage. Each load registers its own storage event listener, which is invoked for the
+ * other tab only, just like a browser does.
+ */
+
+const localStorageContent = new Map<string, string>();
+const storageEventListeners: Array<(event: Partial<StorageEvent>) => void> = [];
+
+const localStorage = {
+  getItem: (key: string) => localStorageContent.get(key) ?? null,
+  setItem: (key: string, value: string) =>
+    void localStorageContent.set(key, value),
+  removeItem: (key: string) => void localStorageContent.delete(key),
+} as unknown as Storage;
+
+vi.stubGlobal('window', {
+  localStorage,
+  addEventListener: (
+    type: string,
+    listener: (event: Partial<StorageEvent>) => void
+  ) => {
+    if (type === 'storage') storageEventListeners.push(listener);
+  },
+});
+
+const USER = 'user';
+const STORAGE_NAME = 'home-recent-runs-storage';
+
+const recentRun = (runId: number): RecentRunItemInput => ({
+  id: `run:${runId}`,
+  runId,
+  runIndex: runId,
+  organizationId: 2,
+  organizationName: 'Acme',
+  productId: 3,
+  productName: 'Product',
+  repositoryId: 4,
+  repositoryName: 'Repository',
+  to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex',
+  params: {
+    orgId: '2',
+    productId: '3',
+    repoId: '4',
+    runIndex: runId.toString(),
+  },
+});
+
+/** Load the store module again to get an instance that stands for another tab. */
+const openTab = async () => {
+  vi.resetModules();
+  const { useRecentRunsStore } = await import('@/store/recent-runs.store');
+  await useRecentRunsStore.persist.rehydrate();
+
+  return {
+    store: useRecentRunsStore,
+    listenerIndex: storageEventListeners.length - 1,
+    recordRun: (runId: number) =>
+      useRecentRunsStore.getState().recordRecentRun(USER, recentRun(runId)),
+    recordedRunIds: () =>
+      (useRecentRunsStore.getState().recentRunsByUser[USER] ?? []).map(
+        (run) => run.runId
+      ),
+  };
+};
+
+/** Deliver a storage event to the given tab, as a browser does for the other tabs. */
+const notifyTab = (tab: { listenerIndex: number }) =>
+  storageEventListeners[tab.listenerIndex]?.({
+    key: STORAGE_NAME,
+    storageArea: localStorage,
+  });
+
+const storedRunIds = () =>
+  (
+    JSON.parse(localStorageContent.get(STORAGE_NAME) ?? 'null')?.state
+      ?.recentRunsByUser?.[USER] ?? []
+  ).map((run: { runId: number }) => run.runId);
+
+beforeEach(() => {
+  localStorageContent.clear();
+  storageEventListeners.length = 0;
+});
+
+it('keeps the runs of both tabs when each of them starts one', async () => {
+  const firstTab = await openTab();
+  const secondTab = await openTab();
+
+  secondTab.recordRun(45);
+  notifyTab(firstTab);
+  firstTab.recordRun(46);
+
+  expect(firstTab.recordedRunIds()).toStrictEqual([46, 45]);
+  expect(storedRunIds()).toStrictEqual([46, 45]);
+});
+
+it('shows the run of another tab without starting one', async () => {
+  const firstTab = await openTab();
+  const secondTab = await openTab();
+
+  secondTab.recordRun(45);
+  notifyTab(firstTab);
+
+  expect(firstTab.recordedRunIds()).toStrictEqual([45]);
+});

--- a/ui/tests/unit/logic/home-store-migration.test.ts
+++ b/ui/tests/unit/logic/home-store-migration.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { beforeEach, expect, it, vi } from 'vitest';
+
+/*
+ * Rehydrate the persisted stores against a stubbed local storage to cover what the pure
+ * migrations cannot show on their own: that stored data of the current version is left
+ * exactly as it is, and that data of another version survives instead of being dropped.
+ */
+
+const localStorageContent = new Map<string, string>();
+
+vi.stubGlobal('window', {
+  localStorage: {
+    getItem: (key: string) => localStorageContent.get(key) ?? null,
+    setItem: (key: string, value: string) =>
+      void localStorageContent.set(key, value),
+    removeItem: (key: string) => void localStorageContent.delete(key),
+  },
+});
+
+const CURRENT_VERSION = 2;
+
+const recentRun = {
+  id: 'run:1',
+  runId: 1,
+  runIndex: 11,
+  organizationId: 2,
+  organizationName: 'Acme',
+  productId: 3,
+  productName: 'Product',
+  repositoryId: 4,
+  repositoryName: 'Repository',
+  to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex',
+  params: { orgId: '2', productId: '3', repoId: '4', runIndex: '11' },
+  createdAt: '2026-06-16T12:00:00.000Z',
+  recordedAt: '2026-06-16T12:00:01.000Z',
+};
+
+const favorite = {
+  id: 'product:2:3',
+  type: 'product',
+  name: 'Product',
+  breadcrumbs: ['Acme', 'Product'],
+  to: '/organizations/$orgId/products/$productId',
+  params: { orgId: '2', productId: '3' },
+  starredAt: '2026-06-16T12:00:00.000Z',
+};
+
+const seed = (name: string, state: unknown, version: number) =>
+  localStorageContent.set(name, JSON.stringify({ state, version }));
+
+const storedState = (name: string) =>
+  JSON.parse(localStorageContent.get(name) ?? 'null');
+
+const rehydrateRecentRuns = async () => {
+  const { useRecentRunsStore } = await import('@/store/recent-runs.store');
+  await useRecentRunsStore.persist.rehydrate();
+
+  return useRecentRunsStore.getState();
+};
+
+const rehydrateFavorites = async () => {
+  const { useFavoritesStore } = await import('@/store/favorites.store');
+  await useFavoritesStore.persist.rehydrate();
+
+  return useFavoritesStore.getState();
+};
+
+beforeEach(() => {
+  localStorageContent.clear();
+  vi.resetModules();
+});
+
+it('leaves recent runs of the current version untouched', async () => {
+  const state = { recentRunsByUser: { user: [recentRun] } };
+  seed('home-recent-runs-storage', state, CURRENT_VERSION);
+
+  expect((await rehydrateRecentRuns()).recentRunsByUser.user).toStrictEqual([
+    recentRun,
+  ]);
+  expect(storedState('home-recent-runs-storage')).toStrictEqual({
+    state,
+    version: CURRENT_VERSION,
+  });
+});
+
+it('keeps recent runs stored by another version', async () => {
+  seed(
+    'home-recent-runs-storage',
+    { recentRunsByUser: { user: [recentRun] } },
+    CURRENT_VERSION - 1
+  );
+
+  expect((await rehydrateRecentRuns()).recentRunsByUser.user).toStrictEqual([
+    recentRun,
+  ]);
+  expect(storedState('home-recent-runs-storage').version).toBe(CURRENT_VERSION);
+});
+
+it('leaves favorites of the current version untouched', async () => {
+  const state = {
+    favoritesByUser: { user: [favorite] },
+    favoriteGroupOrderByUser: {},
+  };
+  seed('home-favorites-storage', state, CURRENT_VERSION);
+
+  expect((await rehydrateFavorites()).favoritesByUser.user).toStrictEqual([
+    favorite,
+  ]);
+  expect(storedState('home-favorites-storage')).toStrictEqual({
+    state,
+    version: CURRENT_VERSION,
+  });
+});
+
+it('keeps favorites stored by another version', async () => {
+  seed(
+    'home-favorites-storage',
+    { favoritesByUser: { user: [favorite] }, favoriteGroupOrderByUser: {} },
+    CURRENT_VERSION - 1
+  );
+
+  expect((await rehydrateFavorites()).favoritesByUser.user).toStrictEqual([
+    favorite,
+  ]);
+  expect(storedState('home-favorites-storage').version).toBe(CURRENT_VERSION);
+});

--- a/ui/tests/unit/logic/home-store-migration.test.ts
+++ b/ui/tests/unit/logic/home-store-migration.test.ts
@@ -34,6 +34,8 @@ vi.stubGlobal('window', {
       void localStorageContent.set(key, value),
     removeItem: (key: string) => void localStorageContent.delete(key),
   },
+  // The stores listen for the storage events of the other tabs while loading.
+  addEventListener: () => {},
 });
 
 const CURRENT_VERSION = 2;

--- a/ui/tests/unit/logic/persisted-state.test.ts
+++ b/ui/tests/unit/logic/persisted-state.test.ts
@@ -1,0 +1,252 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { DEFAULT_FAVORITE_GROUP_ORDER } from '@/providers/home-data/favorites';
+import {
+  migrateFavoritesState,
+  migrateRecentRunsState,
+} from '@/providers/home-data/persisted-state';
+
+const EPOCH = new Date(0).toISOString();
+
+const recentRun = (overrides: Record<string, unknown> = {}) => ({
+  id: 'run:1',
+  runId: 1,
+  runIndex: 11,
+  organizationId: 2,
+  organizationName: 'Acme',
+  productId: 3,
+  productName: 'Product',
+  repositoryId: 4,
+  repositoryName: 'Repository',
+  revision: 'main',
+  status: 'FINISHED',
+  to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex',
+  params: {
+    orgId: '2',
+    productId: '3',
+    repoId: '4',
+    runIndex: '11',
+  },
+  createdAt: '2026-06-16T12:00:00.000Z',
+  recordedAt: '2026-06-16T12:00:01.000Z',
+  ...overrides,
+});
+
+const favorite = (overrides: Record<string, unknown> = {}) => ({
+  id: 'product:2:3',
+  type: 'product',
+  name: 'Product',
+  breadcrumbs: ['Acme', 'Product'],
+  to: '/organizations/$orgId/products/$productId',
+  params: { orgId: '2', productId: '3' },
+  starredAt: '2026-06-16T12:00:00.000Z',
+  ...overrides,
+});
+
+const recentRunsState = (...recentRuns: unknown[]) => ({
+  recentRunsByUser: { user: recentRuns },
+});
+
+const favoritesState = (...favorites: unknown[]) => ({
+  favoritesByUser: { user: favorites },
+  favoriteGroupOrderByUser: {},
+});
+
+describe('migrateRecentRunsState', () => {
+  it('keeps valid entries stored by an unknown version', () => {
+    const state = migrateRecentRunsState(recentRunsState(recentRun()));
+
+    expect(state.recentRunsByUser.user).toStrictEqual([recentRun()]);
+  });
+
+  it('drops malformed entries but keeps their valid siblings', () => {
+    const state = migrateRecentRunsState(
+      recentRunsState(
+        recentRun(),
+        { id: 'run:2' },
+        null,
+        'run:3',
+        recentRun({ id: 'run:4', runId: 4, runIndex: 'not-a-number' })
+      )
+    );
+
+    expect(state.recentRunsByUser.user).toStrictEqual([recentRun()]);
+  });
+
+  it('returns the empty default for payloads that are not usable', () => {
+    expect(migrateRecentRunsState(null).recentRunsByUser).toStrictEqual({});
+    expect(
+      migrateRecentRunsState('recent runs').recentRunsByUser
+    ).toStrictEqual({});
+    expect(
+      migrateRecentRunsState({ favorites: [] }).recentRunsByUser
+    ).toStrictEqual({});
+  });
+
+  it('drops users without any usable entry', () => {
+    const state = migrateRecentRunsState({
+      recentRunsByUser: { user: [recentRun()], other: [{ id: 'run:2' }] },
+    });
+
+    expect(Object.keys(state.recentRunsByUser)).toStrictEqual(['user']);
+  });
+
+  it('backfills a missing timestamp from the creation time', () => {
+    const state = migrateRecentRunsState(
+      recentRunsState(recentRun({ recordedAt: undefined }))
+    );
+
+    expect(state.recentRunsByUser.user?.[0]?.recordedAt).toBe(
+      '2026-06-16T12:00:00.000Z'
+    );
+  });
+
+  it('falls back to the epoch when no timestamp is stored', () => {
+    const state = migrateRecentRunsState(
+      recentRunsState(
+        recentRun({ createdAt: undefined, recordedAt: undefined })
+      )
+    );
+
+    expect(state.recentRunsByUser.user?.[0]?.recordedAt).toBe(EPOCH);
+  });
+
+  it('rebuilds the identity, route and route parameters when they are missing', () => {
+    const state = migrateRecentRunsState(
+      recentRunsState(
+        recentRun({ id: undefined, to: undefined, params: undefined })
+      )
+    );
+
+    expect(state.recentRunsByUser.user?.[0]).toMatchObject({
+      id: 'run:1',
+      to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex',
+      params: {
+        orgId: '2',
+        productId: '3',
+        repoId: '4',
+        runIndex: '11',
+      },
+    });
+  });
+
+  it('drops unusable optional values instead of the whole entry', () => {
+    const state = migrateRecentRunsState(
+      recentRunsState(
+        recentRun({ status: 'NO_SUCH_STATUS', revision: 42, path: {} })
+      )
+    );
+
+    expect(state.recentRunsByUser.user?.[0]).toMatchObject({
+      id: 'run:1',
+      status: undefined,
+      revision: undefined,
+      path: undefined,
+    });
+  });
+
+  it('keeps unknown fields so that a newer shape survives a downgrade', () => {
+    const state = migrateRecentRunsState(
+      recentRunsState(recentRun({ unavailable: true }))
+    );
+
+    expect(state.recentRunsByUser.user?.[0]).toMatchObject({
+      unavailable: true,
+    });
+  });
+});
+
+describe('migrateFavoritesState', () => {
+  it('keeps valid entries stored by an unknown version', () => {
+    const state = migrateFavoritesState(favoritesState(favorite()));
+
+    expect(state.favoritesByUser.user).toStrictEqual([favorite()]);
+  });
+
+  it('drops malformed entries but keeps their valid siblings', () => {
+    const state = migrateFavoritesState(
+      favoritesState(
+        favorite(),
+        favorite({ id: 'thing:1', type: 'thing' }),
+        favorite({ id: '', name: '' }),
+        undefined
+      )
+    );
+
+    expect(state.favoritesByUser.user).toStrictEqual([favorite()]);
+  });
+
+  it('returns the empty default for payloads that are not usable', () => {
+    const state = migrateFavoritesState(null);
+
+    expect(state.favoritesByUser).toStrictEqual({});
+    expect(state.favoriteGroupOrderByUser).toStrictEqual({});
+  });
+
+  it('backfills missing breadcrumbs and the starring time', () => {
+    const state = migrateFavoritesState(
+      favoritesState(favorite({ breadcrumbs: undefined, starredAt: undefined }))
+    );
+
+    expect(state.favoritesByUser.user?.[0]).toMatchObject({
+      breadcrumbs: ['Product'],
+      starredAt: EPOCH,
+    });
+  });
+
+  it('normalizes an unknown group type out of the group order', () => {
+    const state = migrateFavoritesState({
+      favoritesByUser: {},
+      favoriteGroupOrderByUser: {
+        user: ['thing', 'product', 'product', 'organization'],
+      },
+    });
+
+    expect(state.favoriteGroupOrderByUser.user).toStrictEqual([
+      'product',
+      'organization',
+      'run',
+      'repository',
+    ]);
+  });
+
+  it('falls back to the default group order for an unusable value', () => {
+    const state = migrateFavoritesState({
+      favoritesByUser: {},
+      favoriteGroupOrderByUser: { user: 'product' },
+    });
+
+    expect(state.favoriteGroupOrderByUser.user).toStrictEqual(
+      DEFAULT_FAVORITE_GROUP_ORDER
+    );
+  });
+
+  it('migrates the favorites of one store even if the other one is broken', () => {
+    const state = migrateFavoritesState({
+      favoritesByUser: { user: [favorite()] },
+      favoriteGroupOrderByUser: 'not-a-record',
+    });
+
+    expect(state.favoritesByUser.user).toStrictEqual([favorite()]);
+    expect(state.favoriteGroupOrderByUser).toStrictEqual({});
+  });
+});

--- a/ui/tests/unit/logic/recent-runs.test.ts
+++ b/ui/tests/unit/logic/recent-runs.test.ts
@@ -24,6 +24,7 @@ import {
   buildRecentRunId,
   clearRecentRunItems,
   removeRecentRunItem,
+  setRecentRunItemUnavailable,
 } from '@/providers/home-data/recent-runs';
 import type {
   RecentRunItem,
@@ -121,4 +122,84 @@ it('removes a recent run by ID', () => {
     runs[0],
     runs[2],
   ]);
+});
+
+const markUnavailable = (recentRuns: RecentRunItem[], runIds: number[]) =>
+  runIds.reduce(
+    (runs, runId) =>
+      setRecentRunItemUnavailable(runs, buildRecentRunId(runId), true),
+    recentRuns
+  );
+
+it('marks a recent run as unavailable and leaves the others alone', () => {
+  const runs = seedRecentRuns([1, 2, 3], 10);
+  const marked = markUnavailable(runs, [2]);
+
+  expect(marked.map((run) => run.unavailable)).toStrictEqual([
+    undefined,
+    true,
+    undefined,
+  ]);
+});
+
+it('clears the mark once a run can be loaded again', () => {
+  const marked = markUnavailable(seedRecentRuns([1], 10), [1]);
+  const cleared = setRecentRunItemUnavailable(
+    marked,
+    buildRecentRunId(1),
+    false
+  );
+
+  expect(cleared[0]?.unavailable).toBe(false);
+});
+
+it('keeps the list as it is when the mark does not change', () => {
+  const runs = markUnavailable(seedRecentRuns([1, 2], 10), [1]);
+
+  expect(setRecentRunItemUnavailable(runs, buildRecentRunId(1), true)).toBe(
+    runs
+  );
+  expect(setRecentRunItemUnavailable(runs, buildRecentRunId(2), false)).toBe(
+    runs
+  );
+});
+
+it('keeps the list as it is for an unknown run', () => {
+  const runs = seedRecentRuns([1, 2], 10);
+
+  expect(setRecentRunItemUnavailable(runs, buildRecentRunId(3), true)).toBe(
+    runs
+  );
+});
+
+it('records a run again without its earlier mark', () => {
+  const marked = markUnavailable(seedRecentRuns([1, 2], 10), [1]);
+  const runs = addRecentRunItem(marked, createInput(1), 10);
+
+  expect(runs[0]?.runId).toBe(1);
+  expect(runs[0]?.unavailable).toBeUndefined();
+});
+
+it('evicts unavailable runs before runs that are still there', () => {
+  const runs = markUnavailable(seedRecentRuns([1, 2, 3], 3), [2]);
+  const withNewRun = addRecentRunItem(runs, createInput(4), 3);
+
+  expect(withNewRun.map((run) => run.runId)).toStrictEqual([4, 3, 1]);
+});
+
+it('evicts the oldest unavailable runs first', () => {
+  const runs = markUnavailable(seedRecentRuns([1, 2, 3, 4], 4), [1, 3]);
+  const withNewRun = addRecentRunItem(runs, createInput(5), 4);
+
+  expect(withNewRun.map((run) => run.runId)).toStrictEqual([5, 4, 3, 2]);
+});
+
+it('falls back to evicting the oldest run when no unavailable ones are left', () => {
+  const runs = markUnavailable(seedRecentRuns([1, 2, 3], 3), [3]);
+  const withNewRuns = [4, 5].reduce(
+    (recentRuns, runId) => addRecentRunItem(recentRuns, createInput(runId), 3),
+    runs
+  );
+
+  expect(withNewRuns.map((run) => run.runId)).toStrictEqual([5, 4, 2]);
 });


### PR DESCRIPTION
It has been reported that not all recent runs triggered by the user are always seen in the home screen. This PR (second commit) fixes the most probable bug related to it (runs triggered from different browser tabs did not sync globally in the user's browser local storage). It also includes some other improvements.

#### Runs triggered from two browser tabs get synced globally in the home screen

<img width="648" height="351" alt="Screenshot from 2026-08-04 11-54-42" src="https://github.com/user-attachments/assets/301ed324-5f78-4cd7-a45a-2d692877763c" />

<img width="648" height="351" alt="Screenshot from 2026-08-04 11-55-02" src="https://github.com/user-attachments/assets/ff060be7-b238-459c-ab84-54aca21e0578" />

#### When a recent run becomes temporarily unavailable, it is marked as such instead of being completely deleted from the recent runs list in the browser

<img width="648" height="546" alt="Screenshot from 2026-08-04 11-58-01" src="https://github.com/user-attachments/assets/1ebddde6-6c82-4067-b5f8-eead22022223" />

#### When the run becomes available again in the server, its status is recovered

<img width="642" height="432" alt="Screenshot from 2026-08-04 12-00-07" src="https://github.com/user-attachments/assets/dd2ae393-bfbc-4e26-adad-b8758402729a" />

(This behavior is demonstrated in the above two screenshots by manually making a run's `runIndex` unavailable on the server, then restoring it.)

Please see the commits for details.