### PR TITLE
fix(config): Preserve local config file paths

### DIFF
--- a/config/local/src/main/kotlin/LocalConfigFileProvider.kt
+++ b/config/local/src/main/kotlin/LocalConfigFileProvider.kt
@@ -75,12 +75,15 @@ class LocalConfigFileProvider(
     }
 
     override fun listFiles(context: Context, path: Path): Set<Path> {
+        val requestedDir = configDir.resolve(path.path)
         val dir = configDir.resolveSecurely(path)
 
         if (!dir.isDirectory) {
             throw ConfigException("The provided path '${path.path}' does not refer a directory.")
         }
 
-        return dir.walk().maxDepth(1).filter { it.isFile }.mapTo(mutableSetOf()) { Path(it.path) }
+        return dir.walk().maxDepth(1).filter { it.isFile }.mapTo(mutableSetOf()) {
+            Path(requestedDir.resolve(it.relativeTo(dir)).path)
+        }
     }
 }

--- a/config/local/src/test/kotlin/LocalConfigFileProviderTest.kt
+++ b/config/local/src/test/kotlin/LocalConfigFileProviderTest.kt
@@ -27,6 +27,8 @@ import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 
+import java.nio.file.Files
+
 import org.eclipse.apoapsis.ortserver.config.ConfigException
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.config.Context
@@ -188,6 +190,17 @@ class LocalConfigFileProviderTest : WordSpec({
 
             val expectedFiles = files.map { Path(subDirectory.resolve(it).absolutePath) }
             listFiles shouldContainExactlyInAnyOrder expectedFiles
+        }
+
+        "preserve the configured path when the config directory is a symbolic link" {
+            val directory = tempdir()
+            val configFile = directory.resolve("config-file").apply { createNewFile() }
+            val link = tempdir().resolve("config")
+            Files.createSymbolicLink(link.toPath(), directory.toPath())
+            val provider = LocalConfigFileProvider(link)
+            val expectedFile = Path(link.resolve(configFile.name).path)
+
+            provider.listFiles(ConfigManager.EMPTY_CONTEXT, Path("")) shouldBe setOf(expectedFile)
         }
 
         "throw an exception if the path does not exist" {


### PR DESCRIPTION
Canonical validation resolves symbolic links, but `listFiles()` must keep paths based on the configured directory. Reconstruct listed files from their validated relative paths and cover a symbolic-link configuration directory.