### PR TITLE
ui: Show the other package identifier in the package details

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
@@ -211,8 +211,28 @@ const renderSubComponent = ({
   const pkg = row.original;
   const hasCurations = pkg.curations.length > 0;
 
+  // The card title shows one of the package identifiers, depending on the user
+  // preference, so show the other one here.
+  const showsPurlInTitle = packageIdType === 'PURL' && !!pkg.purl;
+  const alternativeIdLabel = showsPurlInTitle ? 'ORT ID' : 'PURL';
+  const alternativeId = showsPurlInTitle
+    ? identifierToString(pkg.identifier)
+    : pkg.purl;
+
   return (
     <div className='flex flex-col gap-4'>
+      {alternativeId && (
+        <div className='flex gap-2'>
+          <div className='font-semibold'>{alternativeIdLabel}:</div>
+          <div className='min-w-0'>
+            <BreakableString text={alternativeId} />
+            <CopyToClipboard
+              copyText={alternativeId}
+              className='h-5 px-2 align-middle'
+            />
+          </div>
+        </div>
+      )}
       <RenderProperty label='Authors' value={pkg.authors} />
       <RenderProperty
         label='Description'


### PR DESCRIPTION

<img width="1175" height="419" alt="Screenshot from 2026-08-04 13-03-06" src="https://github.com/user-attachments/assets/80413802-c6b6-47ff-b448-7e3f56246cfe" />

<img width="1175" height="419" alt="Screenshot from 2026-08-04 13-04-16" src="https://github.com/user-attachments/assets/f13fbd4d-7d4c-4b62-8a9d-a1a500dab0e2" />

Please see the commit for details.