### PR TITLE
ui: Refactor remaining dropdowns to use infinite queries

### DIFF
--- a/ui/src/components/siblings.tsx
+++ b/ui/src/components/siblings.tsx
@@ -17,86 +17,163 @@
  * License-Filename: LICENSE
  */
 
-import { useQuery } from '@tanstack/react-query';
+import {
+  useQuery,
+  type QueryFunction,
+  type QueryKey,
+  type SkipToken,
+} from '@tanstack/react-query';
 import { Link, useParams, useRouter } from '@tanstack/react-router';
 import { Check, ChevronDown, ExternalLink } from 'lucide-react';
+import { useState } from 'react';
 
 import {
+  getOrganizationProductsInfiniteOptions,
   getOrganizationProductsOptions,
+  getOrganizationsInfiniteOptions,
   getOrganizationsOptions,
+  getProductRepositoriesInfiniteOptions,
   getProductRepositoriesOptions,
   getRepositoryOptions,
   getRepositoryRunsOptions,
 } from '@/api/@tanstack/react-query.gen';
+import { PagingData } from '@/api/types.gen';
+import { SearchableInfiniteList } from '@/components/searchable-infinite-list';
 import { BreadcrumbItem, BreadcrumbLink } from '@/components/ui/breadcrumb';
 import { Button } from '@/components/ui/button';
+import { CommandItem } from '@/components/ui/command';
 import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { useDebounce } from '@/hooks/use-debounce';
+import { useInfiniteList } from '@/hooks/use-infinite-list';
 import { ApiError } from '@/lib/api-error';
-import { ALL_ITEMS } from '@/lib/constants';
+import { DROPDOWN_PAGE_SIZE } from '@/lib/constants';
+import { toSearchFilter } from '@/lib/regex';
 
 type SiblingsProps = {
   entity: 'organization' | 'product' | 'repository' | 'run';
   pathName?: string;
 };
 
