### PR TITLE
Paginate organizations in the database, not in memory

### DIFF
--- a/core/src/main/kotlin/api/OrganizationsRoute.kt
+++ b/core/src/main/kotlin/api/OrganizationsRoute.kt
@@ -22,7 +22,6 @@ package org.eclipse.apoapsis.ortserver.core.api
 import io.github.smiley4.ktoropenapi.get
 
 import io.ktor.http.HttpStatusCode
-import io.ktor.server.auth.principal
 import io.ktor.server.request.receive
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
@@ -37,7 +36,6 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.PostProduct
 import org.eclipse.apoapsis.ortserver.api.v1.model.Username
 import org.eclipse.apoapsis.ortserver.components.authorization.api.OrganizationRole
 import org.eclipse.apoapsis.ortserver.components.authorization.rights.OrganizationPermission
-import org.eclipse.apoapsis.ortserver.components.authorization.routes.OrtServerPrincipal
 import org.eclipse.apoapsis.ortserver.components.authorization.routes.OrtServerPrincipal.Companion.requirePrincipal
 import org.eclipse.apoapsis.ortserver.components.authorization.routes.delete
 import org.eclipse.apoapsis.ortserver.components.authorization.routes.get
@@ -67,6 +65,7 @@ import org.eclipse.apoapsis.ortserver.core.apiDocs.putOrganizationRoleToUser
 import org.eclipse.apoapsis.ortserver.core.utils.vulnerabilityForRunsFilters
 import org.eclipse.apoapsis.ortserver.model.CompoundHierarchyId
 import org.eclipse.apoapsis.ortserver.model.HierarchyLevel
+import org.eclipse.apoapsis.ortserver.model.Organization
 import org.eclipse.apoapsis.ortserver.model.OrganizationId
 import org.eclipse.apoapsis.ortserver.model.Product
 import org.eclipse.apoapsis.ortserver.services.OrganizationService
@@ -81,7 +80,6 @@ import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse
 import org.eclipse.apoapsis.ortserver.shared.apimodel.SortDirection
 import org.eclipse.apoapsis.ortserver.shared.apimodel.SortProperty
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.filterParameter
-import org.eclipse.apoapsis.ortserver.shared.ktorutils.paginate
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.pagingOptions
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireEnumParameter
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireIdParameter
@@ -104,22 +102,16 @@ fun Route.organizations() = route("organizations") {
     get(getOrganizations) {
         val pagingOptions = call.pagingOptions(SortProperty("name", SortDirection.ASCENDING))
         val filter = call.filterParameter("filter")
-        val principal = requireNotNull(call.principal<OrtServerPrincipal>())
+        val principal = requirePrincipal()
 
-        val filteredOrganizations = organizationService
-            .listOrganizationsForUser(
+        val organizationsForUser =
+            organizationService.listOrganizationsForUser(
                 principal.username,
-                parameters = pagingOptions.copy(limit = null, offset = null).mapToModel(),
-                filter = filter?.mapToModel()
-            ).data
+                pagingOptions.mapToModel(),
+                filter?.mapToModel()
+            )
 
-        val pagedOrganizations = filteredOrganizations.paginate(pagingOptions)
-            .map { it.mapToApi() }
-
-        val pagedResponse = PagedResponse(
-            pagedOrganizations,
-            pagingOptions.toPagingData(filteredOrganizations.size.toLong())
-        )
+        val pagedResponse = organizationsForUser.mapToApi(Organization::mapToApi)
 
         call.respond(HttpStatusCode.OK, pagedResponse)
     }

--- a/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
@@ -248,6 +248,71 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
             }
         }
 
+        "support paging with an offset" {
+            integrationTestApplication {
+                createOrganization(name = "name1", description = "description1")
+                val org2 = createOrganization(name = "name2", description = "description2")
+                createOrganization(name = "name3", description = "description3")
+
+                val response = superuserClient.get("/api/v1/organizations?limit=1&offset=1")
+
+                response shouldHaveStatus HttpStatusCode.OK
+                response shouldHaveBody PagedResponse(
+                    listOf(org2.mapToApi()),
+                    PagingData(
+                        limit = 1,
+                        offset = 1,
+                        totalCount = 3,
+                        sortProperties = listOf(SortProperty("name", SortDirection.ASCENDING))
+                    )
+                )
+            }
+        }
+
+        "apply paging to the organizations for which the user has OrganizationPermission.READ" {
+            integrationTestApplication {
+                createOrganization(name = "org1")
+                val org2 = createOrganization(name = "org2")
+                createOrganization(name = "org3")
+                val org4 = createOrganization(name = "org4")
+                createOrganization(name = "org5")
+
+                listOf(org2, org4).forEach { org ->
+                    authorizationService.assignRole(
+                        TEST_USER.username.value,
+                        OrganizationRole.READER,
+                        CompoundHierarchyId.forOrganization(OrganizationId(org.id))
+                    )
+                }
+
+                val firstPage = testUserClient.get("/api/v1/organizations?limit=1")
+
+                firstPage shouldHaveStatus HttpStatusCode.OK
+                firstPage shouldHaveBody PagedResponse(
+                    listOf(org2.mapToApi()),
+                    PagingData(
+                        limit = 1,
+                        offset = 0,
+                        totalCount = 2,
+                        sortProperties = listOf(SortProperty("name", SortDirection.ASCENDING))
+                    )
+                )
+
+                val secondPage = testUserClient.get("/api/v1/organizations?limit=1&offset=1")
+
+                secondPage shouldHaveStatus HttpStatusCode.OK
+                secondPage shouldHaveBody PagedResponse(
+                    listOf(org4.mapToApi()),
+                    PagingData(
+                        limit = 1,
+                        offset = 1,
+                        totalCount = 2,
+                        sortProperties = listOf(SortProperty("name", SortDirection.ASCENDING))
+                    )
+                )
+            }
+        }
+
         "support filter query parameters" {
             integrationTestApplication {
                 createOrganization(name = "name1", description = "description1")


### PR DESCRIPTION
While starting investigations for #5383 it was found that the `/organizations` endpoint still paginates in memory, although it could do it as it does for products and repositories already. This is a performance problem, so probably best to fix it now as it was found.

Git history shows that slicing the full list was the only correct option before commit https://github.com/eclipse-apoapsis/ort-server/commit/22f72b55f moved filtering to the database, but the commit left the workaround in the code. This PR changes `/organizations` route implementation to work the same way as `/organizations/:organizationId/products`. The API contract doesn't change. Two new tests are added: paging with an offset, and paging a result filtered by the permissions of the user.

Please see the commit for details.