### PR TITLE
fix(ort-run): Resolve license choices in generated results

### DIFF
--- a/services/ort-run/src/main/kotlin/OrtRunService.kt
+++ b/services/ort-run/src/main/kotlin/OrtRunService.kt
@@ -437,6 +437,9 @@ class OrtRunService(
         )
 
         return baseResult.copy(
+            resolvedConfiguration = baseResult.resolvedConfiguration.copy(
+                licenseChoices = baseResult.repository.config.licenseChoices
+            ),
             // Add common labels for all types of workers
             labels = baseResult.labels + mapOf(
                 RUN_ID_LABEL to ortRun.id.toString()

--- a/services/ort-run/src/test/kotlin/OrtRunServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/OrtRunServiceTest.kt
@@ -1627,11 +1627,44 @@ class OrtRunServiceTest : WordSpec({
                 fixtures
             )
 
+            val packageId = Identifier("Maven", "org.ossreviewtoolkit", "model", "1.0.0")
+            val packageConfiguration = PackageConfiguration(id = packageId)
+            service.storeResolvedPackageConfigurations(ortRun.id, listOf(packageConfiguration.mapToOrt()))
+
+            val resolvedPackageCurations = listOf(
+                ResolvedPackageCurations(
+                    provider = PackageCurationProviderConfig(name = "test"),
+                    curations = listOf(PackageCuration(packageId, PackageCurationData()))
+                )
+            )
+            service.storeResolvedPackageCurations(
+                ortRun.id,
+                resolvedPackageCurations.map(ResolvedPackageCurations::mapToOrt)
+            )
+
+            val issue = Issue(Clock.System.now(), "test", "message", Severity.WARNING)
+            val issueResolution = IssueResolution(
+                message = "message",
+                reason = IssueResolutionReason.CANT_FIX_ISSUE,
+                comment = "comment",
+                source = ResolutionSource.REPOSITORY_FILE
+            )
+            service.storeResolvedItems(ortRun.id, ResolvedItemsResult(issues = mapOf(issue to listOf(issueResolution))))
+
             service.generateOrtResult(ortRun).let { ortResult ->
                 ortResult.repository.vcs shouldBe vcsInfo.mapToOrt()
                 ortResult.repository.vcsProcessed shouldBe processedVcsInfo.mapToOrt()
                 ortResult.repository.nestedRepositories["nested-1"] shouldBe nestedVcsInfo1.mapToOrt()
                 ortResult.repository.nestedRepositories["nested-2"] shouldBe nestedVcsInfo2.mapToOrt()
+
+                with(ortResult.resolvedConfiguration) {
+                    licenseChoices shouldBe ortResult.repository.config.licenseChoices
+                    packageConfigurations should containExactly(packageConfiguration.mapToOrt())
+                    packageCurations should containExactly(
+                        *resolvedPackageCurations.map(ResolvedPackageCurations::mapToOrt).toTypedArray()
+                    )
+                    resolutions.shouldNotBeNull().issues should containExactly(issueResolution.mapToOrt())
+                }
             }
         }
 


### PR DESCRIPTION
ORT moved license-choice accessors to the resolved configuration. Create
that configuration from the repository configuration when constructing an
OrtResult so Server workers apply choices from .ort.yml again.

This fixes a regression introduced in [1].

[1]: https://github.com/oss-review-toolkit/ort/pull/12174