### PR TITLE
Add filtering and sorting to issues endpoint

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
@@ -35,6 +35,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.EvaluatorJob as ApiEvaluatorJ
 import org.eclipse.apoapsis.ortserver.api.v1.model.EvaluatorJobConfiguration as ApiEvaluatorJobConfiguration
 import org.eclipse.apoapsis.ortserver.api.v1.model.FilterOperatorAndValue as ApiFilterOperatorAndValue
 import org.eclipse.apoapsis.ortserver.api.v1.model.Issue as ApiIssue
+import org.eclipse.apoapsis.ortserver.api.v1.model.IssueFilter as ApiIssueFilter
 import org.eclipse.apoapsis.ortserver.api.v1.model.JobConfigurations as ApiJobConfigurations
 import org.eclipse.apoapsis.ortserver.api.v1.model.JobStatus as ApiJobStatus
 import org.eclipse.apoapsis.ortserver.api.v1.model.JobSummaries as ApiJobSummaries
@@ -130,6 +131,7 @@ import org.eclipse.apoapsis.ortserver.model.VulnerabilityForRunsFilters
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityRating
 import org.eclipse.apoapsis.ortserver.model.authentication.OidcConfig
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
+import org.eclipse.apoapsis.ortserver.model.runs.IssueFilter
 import org.eclipse.apoapsis.ortserver.model.runs.LicenseSource
 import org.eclipse.apoapsis.ortserver.model.runs.Package
 import org.eclipse.apoapsis.ortserver.model.runs.PackageFilters
@@ -300,6 +302,15 @@ fun ApiIssue.mapToModel() =
         resolutions = resolutions.map { it.mapToModel() },
         unappliedResolutions = unappliedResolutions.map { it.mapToModel() }
     )
+
+fun ApiIssueFilter.mapToModel(): IssueFilter = IssueFilter(
+    resolved = resolved,
+    identifier = identifier?.mapToModel { it },
+    purl = purl?.mapToModel { it },
+    severity = severity?.mapToModel { severities ->
+        severities.mapTo(mutableSetOf()) { it.mapToModel() }
+    }
+)
 
 fun ApiIssueResolution.mapToModel() =
     IssueResolution(message = message, reason = reason.mapToModel(), comment = comment, source = source.mapToModel())

--- a/api/v1/model/src/commonMain/kotlin/Issue.kt
+++ b/api/v1/model/src/commonMain/kotlin/Issue.kt
@@ -64,3 +64,19 @@ data class Issue(
      */
     val purl: String? = null
 )
+
+/** Filters to apply when querying for issues. */
+@Serializable
+data class IssueFilter(
+    /** Filter by resolution status. Null if both resolved and unresolved issues should be returned. */
+    val resolved: Boolean? = null,
+
+    /** Substring filter for the package identifier. */
+    val identifier: FilterOperatorAndValue<String>? = null,
+
+    /** Substring filter for the package purl. */
+    val purl: FilterOperatorAndValue<String>? = null,
+
+    /** Set of [Severity] values to filter with. */
+    val severity: FilterOperatorAndValue<Set<Severity>>? = null
+)

--- a/core/src/main/kotlin/api/RunsRoute.kt
+++ b/core/src/main/kotlin/api/RunsRoute.kt
@@ -40,6 +40,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToApiSummary
 import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToModel
 import org.eclipse.apoapsis.ortserver.api.v1.model.ComparisonOperator
 import org.eclipse.apoapsis.ortserver.api.v1.model.FilterOperatorAndValue
+import org.eclipse.apoapsis.ortserver.api.v1.model.IssueFilter
 import org.eclipse.apoapsis.ortserver.api.v1.model.JobSummaries
 import org.eclipse.apoapsis.ortserver.api.v1.model.Licenses
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunFilters
@@ -47,6 +48,7 @@ import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatistics
 import org.eclipse.apoapsis.ortserver.api.v1.model.OrtRunStatus
 import org.eclipse.apoapsis.ortserver.api.v1.model.PackageFilters
 import org.eclipse.apoapsis.ortserver.api.v1.model.RuleViolationFilters
+import org.eclipse.apoapsis.ortserver.api.v1.model.Severity
 import org.eclipse.apoapsis.ortserver.api.v1.model.VulnerabilityFilters
 import org.eclipse.apoapsis.ortserver.components.authorization.rights.EffectiveRole
 import org.eclipse.apoapsis.ortserver.components.authorization.rights.HierarchyPermissions
@@ -84,7 +86,6 @@ import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.RepositoryId
 import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
 import org.eclipse.apoapsis.ortserver.model.runs.Issue
-import org.eclipse.apoapsis.ortserver.model.runs.IssueFilter
 import org.eclipse.apoapsis.ortserver.model.runs.Project
 import org.eclipse.apoapsis.ortserver.model.runs.RuleViolation
 import org.eclipse.apoapsis.ortserver.services.ProjectService