+// To improve the performance of the siblings component, set a stale time of
+// 2 hours for all queries. This is because the entities (organizations, products,
+// repositories, runs) are not expected to change frequently, and when changes do
+// occur, cache invalidation will ensure that the latest data is fetched.
+const staleTime = 2 * 60 * 60 * 1000;
+
+/**
+ * Ask a paged endpoint of the API how many entries it has, by reading a single one of them.
+ *
+ * This is what tells a breadcrumb whether its dropdown is worth showing at all, without loading the
+ * list itself. Pass the generated `*Options` for the endpoint, with a `limit` of 1 and neither a
+ * `filter` nor a `sort`, so that the count is cached on its own and searching the list that the
+ * dropdown shows leaves it alone.
+ */
+function useTotalCount<
+  TData extends { pagination: PagingData },
+  TQueryKey extends QueryKey,
+>(
+  {
+    queryKey,
+    queryFn,
+  }: {
+    queryKey: TQueryKey;
+    queryFn?: QueryFunction<TData, TQueryKey> | SkipToken;
+  },
+  enabled: boolean
+) {
+  const { data } = useQuery({
+    queryKey,
+    queryFn,
+    enabled,
+    staleTime: staleTime,
+    select: (page) => page.pagination.totalCount,
+  });
+
+  return data ?? 0;
+}
+
 export const Siblings = ({ entity, pathName }: SiblingsProps) => {
   const router = useRouter();
   const breadcrumbs = router.options.context.breadcrumbs;
   const params = useParams({ strict: false });
 
-  // To improve the performance of the siblings component, set a stale time of
-  // 2 hours for all queries. This is because the entities (organizations, products,
-  // repositories, runs) are not expected to change frequently, and when changes do
-  // occur, cache invalidation will ensure that the latest data is fetched.
-  const staleTime = 2 * 60 * 60 * 1000;
+  // Only one of the dropdowns below is rendered, the one that belongs to this breadcrumb, so a
+  // single open state and a single search term are enough for all of them.
+  const [isOpen, setIsOpen] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+  const filter = toSearchFilter(useDebounce(searchTerm, 300));
 
-  // By using the `enabled` option in the query hooks, unnecessary API calls can be prevented.
-  // Now, only the single query relevant to the clicked dropdown will be executed. Also ensure
-  // that queries that depend on a path parameter (like orgId) do not run until that parameter
-  // is actually present.
-  const {
-    data: organizations,
-    isPending: isOrgPending,
-    isError: isOrgError,
-    error: orgError,
-  } = useQuery({
-    ...getOrganizationsOptions({ query: { limit: ALL_ITEMS } }),
-    staleTime: staleTime,
-    enabled: entity === 'organization',
-  });
+  // The links in the dropdowns below turn preloading off. The router preloads on hover, and the
+  // loader of a route writes the name of the entity it loads into the breadcrumbs, so merely
+  // scrolling past the entries would replace the name shown in this breadcrumb, besides fetching
+  // an entity and its permissions for every entry the pointer happens to cross.
+  const closeDropdown = () => setIsOpen(false);
 
-  const {
-    data: products,
-    isPending: isProductsPending,
-    isError: isProductsError,
-    error: productsError,
-  } = useQuery({
-    ...getOrganizationProductsOptions({
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open);
+    // Start from the whole list again the next time the dropdown is opened.
+    if (!open) setSearchTerm('');
+  };
+
+  // A dropdown is only shown when there is more than one entry to pick from, which the counts below
+  // tell for the price of a single entry each. Queries that depend on a path parameter (like orgId)
+  // do not run until that parameter is actually present.
+  const organizationCount = useTotalCount(
+    getOrganizationsOptions({ query: { limit: 1 } }),
+    entity === 'organization'
+  );
+
+  const productCount = useTotalCount(
+    getOrganizationProductsOptions({
       path: { organizationId: Number(params.orgId) },
-      query: { limit: ALL_ITEMS },
+      query: { limit: 1 },
     }),
-    staleTime: staleTime,
-    enabled: entity === 'product' || !!params.orgId,
-  });
+    entity === 'product' && !!params.orgId
+  );
 
-  const {
-    data: repositories,
-    isPending: isRepositoriesPending,
-    isError: isRepositoriesError,
-    error: repositoriesError,
-  } = useQuery({
-    ...getProductRepositoriesOptions({
+  const repositoryCount = useTotalCount(
+    getProductRepositoriesOptions({
       path: { productId: Number(params.productId) },
-      query: { limit: ALL_ITEMS },
+      query: { limit: 1 },
     }),
-    staleTime: staleTime,
-    enabled: entity === 'repository' || !!params.productId,
-  });
+    entity === 'repository' && !!params.productId
+  );
+
+  // The lists themselves are fetched only while their dropdown is open, so a breadcrumb that is
+  // never clicked costs no more than the count above.
+  const organizations = useInfiniteList(
+    getOrganizationsInfiniteOptions({
+      query: { limit: DROPDOWN_PAGE_SIZE, filter: filter },
+    }),
+    { staleTime: staleTime, enabled: entity === 'organization' && isOpen }
+  );
+
+  const products = useInfiniteList(
+    getOrganizationProductsInfiniteOptions({
+      path: { organizationId: Number(params.orgId) },
+      query: { limit: DROPDOWN_PAGE_SIZE, filter: filter },
+    }),
+    {
+      staleTime: staleTime,
+      enabled: entity === 'product' && isOpen && !!params.orgId,
+    }
+  );
+
+  const repositories = useInfiniteList(
+    getProductRepositoriesInfiniteOptions({
+      path: { productId: Number(params.productId) },
+      query: { limit: DROPDOWN_PAGE_SIZE, filter: filter },
+    }),
+    {
+      staleTime: staleTime,
+      enabled: entity === 'repository' && isOpen && !!params.productId,
+    }
+  );
 
   const {
     data: runs,
@@ -121,9 +198,6 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
     enabled: entity === 'repository' && !!params.repoId,
   });
 
-  const orgs = organizations?.data;
-  const prods = products?.data;
-  const repos = repositories?.data;
   const runIndexes = runs?.data;
 
   const name =
@@ -141,115 +215,106 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
 
   return (
     <BreadcrumbItem>
-      {entity === 'organization' && orgs && orgs.length > 1 && (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <ChevronDown className='ml-1 size-4 cursor-pointer' />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent className='max-h-96' align='start'>
-            <>
-              {isOrgPending && <DropdownMenuItem>Loading...</DropdownMenuItem>}
-              {isOrgError && (
-                <DropdownMenuItem className='text-red-500'>
-                  Error:{' '}
-                  {`Failed to load organizations: ${(orgError as ApiError).message}`}
-                </DropdownMenuItem>
-              )}
-              {orgs.map((org) => (
-                <DropdownMenuItem key={org.id} className='ml-2' asChild>
-                  <Link
-                    to='/organizations/$orgId'
-                    params={{ orgId: org.id.toString() ?? '' }}
-                  >
-                    <div className='grid w-full grid-cols-6 items-center gap-2'>
-                      <div className='col-span-5'>{org.name}</div>
-                      {org.id === Number(params.orgId) && (
-                        <Check className='ml-auto h-4 w-4' />
-                      )}
-                    </div>
-                  </Link>
-                </DropdownMenuItem>
-              ))}
-            </>
-          </DropdownMenuContent>
-        </DropdownMenu>
+      {entity === 'organization' && organizationCount > 1 && (
+        <SearchableInfiniteList
+          trigger={<ChevronDown className='ml-1 size-4 cursor-pointer' />}
+          open={isOpen}
+          onOpenChange={handleOpenChange}
+          list={organizations}
+          getItemKey={(org) => org.id}
+          renderItem={(org) => (
+            <CommandItem asChild value={org.name} onSelect={closeDropdown}>
+              <Link
+                to='/organizations/$orgId'
+                params={{ orgId: org.id.toString() ?? '' }}
+                preload={false}
+              >
+                <div className='grid w-full grid-cols-6 items-center gap-2'>
+                  <div className='col-span-5'>{org.name}</div>
+                  {org.id === Number(params.orgId) && (
+                    <Check className='ml-auto h-4 w-4' />
+                  )}
+                </div>
+              </Link>
+            </CommandItem>
+          )}
+          searchPlaceholder='Search organizations...'
+          searchTerm={searchTerm}
+          onSearchTermChange={setSearchTerm}
+          emptyMessage='No organizations found.'
+          errorMessage='Failed to load organizations'
+        />
       )}
-      {entity === 'product' && prods && prods.length > 1 && (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <ChevronDown className='ml-1 size-4 cursor-pointer' />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent className='max-h-96' align='start'>
-            <>
-              {isProductsPending && (
-                <DropdownMenuItem>Loading...</DropdownMenuItem>
-              )}
-              {isProductsError && (
-                <DropdownMenuItem className='text-red-500'>
-                  Error:{' '}
-                  {`Failed to load products: ${(productsError as ApiError).message}`}
-                </DropdownMenuItem>
-              )}
-              {prods.map((prod) => (
-                <DropdownMenuItem key={prod.id} className='ml-2' asChild>
-                  <Link
-                    to='/organizations/$orgId/products/$productId'
-                    params={{
-                      orgId: params.orgId ?? '',
-                      productId: prod.id.toString() ?? '',
-                    }}
-                  >
-                    <div className='grid w-full grid-cols-6 items-center gap-2'>
-                      <div className='col-span-5'>{prod.name}</div>
-                      {prod.id === Number(params.productId) && (
-                        <Check className='ml-auto h-4 w-4' />
-                      )}
-                    </div>
-                  </Link>
-                </DropdownMenuItem>
-              ))}
-            </>
-          </DropdownMenuContent>
-        </DropdownMenu>
+      {entity === 'product' && productCount > 1 && (
+        <SearchableInfiniteList
+          trigger={<ChevronDown className='ml-1 size-4 cursor-pointer' />}
+          open={isOpen}
+          onOpenChange={handleOpenChange}
+          list={products}
+          getItemKey={(prod) => prod.id}
+          renderItem={(prod) => (
+            <CommandItem asChild value={prod.name} onSelect={closeDropdown}>
+              <Link
+                to='/organizations/$orgId/products/$productId'
+                params={{
+                  orgId: params.orgId ?? '',
+                  productId: prod.id.toString() ?? '',
+                }}
+                preload={false}
+              >
+                <div className='grid w-full grid-cols-6 items-center gap-2'>
+                  <div className='col-span-5'>{prod.name}</div>
+                  {prod.id === Number(params.productId) && (
+                    <Check className='ml-auto h-4 w-4' />
+                  )}
+                </div>
+              </Link>
+            </CommandItem>
+          )}
+          searchPlaceholder='Search products...'
+          searchTerm={searchTerm}
+          onSearchTermChange={setSearchTerm}
+          emptyMessage='No products found.'
+          errorMessage='Failed to load products'
+        />
       )}
-      {entity === 'repository' && repos && repos.length > 1 && (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <ChevronDown className='ml-1 size-4 cursor-pointer' />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent className='max-h-96' align='start'>
-            <>
-              {isRepositoriesPending && (
-                <DropdownMenuItem>Loading...</DropdownMenuItem>
-              )}
-              {isRepositoriesError && (
-                <DropdownMenuItem className='text-red-500'>
-                  Error:{' '}
-                  {`Failed to load repositories: ${(repositoriesError as ApiError).message}`}
-                </DropdownMenuItem>
-              )}
-              {repos.map((repo) => (
-                <DropdownMenuItem key={repo.id} className='ml-2' asChild>
-                  <Link
-                    to='/organizations/$orgId/products/$productId/repositories/$repoId'
-                    params={{
-                      orgId: params.orgId ?? '',
-                      productId: params.productId ?? '',
-                      repoId: repo.id.toString() ?? '',
-                    }}
-                  >
-                    <div className='grid w-full grid-cols-6 items-center gap-2'>
-                      <div className='col-span-5'>{repo.name || repo.url}</div>
-                      {repo.id === Number(params.repoId) && (
-                        <Check className='ml-auto h-4 w-4' />
-                      )}
-                    </div>
-                  </Link>
-                </DropdownMenuItem>
-              ))}
-            </>
-          </DropdownMenuContent>
-        </DropdownMenu>
+      {entity === 'repository' && repositoryCount > 1 && (
+        <SearchableInfiniteList
+          trigger={<ChevronDown className='ml-1 size-4 cursor-pointer' />}
+          open={isOpen}
+          onOpenChange={handleOpenChange}
+          list={repositories}
+          getItemKey={(repo) => repo.id}
+          renderItem={(repo) => (
+            <CommandItem
+              asChild
+              value={repo.name || repo.url}
+              onSelect={closeDropdown}
+            >
+              <Link
+                to='/organizations/$orgId/products/$productId/repositories/$repoId'
+                params={{
+                  orgId: params.orgId ?? '',
+                  productId: params.productId ?? '',
+                  repoId: repo.id.toString() ?? '',
+                }}
+                preload={false}
+              >
+                <div className='grid w-full grid-cols-6 items-center gap-2'>
+                  <div className='col-span-5'>{repo.name || repo.url}</div>
+                  {repo.id === Number(params.repoId) && (
+                    <Check className='ml-auto h-4 w-4' />
+                  )}
+                </div>
+              </Link>
+            </CommandItem>
+          )}
+          searchPlaceholder='Search repositories...'
+          searchTerm={searchTerm}
+          onSearchTermChange={setSearchTerm}
+          emptyMessage='No repositories found.'
+          errorMessage='Failed to load repositories'
+        />
       )}
       {entity === 'run' && runIndexes && runIndexes.length > 1 && (
         <DropdownMenu>
@@ -275,6 +340,7 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
                       repoId: params.repoId ?? '',
                       runIndex: run.index.toString() ?? '',
                     }}
+                    preload={false}
                   >
                     <div className='grid w-full grid-cols-6 items-center gap-2'>
                       <div className='col-span-5'>{run.index}</div>

--- a/ui/src/components/siblings.tsx
+++ b/ui/src/components/siblings.tsx
@@ -35,6 +35,7 @@ import {
   getProductRepositoriesInfiniteOptions,
   getProductRepositoriesOptions,
   getRepositoryOptions,
+  getRepositoryRunsInfiniteOptions,
   getRepositoryRunsOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { PagingData } from '@/api/types.gen';
@@ -42,15 +43,8 @@ import { SearchableInfiniteList } from '@/components/searchable-infinite-list';
 import { BreadcrumbItem, BreadcrumbLink } from '@/components/ui/breadcrumb';
 import { Button } from '@/components/ui/button';
 import { CommandItem } from '@/components/ui/command';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
 import { useDebounce } from '@/hooks/use-debounce';
 import { useInfiniteList } from '@/hooks/use-infinite-list';
-import { ApiError } from '@/lib/api-error';
 import { DROPDOWN_PAGE_SIZE } from '@/lib/constants';
 import { toSearchFilter } from '@/lib/regex';
 
@@ -144,6 +138,14 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
     entity === 'repository' && !!params.productId
   );
 
+  const runCount = useTotalCount(
+    getRepositoryRunsOptions({
+      path: { repositoryId: Number(params.repoId) },
+      query: { limit: 1 },
+    }),
+    entity === 'run' && !!params.repoId
+  );
+
   // The lists themselves are fetched only while their dropdown is open, so a breadcrumb that is
   // never clicked costs no more than the count above.
   const organizations = useInfiniteList(
@@ -175,19 +177,16 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
     }
   );
 
-  const {
-    data: runs,
-    isPending: isRunsPending,
-    isError: isRunsError,
-    error: runsError,
-  } = useQuery({
-    ...getRepositoryRunsOptions({
+  const runs = useInfiniteList(
+    getRepositoryRunsInfiniteOptions({
       path: { repositoryId: Number(params.repoId) },
-      query: { limit: 100, sort: '-index' },
+      query: { limit: DROPDOWN_PAGE_SIZE, sort: '-index' },
     }),
-    staleTime: staleTime,
-    enabled: entity === 'run' || !!params.repoId,
-  });
+    {
+      staleTime: staleTime,
+      enabled: entity === 'run' && isOpen && !!params.repoId,
+    }
+  );
 
   // The repository of the page itself, which the route loader has already put into the cache.
   const { data: currentRepo } = useQuery({
@@ -197,8 +196,6 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
     staleTime: staleTime,
     enabled: entity === 'repository' && !!params.repoId,
   });
-
-  const runIndexes = runs?.data;
 
   const name =
     entity === 'organization'
@@ -316,44 +313,43 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
           errorMessage='Failed to load repositories'
         />
       )}
-      {entity === 'run' && runIndexes && runIndexes.length > 1 && (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <ChevronDown className='ml-1 size-4 cursor-pointer' />
-          </DropdownMenuTrigger>
-          <DropdownMenuContent className='max-h-96' align='start'>
-            <>
-              {isRunsPending && <DropdownMenuItem>Loading...</DropdownMenuItem>}
-              {isRunsError && (
-                <DropdownMenuItem className='text-red-500'>
-                  Error:{' '}
-                  {`Failed to load runs: ${(runsError as ApiError).message}`}
-                </DropdownMenuItem>
-              )}
-              {runIndexes.map((run) => (
-                <DropdownMenuItem key={run.index} className='ml-2' asChild>
-                  <Link
-                    to='/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex'
-                    params={{
-                      orgId: params.orgId ?? '',
-                      productId: params.productId ?? '',
-                      repoId: params.repoId ?? '',
-                      runIndex: run.index.toString() ?? '',
-                    }}
-                    preload={false}
-                  >
-                    <div className='grid w-full grid-cols-6 items-center gap-2'>
-                      <div className='col-span-5'>{run.index}</div>
-                      {run.index === Number(params.runIndex) && (
-                        <Check className='ml-auto h-4 w-4' />
-                      )}
-                    </div>
-                  </Link>
-                </DropdownMenuItem>
-              ))}
-            </>
-          </DropdownMenuContent>
-        </DropdownMenu>
+      {/* The runs of a repository cannot be filtered on the server, so this list has no search. */}
+      {entity === 'run' && runCount > 1 && (
+        <SearchableInfiniteList
+          trigger={<ChevronDown className='ml-1 size-4 cursor-pointer' />}
+          open={isOpen}
+          onOpenChange={handleOpenChange}
+          list={runs}
+          getItemKey={(run) => run.index}
+          renderItem={(run) => (
+            <CommandItem
+              asChild
+              value={run.index.toString()}
+              onSelect={closeDropdown}
+            >
+              <Link
+                to='/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex'
+                params={{
+                  orgId: params.orgId ?? '',
+                  productId: params.productId ?? '',
+                  repoId: params.repoId ?? '',
+                  runIndex: run.index.toString() ?? '',
+                }}
+                preload={false}
+              >
+                <div className='grid w-full grid-cols-6 items-center gap-2'>
+                  <div className='col-span-5'>{run.index}</div>
+                  {run.index === Number(params.runIndex) && (
+                    <Check className='ml-auto h-4 w-4' />
+                  )}
+                </div>
+              </Link>
+            </CommandItem>
+          )}
+          searchable={false}
+          emptyMessage='No runs found.'
+          errorMessage='Failed to load runs'
+        />
       )}
       <BreadcrumbLink asChild>
         <Link to={pathName}>{name}</Link>

--- a/ui/src/components/siblings.tsx
+++ b/ui/src/components/siblings.tsx
@@ -25,6 +25,7 @@ import {
   getOrganizationProductsOptions,
   getOrganizationsOptions,
   getProductRepositoriesOptions,
+  getRepositoryOptions,
   getRepositoryRunsOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { BreadcrumbItem, BreadcrumbLink } from '@/components/ui/breadcrumb';
@@ -111,6 +112,15 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
     enabled: entity === 'run' || !!params.repoId,
   });
 
+  // The repository of the page itself, which the route loader has already put into the cache.
+  const { data: currentRepo } = useQuery({
+    ...getRepositoryOptions({
+      path: { repositoryId: Number(params.repoId) },
+    }),
+    staleTime: staleTime,
+    enabled: entity === 'repository' && !!params.repoId,
+  });
+
   const orgs = organizations?.data;
   const prods = products?.data;
   const repos = repositories?.data;
@@ -125,10 +135,9 @@ export const Siblings = ({ entity, pathName }: SiblingsProps) => {
           ? breadcrumbs.repo
           : breadcrumbs.run;
 
-  const currentRepoUrl =
-    entity === 'repository'
-      ? repos?.find((r) => r.id === Number(params.repoId))?.url
-      : undefined;
+  // The query above is cached under the same key for the run breadcrumb, which also knows the
+  // repository, so the link is shown for the repository breadcrumb only.
+  const currentRepoUrl = entity === 'repository' ? currentRepo?.url : undefined;
 
   return (
     <BreadcrumbItem>

--- a/ui/src/components/ui/multiple-selector.tsx
+++ b/ui/src/components/ui/multiple-selector.tsx
@@ -21,6 +21,7 @@ import {
   CommandList,
 } from '@/components/ui/command';
 import { useDebounce } from '@/hooks/use-debounce';
+import { useInView } from '@/hooks/use-in-view';
 import { cn } from '@/lib/utils';
 
 export interface Option {
@@ -91,6 +92,20 @@ interface MultipleSelectorProps {
   >;
   /** hide the clear all button. */
   hideClearAllButton?: boolean;
+  /**
+   * Show the loading indicator although the options are not searched through `onSearch`. This is
+   * for options that are loaded by the caller, for example page by page.
+   */
+  loading?: boolean;
+  /** Whether there are options left to load. Only has an effect together with `onLoadMore`. */
+  hasMore?: boolean;
+  /** Whether the options that come next are being loaded. */
+  isLoadingMore?: boolean;
+  /**
+   * Called when the end of the list of options is scrolled into view, so that the caller can add
+   * the options that come next.
+   */
+  onLoadMore?: () => void;
 }
 
 export interface MultipleSelectorRef {
@@ -199,6 +214,10 @@ const MultipleSelector = React.forwardRef<
       commandProps,
       inputProps,
       hideClearAllButton = false,
+      loading = false,
+      hasMore = false,
+      isLoadingMore = false,
+      onLoadMore,
     }: MultipleSelectorProps,
     ref: React.Ref<MultipleSelectorRef>
   ) => {
@@ -214,6 +233,16 @@ const MultipleSelector = React.forwardRef<
     );
     const [inputValue, setInputValue] = React.useState('');
     const debouncedSearchTerm = useDebounce(inputValue, delay || 500);
+
+    // The end of the list of options. Scrolling it into view asks the caller for the options that
+    // come next.
+    const { ref: loadMoreRef, inView: isEndOfListInView } = useInView();
+
+    useEffect(() => {
+      if (isEndOfListInView && hasMore && !isLoadingMore) {
+        onLoadMore?.();
+      }
+    }, [isEndOfListInView, hasMore, isLoadingMore, onLoadMore]);
 
     React.useImperativeHandle(
       ref,
@@ -571,7 +600,7 @@ const MultipleSelector = React.forwardRef<
                 inputRef?.current?.focus();
               }}
             >
-              {isLoading ? (
+              {isLoading || loading ? (
                 <>{loadingIndicator}</>
               ) : (
                 <>
@@ -620,6 +649,16 @@ const MultipleSelector = React.forwardRef<
                       </>
                     </CommandGroup>
                   ))}
+                  {onLoadMore && (
+                    <>
+                      <div ref={loadMoreRef} />
+                      {isLoadingMore && (
+                        <div className='text-muted-foreground py-2 text-center text-sm'>
+                          Loading more...
+                        </div>
+                      )}
+                    </>
+                  )}
                 </>
               )}
             </CommandList>

--- a/ui/src/lib/constants.ts
+++ b/ui/src/lib/constants.ts
@@ -19,10 +19,16 @@
 
 // Paginated list queries have a "limit" query parameter, which is the maximum number of items to return.
 // When the limit is not set, the queries return a default number of items.
-// As some components, like the item distribution color bar, require all items to calculate the distribution,
-// the limit is set to (an arbitrary) high number to ensure that all items are returned.
-// This probably needs to be changed in the future to a more sophisticated solution, e.g., by using a separate query
-// to get the distribution of items without fetching all items from back-end, which is costly.
+// Some views need every item at once, rather than a page of them, and set the limit to (an
+// arbitrary) high number to get them:
+// - The issue, rule violation and project tables of a run filter, sort and paginate in the browser,
+//   which they cannot stop doing until those endpoints support filtering, see
+//   https://github.com/eclipse-apoapsis/ort-server/issues/5349.
+// - The secrets and the infrastructure services of a hierarchy are read as one complete list, see
+//   https://github.com/eclipse-apoapsis/ort-server/issues/5646.
+// Both are costly and meant to go away.
+// Dropdowns and other lists the user picks from must not use this. They ask for one page at a time,
+// see DROPDOWN_PAGE_SIZE below and the useInfiniteList hook.
 export const ALL_ITEMS = 100000;
 
 // The number of items a dropdown asks for at a time. Dropdowns load their content page by page as

--- a/ui/src/lib/regex.ts
+++ b/ui/src/lib/regex.ts
@@ -25,3 +25,11 @@
 export function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
+
+/**
+ * Turn what a user typed into a search box into a `filter` query parameter, leaving it out entirely
+ * while nothing has been typed.
+ */
+export function toSearchFilter(searchTerm: string): string | undefined {
+  return searchTerm ? escapeRegex(searchTerm) : undefined;
+}

--- a/ui/src/routes/admin/plugins/$pluginType/$pluginId/index.tsx
+++ b/ui/src/routes/admin/plugins/$pluginType/$pluginId/index.tsx
@@ -17,9 +17,10 @@
  * License-Filename: LICENSE
  */
 
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQueries, useQuery } from '@tanstack/react-query';
 import { createFileRoute, Link, useLoaderData } from '@tanstack/react-router';
 import { Pencil } from 'lucide-react';
+import { useState } from 'react';
 
 import { PluginDescriptor, PluginTemplate } from '@/api';
 import {
@@ -27,7 +28,8 @@ import {
   deletePluginTemplateMutation,
   disableGlobalPluginTemplateMutation,
   enableGlobalPluginTemplateMutation,
-  getOrganizationsOptions,
+  getOrganizationOptions,
+  getOrganizationsInfiniteOptions,
   getPluginTemplatesOptions,
   getPluginTemplatesQueryKey,
   removeTemplateFromOrganizationMutation,
@@ -53,9 +55,12 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import { useDebounce } from '@/hooks/use-debounce';
+import { useInfiniteList } from '@/hooks/use-infinite-list';
 import { ApiError } from '@/lib/api-error';
-import { ALL_ITEMS } from '@/lib/constants.ts';
+import { DROPDOWN_PAGE_SIZE } from '@/lib/constants.ts';
 import { queryClient, routePrefetchStaleTime } from '@/lib/query-client.ts';
+import { toSearchFilter } from '@/lib/regex';
 import { toast, toastError } from '@/lib/toast';
 import { getPluginTypeLabel } from '@/lib/types';
 import { Route as LayoutRoute } from '@/routes/admin/plugins/route.tsx';
@@ -63,14 +68,48 @@ import { Route as LayoutRoute } from '@/routes/admin/plugins/route.tsx';
 type PluginTemplateCardProps = {
   plugin: PluginDescriptor;
   template: PluginTemplate;
-  organizationOptions: Option[];
 };
 
-const PluginTemplateCard = ({
-  plugin,
-  template,
-  organizationOptions,
-}: PluginTemplateCardProps) => {
+const PluginTemplateCard = ({ plugin, template }: PluginTemplateCardProps) => {
+  // Nothing is loaded before the user has touched the field, so a page with many templates on it
+  // costs no request for the organizations of any of them.
+  const [isSelectorUsed, setIsSelectorUsed] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const filter = toSearchFilter(useDebounce(searchTerm, 300));
+
+  const organizations = useInfiniteList(
+    getOrganizationsInfiniteOptions({
+      query: { limit: DROPDOWN_PAGE_SIZE, filter: filter },
+    }),
+    { enabled: isSelectorUsed }
+  );
+
+  const organizationOptions: Option[] = organizations.items.map(
+    (organization) => ({
+      label: organization.name,
+      value: organization.id.toString(),
+    })
+  );
+
+  // The organizations this template is assigned to are not necessarily part of the page that is
+  // shown, so their names are read one by one. The queries are shared by all the cards.
+  const assignedIds = template.organizationIds ?? [];
+
+  const assignedOrganizations = useQueries({
+    queries: assignedIds.map((organizationId) =>
+      getOrganizationOptions({ path: { organizationId: organizationId } })
+    ),
+  });
+
+  const assignedOptions: Option[] = assignedIds.map(
+    (organizationId, index) => ({
+      label:
+        assignedOrganizations[index]?.data?.name ?? organizationId.toString(),
+      value: organizationId.toString(),
+    })
+  );
+
   const { mutateAsync: enableGlobal } = useMutation({
     ...enableGlobalPluginTemplateMutation(),
   });
@@ -271,10 +310,29 @@ const PluginTemplateCard = ({
             : 'This template is not assigned to any organizations.'}
         </p>
         <MultipleSelector
-          value={organizationOptions.filter((o) =>
-            template.organizationIds?.includes(Number(o.value))
-          )}
+          value={assignedOptions}
           options={organizationOptions}
+          loading={organizations.isPending}
+          hasMore={organizations.hasNextPage}
+          isLoadingMore={organizations.isFetchingNextPage}
+          onLoadMore={organizations.fetchNextPage}
+          // The organizations are searched on the server, so the list must not be filtered again
+          // by what has been typed.
+          commandProps={{ shouldFilter: false }}
+          inputProps={{
+            onValueChange: setSearchTerm,
+            onFocus: () => setIsSelectorUsed(true),
+          }}
+          emptyIndicator={
+            <p className='text-center text-lg leading-10 text-gray-600 dark:text-gray-400'>
+              No results found.
+            </p>
+          }
+          loadingIndicator={
+            <p className='text-center text-lg leading-10 text-gray-600 dark:text-gray-400'>
+              Loading...
+            </p>
+          }
           placeholder='Assign organizations...'
           badgeClassName='bg-amber-200 text-black'
           onChange={(newSelected) => {
@@ -359,19 +417,6 @@ const PluginTemplatesComponent = () => {
   );
 
   const {
-    data: organizations,
-    isPending: orgIsPending,
-    isError: orgIsError,
-    error: orgError,
-  } = useQuery({
-    ...getOrganizationsOptions({
-      query: {
-        limit: ALL_ITEMS,
-      },
-    }),
-  });
-
-  const {
     data: pluginTemplates,
     error: pluginTemplatesError,
     isPending: pluginTemplatesIsPending,
@@ -406,20 +451,6 @@ const PluginTemplatesComponent = () => {
     toastError('Failed to load plugin templates', pluginTemplatesError);
     return;
   }
-
-  if (orgIsPending) {
-    return <LoadingIndicator />;
-  }
-
-  if (orgIsError) {
-    toastError('Unable to load data', orgError);
-    return;
-  }
-
-  const organizationOptions: Option[] = organizations.data.map((o) => ({
-    label: o.name,
-    value: o.id.toString(),
-  }));
 
   return (
     <Card className='mb-4 h-fit'>
@@ -459,7 +490,6 @@ const PluginTemplatesComponent = () => {
               key={template.name}
               plugin={plugin}
               template={template}
-              organizationOptions={organizationOptions}
             />
           ))
         ) : (

--- a/ui/src/routes/admin/users/create-user/index.tsx
+++ b/ui/src/routes/admin/users/create-user/index.tsx
@@ -18,21 +18,21 @@
  */
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { Loader2 } from 'lucide-react';
+import { useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
 import {
-  getOrganizationsOptions,
+  getOrganizationsInfiniteOptions,
   postUserMutation,
   putOrganizationRoleToUserMutation,
 } from '@/api/@tanstack/react-query.gen';
 import { asOptionalField } from '@/components/form/as-optional-field';
 import { OptionalInput } from '@/components/form/optional-input';
 import { PasswordInput } from '@/components/form/password-input';
-import { LoadingIndicator } from '@/components/loading-indicator';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -54,8 +54,11 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import MultipleSelector, { Option } from '@/components/ui/multiple-selector';
+import { useDebounce } from '@/hooks/use-debounce';
+import { useInfiniteList } from '@/hooks/use-infinite-list';
 import { ApiError } from '@/lib/api-error';
-import { ALL_ITEMS } from '@/lib/constants';
+import { DROPDOWN_PAGE_SIZE } from '@/lib/constants';
+import { toSearchFilter } from '@/lib/regex';
 import { toast, toastError } from '@/lib/toast';
 
 const formSchema = z.object({
@@ -73,14 +76,30 @@ const formSchema = z.object({
 const CreateUser = () => {
   const navigate = useNavigate();
 
-  const {
-    data: organizations,
-    isPending: orgIsPending,
-    isError: orgIsError,
-    error: orgError,
-  } = useQuery({
-    ...getOrganizationsOptions({ query: { limit: ALL_ITEMS } }),
-  });
+  // The name of every organization that has been picked so far. A picked organization is not
+  // necessarily part of the page that is shown after the search term changes, and its badge still
+  // has to show its name.
+  const organizationNames = useRef(new Map<string, string>());
+
+  // Nothing is loaded before the user has touched the field, so opening the form costs no request.
+  const [isSelectorUsed, setIsSelectorUsed] = useState(false);
+  const [searchTerm, setSearchTerm] = useState('');
+
+  const filter = toSearchFilter(useDebounce(searchTerm, 300));
+
+  const organizations = useInfiniteList(
+    getOrganizationsInfiniteOptions({
+      query: { limit: DROPDOWN_PAGE_SIZE, filter: filter },
+    }),
+    { enabled: isSelectorUsed }
+  );
+
+  const organizationOptions: Option[] = organizations.items.map(
+    (organization) => ({
+      label: organization.name,
+      value: organization.id.toString(),
+    })
+  );
 
   const { mutateAsync: createUser, isPending: isCreateUserPending } =
     useMutation({
@@ -96,9 +115,9 @@ const CreateUser = () => {
   } = useMutation({
     ...putOrganizationRoleToUserMutation(),
     onSuccess(_, variables) {
-      const organizationName = organizations?.data.find(
-        (org) => org.id === variables.path.organizationId
-      )?.name;
+      const organizationName = organizationNames.current.get(
+        variables.path.organizationId.toString()
+      );
 
       toast.info('Add Access Rights', {
         description: `The "${variables.body?.username}" user was created and assigned the READER role for the "${organizationName}" organization.`,
@@ -148,20 +167,6 @@ const CreateUser = () => {
       )
     );
   }
-
-  if (orgIsPending) {
-    return <LoadingIndicator />;
-  }
-
-  if (orgIsError) {
-    toastError('Unable to load data', orgError);
-    return;
-  }
-
-  const options: Option[] = organizations.data.map((o) => ({
-    label: o.name,
-    value: o.id.toString(),
-  }));
 
   return (
     <Card className='col-span-2 w-full'>
@@ -276,17 +281,38 @@ const CreateUser = () => {
                           No results found.
                         </p>
                       }
-                      value={(field.value || []).map(
-                        (v) =>
-                          options.find((o) => o.value === v) || {
-                            label: v,
-                            value: v,
-                          }
-                      )}
-                      defaultOptions={options}
-                      onChange={(selected) =>
-                        field.onChange(selected.map((s) => s.value))
+                      loadingIndicator={
+                        <p className='text-center text-lg leading-10 text-gray-600 dark:text-gray-400'>
+                          Loading...
+                        </p>
                       }
+                      value={(field.value || []).map((organizationId) => ({
+                        label:
+                          organizationNames.current.get(organizationId) ??
+                          organizationId,
+                        value: organizationId,
+                      }))}
+                      options={organizationOptions}
+                      loading={organizations.isPending}
+                      hasMore={organizations.hasNextPage}
+                      isLoadingMore={organizations.isFetchingNextPage}
+                      onLoadMore={organizations.fetchNextPage}
+                      // The organizations are searched on the server, so the list must not be
+                      // filtered again by what has been typed.
+                      commandProps={{ shouldFilter: false }}
+                      inputProps={{
+                        onValueChange: setSearchTerm,
+                        onFocus: () => setIsSelectorUsed(true),
+                      }}
+                      onChange={(selected) => {
+                        selected.forEach((option) =>
+                          organizationNames.current.set(
+                            option.value,
+                            option.label
+                          )
+                        );
+                        field.onChange(selected.map((s) => s.value));
+                      }}
                     />
                   </FormControl>
                   <FormDescription>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/move-repository.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/move-repository.tsx
@@ -36,7 +36,7 @@ import { useDebounce } from '@/hooks/use-debounce';
 import { useInfiniteList } from '@/hooks/use-infinite-list';
 import { ApiError } from '@/lib/api-error';
 import { DROPDOWN_PAGE_SIZE } from '@/lib/constants';
-import { escapeRegex } from '@/lib/regex';
+import { toSearchFilter } from '@/lib/regex';
 import { toastError } from '@/lib/toast';
 import { cn } from '@/lib/utils';
 
@@ -49,10 +49,6 @@ interface MoveRepositoryProps {
  * is not necessarily part of the page that is shown once the search term changes.
  */
 type Selection = { id: number; name: string };
-
-/** Turn what the user typed into a filter, as the API reads it as a regular expression. */
-const toFilter = (searchTerm: string) =>
-  searchTerm ? escapeRegex(searchTerm) : undefined;
 
 export const MoveRepository = ({ repoUrl }: MoveRepositoryProps) => {
   const params = useParams({ strict: false });
@@ -76,7 +72,7 @@ export const MoveRepository = ({ repoUrl }: MoveRepositoryProps) => {
     getOrganizationsInfiniteOptions({
       query: {
         limit: DROPDOWN_PAGE_SIZE,
-        filter: toFilter(debouncedOrgSearch),
+        filter: toSearchFilter(debouncedOrgSearch),
       },
     }),
     { enabled: orgOpen }
@@ -88,7 +84,7 @@ export const MoveRepository = ({ repoUrl }: MoveRepositoryProps) => {
       path: { organizationId: selectedOrg?.id ?? -1 },
       query: {
         limit: DROPDOWN_PAGE_SIZE,
-        filter: toFilter(debouncedProductSearch),
+        filter: toSearchFilter(debouncedProductSearch),
       },
     }),
     { enabled: productOpen && selectedOrg !== null }


### PR DESCRIPTION
After this PR, all dropdowns that used to fetch large amount of data all at once, have been refactored to use infinite querying. Statistics:
- before this PR and #5637: 17 `ALL_ITEMS` usages in 10 files
- after: 10 `ALL_ITEMS` usages in 5 files left
- usages remaining: [use-secrets.ts](https://github.com/eclipse-apoapsis/ort-server/blob/main/ui/src/hooks/use-secrets.ts), [use-infrastructure-services.ts](https://github.com/eclipse-apoapsis/ort-server/blob/main/ui/src/hooks/use-infrastructure-services.ts), and the Issues, Projects, and Rule Violations tables of a run

All refactors have been verified by triggering the refactored dropdowns in the UI with a total of 104 organizations, and checking that when the dropdown list is scrolled from top to bottom, the paged queries are triggered exactly three times (50 + 50 + 4 = 104; page size for the queries is 50).

Please see the commits for details.