### PR TITLE
ui: Fix query cache invalidation

### DIFF
--- a/ui/src/components/siblings.tsx
+++ b/ui/src/components/siblings.tsx
@@ -55,8 +55,9 @@ type SiblingsProps = {
 
 // To improve the performance of the siblings component, set a stale time of
 // 2 hours for all queries. This is because the entities (organizations, products,
-// repositories, runs) are not expected to change frequently, and when changes do
-// occur, cache invalidation will ensure that the latest data is fetched.
+// repositories, runs) are not expected to change frequently. What keeps a stale
+// time this long honest is `@/lib/entity-cache`, which every mutation of these
+// entities calls to invalidate the lists shown here, the counts below included.
 const staleTime = 2 * 60 * 60 * 1000;
 
 /**

--- a/ui/src/lib/entity-cache.ts
+++ b/ui/src/lib/entity-cache.ts
@@ -1,0 +1,239 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { QueryClient } from '@tanstack/react-query';
+
+import type { Organization, Product, Repository } from '@/api';
+import {
+  getOrganizationProductsQueryKey,
+  getOrganizationQueryKey,
+  getOrganizationsQueryKey,
+  getProductQueryKey,
+  getProductRepositoriesQueryKey,
+  getRepositoryQueryKey,
+  getRepositoryRunQueryKey,
+  getRepositoryRunsQueryKey,
+  getUserInfoQueryKey,
+} from '@/api/@tanstack/react-query.gen';
+
+/**
+ * Cache maintenance for the entities of the hierarchy: organizations, products, repositories and
+ * runs. One function per lifecycle event, so that a call site can be read without knowing which
+ * query keys exist.
+ *
+ * Every list endpoint of these entities is read under three different keys — a `limit: 1` count
+ * query behind a breadcrumb chevron, the paged queries of the tables, and the infinite query of a
+ * dropdown — and a key built from a `path` alone matches all of them, as the generated keys hold
+ * `query` and `_infinite` as extra fields that a partial match ignores. That is why refreshing a
+ * parent list is a single call here, and why it must go through the generated `*QueryKey` functions
+ * rather than a hand-written key.
+ *
+ * Two rules apply to every caller:
+ *
+ * 1. **Invalidate before navigating.** The invalidation has to be in place before the loader of the
+ *    destination route runs, or that route renders stale data and only corrects itself once a
+ *    refetch lands. These functions mark the cache synchronously, so calling one before `navigate`
+ *    is enough; they are not awaited.
+ * 2. **A deleted entity is never refetched.** The settings pages read the entity they delete with
+ *    `useSuspenseQuery`, and navigation does not reliably commit React's unmount before the cache
+ *    settles, so refetching the detail query here would request an entity the backend has just
+ *    removed. The deletion functions therefore pass `refetchType: 'none'`: the detail query is
+ *    marked stale without its active observer fetching, and whoever asks for it next gets the 404
+ *    that is by then the truthful answer.
+ */
+
+/**
+ * Refresh the list of organizations after one was created.
+ */
+export function organizationCreated(queryClient: QueryClient): void {
+  queryClient.invalidateQueries({ queryKey: getOrganizationsQueryKey() });
+}
+
+/**
+ * Seed the cache with an updated organization and refresh the list it is shown in.
+ *
+ * The `PATCH` response is the same `Organization` a `GET` returns, so writing it here spares a
+ * request and, more importantly, gives the route loader the new name at once: the loader reads the
+ * organization through `ensureQueryData`, which hands back whatever is cached, and it is the loader
+ * that writes the breadcrumb and through it the document title.
+ */
+export function organizationUpdated(
+  queryClient: QueryClient,
+  organization: Organization
+): void {
+  queryClient.setQueryData(
+    getOrganizationQueryKey({ path: { organizationId: organization.id } }),
+    organization
+  );
+  organizationCreated(queryClient);
+}
+
+/**
+ * Refresh the list of organizations after one was deleted, and mark the deleted organization stale
+ * without refetching it.
+ */
+export function organizationDeleted(
+  queryClient: QueryClient,
+  organizationId: number
+): void {
+  organizationCreated(queryClient);
+  queryClient.invalidateQueries({
+    queryKey: getOrganizationQueryKey({ path: { organizationId } }),
+    refetchType: 'none',
+  });
+}
+
+/**
+ * Refresh the products of an organization after one was created.
+ */
+export function productCreated(
+  queryClient: QueryClient,
+  organizationId: number
+): void {
+  queryClient.invalidateQueries({
+    queryKey: getOrganizationProductsQueryKey({ path: { organizationId } }),
+  });
+}
+
+/**
+ * Seed the cache with an updated product and refresh the list it is shown in.
+ */
+export function productUpdated(
+  queryClient: QueryClient,
+  product: Product
+): void {
+  queryClient.setQueryData(
+    getProductQueryKey({ path: { productId: product.id } }),
+    product
+  );
+  productCreated(queryClient, product.organizationId);
+}
+
+/**
+ * Refresh the products of an organization after one was deleted, and mark the deleted product stale
+ * without refetching it.
+ */
+export function productDeleted(
+  queryClient: QueryClient,
+  product: Product
+): void {
+  productCreated(queryClient, product.organizationId);
+  queryClient.invalidateQueries({
+    queryKey: getProductQueryKey({ path: { productId: product.id } }),
+    refetchType: 'none',
+  });
+}
+
+/**
+ * Refresh the repositories of a product after one was created.
+ */
+export function repositoryCreated(
+  queryClient: QueryClient,
+  productId: number
+): void {
+  queryClient.invalidateQueries({
+    queryKey: getProductRepositoriesQueryKey({ path: { productId } }),
+  });
+}
+
+/**
+ * Seed the cache with an updated repository and refresh the list it is shown in.
+ */
+export function repositoryUpdated(
+  queryClient: QueryClient,
+  repository: Repository
+): void {
+  queryClient.setQueryData(
+    getRepositoryQueryKey({ path: { repositoryId: repository.id } }),
+    repository
+  );
+  repositoryCreated(queryClient, repository.productId);
+}
+
+/**
+ * Refresh both products a repository moved between, and the permissions it inherits.
+ *
+ * `repository` carries the destination `productId`, so the product it came from has to be passed
+ * separately. The move can also change the permissions the repository inherits from its parents.
+ * Those are read per repository id, which the move leaves unchanged, so the entry is invalidated
+ * explicitly — without refetching, as the destination route fetches it while loading anyway.
+ */
+export function repositoryMoved(
+  queryClient: QueryClient,
+  repository: Repository,
+  previousProductId: number
+): void {
+  repositoryUpdated(queryClient, repository);
+  repositoryCreated(queryClient, previousProductId);
+  queryClient.invalidateQueries({
+    queryKey: getUserInfoQueryKey({ query: { repositoryId: repository.id } }),
+    exact: true,
+    refetchType: 'none',
+  });
+}
+
+/**
+ * Refresh the repositories of a product after one was deleted, and mark the deleted repository
+ * stale without refetching it.
+ */
+export function repositoryDeleted(
+  queryClient: QueryClient,
+  repository: Repository
+): void {
+  repositoryCreated(queryClient, repository.productId);
+  queryClient.invalidateQueries({
+    queryKey: getRepositoryQueryKey({ path: { repositoryId: repository.id } }),
+    refetchType: 'none',
+  });
+}
+
+/**
+ * Refresh the runs of a repository after one was created.
+ *
+ * This also covers the latest run shown on the repository page, which is read from the same list.
+ */
+export function runCreated(
+  queryClient: QueryClient,
+  repositoryId: number
+): void {
+  queryClient.invalidateQueries({
+    queryKey: getRepositoryRunsQueryKey({ path: { repositoryId } }),
+  });
+}
+
+/**
+ * Refresh the runs of a repository after one was deleted, and mark the deleted run stale without
+ * refetching it.
+ *
+ * A run is addressed by its repository and its index within that repository, not by an id of its
+ * own, so both are needed to reach its detail entry.
+ */
+export function runDeleted(
+  queryClient: QueryClient,
+  repositoryId: number,
+  runIndex: number
+): void {
+  runCreated(queryClient, repositoryId);
+  queryClient.invalidateQueries({
+    queryKey: getRepositoryRunQueryKey({
+      path: { repositoryId, ortRunIndex: runIndex },
+    }),
+    refetchType: 'none',
+  });
+}

--- a/ui/src/routes/create-organization/index.tsx
+++ b/ui/src/routes/create-organization/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { Loader2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
@@ -44,6 +44,7 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { ApiError } from '@/lib/api-error';
+import { organizationCreated } from '@/lib/entity-cache';
 import { toast, toastError } from '@/lib/toast';
 
 const formSchema = z.object({
@@ -53,6 +54,7 @@ const formSchema = z.object({
 
 const CreateOrganizationPage = () => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const { mutateAsync, isPending } = useMutation({
     ...postOrganizationMutation(),
@@ -60,6 +62,7 @@ const CreateOrganizationPage = () => {
       toast.info('Add Organization', {
         description: `Organization "${data.name}" added successfully.`,
       });
+      organizationCreated(queryClient);
       navigate({
         to: '/organizations/$orgId',
         params: { orgId: data.id.toString() },

--- a/ui/src/routes/organizations/$orgId/create-product/index.tsx
+++ b/ui/src/routes/organizations/$orgId/create-product/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { Loader2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
@@ -46,6 +46,7 @@ import {
 import { Input } from '@/components/ui/input';
 import { useUser } from '@/hooks/use-user';
 import { ApiError } from '@/lib/api-error';
+import { productCreated } from '@/lib/entity-cache';
 import { toast, toastError } from '@/lib/toast';
 
 const formSchema = z.object({
@@ -56,6 +57,7 @@ const formSchema = z.object({
 const CreateProductPage = () => {
   const navigate = useNavigate();
   const params = Route.useParams();
+  const queryClient = useQueryClient();
   const { refreshUser } = useUser();
 
   const { mutateAsync, isPending } = useMutation({
@@ -67,6 +69,7 @@ const CreateProductPage = () => {
       toast.info('Add Product', {
         description: `Product "${data.name}" added successfully.`,
       });
+      productCreated(queryClient, data.organizationId);
       navigate({
         to: '/organizations/$orgId/products/$productId',
         params: { orgId: params.orgId, productId: data.id.toString() },

--- a/ui/src/routes/organizations/$orgId/products/$productId/create-repository/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/create-repository/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { Loader2 } from 'lucide-react';
 import { useForm } from 'react-hook-form';
@@ -53,6 +53,7 @@ import {
 } from '@/components/ui/select';
 import { useUser } from '@/hooks/use-user';
 import { ApiError } from '@/lib/api-error';
+import { repositoryCreated } from '@/lib/entity-cache';
 import { toast, toastError } from '@/lib/toast';
 import { getRepositoryTypeLabel } from '@/lib/types';
 
@@ -66,6 +67,7 @@ const formSchema = zRepository.pick({
 const CreateRepositoryPage = () => {
   const navigate = useNavigate();
   const params = Route.useParams();
+  const queryClient = useQueryClient();
   const { refreshUser } = useUser();
 
   const { mutateAsync, isPending } = useMutation({
@@ -77,6 +79,7 @@ const CreateRepositoryPage = () => {
       toast.info('Add Repository', {
         description: `Repository ${data.url} added successfully.`,
       });
+      repositoryCreated(queryClient, data.productId);
       navigate({
         to: '/organizations/$orgId/products/$productId/repositories/$repoId',
         params: {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/move-repository.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/move-repository.tsx
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate, useParams } from '@tanstack/react-router';
 import { Check, ChevronsUpDown } from 'lucide-react';
 import { useState } from 'react';
@@ -36,6 +36,7 @@ import { useDebounce } from '@/hooks/use-debounce';
 import { useInfiniteList } from '@/hooks/use-infinite-list';
 import { ApiError } from '@/lib/api-error';
 import { DROPDOWN_PAGE_SIZE } from '@/lib/constants';
+import { repositoryMoved } from '@/lib/entity-cache';
 import { toSearchFilter } from '@/lib/regex';
 import { toastError } from '@/lib/toast';
 import { cn } from '@/lib/utils';
@@ -53,6 +54,7 @@ type Selection = { id: number; name: string };
 export const MoveRepository = ({ repoUrl }: MoveRepositoryProps) => {
   const params = useParams({ strict: false });
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const repositoryId = Number.parseInt(params.repoId!);
 
@@ -94,7 +96,8 @@ export const MoveRepository = ({ repoUrl }: MoveRepositoryProps) => {
 
   const { mutateAsync: moveRepository } = useMutation({
     ...patchRepositoryMutation(),
-    onSuccess() {
+    onSuccess(data) {
+      repositoryMoved(queryClient, data, Number.parseInt(params.productId!));
       navigate({
         to: '/organizations/$orgId/products/$productId/repositories/$repoId',
         params: {
@@ -102,7 +105,6 @@ export const MoveRepository = ({ repoUrl }: MoveRepositoryProps) => {
           productId: String(selectedProduct?.id),
           repoId: params.repoId!,
         },
-        reloadDocument: true,
       });
     },
     onError(error: ApiError) {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/repository-runs-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/repository-runs-table.tsx
@@ -40,7 +40,6 @@ import {
   getRepositoryOptions,
   getRepositoryRunOptions,
   getRepositoryRunsOptions,
-  getRepositoryRunsQueryKey,
 } from '@/api/@tanstack/react-query.gen';
 import { DataTable } from '@/components/data-table/data-table';
 import { DeleteDialog } from '@/components/delete-dialog';
@@ -70,6 +69,7 @@ import { diffResolvedJobConfigs } from '@/helpers/config-diff';
 import { getStatusBackgroundColor } from '@/helpers/get-status-class';
 import { useRepositoryPermission } from '@/hooks/use-authorization';
 import { ApiError } from '@/lib/api-error';
+import { runDeleted } from '@/lib/entity-cache';
 import { toast, toastError } from '@/lib/toast';
 import { buildRunFavorite } from '@/providers/home-data';
 import { useTablePrefsStore } from '@/store/table-prefs.store';
@@ -345,13 +345,11 @@ const createColumns = (
           toast.info('Delete Run', {
             description: `Run "${row.original.index}" deleted successfully.`,
           });
-          queryClient.invalidateQueries({
-            queryKey: getRepositoryRunsQueryKey({
-              path: {
-                repositoryId: row.original.repositoryId,
-              },
-            }),
-          });
+          runDeleted(
+            queryClient,
+            row.original.repositoryId,
+            row.original.index
+          );
         },
         onError(error: ApiError) {
           toastError(error.message, error);

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { Loader2, PlusIcon, TrashIcon } from 'lucide-react';
 import { useState } from 'react';
@@ -63,6 +63,7 @@ import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
 import { useUser } from '@/hooks/use-user.ts';
 import { ApiError } from '@/lib/api-error';
+import { runCreated } from '@/lib/entity-cache';
 import { toast, toastError } from '@/lib/toast';
 import { buildRecentRun, useHomeRecentRunActions } from '@/providers/home-data';
 import {
@@ -84,6 +85,7 @@ import {
 const CreateRunPage = () => {
   const navigate = useNavigate();
   const params = Route.useParams();
+  const queryClient = useQueryClient();
   const { ortRun, plugins, secrets } = Route.useLoaderData();
   const { recordRecentRun } = useHomeRecentRunActions();
   const [isTest, setIsTest] = useState(false);
@@ -165,6 +167,7 @@ const CreateRunPage = () => {
       toast.info('Create Run', {
         description: 'New run created successfully for this repository.',
       });
+      runCreated(queryClient, response.repositoryId);
       navigate({
         to: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex',
         params: {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/settings/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/settings/index.tsx
@@ -65,7 +65,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { ApiError } from '@/lib/api-error';
-import { repositoryDeleted } from '@/lib/entity-cache';
+import { repositoryDeleted, repositoryUpdated } from '@/lib/entity-cache';
 import { toast, toastError } from '@/lib/toast';
 import { getRepositoryTypeLabel } from '@/lib/types';
 import { MoveRepository } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components';
@@ -95,11 +95,14 @@ const RepositorySettingsPage = () => {
 
   const { mutateAsync, isPending } = useMutation({
     ...patchRepositoryMutation(),
-    onSuccess(data) {
+    async onSuccess(data) {
       toast.info('Edit repository', {
         description: `Repository "${data.url}" updated successfully.`,
       });
-      router.invalidate();
+      repositoryUpdated(queryClient, data);
+      // The breadcrumb, and through it the document title, is written by the loader of the parent
+      // route, which navigating between its children does not re-run.
+      await router.invalidate();
       navigate({
         to: '/organizations/$orgId/products/$productId/repositories/$repoId',
         params: {
@@ -107,7 +110,6 @@ const RepositorySettingsPage = () => {
           productId: params.productId,
           repoId: params.repoId,
         },
-        reloadDocument: true,
       });
     },
     onError(error: ApiError) {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/settings/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/settings/index.tsx
@@ -18,7 +18,11 @@
  */
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from '@tanstack/react-query';
 import {
   createFileRoute,
   useNavigate,
@@ -61,6 +65,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { ApiError } from '@/lib/api-error';
+import { repositoryDeleted } from '@/lib/entity-cache';
 import { toast, toastError } from '@/lib/toast';
 import { getRepositoryTypeLabel } from '@/lib/types';
 import { MoveRepository } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components';
@@ -76,6 +81,7 @@ const RepositorySettingsPage = () => {
   const params = Route.useParams();
   const navigate = useNavigate();
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   const repositoryId = Number.parseInt(params.repoId);
 
@@ -139,6 +145,7 @@ const RepositorySettingsPage = () => {
       toast.info('Delete Repository', {
         description: `Repository "${repository?.url}" deleted successfully.`,
       });
+      repositoryDeleted(queryClient, repository);
       navigate({
         to: '/organizations/$orgId/products/$productId',
         params: { orgId: params.orgId, productId: params.productId },

--- a/ui/src/routes/organizations/$orgId/products/$productId/settings/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/settings/index.tsx
@@ -18,7 +18,11 @@
  */
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from '@tanstack/react-query';
 import {
   createFileRoute,
   useNavigate,
@@ -52,6 +56,7 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { ApiError } from '@/lib/api-error';
+import { productDeleted } from '@/lib/entity-cache';
 import { toast, toastError } from '@/lib/toast';
 
 const formSchema = z.object({
@@ -63,6 +68,7 @@ const ProductSettingsPage = () => {
   const params = Route.useParams();
   const navigate = useNavigate();
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   const productId = Number.parseInt(params.productId);
 
@@ -118,6 +124,7 @@ const ProductSettingsPage = () => {
       toast.info('Delete Product', {
         description: `Product "${product.name}" deleted successfully.`,
       });
+      productDeleted(queryClient, product);
       navigate({
         to: '/organizations/$orgId',
         params: { orgId: params.orgId },

--- a/ui/src/routes/organizations/$orgId/products/$productId/settings/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/settings/index.tsx
@@ -56,7 +56,7 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { ApiError } from '@/lib/api-error';
-import { productDeleted } from '@/lib/entity-cache';
+import { productDeleted, productUpdated } from '@/lib/entity-cache';
 import { toast, toastError } from '@/lib/toast';
 
 const formSchema = z.object({
@@ -82,15 +82,17 @@ const ProductSettingsPage = () => {
 
   const { mutateAsync, isPending } = useMutation({
     ...patchProductMutation(),
-    onSuccess(data) {
+    async onSuccess(data) {
       toast.info('Edit Product', {
         description: `Product "${data.name}" updated successfully.`,
       });
-      router.invalidate();
+      productUpdated(queryClient, data);
+      // The breadcrumb, and through it the document title, is written by the loader of the parent
+      // route, which navigating between its children does not re-run.
+      await router.invalidate();
       navigate({
         to: '/organizations/$orgId/products/$productId',
         params: { orgId: params.orgId, productId: params.productId },
-        reloadDocument: true,
       });
     },
     onError(error: ApiError) {

--- a/ui/src/routes/organizations/$orgId/settings/index.tsx
+++ b/ui/src/routes/organizations/$orgId/settings/index.tsx
@@ -56,7 +56,7 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { ApiError } from '@/lib/api-error';
-import { organizationDeleted } from '@/lib/entity-cache';
+import { organizationDeleted, organizationUpdated } from '@/lib/entity-cache';
 import { toast, toastError } from '@/lib/toast';
 
 const formSchema = z.object({
@@ -82,15 +82,17 @@ const OrganizationSettingsPage = () => {
 
   const { mutateAsync, isPending } = useMutation({
     ...patchOrganizationMutation(),
-    onSuccess(data) {
+    async onSuccess(data) {
       toast.info('Edit Organization', {
         description: `Organization "${data.name}" updated successfully.`,
       });
-      router.invalidate();
+      organizationUpdated(queryClient, data);
+      // The breadcrumb, and through it the document title, is written by the loader of the parent
+      // route, which navigating between its children does not re-run.
+      await router.invalidate();
       navigate({
         to: '/organizations/$orgId',
         params: { orgId: params.orgId },
-        reloadDocument: true,
       });
     },
     onError(error: ApiError) {

--- a/ui/src/routes/organizations/$orgId/settings/index.tsx
+++ b/ui/src/routes/organizations/$orgId/settings/index.tsx
@@ -18,7 +18,11 @@
  */
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMutation, useSuspenseQuery } from '@tanstack/react-query';
+import {
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from '@tanstack/react-query';
 import {
   createFileRoute,
   useNavigate,
@@ -52,6 +56,7 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { ApiError } from '@/lib/api-error';
+import { organizationDeleted } from '@/lib/entity-cache';
 import { toast, toastError } from '@/lib/toast';
 
 const formSchema = z.object({
@@ -63,6 +68,7 @@ const OrganizationSettingsPage = () => {
   const params = Route.useParams();
   const navigate = useNavigate();
   const router = useRouter();
+  const queryClient = useQueryClient();
 
   const organizationId = Number.parseInt(params.orgId);
 
@@ -118,6 +124,7 @@ const OrganizationSettingsPage = () => {
       toast.info('Delete Organization', {
         description: `Organization "${organization.name}" deleted successfully.`,
       });
+      organizationDeleted(queryClient, organizationId);
       navigate({
         to: '/organizations',
       });

--- a/ui/tests/unit/logic/entity-cache.test.ts
+++ b/ui/tests/unit/logic/entity-cache.test.ts
@@ -1,0 +1,393 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import {
+  QueryClient,
+  QueryObserver,
+  type QueryKey,
+} from '@tanstack/react-query';
+import { beforeEach, expect, it, vi } from 'vitest';
+
+import type { Organization, Product, Repository } from '@/api';
+import {
+  getOrganizationOptions,
+  getOrganizationProductsInfiniteOptions,
+  getOrganizationProductsOptions,
+  getOrganizationsInfiniteOptions,
+  getOrganizationsOptions,
+  getProductOptions,
+  getProductRepositoriesInfiniteOptions,
+  getProductRepositoriesOptions,
+  getRepositoryOptions,
+  getRepositoryRunOptions,
+  getRepositoryRunsInfiniteOptions,
+  getRepositoryRunsOptions,
+  getUserInfoOptions,
+} from '@/api/@tanstack/react-query.gen';
+import { DROPDOWN_PAGE_SIZE } from '@/lib/constants';
+import {
+  organizationCreated,
+  organizationDeleted,
+  organizationUpdated,
+  productCreated,
+  productDeleted,
+  productUpdated,
+  repositoryCreated,
+  repositoryDeleted,
+  repositoryMoved,
+  repositoryUpdated,
+  runCreated,
+  runDeleted,
+} from '@/lib/entity-cache';
+
+const ORG_ID = 1;
+const OTHER_ORG_ID = 2;
+const PRODUCT_ID = 10;
+const OTHER_PRODUCT_ID = 20;
+const REPOSITORY_ID = 100;
+const OTHER_REPOSITORY_ID = 200;
+const RUN_INDEX = 3;
+
+const organization: Organization = { id: ORG_ID, name: 'renamed org' };
+const product: Product = {
+  id: PRODUCT_ID,
+  name: 'renamed product',
+  organizationId: ORG_ID,
+};
+const repository: Repository = {
+  id: REPOSITORY_ID,
+  url: 'https://example.com/repo.git',
+  type: 'GIT',
+  productId: PRODUCT_ID,
+  organizationId: ORG_ID,
+};
+
+/**
+ * The three shapes every list endpoint of the hierarchy is read under: the `limit: 1` count query
+ * behind a breadcrumb chevron, a paged query of a table, and the infinite query of a dropdown.
+ *
+ * The keys come from the generated options rather than being written by hand, so that a change in
+ * the generator, or in how the query cache matches keys partially, fails here instead of in the
+ * browser.
+ */
+type ListKeys = {
+  count: QueryKey;
+  paged: QueryKey;
+  infinite: QueryKey;
+};
+
+const organizationListKeys = (): ListKeys => ({
+  count: getOrganizationsOptions({ query: { limit: 1 } }).queryKey,
+  paged: getOrganizationsOptions({ query: { limit: 25, offset: 25 } }).queryKey,
+  infinite: getOrganizationsInfiniteOptions({
+    query: { limit: DROPDOWN_PAGE_SIZE, filter: 'ac' },
+  }).queryKey,
+});
+
+const productListKeys = (organizationId: number): ListKeys => ({
+  count: getOrganizationProductsOptions({
+    path: { organizationId },
+    query: { limit: 1 },
+  }).queryKey,
+  paged: getOrganizationProductsOptions({
+    path: { organizationId },
+    query: { limit: 25, offset: 25 },
+  }).queryKey,
+  infinite: getOrganizationProductsInfiniteOptions({
+    path: { organizationId },
+    query: { limit: DROPDOWN_PAGE_SIZE, filter: 'ac' },
+  }).queryKey,
+});
+
+const repositoryListKeys = (productId: number): ListKeys => ({
+  count: getProductRepositoriesOptions({
+    path: { productId },
+    query: { limit: 1 },
+  }).queryKey,
+  paged: getProductRepositoriesOptions({
+    path: { productId },
+    query: { limit: 25, offset: 25 },
+  }).queryKey,
+  infinite: getProductRepositoriesInfiniteOptions({
+    path: { productId },
+    query: { limit: DROPDOWN_PAGE_SIZE, filter: 'ac' },
+  }).queryKey,
+});
+
+const runListKeys = (repositoryId: number): ListKeys => ({
+  count: getRepositoryRunsOptions({
+    path: { repositoryId },
+    query: { limit: 1 },
+  }).queryKey,
+  paged: getRepositoryRunsOptions({
+    path: { repositoryId },
+    query: { limit: 25, offset: 25 },
+  }).queryKey,
+  infinite: getRepositoryRunsInfiniteOptions({
+    path: { repositoryId },
+    query: { limit: DROPDOWN_PAGE_SIZE, sort: '-index' },
+  }).queryKey,
+});
+
+const organizationKey = (organizationId: number) =>
+  getOrganizationOptions({ path: { organizationId } }).queryKey;
+const productKey = (productId: number) =>
+  getProductOptions({ path: { productId } }).queryKey;
+const repositoryKey = (repositoryId: number) =>
+  getRepositoryOptions({ path: { repositoryId } }).queryKey;
+const runKey = (repositoryId: number, ortRunIndex: number) =>
+  getRepositoryRunOptions({ path: { repositoryId, ortRunIndex } }).queryKey;
+const permissionsKey = (repositoryId: number) =>
+  getUserInfoOptions({ query: { repositoryId } }).queryKey;
+
+let queryClient: QueryClient;
+
+/** Put something in the cache under a key, so that there is a query to invalidate. */
+const seed = (...keys: QueryKey[]) => {
+  for (const key of keys) queryClient.setQueryData(key, { seeded: true });
+};
+
+const isInvalidated = (key: QueryKey) =>
+  queryClient.getQueryState(key)?.isInvalidated;
+
+const listInvalidations = ({ count, paged, infinite }: ListKeys) => ({
+  count: isInvalidated(count),
+  paged: isInvalidated(paged),
+  infinite: isInvalidated(infinite),
+});
+
+const allInvalidated = { count: true, paged: true, infinite: true };
+const noneInvalidated = { count: false, paged: false, infinite: false };
+
+beforeEach(() => {
+  queryClient = new QueryClient();
+});
+
+it.each([
+  {
+    name: 'organizationCreated',
+    own: organizationListKeys,
+    other: undefined,
+    run: () => organizationCreated(queryClient),
+  },
+  {
+    name: 'productCreated',
+    own: () => productListKeys(ORG_ID),
+    other: () => productListKeys(OTHER_ORG_ID),
+    run: () => productCreated(queryClient, ORG_ID),
+  },
+  {
+    name: 'repositoryCreated',
+    own: () => repositoryListKeys(PRODUCT_ID),
+    other: () => repositoryListKeys(OTHER_PRODUCT_ID),
+    run: () => repositoryCreated(queryClient, PRODUCT_ID),
+  },
+  {
+    name: 'runCreated',
+    own: () => runListKeys(REPOSITORY_ID),
+    other: () => runListKeys(OTHER_REPOSITORY_ID),
+    run: () => runCreated(queryClient, REPOSITORY_ID),
+  },
+])(
+  '$name invalidates the count, paged and infinite forms of its parent list',
+  ({ own, other, run }) => {
+    const ownKeys = own();
+    seed(ownKeys.count, ownKeys.paged, ownKeys.infinite);
+
+    const otherKeys = other?.();
+    if (otherKeys) {
+      seed(otherKeys.count, otherKeys.paged, otherKeys.infinite);
+    }
+
+    run();
+
+    expect(listInvalidations(ownKeys)).toEqual(allInvalidated);
+
+    // A list of another parent is a different `path`, and must be left alone.
+    if (otherKeys) {
+      expect(listInvalidations(otherKeys)).toEqual(noneInvalidated);
+    }
+  }
+);
+
+it.each([
+  {
+    name: 'organizationCreated',
+    run: () => organizationCreated(queryClient),
+  },
+  {
+    name: 'productCreated',
+    run: () => productCreated(queryClient, ORG_ID),
+  },
+  {
+    name: 'repositoryCreated',
+    run: () => repositoryCreated(queryClient, PRODUCT_ID),
+  },
+  {
+    name: 'runCreated',
+    run: () => runCreated(queryClient, REPOSITORY_ID),
+  },
+])(
+  '$name leaves the detail and list queries of other endpoints alone',
+  ({ run }) => {
+    const untouched = [
+      organizationKey(ORG_ID),
+      productKey(PRODUCT_ID),
+      repositoryKey(REPOSITORY_ID),
+      runKey(REPOSITORY_ID, RUN_INDEX),
+      permissionsKey(REPOSITORY_ID),
+    ];
+    seed(...untouched);
+
+    run();
+
+    // `_id` is matched as a whole string, so neighbouring endpoints such as `getOrganization` and
+    // `getOrganizationProducts` never match each other.
+    expect(untouched.map(isInvalidated)).toEqual(untouched.map(() => false));
+  }
+);
+
+it.each([
+  {
+    name: 'organizationUpdated',
+    detail: () => organizationKey(ORG_ID),
+    list: organizationListKeys,
+    entity: organization,
+    run: () => organizationUpdated(queryClient, organization),
+  },
+  {
+    name: 'productUpdated',
+    detail: () => productKey(PRODUCT_ID),
+    list: () => productListKeys(ORG_ID),
+    entity: product,
+    run: () => productUpdated(queryClient, product),
+  },
+  {
+    name: 'repositoryUpdated',
+    detail: () => repositoryKey(REPOSITORY_ID),
+    list: () => repositoryListKeys(PRODUCT_ID),
+    entity: repository,
+    run: () => repositoryUpdated(queryClient, repository),
+  },
+])(
+  '$name writes the response to the detail key and invalidates the parent list',
+  ({ detail, list, entity, run }) => {
+    const detailKey = detail();
+    const listKeys = list();
+    seed(detailKey, listKeys.count, listKeys.paged, listKeys.infinite);
+
+    run();
+
+    // The route loader reads the entity through `ensureQueryData`, which hands back whatever is
+    // cached, so seeding it here is what lets the breadcrumb and the document title pick up the
+    // new name without a request.
+    expect(queryClient.getQueryData(detailKey)).toEqual(entity);
+    expect(listInvalidations(listKeys)).toEqual(allInvalidated);
+  }
+);
+
+it.each([
+  {
+    name: 'organizationDeleted',
+    detail: () => organizationKey(ORG_ID),
+    list: organizationListKeys,
+    run: () => organizationDeleted(queryClient, ORG_ID),
+  },
+  {
+    name: 'productDeleted',
+    detail: () => productKey(PRODUCT_ID),
+    list: () => productListKeys(ORG_ID),
+    run: () => productDeleted(queryClient, product),
+  },
+  {
+    name: 'repositoryDeleted',
+    detail: () => repositoryKey(REPOSITORY_ID),
+    list: () => repositoryListKeys(PRODUCT_ID),
+    run: () => repositoryDeleted(queryClient, repository),
+  },
+  {
+    name: 'runDeleted',
+    detail: () => runKey(REPOSITORY_ID, RUN_INDEX),
+    list: () => runListKeys(REPOSITORY_ID),
+    run: () => runDeleted(queryClient, REPOSITORY_ID, RUN_INDEX),
+  },
+])(
+  '$name invalidates the parent list and the deleted detail without refetching it',
+  async ({ detail, list, run }) => {
+    const detailKey = detail();
+    const listKeys = list();
+    seed(detailKey, listKeys.count, listKeys.paged, listKeys.infinite);
+
+    // The settings pages still observe the entity they delete when the mutation succeeds. An
+    // infinite stale time keeps the observer from fetching on its own, so any call of this
+    // function would come from the invalidation.
+    const queryFn = vi.fn().mockResolvedValue({ seeded: true });
+    const observer = new QueryObserver(queryClient, {
+      queryKey: detailKey,
+      queryFn,
+      staleTime: Infinity,
+    });
+    const unsubscribe = observer.subscribe(() => {});
+
+    run();
+    await vi.waitFor(() => expect(isInvalidated(detailKey)).toBe(true));
+
+    expect(listInvalidations(listKeys)).toEqual(allInvalidated);
+    // `refetchType: 'none'`: the deleted entity is marked stale, but never requested again from
+    // the page that just deleted it.
+    expect(queryFn).not.toHaveBeenCalled();
+    expect(queryClient.getQueryData(detailKey)).toEqual({ seeded: true });
+
+    unsubscribe();
+  }
+);
+
+it('repositoryMoved invalidates both products and the permissions of the moved repository', () => {
+  const movedRepository: Repository = {
+    ...repository,
+    productId: OTHER_PRODUCT_ID,
+  };
+  const source = repositoryListKeys(PRODUCT_ID);
+  const destination = repositoryListKeys(OTHER_PRODUCT_ID);
+  const detailKey = repositoryKey(REPOSITORY_ID);
+  const otherPermissions = permissionsKey(OTHER_REPOSITORY_ID);
+
+  seed(
+    detailKey,
+    permissionsKey(REPOSITORY_ID),
+    otherPermissions,
+    source.count,
+    source.paged,
+    source.infinite,
+    destination.count,
+    destination.paged,
+    destination.infinite
+  );
+
+  repositoryMoved(queryClient, movedRepository, PRODUCT_ID);
+
+  expect(listInvalidations(source)).toEqual(allInvalidated);
+  expect(listInvalidations(destination)).toEqual(allInvalidated);
+  expect(queryClient.getQueryData(detailKey)).toEqual(movedRepository);
+
+  // The permissions a repository inherits change with its parents, but are keyed by the repository
+  // id, which the move leaves unchanged. Only this repository's entry may be invalidated.
+  expect(isInvalidated(permissionsKey(REPOSITORY_ID))).toBe(true);
+  expect(isInvalidated(otherPermissions)).toBe(false);
+});


### PR DESCRIPTION
There are some inconsistencies in updating the breadcrumb, entity tables, and browser tab title when doing CRUD in the UI for entities (organizations, products, repositories, and runs). This PR fixes the root cause of the problems by properly handling query cache invalidation for entities created, updated, and deleted. Now also the annoying full-browser refresh (that takes a couple of seconds) after entity update can be safely removed.

There are extensive tests for the cache handling functions implemented in the first commit, but otherwise, verification has been done manually in the UI. A note for the reviewers (at least @lamppu): some manual clicking and operations might be valuable to see whether anything is still unfixed.

Please see the commits for details.