@@ -220,7 +221,8 @@ fun Route.runs() = route("runs") {
                 val pagingOptions = call.pagingOptions(SortProperty("timestamp", SortDirection.DESCENDING))
                 val filters = call.issueFilters()
 
-                val issueForOrtRun = issueService.listForOrtRunId(call.ortRun.id, pagingOptions.mapToModel(), filters)
+                val issueForOrtRun =
+                    issueService.listForOrtRunId(call.ortRun.id, pagingOptions.mapToModel(), filters.mapToModel())
 
                 val pagedResponse = issueForOrtRun.mapToApi(Issue::mapToApi)
 
@@ -555,10 +557,26 @@ private fun ApplicationCall.ruleViolationFilters(): RuleViolationFilters =
 /**
  * Extract the issue filters from this [ApplicationCall].
  */
-private fun ApplicationCall.issueFilters() =
-    IssueFilter(
-        resolved = parameters["resolved"]?.lowercase()?.toBooleanStrictOrNull()
+private fun ApplicationCall.issueFilters(): IssueFilter {
+    val severity: FilterOperatorAndValue<Set<Severity>>? = parameters["severity"]?.let { value ->
+        val parts = value.split(',')
+        val operator = if (parts.first() == "-") ComparisonOperator.NOT_IN else ComparisonOperator.IN
+        val severities = if (operator == ComparisonOperator.NOT_IN) parts.drop(1) else parts
+
+        FilterOperatorAndValue(operator, severities.mapTo(mutableSetOf()) { findByName<Severity>(it) })
+    }
+
+    return IssueFilter(
+        resolved = parameters["resolved"]?.lowercase()?.toBooleanStrictOrNull(),
+        identifier = parameters["identifier"]?.let {
+            FilterOperatorAndValue(ComparisonOperator.ILIKE, it)
+        },
+        purl = parameters["purl"]?.let {
+            FilterOperatorAndValue(ComparisonOperator.ILIKE, it)
+        },
+        severity = severity
     )
+}
 
 /**
  * Extract the vulnerability filters from this [ApplicationCall].

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -211,6 +211,9 @@ val getRunLogs: RouteConfig.() -> Unit = {
 val getRunIssues: RouteConfig.() -> Unit = {
     operationId = "getRunIssues"
     summary = "Get the issues of an ORT run"
+    description = "Supported sort fields are 'timestamp', 'source', 'message', 'severity', 'affectedPath', " +
+            "'identifier', 'purl', 'status', and 'worker'. Package ID tables use 'identifier' or 'purl'; status, " +
+            "severity, and source can also be sorted."
     tags = listOf("Runs")
 
     request {
@@ -224,6 +227,23 @@ val getRunIssues: RouteConfig.() -> Unit = {
                     If true, only resolved issues are returned. If false, only unresolved issues are returned.
                     If missing, both resolved and unresolved issues are returned.
                 """.trimIndent()
+        }
+
+        queryParameter<String>("identifier") {
+            description = "Defines an ORT package identifier to filter the results by. Uses a case-insensitive " +
+                    "substring match against the full ORT coordinates."
+        }
+
+        queryParameter<String>("purl") {
+            description = "Defines a package purl to filter the results by. Uses a case-insensitive substring match " +
+                    "against the effective purl, where a curated purl takes precedence over the analyzer purl."
+        }
+
+        queryParameter<String>("severity") {
+            description = "Defines the severities to filter the results by. This is a comma-separated string with " +
+                    "the following allowed severities: " + Severity.entries.joinToString { "'$it'" } +
+                    " (ignoring case). Add a minus as the first item to exclude issues with the specified " +
+                    "severities, e.g. '-,HINT,WARNING'."
         }
 
         standardListQueryParameters()

--- a/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
@@ -290,6 +290,66 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
         checkLogArchive(downloadFile, sources)
     }
 
+    data class IssueRouteScenario(
+        val ortRun: OrtRun,
+        val resolvedIssue: Issue,
+        val unresolvedIssue: Issue,
+        val resolvedIssuePurl: String
+    )
+
+    fun createIssueRouteScenario(): IssueRouteScenario {
+        val ortRun = dbExtension.fixtures.createOrtRun(
+            repositoryId = repositoryId,
+            revision = "revision",
+            jobConfigurations = JobConfigurations()
+        )
+        val resolvedPackage = dbExtension.fixtures.generatePackage(
+            Identifier("Maven", "com.example", "alpha-lib", "1.0")
+        )
+        val unresolvedPackage = dbExtension.fixtures.generatePackage(
+            Identifier("NPM", "org.example", "beta-lib", "2.0")
+        )
+        val now = Clock.System.now()
+        val resolvedIssue = Issue(
+            timestamp = now.toDatabasePrecision(),
+            source = "Zulu",
+            message = "resolved alpha issue",
+            severity = Severity.ERROR,
+            identifier = resolvedPackage.identifier
+        )
+        val unresolvedIssue = Issue(
+            timestamp = now.plus(1.seconds).toDatabasePrecision(),
+            source = "Alpha",
+            message = "unresolved beta issue",
+            severity = Severity.WARNING,
+            identifier = unresolvedPackage.identifier
+        )
+
+        dbExtension.fixtures.ortRunRepository.update(
+            ortRun.id,
+            issues = listOf(resolvedIssue, unresolvedIssue).asPresent()
+        )
+
+        val analyzerJob = dbExtension.fixtures.createAnalyzerJob(ortRun.id)
+        dbExtension.fixtures.createAnalyzerRun(
+            analyzerJob.id,
+            packages = setOf(resolvedPackage, unresolvedPackage)
+        )
+
+        val resolution = IssueResolution(
+            message = resolvedIssue.message,
+            reason = IssueResolutionReason.CANT_FIX_ISSUE,
+            comment = "Known issue",
+            source = ResolutionSource.REPOSITORY_FILE
+        )
+        dbExtension.fixtures.resolvedConfigurationRepository.addResolutions(
+            ortRun.id,
+            ResolvedItemsResult(issues = mapOf(resolvedIssue to listOf(resolution)))
+        )
+
+        return IssueRouteScenario(ortRun, resolvedIssue, unresolvedIssue, resolvedPackage.purl)
+    }
+
     "GET /runs/{runId}" should {
         "return the requested ORT run" {
             integrationTestApplication {
@@ -1386,6 +1446,154 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                 // Applies a default sort order
                 pagedIssues.pagination.sortProperties.firstOrNull()?.name shouldBe "timestamp"
                 pagedIssues.pagination.sortProperties.firstOrNull()?.direction shouldBe SortDirection.DESCENDING
+            }
+        }
+
+        "filter issues by identifier" {
+            integrationTestApplication {
+                val scenario = createIssueRouteScenario()
+
+                val response = superuserClient.get(
+                    "/api/v1/runs/${scenario.ortRun.id}/issues?identifier=ALPHA-LIB"
+                )
+
+                response shouldHaveStatus HttpStatusCode.OK
+                response.body<PagedResponse<ApiIssue>>().data.shouldBeSingleton {
+                    it.message shouldBe scenario.resolvedIssue.message
+                }
+            }
+        }
+
+        "filter issues by analyzer PURL" {
+            integrationTestApplication {
+                val scenario = createIssueRouteScenario()
+
+                val response = superuserClient.get(
+                    "/api/v1/runs/${scenario.ortRun.id}/issues?purl=ALPHA-LIB"
+                )
+
+                response shouldHaveStatus HttpStatusCode.OK
+                response.body<PagedResponse<ApiIssue>>().data.shouldBeSingleton {
+                    it.message shouldBe scenario.resolvedIssue.message
+                    it.purl shouldBe scenario.resolvedIssuePurl
+                }
+            }
+        }
+
+        "include or exclude issues by severity" {
+            integrationTestApplication {
+                val scenario = createIssueRouteScenario()
+
+                val includedResponse = superuserClient.get(
+                    "/api/v1/runs/${scenario.ortRun.id}/issues?severity=error,warning"
+                )
+                val excludedResponse = superuserClient.get(
+                    "/api/v1/runs/${scenario.ortRun.id}/issues?severity=-,warning"
+                )
+
+                includedResponse shouldHaveStatus HttpStatusCode.OK
+                includedResponse.body<PagedResponse<ApiIssue>>().data.map { it.message }.shouldContainExactlyInAnyOrder(
+                    scenario.resolvedIssue.message,
+                    scenario.unresolvedIssue.message
+                )
+
+                excludedResponse shouldHaveStatus HttpStatusCode.OK
+                excludedResponse.body<PagedResponse<ApiIssue>>().data.shouldBeSingleton {
+                    it.message shouldBe scenario.resolvedIssue.message
+                }
+            }
+        }
+
+        "combine filters before pagination and counting" {
+            integrationTestApplication {
+                val scenario = createIssueRouteScenario()
+
+                val response = superuserClient.get(
+                    "/api/v1/runs/${scenario.ortRun.id}/issues" +
+                            "?identifier=example&purl=pkg:&severity=error,warning&sort=identifier&limit=1&offset=1"
+                )
+
+                response shouldHaveStatus HttpStatusCode.OK
+                val pagedIssues = response.body<PagedResponse<ApiIssue>>()
+                pagedIssues.pagination.totalCount shouldBe 2
+                pagedIssues.pagination.limit shouldBe 1
+                pagedIssues.pagination.offset shouldBe 1
+                pagedIssues.data.shouldBeSingleton {
+                    it.message shouldBe scenario.unresolvedIssue.message
+                }
+            }
+        }
+
+        "reject an invalid severity" {
+            integrationTestApplication {
+                val scenario = createIssueRouteScenario()
+
+                val response = superuserClient.get(
+                    "/api/v1/runs/${scenario.ortRun.id}/issues?severity=critical"
+                )
+
+                response shouldHaveStatus HttpStatusCode.BadRequest
+            }
+        }
+
+        "sort issues by all table fields in both directions" {
+            integrationTestApplication {
+                val scenario = createIssueRouteScenario()
+                val resolvedFirst = listOf(scenario.resolvedIssue.message, scenario.unresolvedIssue.message)
+                val unresolvedFirst = resolvedFirst.reversed()
+                val expectedAscending = mapOf(
+                    "identifier" to resolvedFirst,
+                    "purl" to resolvedFirst,
+                    "status" to resolvedFirst,
+                    "severity" to unresolvedFirst,
+                    "source" to unresolvedFirst
+                )
+
+                expectedAscending.forEach { (field, expectedMessages) ->
+                    val ascendingResponse = superuserClient.get(
+                        "/api/v1/runs/${scenario.ortRun.id}/issues?sort=$field"
+                    )
+                    val descendingResponse = superuserClient.get(
+                        "/api/v1/runs/${scenario.ortRun.id}/issues?sort=-$field"
+                    )
+
+                    ascendingResponse shouldHaveStatus HttpStatusCode.OK
+                    ascendingResponse.body<PagedResponse<ApiIssue>>().data.map { it.message } shouldBe expectedMessages
+
+                    descendingResponse shouldHaveStatus HttpStatusCode.OK
+                    descendingResponse.body<PagedResponse<ApiIssue>>().data.map { it.message } shouldBe
+                        expectedMessages.reversed()
+                }
+            }
+        }
+
+        "apply sorting with filtering and pagination" {
+            integrationTestApplication {
+                val scenario = createIssueRouteScenario()
+
+                val response = superuserClient.get(
+                    "/api/v1/runs/${scenario.ortRun.id}/issues" +
+                            "?severity=error,warning&sort=source&limit=1&offset=1"
+                )
+
+                response shouldHaveStatus HttpStatusCode.OK
+                val pagedIssues = response.body<PagedResponse<ApiIssue>>()
+                pagedIssues.pagination.totalCount shouldBe 2
+                pagedIssues.data.shouldBeSingleton {
+                    it.message shouldBe scenario.resolvedIssue.message
+                }
+            }
+        }
+
+        "reject an unsupported sort field" {
+            integrationTestApplication {
+                val scenario = createIssueRouteScenario()
+
+                val response = superuserClient.get(
+                    "/api/v1/runs/${scenario.ortRun.id}/issues?sort=category"
+                )
+
+                response shouldHaveStatus HttpStatusCode.BadRequest
             }
         }
 

--- a/dao/src/main/kotlin/utils/Extensions.kt
+++ b/dao/src/main/kotlin/utils/Extensions.kt
@@ -29,6 +29,7 @@ import kotlin.time.toDuration
 import org.eclipse.apoapsis.ortserver.dao.QueryParametersException
 import org.eclipse.apoapsis.ortserver.model.CompoundHierarchyId
 import org.eclipse.apoapsis.ortserver.model.HierarchyLevel
+import org.eclipse.apoapsis.ortserver.model.Severity
 import org.eclipse.apoapsis.ortserver.model.util.ComparisonOperator
 import org.eclipse.apoapsis.ortserver.model.util.HierarchyFilter
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
@@ -36,10 +37,12 @@ import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
 import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
 
 import org.jetbrains.exposed.v1.core.AbstractQuery
+import org.jetbrains.exposed.v1.core.Case
 import org.jetbrains.exposed.v1.core.Column
 import org.jetbrains.exposed.v1.core.ComparisonOp
 import org.jetbrains.exposed.v1.core.EqOp
 import org.jetbrains.exposed.v1.core.Expression
+import org.jetbrains.exposed.v1.core.ExpressionWithColumnType
 import org.jetbrains.exposed.v1.core.Op
 import org.jetbrains.exposed.v1.core.QueryParameter
 import org.jetbrains.exposed.v1.core.ResultRow
@@ -49,7 +52,9 @@ import org.jetbrains.exposed.v1.core.TextColumnType
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.dao.id.IdTable
+import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.inList
+import org.jetbrains.exposed.v1.core.intLiteral
 import org.jetbrains.exposed.v1.core.notInList
 import org.jetbrains.exposed.v1.core.or
 import org.jetbrains.exposed.v1.dao.EntityClass
@@ -190,6 +195,13 @@ fun OrderDirection.toSortOrder(): SortOrder =
         OrderDirection.ASCENDING -> SortOrder.ASC
         OrderDirection.DESCENDING -> SortOrder.DESC
     }
+
+/** Return a SQL expression that ranks severities from least to most severe. */
+fun ExpressionWithColumnType<Severity>.severitySortRank(): ExpressionWithColumnType<Int> =
+    Case()
+        .When(this eq Severity.HINT, intLiteral(1))
+        .When(this eq Severity.WARNING, intLiteral(2))
+        .Else(intLiteral(3))
 
 /**
  * Represents a case-insensitive LIKE operation. This is an extension of the [ComparisonOp] class that uses the ILIKE

--- a/model/src/commonMain/kotlin/runs/Issue.kt
+++ b/model/src/commonMain/kotlin/runs/Issue.kt
@@ -26,6 +26,7 @@ import kotlinx.serialization.Serializable
 import org.eclipse.apoapsis.ortserver.model.Severity
 import org.eclipse.apoapsis.ortserver.model.runs.repository.AppliedIssueResolution
 import org.eclipse.apoapsis.ortserver.model.runs.repository.IssueResolution
+import org.eclipse.apoapsis.ortserver.model.util.FilterOperatorAndValue
 
 /**
  * A data class describing an issue that occurred during an ORT run.
@@ -69,8 +70,15 @@ data class Issue(
  * Filters to apply when querying for issues.
  */
 data class IssueFilter(
-    /**
-     * Filter to only return resolved issues. Null if both, resolved an unresolved rule violations should be returned.
-     */
-    val resolved: Boolean? = null
+    /** Filter by resolution status. Null if both resolved and unresolved issues should be returned. */
+    val resolved: Boolean? = null,
+
+    /** Filter issues by their package identifier. */
+    val identifier: FilterOperatorAndValue<String>? = null,
+
+    /** Filter issues by their package PURL. */
+    val purl: FilterOperatorAndValue<String>? = null,
+
+    /** Filter issues by their [Severity]. */
+    val severity: FilterOperatorAndValue<Set<Severity>>? = null
 )

--- a/services/ort-run/src/main/kotlin/IssueService.kt
+++ b/services/ort-run/src/main/kotlin/IssueService.kt
@@ -30,7 +30,10 @@ import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IssuesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.OrtRunsIssuesTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.ResolvedIssuesTable
+import org.eclipse.apoapsis.ortserver.dao.utils.applyFilter
+import org.eclipse.apoapsis.ortserver.dao.utils.applyILike
 import org.eclipse.apoapsis.ortserver.dao.utils.calculateResolutionMessageHash
+import org.eclipse.apoapsis.ortserver.dao.utils.severitySortRank
 import org.eclipse.apoapsis.ortserver.model.CountByCategory
 import org.eclipse.apoapsis.ortserver.model.RepositoryId
 import org.eclipse.apoapsis.ortserver.model.Severity
@@ -40,6 +43,7 @@ import org.eclipse.apoapsis.ortserver.model.runs.IssueFilter
 import org.eclipse.apoapsis.ortserver.model.runs.repository.AppliedIssueResolution
 import org.eclipse.apoapsis.ortserver.model.runs.repository.IssueResolution
 import org.eclipse.apoapsis.ortserver.model.runs.repository.ResolutionSource
+import org.eclipse.apoapsis.ortserver.model.util.ComparisonOperator
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
 import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
@@ -47,20 +51,36 @@ import org.eclipse.apoapsis.ortserver.model.util.OrderField
 import org.eclipse.apoapsis.ortserver.services.ResourceNotFoundException
 import org.eclipse.apoapsis.ortserver.services.utils.toSortOrder
 
+import org.jetbrains.exposed.v1.core.Case
 import org.jetbrains.exposed.v1.core.Count
+import org.jetbrains.exposed.v1.core.ExpressionWithColumnType
 import org.jetbrains.exposed.v1.core.JoinType
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.alias
 import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.concat
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.inSubQuery
 import org.jetbrains.exposed.v1.core.innerJoin
+import org.jetbrains.exposed.v1.core.isNotNull
+import org.jetbrains.exposed.v1.core.isNull
 import org.jetbrains.exposed.v1.core.not
+import org.jetbrains.exposed.v1.core.or
+import org.jetbrains.exposed.v1.core.stringLiteral
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.Query
 import org.jetbrains.exposed.v1.jdbc.andWhere
 import org.jetbrains.exposed.v1.jdbc.select
+
+private class IssueQueryContext(
+    val query: Query,
+    val identifierExpression: ExpressionWithColumnType<String>,
+    val purlColumn: ExpressionWithColumnType<String>,
+    val statusExpression: ExpressionWithColumnType<String>
+)
 
 /**
  * A service to manage and get information about issues.
@@ -70,6 +90,7 @@ class IssueService(
     private val ortRunService: OrtRunService,
     private val issueResolutionService: IssueResolutionService
 ) {
+    /** Return a page of issues for the given ORT run after applying the requested filters. */
     fun listForOrtRunId(
         ortRunId: Long,
         parameters: ListQueryParameters = ListQueryParameters.DEFAULT,
@@ -80,10 +101,10 @@ class IssueService(
         )
 
         return db.blockingQuery {
-            val query = buildListForOrtRunIdQuery(ortRunId, issuesFilter)
+            val context = buildListForOrtRunIdQueryContext(ortRunId, issuesFilter)
 
-            val totalCount = query.count()
-            val ortRunIssueIds = fetchPagedIssueIds(query, parameters)
+            val totalCount = context.query.count()
+            val ortRunIssueIds = fetchPagedIssueIds(context, parameters)
 
             if (ortRunIssueIds.isEmpty()) {
                 return@blockingQuery ListQueryResult(emptyList(), parameters, totalCount)
@@ -110,18 +131,57 @@ class IssueService(
         }
     }
 
-    private fun buildListForOrtRunIdQuery(ortRunId: Long, issuesFilter: IssueFilter): Query {
-        val baseJoin = OrtRunsIssuesTable
-            .innerJoin(IssuesTable, { issueId }, { id })
-            .join(IdentifiersTable, JoinType.LEFT, OrtRunsIssuesTable.identifierId, IdentifiersTable.id)
+    private fun buildListForOrtRunIdQueryContext(
+        ortRunId: Long,
+        issuesFilter: IssueFilter
+    ): IssueQueryContext {
+        val riOrtRunId = OrtRunsIssuesTable.ortRunId.alias("issue_ri_ort_run_id")
 
-        val query = baseJoin
-            .select(OrtRunsIssuesTable.id)
-            .where { OrtRunsIssuesTable.ortRunId eq ortRunId }
+        // Null identifier IDs are excluded from the pairs query before this is passed to the shared PURL builder.
+        @Suppress("UNCHECKED_CAST")
+        val identifierId = OrtRunsIssuesTable.identifierId as ExpressionWithColumnType<EntityID<Long>>
+        val riIdentifierId = identifierId.alias("issue_ri_identifier_id")
+        val runIdPairs = OrtRunsIssuesTable
+            .select(riOrtRunId, riIdentifierId)
+            .where {
+                (OrtRunsIssuesTable.ortRunId eq ortRunId) and OrtRunsIssuesTable.identifierId.isNotNull()
+            }
+            .withDistinct()
+            .alias("issue_run_identifier_pairs")
+
+        val purls = buildPurlByRunIdentifier(
+            runIdPairs,
+            runIdPairs[riOrtRunId],
+            runIdPairs[riIdentifierId]
+        )
+        val purlColumn = purls.alias[purls.purl]
+
+        val identifierExpression = concat(
+            IdentifiersTable.type,
+            stringLiteral(":"),
+            IdentifiersTable.namespace,
+            stringLiteral(":"),
+            IdentifiersTable.name,
+            stringLiteral(":"),
+            IdentifiersTable.version
+        )
 
         val resolvedIssueIdsSubquery = ResolvedIssuesTable
             .select(ResolvedIssuesTable.ortRunIssueId)
             .where { ResolvedIssuesTable.ortRunId eq ortRunId }
+        val statusExpression = Case()
+            .When(OrtRunsIssuesTable.id inSubQuery resolvedIssueIdsSubquery, stringLiteral("Resolved"))
+            .Else(stringLiteral("Unresolved"))
+
+        val query = OrtRunsIssuesTable
+            .innerJoin(IssuesTable, { issueId }, { id })
+            .join(IdentifiersTable, JoinType.LEFT, OrtRunsIssuesTable.identifierId, IdentifiersTable.id)
+            .join(purls.alias, JoinType.LEFT) {
+                (OrtRunsIssuesTable.ortRunId eq purls.alias[purls.ortRunId]) and
+                    (OrtRunsIssuesTable.identifierId eq purls.alias[purls.identifierId])
+            }
+            .select(OrtRunsIssuesTable.id)
+            .where { OrtRunsIssuesTable.ortRunId eq ortRunId }
 
         when (issuesFilter.resolved) {
             true -> query.andWhere { OrtRunsIssuesTable.id inSubQuery resolvedIssueIdsSubquery }
@@ -129,10 +189,31 @@ class IssueService(
             null -> {}
         }
 
-        return query
+        issuesFilter.identifier?.let { filter ->
+            require(filter.operator == ComparisonOperator.ILIKE) {
+                "Unsupported operator for identifier filter: ${filter.operator}"
+            }
+
+            query.andWhere { identifierExpression.applyILike(filter.value) }
+        }
+
+        issuesFilter.purl?.let { filter ->
+            require(filter.operator == ComparisonOperator.ILIKE) {
+                "Unsupported operator for PURL filter: ${filter.operator}"
+            }
+
+            query.andWhere { purlColumn.applyILike(filter.value) }
+        }
+
+        issuesFilter.severity?.let { filter ->
+            query.andWhere { IssuesTable.severity.applyFilter(filter.operator, filter.value) }
+        }
+
+        return IssueQueryContext(query, identifierExpression, purlColumn, statusExpression)
     }
 
-    private fun fetchPagedIssueIds(query: Query, parameters: ListQueryParameters): List<Long> {
+    private fun fetchPagedIssueIds(context: IssueQueryContext, parameters: ListQueryParameters): List<Long> {
+        val query = context.query
         val sortFields = parameters.sortFields.ifEmpty {
             listOf(OrderField("timestamp", OrderDirection.DESCENDING))
         }
@@ -146,7 +227,7 @@ class IssueService(
 
                 "message" -> query.orderBy(IssuesTable.message to sortOrder)
 
-                "severity" -> query.orderBy(IssuesTable.severity to sortOrder)
+                "severity" -> query.orderBy(IssuesTable.severity.severitySortRank() to sortOrder)
 
                 "affectedPath" -> query.orderBy(IssuesTable.affectedPath to sortOrder)
 
@@ -156,6 +237,19 @@ class IssueService(
                     query.orderBy(IdentifiersTable.name to sortOrder)
                     query.orderBy(IdentifiersTable.version to sortOrder)
                 }
+
+                "purl" -> {
+                    val purlWithIdentifierFallback = Case()
+                        .When(
+                            context.purlColumn.isNull() or (context.purlColumn eq ""),
+                            context.identifierExpression
+                        )
+                        .Else(context.purlColumn)
+
+                    query.orderBy(purlWithIdentifierFallback to sortOrder)
+                }
+
+                "status" -> query.orderBy(context.statusExpression to sortOrder)
 
                 "worker" -> query.orderBy(OrtRunsIssuesTable.worker to sortOrder)
 

--- a/services/ort-run/src/main/kotlin/OrtRunVulnerabilityQueryBuilder.kt
+++ b/services/ort-run/src/main/kotlin/OrtRunVulnerabilityQueryBuilder.kt
@@ -27,10 +27,6 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.AdvisorRunsTab
 import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.ResolvedVulnerabilitiesTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.VulnerabilitiesTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.VulnerabilityReferencesTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerjob.AnalyzerJobsTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.AnalyzerRunsTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesAnalyzerRunsTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.ortrun.OrtRunsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
 import org.eclipse.apoapsis.ortserver.dao.utils.applyILike
@@ -38,14 +34,12 @@ import org.eclipse.apoapsis.ortserver.model.VulnerabilityFilters
 import org.eclipse.apoapsis.ortserver.model.util.ComparisonOperator
 import org.eclipse.apoapsis.ortserver.model.util.FilterOperatorAndValue
 
-import org.jetbrains.exposed.v1.core.CustomFunction
 import org.jetbrains.exposed.v1.core.Expression
 import org.jetbrains.exposed.v1.core.ExpressionWithColumnType
 import org.jetbrains.exposed.v1.core.ExpressionWithColumnTypeAlias
 import org.jetbrains.exposed.v1.core.JoinType
 import org.jetbrains.exposed.v1.core.Op
 import org.jetbrains.exposed.v1.core.QueryAlias
-import org.jetbrains.exposed.v1.core.TextColumnType
 import org.jetbrains.exposed.v1.core.alias
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.concat
@@ -53,7 +47,6 @@ import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.innerJoin
-import org.jetbrains.exposed.v1.core.min
 import org.jetbrains.exposed.v1.core.not
 import org.jetbrains.exposed.v1.core.notExists
 import org.jetbrains.exposed.v1.core.notInList
@@ -69,7 +62,19 @@ internal fun buildOrtRunVulnerabilityQueryContext(
 
     val bp = buildOrtRunBasePairs(ortRunId, filters.advisors)
     val ratings = buildOrtRunRatingsByVulnerability(bp, ratingAlias)
-    val purls = buildOrtRunPurlByRunIdentifier(bp)
+
+    val riOrtRunId = bp.alias[bp.ortRunId].alias("ri_ort_run_id")
+    val riIdentifierId = bp.alias[bp.identifierId].alias("ri_identifier_id")
+    val runIdPairs = bp.alias
+        .select(riOrtRunId, riIdentifierId)
+        .withDistinct()
+        .alias("run_identifier_pairs")
+
+    val purls = buildPurlByRunIdentifier(
+        runIdPairs,
+        runIdPairs[riOrtRunId],
+        runIdPairs[riIdentifierId]
+    )
 
     return buildOrtRunFinalQuery(bp, ratings, purls, ratingAlias, filters)
 }
@@ -153,60 +158,6 @@ private fun buildOrtRunRatingsByVulnerability(
         .select(VulnerabilityReferencesTable.vulnerabilityId, ratingAlias)
         .groupBy(VulnerabilityReferencesTable.vulnerabilityId)
         .alias("run_ratings_by_vulnerability")
-}
-
-private fun buildOrtRunPurlByRunIdentifier(bp: OrtRunBasePairsResult): PurlResult {
-    val riOrtRunId = bp.alias[bp.ortRunId].alias("run_ri_ort_run_id")
-    val riIdentifierId = bp.alias[bp.identifierId].alias("run_ri_identifier_id")
-    val runIdPairs = bp.alias
-        .select(riOrtRunId, riIdentifierId)
-        .withDistinct()
-        .alias("run_identifier_pairs")
-
-    val riOrtRunIdCol = runIdPairs[riOrtRunId]
-    val riIdentifierIdCol = runIdPairs[riIdentifierId]
-
-    val bpOrtRunId = riOrtRunIdCol.alias("run_bp_ort_run_id")
-    val bpIdentifierId = riIdentifierIdCol.alias("run_bp_identifier_id")
-    val basePurlMin = PackagesTable.purl.min().alias("run_base_purl")
-
-    val basePurl = AnalyzerJobsTable
-        .innerJoin(AnalyzerRunsTable)
-        .innerJoin(PackagesAnalyzerRunsTable)
-        .innerJoin(PackagesTable)
-        .join(runIdPairs, JoinType.INNER) {
-            (AnalyzerJobsTable.ortRunId eq riOrtRunIdCol) and
-                (PackagesTable.identifierId eq riIdentifierIdCol)
-        }
-        .select(bpOrtRunId, bpIdentifierId, basePurlMin)
-        .groupBy(bpOrtRunId, bpIdentifierId)
-        .alias("run_base_purl_by_run_identifier")
-
-    val curated = buildCuratedPurlByRunIdentifier(runIdPairs, riOrtRunIdCol, riIdentifierIdCol)
-
-    val purl = CustomFunction(
-        "COALESCE",
-        TextColumnType(),
-        curated.alias[curated.purl],
-        basePurl[basePurlMin],
-        stringLiteral("")
-    ).alias("run_purl")
-    val outOrtRunId = riOrtRunIdCol.alias("run_purl_ort_run_id")
-    val outIdentifierId = riIdentifierIdCol.alias("run_purl_identifier_id")
-
-    val query = runIdPairs
-        .join(basePurl, JoinType.LEFT) {
-            (riOrtRunIdCol eq basePurl[bpOrtRunId]) and
-                (riIdentifierIdCol eq basePurl[bpIdentifierId])
-        }
-        .join(curated.alias, JoinType.LEFT) {
-            (riOrtRunIdCol eq curated.alias[curated.ortRunId]) and
-                (riIdentifierIdCol eq curated.alias[curated.identifierId])
-        }
-        .select(outOrtRunId, outIdentifierId, purl)
-        .alias("run_purl_by_run_identifier")
-
-    return PurlResult(query, outOrtRunId, outIdentifierId, purl)
 }
 
 private fun buildOrtRunFinalQuery(

--- a/services/ort-run/src/main/kotlin/OrtRunsVulnerabilityQueryBuilder.kt
+++ b/services/ort-run/src/main/kotlin/OrtRunsVulnerabilityQueryBuilder.kt
@@ -26,33 +26,21 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.AdvisorRunsIde
 import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.AdvisorRunsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.VulnerabilitiesTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.advisorrun.VulnerabilityReferencesTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerjob.AnalyzerJobsTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.AnalyzerRunsTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesAnalyzerRunsTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.ortrun.OrtRunsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.repository.RepositoriesTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageCurationDataTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageCurationsTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.resolvedconfiguration.ResolvedConfigurationsTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.resolvedconfiguration.ResolvedPackageCurationProvidersTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.resolvedconfiguration.ResolvedPackageCurationsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
 import org.eclipse.apoapsis.ortserver.dao.utils.applyILike
 import org.eclipse.apoapsis.ortserver.model.VulnerabilityForRunsFilters
 import org.eclipse.apoapsis.ortserver.model.util.ComparisonOperator
 import org.eclipse.apoapsis.ortserver.model.util.FilterOperatorAndValue
 
-import org.jetbrains.exposed.v1.core.CustomFunction
 import org.jetbrains.exposed.v1.core.Expression
-import org.jetbrains.exposed.v1.core.ExpressionWithColumnType
 import org.jetbrains.exposed.v1.core.ExpressionWithColumnTypeAlias
 import org.jetbrains.exposed.v1.core.IntegerColumnType
 import org.jetbrains.exposed.v1.core.JoinType
 import org.jetbrains.exposed.v1.core.Max
 import org.jetbrains.exposed.v1.core.Op
 import org.jetbrains.exposed.v1.core.QueryAlias
-import org.jetbrains.exposed.v1.core.TextColumnType
 import org.jetbrains.exposed.v1.core.alias
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.concat
@@ -60,12 +48,8 @@ import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.innerJoin
-import org.jetbrains.exposed.v1.core.isNotNull
-import org.jetbrains.exposed.v1.core.min
 import org.jetbrains.exposed.v1.core.notInList
-import org.jetbrains.exposed.v1.core.plus
 import org.jetbrains.exposed.v1.core.stringLiteral
-import org.jetbrains.exposed.v1.core.times
 import org.jetbrains.exposed.v1.jdbc.andWhere
 import org.jetbrains.exposed.v1.jdbc.select
 
@@ -95,7 +79,19 @@ internal fun buildOrtRunsQueryContext(
 
     val bp = buildBasePairs(ortRunIds, filters.advisors)
     val ratings = buildRatingsByVulnerability(bp, ratingAlias)
-    val purls = buildPurlByRunIdentifier(bp)
+
+    val riOrtRunId = bp.alias[bp.ortRunId].alias("ri_ort_run_id")
+    val riIdentifierId = bp.alias[bp.identifierId].alias("ri_identifier_id")
+    val runIdPairs = bp.alias
+        .select(riOrtRunId, riIdentifierId)
+        .withDistinct()
+        .alias("run_identifier_pairs")
+
+    val purls = buildPurlByRunIdentifier(
+        runIdPairs,
+        runIdPairs[riOrtRunId],
+        runIdPairs[riIdentifierId]
+    )
 
     return buildFinalQuery(bp, ratings, purls, ratingAlias, filters, runIdsAlias, repositoriesCountAlias)
 }
@@ -112,20 +108,6 @@ private class BasePairsResult(
     val externalId: ExpressionWithColumnTypeAlias<String>,
     val summary: ExpressionWithColumnTypeAlias<String?>,
     val description: ExpressionWithColumnTypeAlias<String?>
-)
-
-internal class CuratedPurlResult(
-    val alias: QueryAlias,
-    val ortRunId: ExpressionWithColumnTypeAlias<EntityID<Long>>,
-    val identifierId: ExpressionWithColumnTypeAlias<EntityID<Long>>,
-    val purl: ExpressionWithColumnTypeAlias<String?>
-)
-
-internal class PurlResult(
-    val alias: QueryAlias,
-    val ortRunId: ExpressionWithColumnTypeAlias<EntityID<Long>>,
-    val identifierId: ExpressionWithColumnTypeAlias<EntityID<Long>>,
-    val purl: ExpressionWithColumnTypeAlias<String>
 )
 
 // -- Step 1: Base pairs -------------------------------------------------------------------------------
@@ -194,146 +176,6 @@ private fun buildRatingsByVulnerability(
         .select(VulnerabilityReferencesTable.vulnerabilityId, ratingAlias)
         .groupBy(VulnerabilityReferencesTable.vulnerabilityId)
         .alias("ratings_by_vulnerability")
-}
-
-// -- Step 3: PURL lookup ------------------------------------------------------------------------------
-
-/**
- * Build a `purl_by_run_identifier` relation keyed by (ort_run_id, identifier_id).
- * PURL = COALESCE(curated_purl, base_purl, '').
- */
-private fun buildPurlByRunIdentifier(bp: BasePairsResult): PurlResult {
-    // Distinct (ort_run_id, identifier_id) pairs from base_pairs.
-    val riOrtRunId = bp.alias[bp.ortRunId].alias("ri_ort_run_id")
-    val riIdentifierId = bp.alias[bp.identifierId].alias("ri_identifier_id")
-    val runIdPairs = bp.alias
-        .select(riOrtRunId, riIdentifierId)
-        .withDistinct()
-        .alias("run_identifier_pairs")
-
-    val riOrtRunIdCol = runIdPairs[riOrtRunId]
-    val riIdentifierIdCol = runIdPairs[riIdentifierId]
-
-    // Base (uncurated) PURL from analyzer packages.
-    val bpOrtRunId = riOrtRunIdCol.alias("bp_ort_run_id")
-    val bpIdentifierId = riIdentifierIdCol.alias("bp_identifier_id")
-    val basePurlMin = PackagesTable.purl.min().alias("base_purl")
-
-    val basePurl = AnalyzerJobsTable
-        .innerJoin(AnalyzerRunsTable)
-        .innerJoin(PackagesAnalyzerRunsTable)
-        .innerJoin(PackagesTable)
-        .join(runIdPairs, JoinType.INNER) {
-            (AnalyzerJobsTable.ortRunId eq riOrtRunIdCol) and
-                (PackagesTable.identifierId eq riIdentifierIdCol)
-        }
-        .select(bpOrtRunId, bpIdentifierId, basePurlMin)
-        .groupBy(bpOrtRunId, bpIdentifierId)
-        .alias("base_purl_by_run_identifier")
-
-    // Curated PURL using composite rank (provider_rank * 10000 + curation_rank).
-    val curated = buildCuratedPurlByRunIdentifier(runIdPairs, riOrtRunIdCol, riIdentifierIdCol)
-
-    // Combine: COALESCE(curated, base, '').
-    val purl = CustomFunction(
-        "COALESCE",
-        TextColumnType(),
-        curated.alias[curated.purl],
-        basePurl[basePurlMin],
-        stringLiteral("")
-    ).alias("purl")
-    val outOrtRunId = riOrtRunIdCol.alias("purl_ort_run_id")
-    val outIdentifierId = riIdentifierIdCol.alias("purl_identifier_id")
-
-    val query = runIdPairs
-        .join(basePurl, JoinType.LEFT) {
-            (riOrtRunIdCol eq basePurl[bpOrtRunId]) and
-                (riIdentifierIdCol eq basePurl[bpIdentifierId])
-        }
-        .join(curated.alias, JoinType.LEFT) {
-            (riOrtRunIdCol eq curated.alias[curated.ortRunId]) and
-                (riIdentifierIdCol eq curated.alias[curated.identifierId])
-        }
-        .select(outOrtRunId, outIdentifierId, purl)
-        .alias("purl_by_run_identifier")
-
-    return PurlResult(query, outOrtRunId, outIdentifierId, purl)
-}
-
-/**
- * Find the highest-priority curated PURL for each (ort_run_id, identifier_id) pair.
- *
- * Curations are prioritized by two independent rank dimensions: the *provider rank*
- * (which curation provider supplied it) and the *curation rank* (ordering within that provider).
- * The correct priority is lexicographic: lowest provider_rank wins first, then lowest
- * curation_rank breaks ties within the same provider.
- *
- * Replace two separate min/filter passes (find min provider_rank, filter, then find
- * min curation_rank within those, filter again) with collapsing both dimensions into a
- * single composite key which preserves the lexicographic ordering (provider_rank is
- * always the dominant term).
- *
- * With the composite rank, the resolution becomes 3 stages instead of 5:
- * 1. Collect all candidates with their composite rank
- * 2. Find the minimum composite rank per (ort_run_id, identifier_id)
- * 3. Join back once to retrieve the PURL at that rank (with `min()` as a tiebreaker
- *    for the theoretical case of duplicate composite ranks)
- *
- * As a side benefit, fewer subquery stages means fewer plan nodes for PostgreSQL's JIT
- * compiler to process, modestly reducing compilation overhead.
- */
-internal fun buildCuratedPurlByRunIdentifier(
-    runIdPairs: QueryAlias,
-    riOrtRunIdCol: ExpressionWithColumnType<EntityID<Long>>,
-    riIdentifierIdCol: ExpressionWithColumnType<EntityID<Long>>
-): CuratedPurlResult {
-    // Stage 1: All curated PURL candidates with composite rank.
-    val ccOrtRunId = riOrtRunIdCol.alias("cc_ort_run_id")
-    val ccIdentifierId = riIdentifierIdCol.alias("cc_identifier_id")
-    val compositeRank =
-        (ResolvedPackageCurationProvidersTable.rank * 10000 + ResolvedPackageCurationsTable.rank)
-            .alias("composite_rank")
-    val ccPurl = PackageCurationDataTable.purl.alias("cc_purl")
-
-    val candidates = ResolvedConfigurationsTable
-        .innerJoin(ResolvedPackageCurationProvidersTable)
-        .innerJoin(ResolvedPackageCurationsTable)
-        .innerJoin(PackageCurationsTable)
-        .innerJoin(PackageCurationDataTable)
-        .join(runIdPairs, JoinType.INNER) {
-            (ResolvedConfigurationsTable.ortRunId eq riOrtRunIdCol) and
-                (PackageCurationsTable.identifierId eq riIdentifierIdCol)
-        }
-        .select(ccOrtRunId, ccIdentifierId, compositeRank, ccPurl)
-        .where { PackageCurationDataTable.purl.isNotNull() }
-        .alias("curated_candidates")
-
-    // Stage 2: Min composite rank per (ort_run_id, identifier_id).
-    val mrOrtRunId = candidates[ccOrtRunId].alias("mr_ort_run_id")
-    val mrIdentifierId = candidates[ccIdentifierId].alias("mr_identifier_id")
-    val minRank = candidates[compositeRank].min().alias("min_composite_rank")
-
-    val minRanks = candidates
-        .select(mrOrtRunId, mrIdentifierId, minRank)
-        .groupBy(mrOrtRunId, mrIdentifierId)
-        .alias("curated_min_rank")
-
-    // Stage 3: Join back to get PURL at min rank, with min() as tiebreaker.
-    val outOrtRunId = candidates[ccOrtRunId].alias("cp_ort_run_id")
-    val outIdentifierId = candidates[ccIdentifierId].alias("cp_identifier_id")
-    val curatedPurl = candidates[ccPurl].min().alias("curated_purl")
-
-    val query = candidates
-        .join(minRanks, JoinType.INNER) {
-            (candidates[ccOrtRunId] eq minRanks[mrOrtRunId]) and
-                (candidates[ccIdentifierId] eq minRanks[mrIdentifierId]) and
-                (candidates[compositeRank] eq minRanks[minRank])
-        }
-        .select(outOrtRunId, outIdentifierId, curatedPurl)
-        .groupBy(outOrtRunId, outIdentifierId)
-        .alias("curated_purl_by_run_identifier")
-
-    return CuratedPurlResult(query, outOrtRunId, outIdentifierId, curatedPurl)
 }
 
 // -- Steps 4-5: Final query ---------------------------------------------------------------------------

--- a/services/ort-run/src/main/kotlin/PurlQueryBuilder.kt
+++ b/services/ort-run/src/main/kotlin/PurlQueryBuilder.kt
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.services.ortrun
+
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerjob.AnalyzerJobsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.AnalyzerRunsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesAnalyzerRunsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.analyzerrun.PackagesTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageCurationDataTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.PackageCurationsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.resolvedconfiguration.ResolvedConfigurationsTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.resolvedconfiguration.ResolvedPackageCurationProvidersTable
+import org.eclipse.apoapsis.ortserver.dao.repositories.resolvedconfiguration.ResolvedPackageCurationsTable
+
+import org.jetbrains.exposed.v1.core.CustomFunction
+import org.jetbrains.exposed.v1.core.ExpressionWithColumnType
+import org.jetbrains.exposed.v1.core.ExpressionWithColumnTypeAlias
+import org.jetbrains.exposed.v1.core.JoinType
+import org.jetbrains.exposed.v1.core.QueryAlias
+import org.jetbrains.exposed.v1.core.TextColumnType
+import org.jetbrains.exposed.v1.core.alias
+import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
+import org.jetbrains.exposed.v1.core.eq
+import org.jetbrains.exposed.v1.core.innerJoin
+import org.jetbrains.exposed.v1.core.isNotNull
+import org.jetbrains.exposed.v1.core.min
+import org.jetbrains.exposed.v1.core.plus
+import org.jetbrains.exposed.v1.core.stringLiteral
+import org.jetbrains.exposed.v1.core.times
+import org.jetbrains.exposed.v1.jdbc.select
+
+internal class CuratedPurlResult(
+    val alias: QueryAlias,
+    val ortRunId: ExpressionWithColumnTypeAlias<EntityID<Long>>,
+    val identifierId: ExpressionWithColumnTypeAlias<EntityID<Long>>,
+    val purl: ExpressionWithColumnTypeAlias<String?>
+)
+
+internal class PurlResult(
+    val alias: QueryAlias,
+    val ortRunId: ExpressionWithColumnTypeAlias<EntityID<Long>>,
+    val identifierId: ExpressionWithColumnTypeAlias<EntityID<Long>>,
+    val purl: ExpressionWithColumnTypeAlias<String>
+)
+
+/**
+ * Build a `purl_by_run_identifier` relation keyed by (ort_run_id, identifier_id).
+ * PURL = COALESCE(curated_purl, base_purl, '').
+ */
+internal fun buildPurlByRunIdentifier(
+    runIdPairs: QueryAlias,
+    riOrtRunIdCol: ExpressionWithColumnType<EntityID<Long>>,
+    riIdentifierIdCol: ExpressionWithColumnType<EntityID<Long>>
+): PurlResult {
+    // Base (uncurated) PURL from analyzer packages.
+    val bpOrtRunId = riOrtRunIdCol.alias("bp_ort_run_id")
+    val bpIdentifierId = riIdentifierIdCol.alias("bp_identifier_id")
+    val basePurlMin = PackagesTable.purl.min().alias("base_purl")
+
+    val basePurl = AnalyzerJobsTable
+        .innerJoin(AnalyzerRunsTable)
+        .innerJoin(PackagesAnalyzerRunsTable)
+        .innerJoin(PackagesTable)
+        .join(runIdPairs, JoinType.INNER) {
+            (AnalyzerJobsTable.ortRunId eq riOrtRunIdCol) and
+                (PackagesTable.identifierId eq riIdentifierIdCol)
+        }
+        .select(bpOrtRunId, bpIdentifierId, basePurlMin)
+        .groupBy(bpOrtRunId, bpIdentifierId)
+        .alias("base_purl_by_run_identifier")
+
+    // Curated PURL using composite rank (provider_rank * 10000 + curation_rank).
+    val curated = buildCuratedPurlByRunIdentifier(runIdPairs, riOrtRunIdCol, riIdentifierIdCol)
+
+    // Combine: COALESCE(curated, base, '').
+    val purl = CustomFunction(
+        "COALESCE",
+        TextColumnType(),
+        curated.alias[curated.purl],
+        basePurl[basePurlMin],
+        stringLiteral("")
+    ).alias("purl")
+    val outOrtRunId = riOrtRunIdCol.alias("purl_ort_run_id")
+    val outIdentifierId = riIdentifierIdCol.alias("purl_identifier_id")
+
+    val query = runIdPairs
+        .join(basePurl, JoinType.LEFT) {
+            (riOrtRunIdCol eq basePurl[bpOrtRunId]) and
+                (riIdentifierIdCol eq basePurl[bpIdentifierId])
+        }
+        .join(curated.alias, JoinType.LEFT) {
+            (riOrtRunIdCol eq curated.alias[curated.ortRunId]) and
+                (riIdentifierIdCol eq curated.alias[curated.identifierId])
+        }
+        .select(outOrtRunId, outIdentifierId, purl)
+        .alias("purl_by_run_identifier")
+
+    return PurlResult(query, outOrtRunId, outIdentifierId, purl)
+}
+
+/**
+ * Find the highest-priority curated PURL for each (ort_run_id, identifier_id) pair.
+ *
+ * Curations are prioritized by two independent rank dimensions: the *provider rank*
+ * (which curation provider supplied it) and the *curation rank* (ordering within that provider).
+ * The correct priority is lexicographic: lowest provider_rank wins first, then lowest
+ * curation_rank breaks ties within the same provider.
+ *
+ * Replace two separate min/filter passes (find min provider_rank, filter, then find
+ * min curation_rank within those, filter again) with collapsing both dimensions into a
+ * single composite key which preserves the lexicographic ordering (provider_rank is
+ * always the dominant term).
+ *
+ * With the composite rank, the resolution becomes 3 stages instead of 5:
+ * 1. Collect all candidates with their composite rank
+ * 2. Find the minimum composite rank per (ort_run_id, identifier_id)
+ * 3. Join back once to retrieve the PURL at that rank (with `min()` as a tiebreaker
+ *    for the theoretical case of duplicate composite ranks)
+ *
+ * As a side benefit, fewer subquery stages means fewer plan nodes for PostgreSQL's JIT
+ * compiler to process, modestly reducing compilation overhead.
+ */
+internal fun buildCuratedPurlByRunIdentifier(
+    runIdPairs: QueryAlias,
+    riOrtRunIdCol: ExpressionWithColumnType<EntityID<Long>>,
+    riIdentifierIdCol: ExpressionWithColumnType<EntityID<Long>>
+): CuratedPurlResult {
+    // Stage 1: All curated PURL candidates with composite rank.
+    val ccOrtRunId = riOrtRunIdCol.alias("cc_ort_run_id")
+    val ccIdentifierId = riIdentifierIdCol.alias("cc_identifier_id")
+    val compositeRank =
+        (ResolvedPackageCurationProvidersTable.rank * 10000 + ResolvedPackageCurationsTable.rank)
+            .alias("composite_rank")
+    val ccPurl = PackageCurationDataTable.purl.alias("cc_purl")
+
+    val candidates = ResolvedConfigurationsTable
+        .innerJoin(ResolvedPackageCurationProvidersTable)
+        .innerJoin(ResolvedPackageCurationsTable)
+        .innerJoin(PackageCurationsTable)
+        .innerJoin(PackageCurationDataTable)
+        .join(runIdPairs, JoinType.INNER) {
+            (ResolvedConfigurationsTable.ortRunId eq riOrtRunIdCol) and
+                (PackageCurationsTable.identifierId eq riIdentifierIdCol)
+        }
+        .select(ccOrtRunId, ccIdentifierId, compositeRank, ccPurl)
+        .where { PackageCurationDataTable.purl.isNotNull() }
+        .alias("curated_candidates")
+
+    // Stage 2: Min composite rank per (ort_run_id, identifier_id).
+    val mrOrtRunId = candidates[ccOrtRunId].alias("mr_ort_run_id")
+    val mrIdentifierId = candidates[ccIdentifierId].alias("mr_identifier_id")
+    val minRank = candidates[compositeRank].min().alias("min_composite_rank")
+
+    val minRanks = candidates
+        .select(mrOrtRunId, mrIdentifierId, minRank)
+        .groupBy(mrOrtRunId, mrIdentifierId)
+        .alias("curated_min_rank")
+
+    // Stage 3: Join back to get PURL at min rank, with min() as tiebreaker.
+    val outOrtRunId = candidates[ccOrtRunId].alias("cp_ort_run_id")
+    val outIdentifierId = candidates[ccIdentifierId].alias("cp_identifier_id")
+    val curatedPurl = candidates[ccPurl].min().alias("curated_purl")
+
+    val query = candidates
+        .join(minRanks, JoinType.INNER) {
+            (candidates[ccOrtRunId] eq minRanks[mrOrtRunId]) and
+                (candidates[ccIdentifierId] eq minRanks[mrIdentifierId]) and
+                (candidates[compositeRank] eq minRanks[minRank])
+        }
+        .select(outOrtRunId, outIdentifierId, curatedPurl)
+        .groupBy(outOrtRunId, outIdentifierId)
+        .alias("curated_purl_by_run_identifier")
+
+    return CuratedPurlResult(query, outOrtRunId, outIdentifierId, curatedPurl)
+}

--- a/services/ort-run/src/test/kotlin/IssueServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/IssueServiceTest.kt
@@ -23,6 +23,8 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldBeSingleton
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.beNull
@@ -48,7 +50,9 @@ import org.eclipse.apoapsis.ortserver.model.JobConfigurations
 import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.RepositoryId
 import org.eclipse.apoapsis.ortserver.model.Severity
+import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.PackageCurationProviderConfig
 import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.ResolvedItemsResult
+import org.eclipse.apoapsis.ortserver.model.resolvedconfiguration.ResolvedPackageCurations
 import org.eclipse.apoapsis.ortserver.model.runs.AnalyzerConfiguration
 import org.eclipse.apoapsis.ortserver.model.runs.Environment
 import org.eclipse.apoapsis.ortserver.model.runs.Identifier
@@ -57,8 +61,12 @@ import org.eclipse.apoapsis.ortserver.model.runs.IssueFilter
 import org.eclipse.apoapsis.ortserver.model.runs.repository.AppliedIssueResolution
 import org.eclipse.apoapsis.ortserver.model.runs.repository.IssueResolution
 import org.eclipse.apoapsis.ortserver.model.runs.repository.IssueResolutionReason
+import org.eclipse.apoapsis.ortserver.model.runs.repository.PackageCuration
+import org.eclipse.apoapsis.ortserver.model.runs.repository.PackageCurationData
 import org.eclipse.apoapsis.ortserver.model.runs.repository.ResolutionSource
 import org.eclipse.apoapsis.ortserver.model.runs.repository.Resolutions
+import org.eclipse.apoapsis.ortserver.model.util.ComparisonOperator
+import org.eclipse.apoapsis.ortserver.model.util.FilterOperatorAndValue
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
 import org.eclipse.apoapsis.ortserver.model.util.OrderField
@@ -470,6 +478,311 @@ class IssueServiceTest : WordSpec() {
                 dependencyIssue.purl shouldBe pkg.purl
             }
 
+            "filter by identifier using case-insensitive coordinate substrings" {
+                val scenario = createIssuePackageScenario()
+                val filter = IssueFilter(
+                    identifier = FilterOperatorAndValue(ComparisonOperator.ILIKE, "EXAMPLE:ALPHA-LIB:1")
+                )
+
+                val result = service.listForOrtRunId(scenario.ortRun.id, issuesFilter = filter)
+
+                result.data.shouldBeSingleton {
+                    it.message shouldBe scenario.packageIssue.message
+                }
+                result.totalCount shouldBe 1
+            }
+
+            "filter by analyzer PURL within the requested run" {
+                val scenario = createIssuePackageScenario()
+                val otherScenario = createIssuePackageScenario(
+                    repositoryId = scenario.ortRun.repositoryId,
+                    primaryPackageName = "other-lib"
+                )
+
+                val matchingResult = service.listForOrtRunId(
+                    scenario.ortRun.id,
+                    issuesFilter = IssueFilter(
+                        purl = FilterOperatorAndValue(ComparisonOperator.ILIKE, "ALPHA-LIB")
+                    )
+                )
+                val otherRunResult = service.listForOrtRunId(
+                    scenario.ortRun.id,
+                    issuesFilter = IssueFilter(
+                        purl = FilterOperatorAndValue(
+                            ComparisonOperator.ILIKE,
+                            otherScenario.packagePurl
+                        )
+                    )
+                )
+
+                matchingResult.data.shouldBeSingleton {
+                    it.purl shouldBe scenario.packagePurl
+                    it.purl.orEmpty().lowercase() shouldContain "alpha-lib"
+                }
+                matchingResult.totalCount shouldBe 1
+                otherRunResult.data should beEmpty()
+            }
+
+            "filter by curated PURL instead of analyzer PURL" {
+                val curatedPurl = "pkg:maven/com.example/curated-alpha@2.0"
+                val scenario = createIssuePackageScenario(curatedPurl = curatedPurl)
+
+                val curatedResult = service.listForOrtRunId(
+                    scenario.ortRun.id,
+                    issuesFilter = IssueFilter(
+                        purl = FilterOperatorAndValue(ComparisonOperator.ILIKE, "CURATED-ALPHA")
+                    )
+                )
+                val analyzerResult = service.listForOrtRunId(
+                    scenario.ortRun.id,
+                    issuesFilter = IssueFilter(
+                        purl = FilterOperatorAndValue(ComparisonOperator.ILIKE, scenario.packagePurl)
+                    )
+                )
+
+                curatedResult.data.shouldBeSingleton {
+                    it.purl shouldBe curatedPurl
+                    it.purl.orEmpty().lowercase() shouldContain "curated-alpha"
+                }
+                analyzerResult.data should beEmpty()
+            }
+
+            "filter by multiple included and excluded severities" {
+                val scenario = createIssuePackageScenario()
+
+                val includedResult = service.listForOrtRunId(
+                    scenario.ortRun.id,
+                    issuesFilter = IssueFilter(
+                        severity = FilterOperatorAndValue(
+                            ComparisonOperator.IN,
+                            setOf(Severity.HINT, Severity.WARNING)
+                        )
+                    )
+                )
+                val excludedResult = service.listForOrtRunId(
+                    scenario.ortRun.id,
+                    issuesFilter = IssueFilter(
+                        severity = FilterOperatorAndValue(
+                            ComparisonOperator.NOT_IN,
+                            setOf(Severity.HINT, Severity.WARNING)
+                        )
+                    )
+                )
+
+                includedResult.data.map { it.severity }.shouldContainExactlyInAnyOrder(
+                    Severity.HINT,
+                    Severity.WARNING
+                )
+                excludedResult.data.map { it.severity }.shouldContainExactly(Severity.ERROR, Severity.ERROR)
+            }
+
+            "combine identifier, PURL, severity, and resolved filters" {
+                val scenario = createIssuePackageScenario()
+                val resolution = IssueResolution(
+                    message = scenario.packageIssue.message,
+                    reason = IssueResolutionReason.CANT_FIX_ISSUE,
+                    comment = "Known issue.",
+                    source = ResolutionSource.REPOSITORY_FILE
+                )
+                fixtures.resolvedConfigurationRepository.addResolutions(
+                    scenario.ortRun.id,
+                    ResolvedItemsResult(issues = mapOf(scenario.packageIssue to listOf(resolution)))
+                )
+
+                val result = service.listForOrtRunId(
+                    scenario.ortRun.id,
+                    issuesFilter = IssueFilter(
+                        resolved = true,
+                        identifier = FilterOperatorAndValue(ComparisonOperator.ILIKE, "alpha-lib"),
+                        purl = FilterOperatorAndValue(ComparisonOperator.ILIKE, "alpha-lib"),
+                        severity = FilterOperatorAndValue(
+                            ComparisonOperator.IN,
+                            setOf(Severity.ERROR, Severity.WARNING)
+                        )
+                    )
+                )
+
+                result.data.shouldBeSingleton {
+                    it.message shouldBe scenario.packageIssue.message
+                    it.purl shouldBe scenario.packagePurl
+                }
+                result.totalCount shouldBe 1
+            }
+
+            "count all filtered issues before pagination" {
+                val scenario = createIssuePackageScenario()
+                val parameters = ListQueryParameters(
+                    sortFields = listOf(OrderField("source", OrderDirection.ASCENDING)),
+                    limit = 1,
+                    offset = 1
+                )
+                val filter = IssueFilter(
+                    severity = FilterOperatorAndValue(
+                        ComparisonOperator.IN,
+                        setOf(Severity.ERROR, Severity.WARNING)
+                    )
+                )
+
+                val result = service.listForOrtRunId(scenario.ortRun.id, parameters, filter)
+
+                result.data shouldHaveSize 1
+                result.totalCount shouldBe 3
+            }
+
+            "reject unsupported filter operators" {
+                val scenario = createIssuePackageScenario()
+
+                shouldThrow<IllegalArgumentException> {
+                    service.listForOrtRunId(
+                        scenario.ortRun.id,
+                        issuesFilter = IssueFilter(
+                            identifier = FilterOperatorAndValue(ComparisonOperator.EQUALS, "alpha-lib")
+                        )
+                    )
+                }.message shouldContain "Unsupported operator for identifier filter"
+
+                shouldThrow<IllegalArgumentException> {
+                    service.listForOrtRunId(
+                        scenario.ortRun.id,
+                        issuesFilter = IssueFilter(
+                            purl = FilterOperatorAndValue(ComparisonOperator.EQUALS, "alpha-lib")
+                        )
+                    )
+                }.message shouldContain "Unsupported operator for PURL filter"
+
+                shouldThrow<IllegalArgumentException> {
+                    service.listForOrtRunId(
+                        scenario.ortRun.id,
+                        issuesFilter = IssueFilter(
+                            severity = FilterOperatorAndValue(ComparisonOperator.ILIKE, setOf(Severity.ERROR))
+                        )
+                    )
+                }.message shouldContain "Unsupported operator for collections"
+            }
+
+            "keep package, project, and unidentified issues in unfiltered results" {
+                val scenario = createIssuePackageScenario()
+
+                val result = service.listForOrtRunId(scenario.ortRun.id)
+
+                result.data.map { it.message }.shouldContainExactlyInAnyOrder(
+                    scenario.packageIssue.message,
+                    scenario.secondPackageIssue.message,
+                    scenario.projectIssue.message,
+                    scenario.unidentifiedIssue.message
+                )
+                result.totalCount shouldBe 4
+            }
+
+            "sort by identifier in both directions" {
+                val scenario = createIssuePackageScenario()
+
+                val ascendingResult = service.listForOrtRunId(
+                    scenario.ortRun.id,
+                    ListQueryParameters(
+                        sortFields = listOf(OrderField("identifier", OrderDirection.ASCENDING))
+                    )
+                )
+                val descendingResult = service.listForOrtRunId(
+                    scenario.ortRun.id,
+                    ListQueryParameters(
+                        sortFields = listOf(OrderField("identifier", OrderDirection.DESCENDING))
+                    )
+                )
+
+                ascendingResult.data.map { it.message }.shouldContainExactly(
+                    scenario.projectIssue.message,
+                    scenario.packageIssue.message,
+                    scenario.secondPackageIssue.message,
+                    scenario.unidentifiedIssue.message
+                )
+                descendingResult.data.map { it.message }.shouldContainExactly(
+                    scenario.unidentifiedIssue.message,
+                    scenario.secondPackageIssue.message,
+                    scenario.packageIssue.message,
+                    scenario.projectIssue.message
+                )
+            }
+
+            "sort by effective PURL with identifier fallbacks in both directions" {
+                val curatedPurl = "pkg:zzz/curated@1.0"
+                val scenario = createIssuePackageScenario(curatedPurl = curatedPurl)
+
+                val ascendingResult = service.listForOrtRunId(
+                    scenario.ortRun.id,
+                    ListQueryParameters(sortFields = listOf(OrderField("purl", OrderDirection.ASCENDING)))
+                )
+                val descendingResult = service.listForOrtRunId(
+                    scenario.ortRun.id,
+                    ListQueryParameters(sortFields = listOf(OrderField("purl", OrderDirection.DESCENDING)))
+                )
+
+                ascendingResult.data.map { it.message }.shouldContainExactly(
+                    scenario.unidentifiedIssue.message,
+                    scenario.projectIssue.message,
+                    scenario.secondPackageIssue.message,
+                    scenario.packageIssue.message
+                )
+                ascendingResult.data.last().purl shouldBe curatedPurl
+                descendingResult.data.map { it.message }.shouldContainExactly(
+                    scenario.packageIssue.message,
+                    scenario.secondPackageIssue.message,
+                    scenario.projectIssue.message,
+                    scenario.unidentifiedIssue.message
+                )
+            }
+
+            "sort by status in both directions" {
+                val scenario = createIssuePackageScenario()
+                val resolution = IssueResolution(
+                    message = scenario.packageIssue.message,
+                    reason = IssueResolutionReason.CANT_FIX_ISSUE,
+                    comment = "Known issue.",
+                    source = ResolutionSource.REPOSITORY_FILE
+                )
+                fixtures.resolvedConfigurationRepository.addResolutions(
+                    scenario.ortRun.id,
+                    ResolvedItemsResult(issues = mapOf(scenario.packageIssue to listOf(resolution)))
+                )
+
+                val ascendingResult = service.listForOrtRunId(
+                    scenario.ortRun.id,
+                    ListQueryParameters(sortFields = listOf(OrderField("status", OrderDirection.ASCENDING)))
+                )
+                val descendingResult = service.listForOrtRunId(
+                    scenario.ortRun.id,
+                    ListQueryParameters(sortFields = listOf(OrderField("status", OrderDirection.DESCENDING)))
+                )
+
+                ascendingResult.data.first().message shouldBe scenario.packageIssue.message
+                descendingResult.data.last().message shouldBe scenario.packageIssue.message
+            }
+
+            "apply multiple sort fields before pagination with a stable tie-breaker" {
+                val now = Clock.System.now()
+                val issues = listOf(
+                    Issue(now, "A", "first error", Severity.ERROR),
+                    Issue(now, "A", "second error", Severity.ERROR),
+                    Issue(now, "B", "warning", Severity.WARNING)
+                )
+                val ortRun = createOrtRunWithIssues(issues = issues)
+                val parameters = ListQueryParameters(
+                    sortFields = listOf(
+                        OrderField("severity", OrderDirection.ASCENDING),
+                        OrderField("source", OrderDirection.DESCENDING)
+                    ),
+                    limit = 1,
+                    offset = 1
+                )
+
+                val result = service.listForOrtRunId(ortRun.id, parameters)
+
+                result.data.shouldBeSingleton {
+                    it.message shouldBe "first error"
+                }
+                result.totalCount shouldBe 3
+            }
+
             "sort by timestamp descending by default" {
                 val repositoryId = fixtures.createRepository().id
                 val now = Clock.System.now()
@@ -573,10 +886,18 @@ class IssueServiceTest : WordSpec() {
                 val result = service.listForOrtRunId(ortRun.id, params)
 
                 result.data shouldHaveSize 3
-                // Severity is stored as enumerationByName, so SQL sorts alphabetically:
-                // ERROR < HINT < WARNING
                 result.data.map { it.severity } shouldBe
-                    listOf(Severity.ERROR, Severity.HINT, Severity.WARNING)
+                    listOf(Severity.HINT, Severity.WARNING, Severity.ERROR)
+
+                val descendingResult = service.listForOrtRunId(
+                    ortRun.id,
+                    ListQueryParameters(
+                        sortFields = listOf(OrderField("severity", OrderDirection.DESCENDING))
+                    )
+                )
+
+                descendingResult.data.map { it.severity } shouldBe
+                    listOf(Severity.ERROR, Severity.WARNING, Severity.HINT)
             }
 
             "sort by source" {
@@ -640,7 +961,7 @@ class IssueServiceTest : WordSpec() {
 
                 val ortRun = createOrtRunWithIssues(repositoryId, issues)
 
-                // Sort by severity DESC (alphabetically: WARNING > HINT > ERROR), then timestamp ASC.
+                // Sort by severity DESC, then timestamp ASC.
                 val params = ListQueryParameters(
                     sortFields = listOf(
                         OrderField("severity", OrderDirection.DESCENDING),
@@ -651,9 +972,9 @@ class IssueServiceTest : WordSpec() {
                 val result = service.listForOrtRunId(ortRun.id, params)
 
                 result.data shouldHaveSize 3
-                result.data[0].message shouldBe "warning"
-                result.data[1].message shouldBe "error-older"
-                result.data[2].message shouldBe "error-newer"
+                result.data[0].message shouldBe "error-older"
+                result.data[1].message shouldBe "error-newer"
+                result.data[2].message shouldBe "warning"
             }
 
             "apply pagination with limit and offset" {
@@ -1188,6 +1509,93 @@ class IssueServiceTest : WordSpec() {
                 affectedPath = "package/dist/somefile"
             )
         )
+
+    private data class IssuePackageScenario(
+        val ortRun: OrtRun,
+        val packageIssue: Issue,
+        val secondPackageIssue: Issue,
+        val projectIssue: Issue,
+        val unidentifiedIssue: Issue,
+        val packagePurl: String
+    )
+
+    private fun createIssuePackageScenario(
+        repositoryId: Long = fixtures.createRepository().id,
+        primaryPackageName: String = "alpha-lib",
+        curatedPurl: String? = null
+    ): IssuePackageScenario {
+        val pkg = fixtures.generatePackage(
+            Identifier("Maven", "com.example", primaryPackageName, "1.0")
+        )
+        val secondPkg = fixtures.generatePackage(
+            Identifier("NPM", "org.example", "zeta-lib", "2.0")
+        )
+        val project = fixtures.getProject()
+        val now = Clock.System.now()
+        val packageIssue = Issue(
+            timestamp = now,
+            source = "Analyzer",
+            message = "issue for $primaryPackageName",
+            severity = Severity.ERROR,
+            identifier = pkg.identifier
+        )
+        val secondPackageIssue = Issue(
+            timestamp = now.plus(1.seconds),
+            source = "Scanner",
+            message = "issue for zeta-lib",
+            severity = Severity.WARNING,
+            identifier = secondPkg.identifier
+        )
+        val projectIssue = Issue(
+            timestamp = now.plus(2.seconds),
+            source = "Project",
+            message = "project issue",
+            severity = Severity.HINT,
+            identifier = project.identifier
+        )
+        val unidentifiedIssue = Issue(
+            timestamp = now.plus(3.seconds),
+            source = "Other",
+            message = "unidentified issue",
+            severity = Severity.ERROR
+        )
+        val ortRun = createOrtRunWithIssues(
+            repositoryId,
+            listOf(packageIssue, secondPackageIssue, projectIssue, unidentifiedIssue)
+        )
+        val analyzerJob = fixtures.createAnalyzerJob(ortRun.id)
+        fixtures.createAnalyzerRun(
+            analyzerJob.id,
+            projects = setOf(project),
+            packages = setOf(pkg, secondPkg)
+        )
+
+        if (curatedPurl != null) {
+            fixtures.resolvedConfigurationRepository.addPackageCurations(
+                ortRun.id,
+                listOf(
+                    ResolvedPackageCurations(
+                        provider = PackageCurationProviderConfig("test"),
+                        curations = listOf(
+                            PackageCuration(
+                                id = pkg.identifier,
+                                data = PackageCurationData(purl = curatedPurl)
+                            )
+                        )
+                    )
+                )
+            )
+        }
+
+        return IssuePackageScenario(
+            ortRun,
+            packageIssue,
+            secondPackageIssue,
+            projectIssue,
+            unidentifiedIssue,
+            pkg.purl
+        )
+    }
 
     private fun createOrtRunWithIssueResolutions(
         repositoryId: Long,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues/index.tsx
@@ -24,14 +24,11 @@ import {
   ExpandedState,
   getCoreRowModel,
   getExpandedRowModel,
-  getFilteredRowModel,
-  getPaginationRowModel,
-  getSortedRowModel,
   Row,
   useReactTable,
 } from '@tanstack/react-table';
 import { ChevronDown, ChevronUp } from 'lucide-react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 import z from 'zod';
 
 import { Issue, Severity } from '@/api';
@@ -73,20 +70,19 @@ import {
   getIssueSeverityBackgroundColor,
   getResolvedBackgroundColor,
 } from '@/helpers/get-status-class';
-import { updateColumnSorting } from '@/helpers/handle-multisort';
+import {
+  convertToBackendSorting,
+  updateColumnSorting,
+} from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-conversion';
 import {
   getResolutionAccordionDefaultValue,
   getResolutionAccordionLabel,
   getResolvedStatus,
 } from '@/helpers/resolutions';
-import { compareSeverity } from '@/helpers/sorting-functions';
-import { ACTION_COLUMN_SIZE, ALL_ITEMS } from '@/lib/constants';
+import { ACTION_COLUMN_SIZE } from '@/lib/constants';
 import { toastError } from '@/lib/toast';
 import {
-  IssueCategory,
-  issueCategorySchema,
-  issueCategorySearchParameterSchema,
   ItemResolved,
   itemResolvedSchema,
   itemStatusSearchParameterSchema,
@@ -99,6 +95,13 @@ import {
 import { useUserSettingsStore } from '@/store/user-settings.store';
 
 const defaultPageSize = 10;
+const supportedSortColumns = new Set([
+  'identifier',
+  'purl',
+  'status',
+  'severity',
+  'source',
+]);
 
 const columnHelper = createColumnHelper<Issue>();
 
@@ -274,11 +277,8 @@ const IssuesComponent = () => {
         return getResolvedStatus(issue);
       },
       {
-        id: 'itemStatus',
+        id: 'status',
         header: 'Status',
-        filterFn: (row, _columnId, filterValue): boolean => {
-          return filterValue.includes(getResolvedStatus(row.original));
-        },
         meta: {
           filter: {
             filterVariant: 'select',
@@ -301,12 +301,6 @@ const IssuesComponent = () => {
     ),
     columnHelper.accessor('severity', {
       header: 'Severity',
-      filterFn: (row, _columnId, filterValue): boolean => {
-        return filterValue.includes(row.original.severity);
-      },
-      sortingFn: (rowA, rowB) => {
-        return compareSeverity(rowA.original.severity, rowB.original.severity);
-      },
       meta: {
         filter: {
           filterVariant: 'select',
@@ -326,36 +320,6 @@ const IssuesComponent = () => {
         },
       },
     }),
-    columnHelper.accessor(
-      (issue) => {
-        return getIssueCategory(issue.message);
-      },
-      {
-        id: 'category',
-        header: 'Category',
-        filterFn: (row, _columnId, filterValue): boolean => {
-          return filterValue.includes(getIssueCategory(row.original.message));
-        },
-        meta: {
-          filter: {
-            filterVariant: 'select',
-            selectOptions: issueCategorySchema.options.map((category) => ({
-              label: category,
-              value: category,
-            })),
-            setSelected: (categories: IssueCategory[]) => {
-              navigate({
-                search: {
-                  ...search,
-                  page: 1,
-                  category: categories.length === 0 ? undefined : categories,
-                },
-              });
-            },
-          },
-        },
-      }
-    ),
     columnHelper.accessor('affectedPath', {
       header: 'Affected Path',
       enableSorting: false,
@@ -367,62 +331,22 @@ const IssuesComponent = () => {
     }),
   ];
 
-  // All of these need to be memoized to prevent unnecessary re-renders
-  // and (at least for Firefox) the browser freezing up.
-
-  const pageIndex = useMemo(
-    () => (search.page ? search.page - 1 : 0),
-    [search.page]
-  );
-
-  const pageSize = useMemo(
-    () => (search.pageSize ? search.pageSize : defaultPageSize),
-    [search.pageSize]
-  );
-
-  const severity = useMemo(
-    () => (search.severity ? search.severity : undefined),
-    [search.severity]
-  );
-
-  const itemStatus = useMemo(
-    () => (search.itemResolved ? search.itemResolved : undefined),
-    [search.itemResolved]
-  );
-
-  const category = useMemo(
-    () => (search.category ? search.category : undefined),
-    [search.category]
-  );
-
-  const packageIdentifier = useMemo(
-    () => (search.pkgId ? search.pkgId : undefined),
-    [search.pkgId]
-  );
-
+  const pageIndex = search.page ? search.page - 1 : 0;
+  const pageSize = search.pageSize ? search.pageSize : defaultPageSize;
+  const severity = search.severity;
+  const itemStatus = search.itemResolved;
+  const packageIdentifier = search.pkgId;
   const columnId = packageIdType === 'ORT_ID' ? 'identifier' : 'purl';
+  const resolved =
+    itemStatus?.length === 1 ? itemStatus[0] === 'Resolved' : undefined;
+  const sortBy =
+    search.sortBy?.filter((sort) => supportedSortColumns.has(sort.id)) ?? [];
 
-  const columnFilters = useMemo(() => {
-    const filters = [];
-    if (severity) {
-      filters.push({ id: 'severity', value: severity });
-    }
-    if (itemStatus) {
-      filters.push({ id: 'itemStatus', value: itemStatus });
-    }
-    if (category) {
-      filters.push({ id: 'category', value: category });
-    }
-    if (packageIdentifier) {
-      filters.push({ id: columnId, value: packageIdentifier });
-    }
-    return filters;
-  }, [severity, itemStatus, category, packageIdentifier, columnId]);
-
-  const sortBy = useMemo(
-    () => (search.sortBy ? search.sortBy : undefined),
-    [search.sortBy]
-  );
+  const columnFilters = [
+    { id: 'severity', value: severity },
+    { id: 'status', value: itemStatus },
+    { id: columnId, value: packageIdentifier },
+  ].filter(({ value }) => value !== undefined);
 
   const { data: ortRun } = useSuspenseQuery({
     ...getRepositoryRunOptions({
@@ -434,6 +358,18 @@ const IssuesComponent = () => {
   });
 
   const {
+    data: totalIssues,
+    isPending: totalIsPending,
+    isError: totalIsError,
+    error: totalError,
+  } = useQuery({
+    ...getRunIssuesOptions({
+      path: { runId: ortRun.id },
+      query: { limit: 1 },
+    }),
+  });
+
+  const {
     data: issues,
     isPending,
     isError,
@@ -441,7 +377,16 @@ const IssuesComponent = () => {
   } = useQuery({
     ...getRunIssuesOptions({
       path: { runId: ortRun.id },
-      query: { limit: ALL_ITEMS },
+      query: {
+        limit: pageSize,
+        offset: pageIndex * pageSize,
+        sort: convertToBackendSorting(sortBy),
+        resolved,
+        severity: severity?.join(','),
+        ...(packageIdType === 'ORT_ID'
+          ? { identifier: packageIdentifier }
+          : { purl: packageIdentifier }),
+      },
     }),
   });
 
@@ -494,6 +439,7 @@ const IssuesComponent = () => {
   const table = useReactTable({
     data: issues?.data || [],
     columns,
+    pageCount: Math.ceil((issues?.pagination.totalCount ?? 0) / pageSize),
     state: {
       pagination: {
         pageIndex,
@@ -503,8 +449,7 @@ const IssuesComponent = () => {
       columnVisibility: {
         [columnId]: false,
         severity: false,
-        itemStatus: false,
-        category: false,
+        status: false,
         affectedPath: false,
         source: false,
       },
@@ -514,28 +459,29 @@ const IssuesComponent = () => {
     onExpandedChange: setExpanded,
     getCoreRowModel: getCoreRowModel(),
     getExpandedRowModel: getExpandedRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
-    getSortedRowModel: getSortedRowModel(),
     getRowCanExpand: () => true,
+    manualFiltering: true,
+    manualPagination: true,
+    manualSorting: true,
   });
 
-  if (isPending) {
+  if (isPending || totalIsPending) {
     return <LoadingIndicator />;
   }
 
-  if (isError) {
-    toastError('Unable to load data', error);
+  if (isError || totalIsError) {
+    toastError('Unable to load data', error || totalError);
     return;
   }
-  const filtersInUse = table.getState().columnFilters.length > 0;
-  const matching = `, ${table.getPrePaginationRowModel().rows.length} matching filters`;
+  const filtersInUse =
+    totalIssues.pagination.totalCount !== issues.pagination.totalCount;
+  const matching = `, ${issues.pagination.totalCount} matching filters`;
 
   return (
     <Card className='h-fit'>
       <CardHeader>
         <CardTitle>
-          Issues ({issues.pagination.totalCount} in total
+          Issues ({totalIssues.pagination.totalCount} in total
           {filtersInUse && matching})
         </CardTitle>
         <CardDescription>
@@ -584,7 +530,6 @@ export const Route = createFileRoute(
     ...severitySearchParameterSchema.shape,
     ...itemStatusSearchParameterSchema.shape,
     ...packageIdentifierSearchParameterSchema.shape,
-    ...issueCategorySearchParameterSchema.shape,
     ...sortingSearchParameterSchema.shape,
     ...markedSearchParameterSchema.shape,
   }),

--- a/ui/src/schemas/index.ts
+++ b/ui/src/schemas/index.ts
@@ -169,10 +169,6 @@ export const detectedLicenseSearchParameterSchema = z.object({
     .optional(),
 });
 
-export const issueCategorySearchParameterSchema = z.object({
-  category: z.array(issueCategorySchema).optional(),
-});
-
 export const ruleSearchParameterSchema = z.object({
   rule: z
     .array(z.string())


### PR DESCRIPTION
This PR adds back-end filtering and sorting to issues endpoint and converts the issues table in the UI to using server-side data manipulation, as described in #5349. The two first commits are just refactors, which prepare for using helper functions for PURLs and severities for several endpoints.

Please see the commits for details.