### PR TITLE
ui: Start switching dropdowns to use infinite queries

### DIFF
--- a/ui/src/components/searchable-infinite-list.tsx
+++ b/ui/src/components/searchable-infinite-list.tsx
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { Fragment, ReactNode, useEffect, type Key } from 'react';
+
+import {
+  Command,
+  CommandGroup,
+  CommandInput,
+  CommandList,
+} from '@/components/ui/command';
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { useInView } from '@/hooks/use-in-view';
+import { InfiniteList } from '@/hooks/use-infinite-list';
+import { cn } from '@/lib/utils';
+
+type SearchableInfiniteListProps<TItem> = {
+  /** What opens the list, for example a chevron or a combobox button. */
+  trigger: ReactNode;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  list: InfiniteList<TItem>;
+  /** Render one entry of the list, usually as a `CommandItem`. */
+  renderItem: (item: TItem) => ReactNode;
+  getItemKey: (item: TItem) => Key;
+  /** Shown when the list has loaded without returning anything. */
+  emptyMessage: string;
+  /** Shown in front of the reason when the list fails to load. */
+  errorMessage: string;
+  /**
+   * Whether the list has a search box. Turn this off for endpoints that cannot be filtered, such
+   * as the runs of a repository.
+   */
+  searchable?: boolean;
+  searchPlaceholder?: string;
+  searchTerm?: string;
+  onSearchTermChange?: (value: string) => void;
+  align?: 'start' | 'center' | 'end';
+  className?: string;
+};
+
+/**
+ * A dropdown that loads its entries from a paged endpoint of the API, a page at a time, and lets
+ * the user search them.
+ *
+ * The list is searched on the server, so the client-side filtering of `Command` is turned off, and
+ * the search term itself is owned by the caller, which is what decides how it is debounced and how
+ * it reaches the query. The next page is requested once the end of the list is scrolled into view.
+ */
+export function SearchableInfiniteList<TItem>({
+  trigger,
+  open,
+  onOpenChange,
+  list,
+  renderItem,
+  getItemKey,
+  emptyMessage,
+  errorMessage,
+  searchable = true,
+  searchPlaceholder = 'Search...',
+  searchTerm = '',
+  onSearchTermChange,
+  align = 'start',
+  className,
+}: SearchableInfiniteListProps<TItem>) {
+  const { ref, inView } = useInView();
+  const { items, isPending, isError, error } = list;
+  const { hasNextPage, isFetchingNextPage, fetchNextPage } = list;
+
+  useEffect(() => {
+    if (inView && hasNextPage && !isFetchingNextPage) {
+      fetchNextPage();
+    }
+  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      <PopoverContent
+        align={align}
+        className={cn(
+          'w-auto max-w-[min(32rem,calc(100vw-2rem))] min-w-[var(--radix-popover-trigger-width)] p-0',
+          className
+        )}
+      >
+        <Command shouldFilter={false}>
+          {searchable && (
+            <CommandInput
+              placeholder={searchPlaceholder}
+              value={searchTerm}
+              onValueChange={onSearchTermChange}
+            />
+          )}
+          <CommandList>
+            {isPending && (
+              <div className='text-muted-foreground py-6 text-center text-sm'>
+                Loading...
+              </div>
+            )}
+            {isError && (
+              <div className='text-destructive py-6 text-center text-sm'>
+                {`${errorMessage}: ${error?.message}`}
+              </div>
+            )}
+            {!isPending && !isError && items.length === 0 && (
+              <div className='text-muted-foreground py-6 text-center text-sm'>
+                {emptyMessage}
+              </div>
+            )}
+            {items.length > 0 && (
+              <CommandGroup>
+                {items.map((item) => (
+                  <Fragment key={getItemKey(item)}>{renderItem(item)}</Fragment>
+                ))}
+              </CommandGroup>
+            )}
+            {/* Scrolling this into view is what asks for the next page. */}
+            <div ref={ref} />
+            {isFetchingNextPage && (
+              <div className='text-muted-foreground py-2 text-center text-sm'>
+                Loading more...
+              </div>
+            )}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/ui/src/hooks/use-in-view.ts
+++ b/ui/src/hooks/use-in-view.ts
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+
+type UseInViewOptions = {
+  /** Margin around the scroll container, in CSS units, as for `IntersectionObserver`. */
+  rootMargin?: string;
+  /** How much of the element has to be visible before it counts as being in view. */
+  threshold?: number;
+};
+
+/**
+ * Track whether an element is visible in the scroll container it lives in.
+ *
+ * Attach the returned `ref` to the element to watch. Because it is a callback ref, the element is
+ * observed as soon as it is mounted, and observing switches over if the ref moves to another
+ * element. The observer is disconnected when the element goes away or the component unmounts.
+ */
+export function useInView<T extends Element = HTMLDivElement>({
+  rootMargin,
+  threshold,
+}: UseInViewOptions = {}) {
+  const [element, setElement] = useState<T | null>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    if (!element) return;
+
+    const observer = new IntersectionObserver(
+      (entries) => setInView(entries.some((entry) => entry.isIntersecting)),
+      { rootMargin, threshold }
+    );
+    observer.observe(element);
+
+    return () => observer.disconnect();
+  }, [element, rootMargin, threshold]);
+
+  const ref = useCallback((element: T | null) => {
+    setElement(element);
+    // The element that was in view is gone, so nothing is in view anymore.
+    if (!element) setInView(false);
+  }, []);
+
+  return { ref, inView };
+}

--- a/ui/src/hooks/use-infinite-list.ts
+++ b/ui/src/hooks/use-infinite-list.ts
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import {
+  keepPreviousData,
+  useInfiniteQuery,
+  type QueryFunction,
+  type QueryKey,
+  type SkipToken,
+} from '@tanstack/react-query';
+
+import { PagingData } from '@/api/types.gen';
+
+/**
+ * The shape shared by all the paged endpoints of the API, that is, by every generated
+ * `PagedResponse*` type.
+ */
+type PagedResponse<TItem> = {
+  data: Array<TItem>;
+  pagination: PagingData;
+};
+
+/**
+ * The parts of the generated `*InfiniteOptions` the hook actually needs. Everything else they carry
+ * is deliberately left out of this type, so that the generated options can be passed in as they
+ * are.
+ *
+ * This is also why the query options below are a separate argument instead of fields of this type:
+ * as soon as a field the generated options also have, such as `staleTime`, is named here, their
+ * far more elaborate version of it has to match the one here, and it does not.
+ */
+type InfiniteListOptions<TItem, TQueryKey extends QueryKey, TPageParam> = {
+  queryKey: TQueryKey;
+  queryFn?:
+    QueryFunction<PagedResponse<TItem>, TQueryKey, TPageParam> | SkipToken;
+};
+
+/**
+ * What a caller says about the query itself, such as fetching only while a dropdown is open.
+ */
+type InfiniteListQueryOptions = {
+  enabled?: boolean;
+  staleTime?: number;
+  gcTime?: number;
+};
+
+/**
+ * What the hook gives back, so that components can take a list without repeating the generics.
+ */
+export type InfiniteList<TItem> = {
+  items: Array<TItem>;
+  totalCount: number;
+  isPending: boolean;
+  isError: boolean;
+  error: Error | null;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: () => void;
+};
+
+/**
+ * Work out the offset the next page has to be requested at, based on the page that was received
+ * last. Return `undefined` once the whole `totalCount` has been read, which tells the query that
+ * there is nothing more to load.
+ */
+export function getNextPageParam(lastPage: PagedResponse<unknown>) {
+  const { limit, offset, totalCount } = lastPage.pagination;
+  const next = offset + limit;
+
+  return next < totalCount ? next : undefined;
+}
+
+/**
+ * Load a paged endpoint of the API one page at a time.
+ *
+ * The generated `*InfiniteOptions` deliberately leave out `initialPageParam` and
+ * `getNextPageParam`, which this hook fills in: paging starts at offset 0, and every following page
+ * is requested at the offset right after the page that was received last, until the whole
+ * `totalCount` has been read. The pages are flattened into a single `items` list for the caller.
+ *
+ * Pass the generated options as the first argument and anything to say about the query itself as
+ * the second one, as in
+ * `useInfiniteList(getOrganizationsInfiniteOptions({ query }), { enabled: isOpen })`.
+ */
+export function useInfiniteList<TItem, TQueryKey extends QueryKey, TPageParam>(
+  { queryKey, queryFn }: InfiniteListOptions<TItem, TQueryKey, TPageParam>,
+  { enabled, staleTime, gcTime }: InfiniteListQueryOptions = {}
+): InfiniteList<TItem> {
+  const { data, isPending, isError, error, hasNextPage, ...query } =
+    useInfiniteQuery({
+      queryKey,
+      // The generated query functions take the page parameter either as a number, which they turn
+      // into the `offset` of the request, or as a whole set of request parameters. Only the number
+      // is used here, which the generic page parameter of the query function does not spell out.
+      queryFn: queryFn as
+        QueryFunction<PagedResponse<TItem>, TQueryKey, number> | SkipToken,
+      enabled,
+      staleTime,
+      gcTime,
+      initialPageParam: 0,
+      getNextPageParam,
+      // Keep the pages that are shown while a new search term is being fetched, to avoid flicker.
+      placeholderData: keepPreviousData,
+    });
+
+  return {
+    items: data?.pages.flatMap((page) => page.data) ?? [],
+    totalCount: data?.pages.at(-1)?.pagination.totalCount ?? 0,
+    isPending,
+    isError,
+    error,
+    hasNextPage,
+    isFetchingNextPage: query.isFetchingNextPage,
+    fetchNextPage: query.fetchNextPage,
+  };
+}

--- a/ui/src/lib/constants.ts
+++ b/ui/src/lib/constants.ts
@@ -25,6 +25,10 @@
 // to get the distribution of items without fetching all items from back-end, which is costly.
 export const ALL_ITEMS = 100000;
 
+// The number of items a dropdown asks for at a time. Dropdowns load their content page by page as
+// the user scrolls, so this is only the size of one page, not the number of items reachable in it.
+export const DROPDOWN_PAGE_SIZE = 50;
+
 // The base download URL for the downloadable assets of the latest ORT Server release.
 export const ORT_SERVER_GITHUB_RELEASES_BASE_URL =
   'https://github.com/eclipse-apoapsis/ort-server/releases';

--- a/ui/src/lib/regex.ts
+++ b/ui/src/lib/regex.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+/**
+ * Escape the POSIX regex metacharacters in `value` so that it matches literally when it is passed
+ * to a backend filter that interprets its argument as a regular expression. Typing a character like
+ * `(` into a search field must narrow the results instead of producing an invalid pattern.
+ */
+export function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/move-repository.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/move-repository.tsx
@@ -17,34 +17,26 @@
  * License-Filename: LICENSE
  */
 
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { useNavigate, useParams } from '@tanstack/react-router';
 import { Check, ChevronsUpDown } from 'lucide-react';
 import { useState } from 'react';
 
 import {
-  getOrganizationProductsOptions,
-  getOrganizationsOptions,
+  getOrganizationProductsInfiniteOptions,
+  getOrganizationsInfiniteOptions,
   patchRepositoryMutation,
 } from '@/api/@tanstack/react-query.gen';
 import { OptionalValueLong } from '@/api/types.gen';
 import { MoveDialog } from '@/components/move-dialog';
+import { SearchableInfiniteList } from '@/components/searchable-infinite-list';
 import { Button } from '@/components/ui/button';
-import {
-  Command,
-  CommandEmpty,
-  CommandGroup,
-  CommandInput,
-  CommandItem,
-  CommandList,
-} from '@/components/ui/command';
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '@/components/ui/popover';
+import { CommandItem } from '@/components/ui/command';
+import { useDebounce } from '@/hooks/use-debounce';
+import { useInfiniteList } from '@/hooks/use-infinite-list';
 import { ApiError } from '@/lib/api-error';
-import { ALL_ITEMS } from '@/lib/constants';
+import { DROPDOWN_PAGE_SIZE } from '@/lib/constants';
+import { escapeRegex } from '@/lib/regex';
 import { toastError } from '@/lib/toast';
 import { cn } from '@/lib/utils';
 
@@ -52,40 +44,57 @@ interface MoveRepositoryProps {
   repoUrl: string;
 }
 
+/**
+ * A selection is kept as the whole entry instead of only its ID, because the entry the user picked
+ * is not necessarily part of the page that is shown once the search term changes.
+ */
+type Selection = { id: number; name: string };
+
+/** Turn what the user typed into a filter, as the API reads it as a regular expression. */
+const toFilter = (searchTerm: string) =>
+  searchTerm ? escapeRegex(searchTerm) : undefined;
+
 export const MoveRepository = ({ repoUrl }: MoveRepositoryProps) => {
   const params = useParams({ strict: false });
   const navigate = useNavigate();
 
   const repositoryId = Number.parseInt(params.repoId!);
 
-  const [selectedOrgId, setSelectedOrgId] = useState<number | null>(null);
-  const [selectedProductId, setSelectedProductId] = useState<number | null>(
+  const [selectedOrg, setSelectedOrg] = useState<Selection | null>(null);
+  const [selectedProduct, setSelectedProduct] = useState<Selection | null>(
     null
   );
   const [orgOpen, setOrgOpen] = useState(false);
   const [productOpen, setProductOpen] = useState(false);
+  const [orgSearch, setOrgSearch] = useState('');
+  const [productSearch, setProductSearch] = useState('');
 
-  const { data: orgsData } = useQuery({
-    ...getOrganizationsOptions({
-      query: { limit: ALL_ITEMS },
+  const debouncedOrgSearch = useDebounce(orgSearch, 300);
+  const debouncedProductSearch = useDebounce(productSearch, 300);
+
+  const organizations = useInfiniteList(
+    getOrganizationsInfiniteOptions({
+      query: {
+        limit: DROPDOWN_PAGE_SIZE,
+        filter: toFilter(debouncedOrgSearch),
+      },
     }),
-  });
+    { enabled: orgOpen }
+  );
 
-  const { data: productsData } = useQuery({
-    ...getOrganizationProductsOptions({
-      path: { organizationId: selectedOrgId! },
-      query: { limit: ALL_ITEMS },
+  const products = useInfiniteList(
+    getOrganizationProductsInfiniteOptions({
+      // The query is disabled until an organization has been selected.
+      path: { organizationId: selectedOrg?.id ?? -1 },
+      query: {
+        limit: DROPDOWN_PAGE_SIZE,
+        filter: toFilter(debouncedProductSearch),
+      },
     }),
-    enabled: selectedOrgId !== null,
-  });
+    { enabled: productOpen && selectedOrg !== null }
+  );
 
-  const organizations = orgsData?.data ?? [];
-  const products = productsData?.data ?? [];
-
-  const selectedOrg = organizations.find((o) => o.id === selectedOrgId);
-  const selectedProduct = products.find((p) => p.id === selectedProductId);
-
-  const isMoveEnabled = selectedOrgId !== null && selectedProductId !== null;
+  const isMoveEnabled = selectedOrg !== null && selectedProduct !== null;
 
   const { mutateAsync: moveRepository } = useMutation({
     ...patchRepositoryMutation(),
@@ -93,8 +102,8 @@ export const MoveRepository = ({ repoUrl }: MoveRepositoryProps) => {
       navigate({
         to: '/organizations/$orgId/products/$productId/repositories/$repoId',
         params: {
-          orgId: String(selectedOrgId),
-          productId: String(selectedProductId),
+          orgId: String(selectedOrg?.id),
+          productId: String(selectedProduct?.id),
           repoId: params.repoId!,
         },
         reloadDocument: true,
@@ -109,15 +118,15 @@ export const MoveRepository = ({ repoUrl }: MoveRepositoryProps) => {
     await moveRepository({
       path: { repositoryId },
       body: {
-        productId: selectedProductId as unknown as OptionalValueLong,
+        productId: selectedProduct?.id as unknown as OptionalValueLong,
       },
     });
   }
 
   return (
     <div className='flex items-center gap-2'>
-      <Popover open={orgOpen} onOpenChange={setOrgOpen}>
-        <PopoverTrigger asChild>
+      <SearchableInfiniteList
+        trigger={
           <Button
             variant='outline'
             role='combobox'
@@ -129,86 +138,81 @@ export const MoveRepository = ({ repoUrl }: MoveRepositoryProps) => {
             </span>
             <ChevronsUpDown className='ml-2 h-4 w-4 shrink-0 opacity-50' />
           </Button>
-        </PopoverTrigger>
-        <PopoverContent className='w-auto max-w-[min(32rem,calc(100vw-2rem))] min-w-[var(--radix-popover-trigger-width)] p-0'>
-          <Command>
-            <CommandInput placeholder='Search organization...' />
-            <CommandList>
-              <CommandEmpty>No organization found.</CommandEmpty>
-              <CommandGroup>
-                {organizations.map((org) => (
-                  <CommandItem
-                    key={org.id}
-                    value={org.name}
-                    onSelect={() => {
-                      const newOrgId = org.id === selectedOrgId ? null : org.id;
-                      setSelectedOrgId(newOrgId);
-                      setSelectedProductId(null);
-                      setOrgOpen(false);
-                    }}
-                  >
-                    <Check
-                      className={cn(
-                        'mr-2 h-4 w-4',
-                        selectedOrgId === org.id ? 'opacity-100' : 'opacity-0'
-                      )}
-                    />
-                    <span className='truncate'>{org.name}</span>
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            </CommandList>
-          </Command>
-        </PopoverContent>
-      </Popover>
-      <Popover open={productOpen} onOpenChange={setProductOpen}>
-        <PopoverTrigger asChild>
+        }
+        open={orgOpen}
+        onOpenChange={setOrgOpen}
+        list={organizations}
+        getItemKey={(org) => org.id}
+        renderItem={(org) => (
+          <CommandItem
+            value={org.name}
+            onSelect={() => {
+              setSelectedOrg(org.id === selectedOrg?.id ? null : org);
+              // The products of another organization are different ones.
+              setSelectedProduct(null);
+              setProductSearch('');
+              setOrgOpen(false);
+            }}
+          >
+            <Check
+              className={cn(
+                'mr-2 h-4 w-4',
+                selectedOrg?.id === org.id ? 'opacity-100' : 'opacity-0'
+              )}
+            />
+            <span className='truncate'>{org.name}</span>
+          </CommandItem>
+        )}
+        searchPlaceholder='Search organization...'
+        searchTerm={orgSearch}
+        onSearchTermChange={setOrgSearch}
+        emptyMessage='No organization found.'
+        errorMessage='Failed to load organizations'
+      />
+      <SearchableInfiniteList
+        trigger={
           <Button
             variant='outline'
             role='combobox'
             aria-expanded={productOpen}
             className='w-[240px] justify-between gap-2'
-            disabled={selectedOrgId === null}
+            disabled={selectedOrg === null}
           >
             <span className='min-w-0 truncate text-left'>
               {selectedProduct ? selectedProduct.name : 'Select product'}
             </span>
             <ChevronsUpDown className='ml-2 h-4 w-4 shrink-0 opacity-50' />
           </Button>
-        </PopoverTrigger>
-        <PopoverContent className='w-auto max-w-[min(32rem,calc(100vw-2rem))] min-w-[var(--radix-popover-trigger-width)] p-0'>
-          <Command>
-            <CommandInput placeholder='Search product...' />
-            <CommandList>
-              <CommandEmpty>No product found.</CommandEmpty>
-              <CommandGroup>
-                {products.map((product) => (
-                  <CommandItem
-                    key={product.id}
-                    value={product.name}
-                    onSelect={() => {
-                      setSelectedProductId(
-                        product.id === selectedProductId ? null : product.id
-                      );
-                      setProductOpen(false);
-                    }}
-                  >
-                    <Check
-                      className={cn(
-                        'mr-2 h-4 w-4',
-                        selectedProductId === product.id
-                          ? 'opacity-100'
-                          : 'opacity-0'
-                      )}
-                    />
-                    <span className='truncate'>{product.name}</span>
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            </CommandList>
-          </Command>
-        </PopoverContent>
-      </Popover>
+        }
+        open={productOpen}
+        onOpenChange={setProductOpen}
+        list={products}
+        getItemKey={(product) => product.id}
+        renderItem={(product) => (
+          <CommandItem
+            value={product.name}
+            onSelect={() => {
+              setSelectedProduct(
+                product.id === selectedProduct?.id ? null : product
+              );
+              setProductOpen(false);
+            }}
+          >
+            <Check
+              className={cn(
+                'mr-2 h-4 w-4',
+                selectedProduct?.id === product.id ? 'opacity-100' : 'opacity-0'
+              )}
+            />
+            <span className='truncate'>{product.name}</span>
+          </CommandItem>
+        )}
+        searchPlaceholder='Search product...'
+        searchTerm={productSearch}
+        onSearchTermChange={setProductSearch}
+        emptyMessage='No product found.'
+        errorMessage='Failed to load products'
+      />
       <div className='flex-1' />
       <MoveDialog
         thingName='repository'

--- a/ui/tests/unit/logic/escape-regex.test.ts
+++ b/ui/tests/unit/logic/escape-regex.test.ts
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { expect, it } from 'vitest';
+
+import { escapeRegex } from '@/lib/regex';
+
+it.each([
+  { name: 'dot', input: '.', expected: '\\.' },
+  { name: 'asterisk', input: '*', expected: '\\*' },
+  { name: 'plus', input: '+', expected: '\\+' },
+  { name: 'question mark', input: '?', expected: '\\?' },
+  { name: 'caret', input: '^', expected: '\\^' },
+  { name: 'dollar', input: '$', expected: '\\$' },
+  { name: 'opening brace', input: '{', expected: '\\{' },
+  { name: 'closing brace', input: '}', expected: '\\}' },
+  { name: 'opening parenthesis', input: '(', expected: '\\(' },
+  { name: 'closing parenthesis', input: ')', expected: '\\)' },
+  { name: 'pipe', input: '|', expected: '\\|' },
+  { name: 'opening bracket', input: '[', expected: '\\[' },
+  { name: 'closing bracket', input: ']', expected: '\\]' },
+  { name: 'backslash', input: '\\', expected: '\\\\' },
+  {
+    name: 'all metacharacters at once',
+    input: '.*+?^${}()|[]\\',
+    expected: '\\.\\*\\+\\?\\^\\$\\{\\}\\(\\)\\|\\[\\]\\\\',
+  },
+  { name: 'empty string', input: '', expected: '' },
+  { name: 'plain word', input: 'ort-server', expected: 'ort-server' },
+  {
+    name: 'plain text with spaces',
+    input: 'The ORT Server',
+    expected: 'The ORT Server',
+  },
+  {
+    name: 'metacharacters mixed into plain text',
+    input: 'org.apache (core)',
+    expected: 'org\\.apache \\(core\\)',
+  },
+])('escapeRegex - $name', ({ input, expected }) => {
+  expect(escapeRegex(input)).toBe(expected);
+});
+
+it('escapes input so that it matches itself literally', () => {
+  const input = 'a.b*c(d)[e]';
+
+  expect(new RegExp(escapeRegex(input)).test(input)).toBe(true);
+  expect(new RegExp(escapeRegex(input)).test('axbxcd e')).toBe(false);
+});

--- a/ui/tests/unit/logic/infinite-list.test.ts
+++ b/ui/tests/unit/logic/infinite-list.test.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { expect, it } from 'vitest';
+
+import { getNextPageParam } from '@/hooks/use-infinite-list';
+
+/**
+ * Build a page of the given size, as the API would return it. The items themselves do not matter
+ * here, only the paging information does.
+ */
+const page = (limit: number, offset: number, totalCount: number) => ({
+  data: Array.from({
+    length: Math.max(Math.min(limit, totalCount - offset), 0),
+  }),
+  pagination: { limit, offset, totalCount, sortProperties: [] },
+});
+
+it.each([
+  {
+    name: 'first page of several',
+    page: page(50, 0, 120),
+    expected: 50,
+  },
+  {
+    name: 'page in the middle',
+    page: page(50, 50, 120),
+    expected: 100,
+  },
+  {
+    name: 'partial last page',
+    page: page(50, 100, 120),
+    expected: undefined,
+  },
+  {
+    name: 'last page that is exactly full',
+    page: page(50, 50, 100),
+    expected: undefined,
+  },
+  {
+    name: 'second to last page of a result that is an exact multiple of the page size',
+    page: page(50, 0, 100),
+    expected: 50,
+  },
+  {
+    name: 'total count smaller than the page size',
+    page: page(50, 0, 10),
+    expected: undefined,
+  },
+  {
+    name: 'total count equal to the page size',
+    page: page(50, 0, 50),
+    expected: undefined,
+  },
+  {
+    name: 'empty result',
+    page: page(50, 0, 0),
+    expected: undefined,
+  },
+])('getNextPageParam - $name', ({ page, expected }) => {
+  expect(getNextPageParam(page)).toBe(expected);
+});


### PR DESCRIPTION
This PR lays the groundwork to refactoring fetch-heavy UI dropdowns to use inifinite queries, to get rid of some of `ALL_ITEMS` mentioned in #5383.

As a demonstration of the technique, the move-repository dropdowns for organization and product are refactored. More to follow in an upcoming PR.

In theory, infinite queries load more data page by page, but due to our implementation, two pages can "overlap". That's why in this video (look at the devTools/Network tab on the right side), for a total of 104 organizations, dropdown page size of 50, and the infinite list , three queries with 50+50+4 are firing, but the first two fire at the same time. This however won't be a problem performance-wise. Also, when filtering the dropdown list (100 matching items), it is correctly shown in the network tab, that the filtered query fires exactly twice (50+50), as expected.

https://github.com/user-attachments/assets/51ee61c2-9bf8-414f-9fa9-651cf77bc5f6

