### PR TITLE
ui: Refactor secrets and infrastructure service dropdowns use infinite queries

### DIFF
--- a/ui/src/components/infrastructure-service-select.tsx
+++ b/ui/src/components/infrastructure-service-select.tsx
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { useParams, useRouter } from '@tanstack/react-router';
+
+import { FormControl } from '@/components/ui/form';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { capitalize } from '@/helpers/capitalize';
+import { useInfrastructureServices } from '@/hooks/use-infrastructure-services';
+
+type InfrastructureServiceSelectProps = {
+  /** The name of the selected service, empty when nothing is selected yet. */
+  value: string | undefined;
+  onChange: (value: string) => void;
+  placeholder: string;
+  className?: string;
+};
+
+/**
+ * A field for picking one of the infrastructure services of a hierarchy.
+ *
+ * The only place this is used is a field of an environment definition, which sits three components
+ * deep in the create-run form, so it reads the repository it belongs to and what the user is
+ * allowed to see itself rather than having them handed down through all of them.
+ *
+ * Render it inside a `FormField`, as it brings the `FormControl` of the field with it.
+ */
+export const InfrastructureServiceSelect = ({
+  value,
+  onChange,
+  placeholder,
+  className,
+}: InfrastructureServiceSelectProps) => {
+  const { orgId, productId, repoId } = useParams({ strict: false });
+  const permissions = useRouter().options.context.permissions;
+
+  const services = useInfrastructureServices({
+    orgId,
+    productId,
+    repoId,
+    permissions,
+  });
+
+  return (
+    <Select value={value || undefined} onValueChange={onChange}>
+      <FormControl>
+        <SelectTrigger className={className}>
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+      </FormControl>
+      <SelectContent>
+        {services.map((service) => (
+          <SelectItem
+            key={`${service.hierarchy}:${service.name}`}
+            value={service.name}
+          >
+            {`${service.name} (${capitalize(service.hierarchy)})`}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+};

--- a/ui/src/components/infrastructure-service-select.tsx
+++ b/ui/src/components/infrastructure-service-select.tsx
@@ -18,17 +18,16 @@
  */
 
 import { useParams, useRouter } from '@tanstack/react-router';
+import { Check, ChevronsUpDown } from 'lucide-react';
+import { useState } from 'react';
 
+import { SearchableInfiniteList } from '@/components/searchable-infinite-list';
+import { Button } from '@/components/ui/button';
+import { CommandItem } from '@/components/ui/command';
 import { FormControl } from '@/components/ui/form';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { capitalize } from '@/helpers/capitalize';
 import { useInfrastructureServices } from '@/hooks/use-infrastructure-services';
+import { cn } from '@/lib/utils';
 
 type InfrastructureServiceSelectProps = {
   /** The name of the selected service, empty when nothing is selected yet. */
@@ -45,6 +44,10 @@ type InfrastructureServiceSelectProps = {
  * deep in the create-run form, so it reads the repository it belongs to and what the user is
  * allowed to see itself rather than having them handed down through all of them.
  *
+ * The services are read a page at a time, and only while the list is open. The trigger shows the
+ * name that is selected as it is, without looking it up, so that a service saved earlier, or one a
+ * rerun refers to from outside the hierarchy, is shown even when its page has not been read.
+ *
  * Render it inside a `FormField`, as it brings the `FormControl` of the field with it.
  */
 export const InfrastructureServiceSelect = ({
@@ -56,30 +59,66 @@ export const InfrastructureServiceSelect = ({
   const { orgId, productId, repoId } = useParams({ strict: false });
   const permissions = useRouter().options.context.permissions;
 
+  const [open, setOpen] = useState(false);
   const services = useInfrastructureServices({
     orgId,
     productId,
     repoId,
     permissions,
+    enabled: open,
   });
 
   return (
-    <Select value={value || undefined} onValueChange={onChange}>
-      <FormControl>
-        <SelectTrigger className={className}>
-          <SelectValue placeholder={placeholder} />
-        </SelectTrigger>
-      </FormControl>
-      <SelectContent>
-        {services.map((service) => (
-          <SelectItem
-            key={`${service.hierarchy}:${service.name}`}
-            value={service.name}
+    <SearchableInfiniteList
+      trigger={
+        <FormControl>
+          <Button
+            variant='outline'
+            role='combobox'
+            aria-expanded={open}
+            className={cn(
+              'w-full justify-between gap-2 font-normal',
+              className
+            )}
           >
+            <span
+              className={cn(
+                'min-w-0 truncate text-left',
+                !value && 'text-muted-foreground'
+              )}
+            >
+              {value || placeholder}
+            </span>
+            <ChevronsUpDown className='ml-2 h-4 w-4 shrink-0 opacity-50' />
+          </Button>
+        </FormControl>
+      }
+      open={open}
+      onOpenChange={setOpen}
+      list={services}
+      getItemKey={(service) => `${service.hierarchy}:${service.name}`}
+      renderItem={(service) => (
+        <CommandItem
+          value={`${service.hierarchy}:${service.name}`}
+          onSelect={() => {
+            onChange(service.name);
+            setOpen(false);
+          }}
+        >
+          <Check
+            className={cn(
+              'mr-2 h-4 w-4',
+              service.name === value ? 'opacity-100' : 'opacity-0'
+            )}
+          />
+          <span className='truncate'>
             {`${service.name} (${capitalize(service.hierarchy)})`}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+          </span>
+        </CommandItem>
+      )}
+      searchable={false}
+      emptyMessage='No infrastructure services found.'
+      errorMessage='Failed to load infrastructure services'
+    />
   );
 };

--- a/ui/src/components/searchable-infinite-list.tsx
+++ b/ui/src/components/searchable-infinite-list.tsx
@@ -31,7 +31,7 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover';
 import { useInView } from '@/hooks/use-in-view';
-import { InfiniteList } from '@/hooks/use-infinite-list';
+import { InfiniteList } from '@/lib/infinite-list';
 import { cn } from '@/lib/utils';
 
 type SearchableInfiniteListProps<TItem> = {

--- a/ui/src/components/searchable-infinite-list.tsx
+++ b/ui/src/components/searchable-infinite-list.tsx
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-import { Fragment, ReactNode, useEffect, type Key } from 'react';
+import { Fragment, ReactNode, useEffect, useRef, type Key } from 'react';
 
 import {
   Command,
@@ -85,13 +85,21 @@ export function SearchableInfiniteList<TItem>({
 }: SearchableInfiniteListProps<TItem>) {
   const { ref, inView } = useInView();
   const { items, isPending, isError, error } = list;
-  const { hasNextPage, isFetchingNextPage, fetchNextPage } = list;
+  const { hasNextPage, isFetchingNextPage } = list;
+
+  // A list that combines several others hands over a new `fetchNextPage` on every render, which as
+  // a dependency of the effect below would ask for a page again before the one in flight is there.
+  const fetchNextPage = useRef(list.fetchNextPage);
+
+  useEffect(() => {
+    fetchNextPage.current = list.fetchNextPage;
+  });
 
   useEffect(() => {
     if (inView && hasNextPage && !isFetchingNextPage) {
-      fetchNextPage();
+      fetchNextPage.current();
     }
-  }, [inView, hasNextPage, isFetchingNextPage, fetchNextPage]);
+  }, [inView, hasNextPage, isFetchingNextPage]);
 
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
@@ -112,7 +120,9 @@ export function SearchableInfiniteList<TItem>({
             />
           )}
           <CommandList>
-            {isPending && (
+            {/* A list that combines several others is pending until the slowest of them is read,
+                so wait for the entries to run out before saying that it is loading. */}
+            {isPending && items.length === 0 && (
               <div className='text-muted-foreground py-6 text-center text-sm'>
                 Loading...
               </div>

--- a/ui/src/components/secret-select.tsx
+++ b/ui/src/components/secret-select.tsx
@@ -17,16 +17,16 @@
  * License-Filename: LICENSE
  */
 
+import { Check, ChevronsUpDown } from 'lucide-react';
+import { useState } from 'react';
+
+import { SearchableInfiniteList } from '@/components/searchable-infinite-list';
+import { Button } from '@/components/ui/button';
+import { CommandItem } from '@/components/ui/command';
 import { FormControl } from '@/components/ui/form';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { capitalize } from '@/helpers/capitalize';
 import { useSecrets, UseSecretsParams } from '@/hooks/use-secrets';
+import { cn } from '@/lib/utils';
 
 type SecretSelectProps = {
   /** The name of the selected secret, empty when nothing is selected yet. */
@@ -44,6 +44,10 @@ type SecretSelectProps = {
  * A field for picking one of the secrets of a hierarchy. Which levels it offers depends on the ids
  * that are given and on what the user is allowed to read.
  *
+ * The secrets are read a page at a time, and only while the list is open. The trigger shows the
+ * name that is selected as it is, without looking it up, so that a name saved earlier is shown even
+ * when the page it is on has not been read.
+ *
  * Render it inside a `FormField`, as it brings the `FormControl` of the field with it.
  */
 export const SecretSelect = ({
@@ -56,25 +60,66 @@ export const SecretSelect = ({
   permissions,
   className,
 }: SecretSelectProps) => {
-  const secrets = useSecrets({ orgId, productId, repositoryId, permissions });
+  const [open, setOpen] = useState(false);
+  const secrets = useSecrets({
+    orgId,
+    productId,
+    repositoryId,
+    permissions,
+    enabled: open,
+  });
 
   return (
-    <Select value={value || undefined} onValueChange={onChange}>
-      <FormControl>
-        <SelectTrigger className={className}>
-          <SelectValue placeholder={placeholder} />
-        </SelectTrigger>
-      </FormControl>
-      <SelectContent>
-        {secrets.map((secret) => (
-          <SelectItem
-            key={`${secret.hierarchy}:${secret.name}`}
-            value={secret.name}
+    <SearchableInfiniteList
+      trigger={
+        <FormControl>
+          <Button
+            variant='outline'
+            role='combobox'
+            aria-expanded={open}
+            className={cn(
+              'w-full justify-between gap-2 font-normal',
+              className
+            )}
           >
+            <span
+              className={cn(
+                'min-w-0 truncate text-left',
+                !value && 'text-muted-foreground'
+              )}
+            >
+              {value || placeholder}
+            </span>
+            <ChevronsUpDown className='ml-2 h-4 w-4 shrink-0 opacity-50' />
+          </Button>
+        </FormControl>
+      }
+      open={open}
+      onOpenChange={setOpen}
+      list={secrets}
+      getItemKey={(secret) => `${secret.hierarchy}:${secret.name}`}
+      renderItem={(secret) => (
+        <CommandItem
+          value={`${secret.hierarchy}:${secret.name}`}
+          onSelect={() => {
+            onChange(secret.name);
+            setOpen(false);
+          }}
+        >
+          <Check
+            className={cn(
+              'mr-2 h-4 w-4',
+              secret.name === value ? 'opacity-100' : 'opacity-0'
+            )}
+          />
+          <span className='truncate'>
             {`${secret.name} (${capitalize(secret.hierarchy)})`}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
+          </span>
+        </CommandItem>
+      )}
+      searchable={false}
+      emptyMessage='No secrets found.'
+      errorMessage='Failed to load secrets'
+    />
   );
 };

--- a/ui/src/components/secret-select.tsx
+++ b/ui/src/components/secret-select.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { FormControl } from '@/components/ui/form';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { capitalize } from '@/helpers/capitalize';
+import { useSecrets, UseSecretsParams } from '@/hooks/use-secrets';
+
+type SecretSelectProps = {
+  /** The name of the selected secret, empty when nothing is selected yet. */
+  value: string | undefined;
+  onChange: (value: string) => void;
+  placeholder: string;
+  orgId?: string;
+  productId?: string;
+  repositoryId?: string;
+  permissions: UseSecretsParams['permissions'];
+  className?: string;
+};
+
+/**
+ * A field for picking one of the secrets of a hierarchy. Which levels it offers depends on the ids
+ * that are given and on what the user is allowed to read.
+ *
+ * Render it inside a `FormField`, as it brings the `FormControl` of the field with it.
+ */
+export const SecretSelect = ({
+  value,
+  onChange,
+  placeholder,
+  orgId,
+  productId,
+  repositoryId,
+  permissions,
+  className,
+}: SecretSelectProps) => {
+  const secrets = useSecrets({ orgId, productId, repositoryId, permissions });
+
+  return (
+    <Select value={value || undefined} onValueChange={onChange}>
+      <FormControl>
+        <SelectTrigger className={className}>
+          <SelectValue placeholder={placeholder} />
+        </SelectTrigger>
+      </FormControl>
+      <SelectContent>
+        {secrets.map((secret) => (
+          <SelectItem
+            key={`${secret.hierarchy}:${secret.name}`}
+            value={secret.name}
+          >
+            {`${secret.name} (${capitalize(secret.hierarchy)})`}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+};

--- a/ui/src/components/siblings.tsx
+++ b/ui/src/components/siblings.tsx
@@ -38,7 +38,6 @@ import {
   getRepositoryRunsInfiniteOptions,
   getRepositoryRunsOptions,
 } from '@/api/@tanstack/react-query.gen';
-import { PagingData } from '@/api/types.gen';
 import { SearchableInfiniteList } from '@/components/searchable-infinite-list';
 import { BreadcrumbItem, BreadcrumbLink } from '@/components/ui/breadcrumb';
 import { Button } from '@/components/ui/button';
@@ -46,6 +45,7 @@ import { CommandItem } from '@/components/ui/command';
 import { useDebounce } from '@/hooks/use-debounce';
 import { useInfiniteList } from '@/hooks/use-infinite-list';
 import { DROPDOWN_PAGE_SIZE } from '@/lib/constants';
+import { PagedResponse } from '@/lib/infinite-list';
 import { toSearchFilter } from '@/lib/regex';
 
 type SiblingsProps = {
@@ -68,7 +68,7 @@ const staleTime = 2 * 60 * 60 * 1000;
  * dropdown shows leaves it alone.
  */
 function useTotalCount<
-  TData extends { pagination: PagingData },
+  TData extends PagedResponse<unknown>,
   TQueryKey extends QueryKey,
 >(
   {

--- a/ui/src/hooks/use-infinite-list.ts
+++ b/ui/src/hooks/use-infinite-list.ts
@@ -25,16 +25,11 @@ import {
   type SkipToken,
 } from '@tanstack/react-query';
 
-import { PagingData } from '@/api/types.gen';
-
-/**
- * The shape shared by all the paged endpoints of the API, that is, by every generated
- * `PagedResponse*` type.
- */
-type PagedResponse<TItem> = {
-  data: Array<TItem>;
-  pagination: PagingData;
-};
+import {
+  getNextPageParam,
+  type InfiniteList,
+  type PagedResponse,
+} from '@/lib/infinite-list';
 
 /**
  * The parts of the generated `*InfiniteOptions` the hook actually needs. Everything else they carry
@@ -59,32 +54,6 @@ type InfiniteListQueryOptions = {
   staleTime?: number;
   gcTime?: number;
 };
-
-/**
- * What the hook gives back, so that components can take a list without repeating the generics.
- */
-export type InfiniteList<TItem> = {
-  items: Array<TItem>;
-  totalCount: number;
-  isPending: boolean;
-  isError: boolean;
-  error: Error | null;
-  hasNextPage: boolean;
-  isFetchingNextPage: boolean;
-  fetchNextPage: () => void;
-};
-
-/**
- * Work out the offset the next page has to be requested at, based on the page that was received
- * last. Return `undefined` once the whole `totalCount` has been read, which tells the query that
- * there is nothing more to load.
- */
-export function getNextPageParam(lastPage: PagedResponse<unknown>) {
-  const { limit, offset, totalCount } = lastPage.pagination;
-  const next = offset + limit;
-
-  return next < totalCount ? next : undefined;
-}
 
 /**
  * Load a paged endpoint of the API one page at a time.

--- a/ui/src/hooks/use-infrastructure-services.ts
+++ b/ui/src/hooks/use-infrastructure-services.ts
@@ -17,15 +17,15 @@
  * License-Filename: LICENSE
  */
 
-import { useQueries } from '@tanstack/react-query';
-
 import { InfrastructureService } from '@/api';
 import {
-  getOrganizationInfrastructureServicesOptions,
-  getProductInfrastructureServicesOptions,
-  getRepositoryInfrastructureServicesOptions,
+  getOrganizationInfrastructureServicesInfiniteOptions,
+  getProductInfrastructureServicesInfiniteOptions,
+  getRepositoryInfrastructureServicesInfiniteOptions,
 } from '@/api/@tanstack/react-query.gen';
-import { ALL_ITEMS } from '@/lib/constants';
+import { useInfiniteList } from '@/hooks/use-infinite-list';
+import { DROPDOWN_PAGE_SIZE } from '@/lib/constants';
+import { combineInfiniteLists, InfiniteList } from '@/lib/infinite-list';
 import {
   OrganizationPermissions,
   ProductPermissions,
@@ -45,72 +45,80 @@ type UseInfrastructureServicesParams = {
     product: ProductPermissions | undefined;
     repository: RepositoryPermissions | undefined;
   };
+  /** Whether to read anything at all, so that a closed dropdown costs no request. */
+  enabled?: boolean;
 };
 
+// Infrastructure services are not expected to change while a form is open, and closing a dropdown
+// only turns its queries off. Without a stale time, opening it again would read every page that was
+// loaded before.
+const staleTime = 2 * 60 * 60 * 1000;
+
+/**
+ * Read the infrastructure services a user can pick from, a page at a time, as one list of the
+ * organization, product and repository services, in that order. Which levels it reads depends on
+ * the ids that are given and on what the user is allowed to read.
+ */
 export const useInfrastructureServices = ({
   orgId,
   productId,
   repoId,
   permissions,
-}: UseInfrastructureServicesParams) => {
-  // Only fetch infrastructure services the user has access to.
-  const infrastructureServices = useQueries({
-    queries: [
-      {
-        ...getOrganizationInfrastructureServicesOptions({
-          path: {
-            organizationId: Number.parseInt(orgId || ''),
-          },
-          query: {
-            limit: ALL_ITEMS,
-          },
-        }),
-        enabled: permissions.organization?.includes('READ'),
-      },
-      {
-        ...getProductInfrastructureServicesOptions({
-          path: {
-            productId: Number.parseInt(productId || ''),
-          },
-          query: {
-            limit: ALL_ITEMS,
-          },
-        }),
-        enabled: permissions.product?.includes('READ'),
-      },
-      {
-        ...getRepositoryInfrastructureServicesOptions({
-          path: {
-            repositoryId: Number.parseInt(repoId || ''),
-          },
-          query: {
-            limit: ALL_ITEMS,
-          },
-        }),
-        enabled: permissions.repository?.includes('READ'),
-      },
-    ],
-    combine: (results) => {
-      const [orgServices, productServices, repoServices] = results;
-      // Combine all infrastructure services into an array of objects.
-      // Each object contains the name of the service and to which hierarchy
-      // level it belongs (organization, product, repository).
-      return [
-        ...(orgServices.data?.data?.map((service) => ({
-          ...service,
-          hierarchy: 'organization',
-        })) ?? []),
-        ...(productServices.data?.data?.map((service) => ({
-          ...service,
-          hierarchy: 'product',
-        })) ?? []),
-        ...(repoServices.data?.data?.map((service) => ({
-          ...service,
-          hierarchy: 'repository',
-        })) ?? []),
-      ];
-    },
-  }) as InfrastructureServiceWithHierarchy[];
+  enabled = true,
+}: UseInfrastructureServicesParams): InfiniteList<InfrastructureServiceWithHierarchy> => {
+  const readsOrganization =
+    enabled && !!orgId && !!permissions.organization?.includes('READ');
+  const readsProduct =
+    enabled && !!productId && !!permissions.product?.includes('READ');
+  const readsRepository =
+    enabled && !!repoId && !!permissions.repository?.includes('READ');
 
-  return infrastructureServices;
+  const organizationServices = useInfiniteList(
+    getOrganizationInfrastructureServicesInfiniteOptions({
+      path: { organizationId: Number.parseInt(orgId || '') },
+      query: { limit: DROPDOWN_PAGE_SIZE },
+    }),
+    { enabled: readsOrganization, staleTime: staleTime }
+  );
+
+  const productServices = useInfiniteList(
+    getProductInfrastructureServicesInfiniteOptions({
+      path: { productId: Number.parseInt(productId || '') },
+      query: { limit: DROPDOWN_PAGE_SIZE },
+    }),
+    { enabled: readsProduct, staleTime: staleTime }
+  );
+
+  const repositoryServices = useInfiniteList(
+    getRepositoryInfrastructureServicesInfiniteOptions({
+      path: { repositoryId: Number.parseInt(repoId || '') },
+      query: { limit: DROPDOWN_PAGE_SIZE },
+    }),
+    { enabled: readsRepository, staleTime: staleTime }
+  );
+
+  // Only the levels that are read are combined, as a query that is turned off never leaves
+  // `pending` and would keep the whole list loading.
+  return combineInfiniteLists([
+    ...(readsOrganization
+      ? [withHierarchy(organizationServices, 'organization')]
+      : []),
+    ...(readsProduct ? [withHierarchy(productServices, 'product')] : []),
+    ...(readsRepository
+      ? [withHierarchy(repositoryServices, 'repository')]
+      : []),
+  ]);
 };
+
+/**
+ * Tag the services of a list with the hierarchy level they belong to.
+ */
+function withHierarchy(
+  list: InfiniteList<InfrastructureService>,
+  hierarchy: InfrastructureServiceWithHierarchy['hierarchy']
+): InfiniteList<InfrastructureServiceWithHierarchy> {
+  return {
+    ...list,
+    items: list.items.map((service) => ({ ...service, hierarchy })),
+  };
+}

--- a/ui/src/hooks/use-secrets.ts
+++ b/ui/src/hooks/use-secrets.ts
@@ -36,7 +36,7 @@ export type SecretWithHierarchy = Secret & {
   hierarchy: 'organization' | 'product' | 'repository';
 };
 
-type UseSecretsParams = {
+export type UseSecretsParams = {
   orgId?: string;
   productId?: string;
   repositoryId?: string;

--- a/ui/src/hooks/use-secrets.ts
+++ b/ui/src/hooks/use-secrets.ts
@@ -17,15 +17,15 @@
  * License-Filename: LICENSE
  */
 
-import { useQueries } from '@tanstack/react-query';
-
 import { Secret } from '@/api';
 import {
-  getOrganizationSecretsOptions,
-  getProductSecretsOptions,
-  getRepositorySecretsOptions,
+  getOrganizationSecretsInfiniteOptions,
+  getProductSecretsInfiniteOptions,
+  getRepositorySecretsInfiniteOptions,
 } from '@/api/@tanstack/react-query.gen';
-import { ALL_ITEMS } from '@/lib/constants';
+import { useInfiniteList } from '@/hooks/use-infinite-list';
+import { DROPDOWN_PAGE_SIZE } from '@/lib/constants';
+import { combineInfiniteLists, InfiniteList } from '@/lib/infinite-list';
 import {
   OrganizationPermissions,
   ProductPermissions,
@@ -45,71 +45,79 @@ export type UseSecretsParams = {
     product: ProductPermissions | undefined;
     repository: RepositoryPermissions | undefined;
   };
+  /** Whether to read anything at all, so that a closed dropdown costs no request. */
+  enabled?: boolean;
 };
 
+// Secrets are not expected to change while a form is open, and closing a dropdown only turns its
+// queries off. Without a stale time, opening it again would read every page that was loaded before.
+const staleTime = 2 * 60 * 60 * 1000;
+
+/**
+ * Read the secrets a user can pick from, a page at a time, as one list of the organization, product
+ * and repository secrets, in that order. Which levels it reads depends on the ids that are given
+ * and on what the user is allowed to read.
+ */
 export function useSecrets({
   orgId,
   productId,
   repositoryId,
   permissions,
-}: UseSecretsParams) {
-  const secrets = useQueries({
-    queries: [
-      {
-        ...getOrganizationSecretsOptions({
-          path: {
-            organizationId: Number.parseInt(orgId || ''),
-          },
-          query: {
-            limit: ALL_ITEMS,
-          },
-        }),
-        enabled: permissions.organization?.includes('READ'),
-      },
-      {
-        ...getProductSecretsOptions({
-          path: {
-            productId: Number.parseInt(productId || ''),
-          },
-          query: {
-            limit: ALL_ITEMS,
-          },
-        }),
-        enabled: permissions.product?.includes('READ'),
-      },
-      {
-        ...getRepositorySecretsOptions({
-          path: {
-            repositoryId: Number.parseInt(repositoryId || ''),
-          },
-          query: {
-            limit: ALL_ITEMS,
-          },
-        }),
-        enabled: permissions.repository?.includes('READ'),
-      },
-    ],
-    combine: (results) => {
-      const [orgSecrets, productSecrets, repoSecrets] = results;
-      // Combine all secrets into an array of objects.
-      // Each object contains the name of the secret and to which hierarchy
-      // level it belongs (organization, product, repository).
-      return [
-        ...(orgSecrets.data?.data?.map((secret) => ({
-          ...secret,
-          hierarchy: 'organization',
-        })) ?? []),
-        ...(productSecrets.data?.data?.map((secret) => ({
-          ...secret,
-          hierarchy: 'product',
-        })) ?? []),
-        ...(repoSecrets.data?.data?.map((secret) => ({
-          ...secret,
-          hierarchy: 'repository',
-        })) ?? []),
-      ];
-    },
-  }) as SecretWithHierarchy[];
+  enabled = true,
+}: UseSecretsParams): InfiniteList<SecretWithHierarchy> {
+  const readsOrganization =
+    enabled && !!orgId && !!permissions.organization?.includes('READ');
+  const readsProduct =
+    enabled && !!productId && !!permissions.product?.includes('READ');
+  const readsRepository =
+    enabled && !!repositoryId && !!permissions.repository?.includes('READ');
 
-  return secrets;
+  const organizationSecrets = useInfiniteList(
+    getOrganizationSecretsInfiniteOptions({
+      path: { organizationId: Number.parseInt(orgId || '') },
+      query: { limit: DROPDOWN_PAGE_SIZE },
+    }),
+    { enabled: readsOrganization, staleTime: staleTime }
+  );
+
+  const productSecrets = useInfiniteList(
+    getProductSecretsInfiniteOptions({
+      path: { productId: Number.parseInt(productId || '') },
+      query: { limit: DROPDOWN_PAGE_SIZE },
+    }),
+    { enabled: readsProduct, staleTime: staleTime }
+  );
+
+  const repositorySecrets = useInfiniteList(
+    getRepositorySecretsInfiniteOptions({
+      path: { repositoryId: Number.parseInt(repositoryId || '') },
+      query: { limit: DROPDOWN_PAGE_SIZE },
+    }),
+    { enabled: readsRepository, staleTime: staleTime }
+  );
+
+  // Only the levels that are read are combined, as a query that is turned off never leaves
+  // `pending` and would keep the whole list loading.
+  return combineInfiniteLists([
+    ...(readsOrganization
+      ? [withHierarchy(organizationSecrets, 'organization')]
+      : []),
+    ...(readsProduct ? [withHierarchy(productSecrets, 'product')] : []),
+    ...(readsRepository
+      ? [withHierarchy(repositorySecrets, 'repository')]
+      : []),
+  ]);
+}
+
+/**
+ * Tag the secrets of a list with the hierarchy level they belong to.
+ */
+function withHierarchy(
+  list: InfiniteList<Secret>,
+  hierarchy: SecretWithHierarchy['hierarchy']
+): InfiniteList<SecretWithHierarchy> {
+  return {
+    ...list,
+    items: list.items.map((secret) => ({ ...secret, hierarchy })),
+  };
 }

--- a/ui/src/lib/constants.ts
+++ b/ui/src/lib/constants.ts
@@ -20,13 +20,10 @@
 // Paginated list queries have a "limit" query parameter, which is the maximum number of items to return.
 // When the limit is not set, the queries return a default number of items.
 // Some views need every item at once, rather than a page of them, and set the limit to (an
-// arbitrary) high number to get them:
-// - The issue, rule violation and project tables of a run filter, sort and paginate in the browser,
-//   which they cannot stop doing until those endpoints support filtering, see
-//   https://github.com/eclipse-apoapsis/ort-server/issues/5349.
-// - The secrets and the infrastructure services of a hierarchy are read as one complete list, see
-//   https://github.com/eclipse-apoapsis/ort-server/issues/5646.
-// Both are costly and meant to go away.
+// arbitrary) high number to get them: the issue, rule violation and project tables of a run filter,
+// sort and paginate in the browser, which they cannot stop doing until those endpoints support
+// filtering, see https://github.com/eclipse-apoapsis/ort-server/issues/5349.
+// This is costly and meant to go away.
 // Dropdowns and other lists the user picks from must not use this. They ask for one page at a time,
 // see DROPDOWN_PAGE_SIZE below and the useInfiniteList hook.
 export const ALL_ITEMS = 100000;

--- a/ui/src/lib/infinite-list.ts
+++ b/ui/src/lib/infinite-list.ts
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { PagingData } from '@/api/types.gen';
+
+/**
+ * The shape shared by all the paged endpoints of the API, that is, by every generated
+ * `PagedResponse*` type.
+ */
+export type PagedResponse<TItem> = {
+  data: Array<TItem>;
+  pagination: PagingData;
+};
+
+/**
+ * What the `useInfiniteList` hook gives back, so that components can take a list without repeating
+ * the generics.
+ */
+export type InfiniteList<TItem> = {
+  items: Array<TItem>;
+  totalCount: number;
+  isPending: boolean;
+  isError: boolean;
+  error: Error | null;
+  hasNextPage: boolean;
+  isFetchingNextPage: boolean;
+  fetchNextPage: () => void;
+};
+
+/**
+ * Work out the offset the next page has to be requested at, based on the page that was received
+ * last. Return `undefined` once the whole `totalCount` has been read, which tells the query that
+ * there is nothing more to load.
+ */
+export function getNextPageParam(lastPage: PagedResponse<unknown>) {
+  const { limit, offset, totalCount } = lastPage.pagination;
+  const next = offset + limit;
+
+  return next < totalCount ? next : undefined;
+}

--- a/ui/src/lib/infinite-list.ts
+++ b/ui/src/lib/infinite-list.ts
@@ -54,3 +54,26 @@ export function getNextPageParam(lastPage: PagedResponse<unknown>) {
 
   return next < totalCount ? next : undefined;
 }
+
+/**
+ * Present several infinite lists as a single one, in the order they are given: `fetchNextPage` asks
+ * the first list that still has a page, so a later list grows only once the ones before it have
+ * been read to the end. Pending, error and fetching are true if any list is, which means only
+ * enabled lists may be passed in, as a disabled query never leaves `pending`.
+ */
+export function combineInfiniteLists<TItem>(
+  lists: Array<InfiniteList<TItem>>
+): InfiniteList<TItem> {
+  return {
+    items: lists.flatMap((list) => list.items),
+    totalCount: lists.reduce((total, list) => total + list.totalCount, 0),
+    isPending: lists.some((list) => list.isPending),
+    isError: lists.some((list) => list.isError),
+    error: lists.find((list) => list.error)?.error ?? null,
+    hasNextPage: lists.some((list) => list.hasNextPage),
+    isFetchingNextPage: lists.some((list) => list.isFetchingNextPage),
+    fetchNextPage: () => {
+      lists.find((list) => list.hasNextPage)?.fetchNextPage();
+    },
+  };
+}

--- a/ui/src/routes/organizations/$orgId/infrastructure-services/$serviceName/edit/index.tsx
+++ b/ui/src/routes/organizations/$orgId/infrastructure-services/$serviceName/edit/index.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/api/@tanstack/react-query.gen';
 import { MultiSelectField } from '@/components/form/multi-select-field';
 import { LoadingIndicator } from '@/components/loading-indicator';
+import { SecretSelect } from '@/components/secret-select';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -47,15 +48,6 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { capitalize } from '@/helpers/capitalize';
-import { useSecrets } from '@/hooks/use-secrets';
 import { ApiError } from '@/lib/api-error';
 import { toast, toastError } from '@/lib/toast';
 
@@ -76,11 +68,6 @@ const EditInfrastructureServicePage = () => {
   const navigate = useNavigate();
   const params = Route.useParams();
   const permissions = Route.useRouteContext().permissions;
-
-  const secrets = useSecrets({
-    orgId: params.orgId,
-    permissions,
-  });
 
   const { data: service } = useSuspenseQuery({
     ...getOrganizationInfrastructureServiceOptions({
@@ -196,30 +183,13 @@ const EditInfrastructureServicePage = () => {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Username Secret</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder='Select an existing username secret from the list' />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {secrets.map((secret) => {
-                        const hierarchyLabel = capitalize(secret.hierarchy);
-                        const label = `${secret.name} (${hierarchyLabel})`;
-                        return (
-                          <SelectItem
-                            key={`${secret.hierarchy}:${secret.name}`}
-                            value={secret.name}
-                          >
-                            {label}
-                          </SelectItem>
-                        );
-                      })}
-                    </SelectContent>
-                  </Select>
+                  <SecretSelect
+                    value={field.value}
+                    onChange={field.onChange}
+                    placeholder='Select an existing username secret from the list'
+                    orgId={params.orgId}
+                    permissions={permissions}
+                  />
                   <FormDescription>
                     The name of the organization secret that contains the
                     username of the credentials for the infrastructure service.
@@ -236,30 +206,13 @@ const EditInfrastructureServicePage = () => {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Password Secret</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder='Select an existing password secret from the list' />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {secrets.map((secret) => {
-                        const hierarchyLabel = capitalize(secret.hierarchy);
-                        const label = `${secret.name} (${hierarchyLabel})`;
-                        return (
-                          <SelectItem
-                            key={`${secret.hierarchy}:${secret.name}`}
-                            value={secret.name}
-                          >
-                            {label}
-                          </SelectItem>
-                        );
-                      })}
-                    </SelectContent>
-                  </Select>
+                  <SecretSelect
+                    value={field.value}
+                    onChange={field.onChange}
+                    placeholder='Select an existing password secret from the list'
+                    orgId={params.orgId}
+                    permissions={permissions}
+                  />
                   <FormDescription>
                     The name of the organization secret that contains the
                     password of the credentials for the infrastructure service.

--- a/ui/src/routes/organizations/$orgId/infrastructure-services/create/index.tsx
+++ b/ui/src/routes/organizations/$orgId/infrastructure-services/create/index.tsx
@@ -26,6 +26,7 @@ import { z } from 'zod';
 
 import { postOrganizationInfrastructureServiceMutation } from '@/api/@tanstack/react-query.gen';
 import { MultiSelectField } from '@/components/form/multi-select-field';
+import { SecretSelect } from '@/components/secret-select';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -45,15 +46,6 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { capitalize } from '@/helpers/capitalize';
-import { useSecrets } from '@/hooks/use-secrets';
 import { ApiError } from '@/lib/api-error';
 import { toast, toastError } from '@/lib/toast';
 
@@ -72,11 +64,6 @@ const CreateInfrastructureServicePage = () => {
   const navigate = useNavigate();
   const params = Route.useParams();
   const permissions = Route.useRouteContext().permissions;
-
-  const secrets = useSecrets({
-    orgId: params.orgId,
-    permissions,
-  });
 
   const { mutateAsync, isPending } = useMutation({
     ...postOrganizationInfrastructureServiceMutation(),
@@ -197,30 +184,13 @@ const CreateInfrastructureServicePage = () => {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Username Secret</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder='Select an existing username secret from the list' />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {secrets.map((secret) => {
-                        const hierarchyLabel = capitalize(secret.hierarchy);
-                        const label = `${secret.name} (${hierarchyLabel})`;
-                        return (
-                          <SelectItem
-                            key={`${secret.hierarchy}:${secret.name}`}
-                            value={secret.name}
-                          >
-                            {label}
-                          </SelectItem>
-                        );
-                      })}
-                    </SelectContent>
-                  </Select>
+                  <SecretSelect
+                    value={field.value}
+                    onChange={field.onChange}
+                    placeholder='Select an existing username secret from the list'
+                    orgId={params.orgId}
+                    permissions={permissions}
+                  />
                   <FormDescription>
                     The name of the secret that contains the username of the
                     credentials for the infrastructure service. Please note that
@@ -237,30 +207,13 @@ const CreateInfrastructureServicePage = () => {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Password Secret</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder='Select an existing password secret from the list' />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {secrets.map((secret) => {
-                        const hierarchyLabel = capitalize(secret.hierarchy);
-                        const label = `${secret.name} (${hierarchyLabel})`;
-                        return (
-                          <SelectItem
-                            key={`${secret.hierarchy}:${secret.name}`}
-                            value={secret.name}
-                          >
-                            {label}
-                          </SelectItem>
-                        );
-                      })}
-                    </SelectContent>
-                  </Select>
+                  <SecretSelect
+                    value={field.value}
+                    onChange={field.onChange}
+                    placeholder='Select an existing password secret from the list'
+                    orgId={params.orgId}
+                    permissions={permissions}
+                  />
                   <FormDescription>
                     The name of the secret that contains the password of the
                     credentials for the infrastructure service. Please note that

--- a/ui/src/routes/organizations/$orgId/products/$productId/infrastructure-services/$serviceName/edit/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/infrastructure-services/$serviceName/edit/index.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/api/@tanstack/react-query.gen';
 import { MultiSelectField } from '@/components/form/multi-select-field';
 import { LoadingIndicator } from '@/components/loading-indicator';
+import { SecretSelect } from '@/components/secret-select';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -47,15 +48,6 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { capitalize } from '@/helpers/capitalize';
-import { useSecrets } from '@/hooks/use-secrets';
 import { ApiError } from '@/lib/api-error';
 import { toast, toastError } from '@/lib/toast';
 
@@ -76,12 +68,6 @@ const EditInfrastructureServicePage = () => {
   const navigate = useNavigate();
   const params = Route.useParams();
   const permissions = Route.useRouteContext().permissions;
-
-  const secrets = useSecrets({
-    orgId: params.orgId,
-    productId: params.productId,
-    permissions,
-  });
 
   const { data: service } = useSuspenseQuery({
     ...getProductInfrastructureServiceOptions({
@@ -197,30 +183,14 @@ const EditInfrastructureServicePage = () => {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Username Secret</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder='Select an existing username secret from the list' />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {secrets.map((secret) => {
-                        const hierarchyLabel = capitalize(secret.hierarchy);
-                        const label = `${secret.name} (${hierarchyLabel})`;
-                        return (
-                          <SelectItem
-                            key={`${secret.hierarchy}:${secret.name}`}
-                            value={secret.name}
-                          >
-                            {label}
-                          </SelectItem>
-                        );
-                      })}
-                    </SelectContent>
-                  </Select>
+                  <SecretSelect
+                    value={field.value}
+                    onChange={field.onChange}
+                    placeholder='Select an existing username secret from the list'
+                    orgId={params.orgId}
+                    productId={params.productId}
+                    permissions={permissions}
+                  />
                   <FormDescription>
                     The name of the product secret that contains the username of
                     the credentials for the infrastructure service. Please note
@@ -237,30 +207,14 @@ const EditInfrastructureServicePage = () => {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Password Secret</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder='Select an existing password secret from the list' />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {secrets.map((secret) => {
-                        const hierarchyLabel = capitalize(secret.hierarchy);
-                        const label = `${secret.name} (${hierarchyLabel})`;
-                        return (
-                          <SelectItem
-                            key={`${secret.hierarchy}:${secret.name}`}
-                            value={secret.name}
-                          >
-                            {label}
-                          </SelectItem>
-                        );
-                      })}
-                    </SelectContent>
-                  </Select>
+                  <SecretSelect
+                    value={field.value}
+                    onChange={field.onChange}
+                    placeholder='Select an existing password secret from the list'
+                    orgId={params.orgId}
+                    productId={params.productId}
+                    permissions={permissions}
+                  />
                   <FormDescription>
                     The name of the product secret that contains the password of
                     the credentials for the infrastructure service. Please note

--- a/ui/src/routes/organizations/$orgId/products/$productId/infrastructure-services/create/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/infrastructure-services/create/index.tsx
@@ -26,6 +26,7 @@ import { z } from 'zod';
 
 import { postProductInfrastructureServiceMutation } from '@/api/@tanstack/react-query.gen';
 import { MultiSelectField } from '@/components/form/multi-select-field';
+import { SecretSelect } from '@/components/secret-select';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -45,15 +46,6 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import { capitalize } from '@/helpers/capitalize';
-import { useSecrets } from '@/hooks/use-secrets';
 import { ApiError } from '@/lib/api-error';
 import { toast, toastError } from '@/lib/toast';
 
@@ -72,12 +64,6 @@ const CreateInfrastructureServicePage = () => {
   const navigate = useNavigate();
   const params = Route.useParams();
   const permissions = Route.useRouteContext().permissions;
-
-  const secrets = useSecrets({
-    orgId: params.orgId,
-    productId: params.productId,
-    permissions,
-  });
 
   const { mutateAsync, isPending } = useMutation({
     ...postProductInfrastructureServiceMutation(),
@@ -198,30 +184,14 @@ const CreateInfrastructureServicePage = () => {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Username Secret</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder='Select an existing username secret from the list' />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {secrets.map((secret) => {
-                        const hierarchyLabel = capitalize(secret.hierarchy);
-                        const label = `${secret.name} (${hierarchyLabel})`;
-                        return (
-                          <SelectItem
-                            key={`${secret.hierarchy}:${secret.name}`}
-                            value={secret.name}
-                          >
-                            {label}
-                          </SelectItem>
-                        );
-                      })}
-                    </SelectContent>
-                  </Select>
+                  <SecretSelect
+                    value={field.value}
+                    onChange={field.onChange}
+                    placeholder='Select an existing username secret from the list'
+                    orgId={params.orgId}
+                    productId={params.productId}
+                    permissions={permissions}
+                  />
                   <FormDescription>
                     The name of the product secret that contains the username of
                     the credentials for the infrastructure service. Please note
@@ -238,30 +208,14 @@ const CreateInfrastructureServicePage = () => {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Password Secret</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder='Select an existing password secret from the list' />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {secrets.map((secret) => {
-                        const hierarchyLabel = capitalize(secret.hierarchy);
-                        const label = `${secret.name} (${hierarchyLabel})`;
-                        return (
-                          <SelectItem
-                            key={`${secret.hierarchy}:${secret.name}`}
-                            value={secret.name}
-                          >
-                            {label}
-                          </SelectItem>
-                        );
-                      })}
-                    </SelectContent>
-                  </Select>
+                  <SecretSelect
+                    value={field.value}
+                    onChange={field.onChange}
+                    placeholder='Select an existing password secret from the list'
+                    orgId={params.orgId}
+                    productId={params.productId}
+                    permissions={permissions}
+                  />
                   <FormDescription>
                     The name of the product secret that contains the password of
                     the credentials for the infrastructure service. Please note

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
@@ -30,6 +30,7 @@ import {
 import { zAnalyzerPhase } from '@/api/zod.gen';
 import { MultiSelectField } from '@/components/form/multi-select-field.tsx';
 import { PluginMultiSelectField } from '@/components/form/plugin-multi-select-field.tsx';
+import { SecretSelect } from '@/components/secret-select';
 import { InlineCode } from '@/components/typography.tsx';
 import {
   AccordionContent,
@@ -46,17 +47,9 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
 import { capitalize } from '@/helpers/capitalize';
 import { useInfrastructureServices } from '@/hooks/use-infrastructure-services.ts';
-import { useSecrets } from '@/hooks/use-secrets';
 import {
   OrganizationPermissions,
   ProductPermissions,
@@ -106,13 +99,6 @@ export const AnalyzerFields = ({
     orgId,
     productId,
     repoId,
-    permissions,
-  });
-
-  const secrets = useSecrets({
-    orgId,
-    productId,
-    repositoryId: repoId,
     permissions,
   });
 
@@ -267,49 +253,28 @@ export const AnalyzerFields = ({
                         <FormField
                           control={form.control}
                           name={`jobConfigs.analyzer.environmentVariables.${index}.secretName`}
-                          render={({ field }) => {
-                            const selectedValue =
-                              typeof field.value === 'string' &&
-                              field.value.length > 0
-                                ? field.value
-                                : undefined;
-                            return (
-                              <FormItem>
-                                {index === 0 && (
-                                  <FormLabel>{secondColumnLabel}</FormLabel>
-                                )}
-                                <Select
-                                  value={selectedValue}
-                                  onValueChange={(value) => {
-                                    field.onChange(value);
-                                  }}
-                                >
-                                  <FormControl>
-                                    <SelectTrigger className='w-full'>
-                                      <SelectValue placeholder='Select a secret' />
-                                    </SelectTrigger>
-                                  </FormControl>
-                                  <SelectContent>
-                                    {secrets.map((secret) => {
-                                      const hierarchyLabel = capitalize(
-                                        secret.hierarchy
-                                      );
-                                      const label = `${secret.name} (${hierarchyLabel})`;
-                                      return (
-                                        <SelectItem
-                                          key={`${secret.hierarchy}:${secret.name}`}
-                                          value={secret.name}
-                                        >
-                                          {label}
-                                        </SelectItem>
-                                      );
-                                    })}
-                                  </SelectContent>
-                                </Select>
-                                <FormMessage />
-                              </FormItem>
-                            );
-                          }}
+                          render={({ field }) => (
+                            <FormItem>
+                              {index === 0 && (
+                                <FormLabel>{secondColumnLabel}</FormLabel>
+                              )}
+                              <SecretSelect
+                                value={
+                                  typeof field.value === 'string'
+                                    ? field.value
+                                    : undefined
+                                }
+                                onChange={field.onChange}
+                                placeholder='Select a secret'
+                                orgId={orgId}
+                                productId={productId}
+                                repositoryId={repoId}
+                                permissions={permissions}
+                                className='w-full'
+                              />
+                              <FormMessage />
+                            </FormItem>
+                          )}
                         />
                       ) : (
                         <FormField

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
@@ -19,14 +19,9 @@
 
 import { useParams } from '@tanstack/react-router';
 import { PlusIcon, TrashIcon } from 'lucide-react';
-import { useEffect } from 'react';
 import { useFieldArray, UseFormReturn } from 'react-hook-form';
 
-import {
-  InfrastructureService,
-  PreconfiguredPluginDescriptor,
-  Secret,
-} from '@/api';
+import { PreconfiguredPluginDescriptor, Secret } from '@/api';
 import { zAnalyzerPhase } from '@/api/zod.gen';
 import { MultiSelectField } from '@/components/form/multi-select-field.tsx';
 import { PluginMultiSelectField } from '@/components/form/plugin-multi-select-field.tsx';
@@ -49,7 +44,6 @@ import {
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
 import { capitalize } from '@/helpers/capitalize';
-import { useInfrastructureServices } from '@/hooks/use-infrastructure-services.ts';
 import {
   OrganizationPermissions,
   ProductPermissions,
@@ -94,26 +88,6 @@ export const AnalyzerFields = ({
     name: 'jobConfigs.analyzer.environmentVariables',
     control: form.control,
   });
-
-  const infrastructureServices = useInfrastructureServices({
-    orgId,
-    productId,
-    repoId,
-    permissions,
-  });
-
-  // Keep the form in sync with the latest infrastructure services fetched for all hierarchy levels.
-  useEffect(() => {
-    const sanitized = infrastructureServices.map((serviceWithHierarchy) => {
-      const { hierarchy, ...service } = serviceWithHierarchy;
-      void hierarchy; // Explicitly ignore the hierarchy helper field.
-      return service;
-    }) as InfrastructureService[];
-
-    form.setValue('jobConfigs.analyzer.infrastructureServices', sanitized, {
-      shouldDirty: false,
-    });
-  }, [form, infrastructureServices]);
 
   const keepAliveWorker = form.watch('jobConfigs.analyzer.keepAliveWorker');
 

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/analyzer-fields.tsx
@@ -340,10 +340,7 @@ export const AnalyzerFields = ({
               </Button>
             </div>
           </div>
-          <EnvironmentDefinitionsFields
-            form={form}
-            infrastructureServices={infrastructureServices}
-          />
+          <EnvironmentDefinitionsFields form={form} />
           <PackageManagerField form={form} />
           <PluginMultiSelectField
             form={form}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/environment-definitions.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/environment-definitions.tsx
@@ -21,6 +21,7 @@ import { PlusIcon, TrashIcon } from 'lucide-react';
 import { ReactNode } from 'react';
 import { FieldPath, UseFormReturn } from 'react-hook-form';
 
+import { InfrastructureServiceSelect } from '@/components/infrastructure-service-select';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import {
@@ -40,8 +41,6 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Switch } from '@/components/ui/switch';
-import { capitalize } from '@/helpers/capitalize';
-import { InfrastructureServiceWithHierarchy } from '@/hooks/use-infrastructure-services';
 import {
   ENVIRONMENT_DEFINITION_SCHEMAS,
   EnvironmentDefinitionSchema,
@@ -58,7 +57,6 @@ type PackageManagerFieldProps = {
   index: number;
   entry: FieldEntry;
   form: UseFormReturn<CreateRunFormValues>;
-  infrastructureServices: InfrastructureServiceWithHierarchy[];
 };
 
 function PackageManagerField({
@@ -66,7 +64,6 @@ function PackageManagerField({
   index,
   entry,
   form,
-  infrastructureServices,
 }: PackageManagerFieldProps): ReactNode {
   const name =
     `jobConfigs.analyzer.environmentDefinitions.${pmKey}.${index}.${entry.key}` as FieldPath<CreateRunFormValues>;
@@ -77,47 +74,27 @@ function PackageManagerField({
       <FormField
         control={form.control}
         name={name}
-        render={({ field }) => {
-          const value =
-            typeof field.value === 'string' && field.value.length > 0
-              ? field.value
-              : undefined;
-          return (
-            <FormItem>
-              <FormLabel>Service</FormLabel>
-              <Select
-                value={value}
-                onValueChange={(v) => {
-                  form.setValue(name, v, {
-                    shouldDirty: true,
-                    shouldTouch: true,
-                    shouldValidate: true,
-                  });
-                }}
-              >
-                <FormControl>
-                  <SelectTrigger className='w-full'>
-                    <SelectValue placeholder='Select an infrastructure service' />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                  {infrastructureServices.map((service) => (
-                    <SelectItem
-                      key={`${service.hierarchy}:${service.name}`}
-                      value={service.name}
-                    >
-                      {`${service.name} (${capitalize(service.hierarchy)})`}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              <FormDescription>
-                Select the infrastructure service from a chosen hierarchy level.
-              </FormDescription>
-              <FormMessage />
-            </FormItem>
-          );
-        }}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>Service</FormLabel>
+            <InfrastructureServiceSelect
+              value={typeof field.value === 'string' ? field.value : undefined}
+              onChange={(service) => {
+                form.setValue(name, service, {
+                  shouldDirty: true,
+                  shouldTouch: true,
+                  shouldValidate: true,
+                });
+              }}
+              placeholder='Select an infrastructure service'
+              className='w-full'
+            />
+            <FormDescription>
+              Select the infrastructure service from a chosen hierarchy level.
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
       />
     );
   }
@@ -220,7 +197,6 @@ function PackageManagerField({
 
 type EnvironmentDefinitionsFieldsProps = {
   form: UseFormReturn<CreateRunFormValues>;
-  infrastructureServices: InfrastructureServiceWithHierarchy[];
 };
 
 type EnvironmentDefinitionCard = {
@@ -243,7 +219,6 @@ function definitionsAsRecord(
 
 export const EnvironmentDefinitionsFields = ({
   form,
-  infrastructureServices,
 }: EnvironmentDefinitionsFieldsProps) => {
   const environmentDefinitions = definitionsAsRecord(
     form.watch('jobConfigs.analyzer.environmentDefinitions')
@@ -385,7 +360,6 @@ export const EnvironmentDefinitionsFields = ({
                   index={card.index}
                   entry={entry}
                   form={form}
-                  infrastructureServices={infrastructureServices}
                 />
               ))}
             </CardContent>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/default-values.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/default-values.ts
@@ -123,7 +123,6 @@ export function defaultValues(
         skipExcluded: true,
         keepAliveWorker: false,
         keepAlivePhases: [],
-        infrastructureServices: [],
         packageCurationProviders: [],
         packageCurationProviderConfig:
           packageCurationProviderPluginDefaultValues,
@@ -247,10 +246,6 @@ export function defaultValues(
             environmentVariables:
               ortRun.jobConfigs.analyzer?.environmentConfig
                 ?.environmentVariables || undefined,
-            infrastructureServices:
-              ortRun.jobConfigs.analyzer?.environmentConfig
-                ?.infrastructureServices ||
-              baseDefaults.jobConfigs.analyzer.infrastructureServices,
             packageCurationProviders:
               packageCurationProviderFormValues.selectedPluginIds,
             packageCurationProviderConfig: mergePluginConfigs(

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/run-schema.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/run-schema.ts
@@ -21,7 +21,7 @@ import { FieldErrors } from 'react-hook-form';
 import { z } from 'zod';
 
 import { PreconfiguredPluginDescriptor } from '@/api';
-import { zAnalyzerPhase, zInfrastructureService } from '@/api/zod.gen';
+import { zAnalyzerPhase } from '@/api/zod.gen';
 import { environmentDefinitionsSchema } from '@/lib/types';
 import {
   environmentVariableSchema,
@@ -76,7 +76,6 @@ export const createRunFormSchema = (
             skipExcluded: z.boolean(),
             environmentDefinitions: environmentDefinitionsSchema.optional(),
             environmentVariables: z.array(environmentVariableSchema).optional(),
-            infrastructureServices: z.array(zInfrastructureService).optional(),
             keepAliveWorker: z.boolean(),
             keepAlivePhases: z.array(zAnalyzerPhase).optional(),
             packageCurationProviders: z.array(z.string()),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/infrastructure-services/$serviceName/edit/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/infrastructure-services/$serviceName/edit/index.tsx
@@ -30,6 +30,7 @@ import {
 } from '@/api/@tanstack/react-query.gen';
 import { MultiSelectField } from '@/components/form/multi-select-field.tsx';
 import { LoadingIndicator } from '@/components/loading-indicator.tsx';
+import { SecretSelect } from '@/components/secret-select';
 import { Button } from '@/components/ui/button.tsx';
 import {
   Card,
@@ -47,15 +48,6 @@ import {
   FormMessage,
 } from '@/components/ui/form.tsx';
 import { Input } from '@/components/ui/input.tsx';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select.tsx';
-import { capitalize } from '@/helpers/capitalize';
-import { useSecrets } from '@/hooks/use-secrets';
 import { ApiError } from '@/lib/api-error';
 import { toast, toastError } from '@/lib/toast';
 
@@ -76,13 +68,6 @@ const EditInfrastructureServicePage = () => {
   const navigate = useNavigate();
   const params = Route.useParams();
   const permissions = Route.useRouteContext().permissions;
-
-  const secrets = useSecrets({
-    orgId: params.orgId,
-    productId: params.productId,
-    repositoryId: params.repoId,
-    permissions,
-  });
 
   const { data: service } = useSuspenseQuery({
     ...getRepositoryInfrastructureServiceOptions({
@@ -202,30 +187,15 @@ const EditInfrastructureServicePage = () => {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Username Secret</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder='Select an existing username secret from the list' />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {secrets.map((secret) => {
-                        const hierarchyLabel = capitalize(secret.hierarchy);
-                        const label = `${secret.name} (${hierarchyLabel})`;
-                        return (
-                          <SelectItem
-                            key={`${secret.hierarchy}:${secret.name}`}
-                            value={secret.name}
-                          >
-                            {label}
-                          </SelectItem>
-                        );
-                      })}
-                    </SelectContent>
-                  </Select>
+                  <SecretSelect
+                    value={field.value}
+                    onChange={field.onChange}
+                    placeholder='Select an existing username secret from the list'
+                    orgId={params.orgId}
+                    productId={params.productId}
+                    repositoryId={params.repoId}
+                    permissions={permissions}
+                  />
                   <FormDescription>
                     The name of the repository secret that contains the username
                     of the credentials for the infrastructure service. Please
@@ -242,30 +212,15 @@ const EditInfrastructureServicePage = () => {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Password Secret</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder='Select an existing password secret from the list' />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {secrets.map((secret) => {
-                        const hierarchyLabel = capitalize(secret.hierarchy);
-                        const label = `${secret.name} (${hierarchyLabel})`;
-                        return (
-                          <SelectItem
-                            key={`${secret.hierarchy}:${secret.name}`}
-                            value={secret.name}
-                          >
-                            {label}
-                          </SelectItem>
-                        );
-                      })}
-                    </SelectContent>
-                  </Select>
+                  <SecretSelect
+                    value={field.value}
+                    onChange={field.onChange}
+                    placeholder='Select an existing password secret from the list'
+                    orgId={params.orgId}
+                    productId={params.productId}
+                    repositoryId={params.repoId}
+                    permissions={permissions}
+                  />
                   <FormDescription>
                     The name of the repository secret that contains the password
                     of the credentials for the infrastructure service. Please

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/infrastructure-services/create/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/infrastructure-services/create/index.tsx
@@ -26,6 +26,7 @@ import { z } from 'zod';
 
 import { postRepositoryInfrastructureServiceMutation } from '@/api/@tanstack/react-query.gen';
 import { MultiSelectField } from '@/components/form/multi-select-field.tsx';
+import { SecretSelect } from '@/components/secret-select';
 import { Button } from '@/components/ui/button.tsx';
 import {
   Card,
@@ -45,15 +46,6 @@ import {
   FormMessage,
 } from '@/components/ui/form.tsx';
 import { Input } from '@/components/ui/input.tsx';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select.tsx';
-import { capitalize } from '@/helpers/capitalize';
-import { useSecrets } from '@/hooks/use-secrets';
 import { ApiError } from '@/lib/api-error';
 import { toast, toastError } from '@/lib/toast';
 
@@ -72,13 +64,6 @@ const CreateInfrastructureServicePage = () => {
   const navigate = useNavigate();
   const params = Route.useParams();
   const permissions = Route.useRouteContext().permissions;
-
-  const secrets = useSecrets({
-    orgId: params.orgId,
-    productId: params.productId,
-    repositoryId: params.repoId,
-    permissions,
-  });
 
   const { mutateAsync, isPending } = useMutation({
     ...postRepositoryInfrastructureServiceMutation(),
@@ -203,30 +188,15 @@ const CreateInfrastructureServicePage = () => {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Username Secret</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder='Select an existing username secret from the list' />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {secrets.map((secret) => {
-                        const hierarchyLabel = capitalize(secret.hierarchy);
-                        const label = `${secret.name} (${hierarchyLabel})`;
-                        return (
-                          <SelectItem
-                            key={`${secret.hierarchy}:${secret.name}`}
-                            value={secret.name}
-                          >
-                            {label}
-                          </SelectItem>
-                        );
-                      })}
-                    </SelectContent>
-                  </Select>
+                  <SecretSelect
+                    value={field.value}
+                    onChange={field.onChange}
+                    placeholder='Select an existing username secret from the list'
+                    orgId={params.orgId}
+                    productId={params.productId}
+                    repositoryId={params.repoId}
+                    permissions={permissions}
+                  />
                   <FormDescription>
                     The name of the secret that contains the username of the
                     credentials for the infrastructure service. Please note that
@@ -243,30 +213,15 @@ const CreateInfrastructureServicePage = () => {
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Password Secret</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder='Select an existing password secret from the list' />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {secrets.map((secret) => {
-                        const hierarchyLabel = capitalize(secret.hierarchy);
-                        const label = `${secret.name} (${hierarchyLabel})`;
-                        return (
-                          <SelectItem
-                            key={`${secret.hierarchy}:${secret.name}`}
-                            value={secret.name}
-                          >
-                            {label}
-                          </SelectItem>
-                        );
-                      })}
-                    </SelectContent>
-                  </Select>
+                  <SecretSelect
+                    value={field.value}
+                    onChange={field.onChange}
+                    placeholder='Select an existing password secret from the list'
+                    orgId={params.orgId}
+                    productId={params.productId}
+                    repositoryId={params.repoId}
+                    permissions={permissions}
+                  />
                   <FormDescription>
                     The name of the secret that contains the password of the
                     credentials for the infrastructure service. Please note that

--- a/ui/tests/unit/logic/infinite-list.test.ts
+++ b/ui/tests/unit/logic/infinite-list.test.ts
@@ -17,9 +17,13 @@
  * License-Filename: LICENSE
  */
 
-import { expect, it } from 'vitest';
+import { expect, it, vi } from 'vitest';
 
-import { getNextPageParam } from '@/lib/infinite-list';
+import {
+  combineInfiniteLists,
+  getNextPageParam,
+  type InfiniteList,
+} from '@/lib/infinite-list';
 
 /**
  * Build a page of the given size, as the API would return it. The items themselves do not matter
@@ -75,4 +79,104 @@ it.each([
   },
 ])('getNextPageParam - $name', ({ page, expected }) => {
   expect(getNextPageParam(page)).toBe(expected);
+});
+
+/**
+ * Build a list of the given entries, as `useInfiniteList` would hand it over once it has loaded
+ * them all. A case that is about something else than the entries says so through the overrides.
+ */
+const list = (
+  items: string[],
+  overrides: Partial<InfiniteList<string>> = {}
+): InfiniteList<string> => ({
+  items,
+  totalCount: items.length,
+  isPending: false,
+  isError: false,
+  error: null,
+  hasNextPage: false,
+  isFetchingNextPage: false,
+  fetchNextPage: () => {},
+  ...overrides,
+});
+
+it('combineInfiniteLists - shows the lists one after another', () => {
+  const combined = combineInfiniteLists([
+    list(['org-a', 'org-b']),
+    list(['product-a']),
+    list(['repository-a']),
+  ]);
+
+  expect(combined.items).toEqual([
+    'org-a',
+    'org-b',
+    'product-a',
+    'repository-a',
+  ]);
+});
+
+it('combineInfiniteLists - counts the entries of every list', () => {
+  const combined = combineInfiniteLists([
+    list(['org-a'], { totalCount: 120 }),
+    list(['product-a'], { totalCount: 7 }),
+    list([], { totalCount: 0 }),
+  ]);
+
+  expect(combined.totalCount).toBe(127);
+});
+
+it('combineInfiniteLists - asks the first list that still has a page', () => {
+  const exhausted = vi.fn();
+  const next = vi.fn();
+  const later = vi.fn();
+
+  const combined = combineInfiniteLists([
+    list(['org-a'], { fetchNextPage: exhausted }),
+    list(['product-a'], { hasNextPage: true, fetchNextPage: next }),
+    list(['repository-a'], { hasNextPage: true, fetchNextPage: later }),
+  ]);
+  combined.fetchNextPage();
+
+  expect(combined.hasNextPage).toBe(true);
+  expect(next).toHaveBeenCalledOnce();
+  expect(exhausted).not.toHaveBeenCalled();
+  expect(later).not.toHaveBeenCalled();
+});
+
+it('combineInfiniteLists - is out of pages once every list is', () => {
+  const fetchNextPage = vi.fn();
+
+  const combined = combineInfiniteLists([
+    list(['org-a'], { fetchNextPage }),
+    list(['product-a'], { fetchNextPage }),
+  ]);
+  combined.fetchNextPage();
+
+  expect(combined.hasNextPage).toBe(false);
+  expect(fetchNextPage).not.toHaveBeenCalled();
+});
+
+it('combineInfiniteLists - stays pending while any list is', () => {
+  const loading = combineInfiniteLists([
+    list([], { isPending: true }),
+    list(['product-a']),
+  ]);
+
+  expect(loading.isPending).toBe(true);
+  expect(combineInfiniteLists([list([]), list(['product-a'])]).isPending).toBe(
+    false
+  );
+});
+
+it('combineInfiniteLists - reports the first error', () => {
+  const error = new Error('Failed to load the products');
+
+  const combined = combineInfiniteLists([
+    list(['org-a']),
+    list([], { isError: true, error }),
+    list([], { isError: true, error: new Error('And the repositories') }),
+  ]);
+
+  expect(combined.isError).toBe(true);
+  expect(combined.error).toBe(error);
 });

--- a/ui/tests/unit/logic/infinite-list.test.ts
+++ b/ui/tests/unit/logic/infinite-list.test.ts
@@ -19,7 +19,7 @@
 
 import { expect, it } from 'vitest';
 
-import { getNextPageParam } from '@/hooks/use-infinite-list';
+import { getNextPageParam } from '@/lib/infinite-list';
 
 /**
  * Build a page of the given size, as the API would return it. The items themselves do not matter

--- a/ui/tests/unit/logic/payload.test.ts
+++ b/ui/tests/unit/logic/payload.test.ts
@@ -141,35 +141,6 @@ describe('formValuesToPayload', () => {
     ]);
   });
 
-  it('omits infrastructure services from environment configs', () => {
-    const values = createFormValues();
-    values.jobConfigs.analyzer.environmentDefinitions = {
-      conan: [
-        {
-          service: 'service-a',
-          name: 'private-conan',
-          url: '',
-          verifySsl: 'true',
-        },
-      ],
-    };
-    values.jobConfigs.analyzer.infrastructureServices = [
-      {
-        credentialsTypes: ['NETRC_FILE'],
-        name: 'inherited-service',
-        passwordSecretRef: 'password',
-        url: 'https://example.org/repository',
-        usernameSecretRef: 'username',
-      },
-    ];
-
-    const payload = formValuesToPayload(values);
-
-    expect(payload.jobConfigs.analyzer?.environmentConfig).not.toHaveProperty(
-      'infrastructureServices'
-    );
-  });
-
   it('omits package configuration providers if none are selected', () => {
     const values = createFormValues();
     values.jobConfigs.evaluator.packageConfigurationProviders = [];
@@ -262,15 +233,6 @@ describe('formValuesToPayload', () => {
 
   it('omits the environment config when no environment settings are configured', () => {
     const values = createFormValues();
-    values.jobConfigs.analyzer.infrastructureServices = [
-      {
-        credentialsTypes: ['NETRC_FILE'],
-        name: 'inherited-service',
-        passwordSecretRef: 'password',
-        url: 'https://example.org/repository',
-        usernameSecretRef: 'username',
-      },
-    ];
 
     const payload = formValuesToPayload(values);
 


### PR DESCRIPTION
This PR concludes removing the usage of `ALL_ITEMS` where it has been possible to do solely in the UI. After the PR, there are only three call sites left which use the `ALL_ITEMS` constant: projects, issues, and rule violation tables. All of them need endpoint support from back-end, as stated in #5349.

Please note that testing the PR manually in the UI has been extremely laborious. The author has used LLM for planning and and assisting in the testing, but some quirks might still be left. Manual testing has shown that the expected (now limited) queries do fire logically, with the correct parameters, and no queries run anymore for secrets and infrastructure services with `limit=100000` (the old `ALL_ITEMS` behaviour). It was also verified that the removal of dead code from the create run feature did not cause any adversarial side effects.

Please see the commits for details.