### PR TITLE
build(ui): Use ESM directory path in Vite config

### DIFF
--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -30,7 +30,7 @@ export default defineConfig({
   plugins: [react(), tanstackRouter()],
   resolve: {
     alias: {
-      '@': path.resolve(__dirname, './src'),
+      '@': path.resolve(import.meta.dirname, './src'),
     },
   },
   test: {


### PR DESCRIPTION
To get rid of a warning message for `pnpm dev`
```
(!) Your Vite config uses features that are unsupported by `configLoader: 'native'`, which is planned to become the default in a future major version of Vite:
  - `__dirname` (vite.config.ts:33:25). Use `import.meta.dirname` instead
```