### PR TITLE
hotfix: Fix plugin template form field contexts

### DIFF
--- a/ui/src/routes/admin/plugins/$pluginType/$pluginId/-components/plugin-option-form-fields.tsx
+++ b/ui/src/routes/admin/plugins/$pluginType/$pluginId/-components/plugin-option-form-fields.tsx
@@ -65,16 +65,19 @@ export function PluginOptionFormFields({ options, form }: Props) {
     const isNotSet = form.watch(`${option.name}_isNotSet`);
 
     return (
-      <FormItem key={option.name}>
-        <FormLabel>
-          {option.name}
-          <Badge className='ml-2 bg-blue-200 text-black'>{option.type}</Badge>
-        </FormLabel>
-        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-          <FormField
-            control={form.control}
-            name={option.name}
-            render={({ field }) => (
+      <FormField
+        key={option.name}
+        control={form.control}
+        name={option.name}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>
+              {option.name}
+              <Badge className='ml-2 bg-blue-200 text-black'>
+                {option.type}
+              </Badge>
+            </FormLabel>
+            <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
               <FormControl>
                 {option.type === 'BOOLEAN' ? (
                   <Switch
@@ -161,78 +164,78 @@ export function PluginOptionFormFields({ options, form }: Props) {
                   />
                 )}
               </FormControl>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name={`${option.name}_isFinal`}
-            render={({ field }) => (
-              <label
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 4,
-                }}
-              >
-                <Checkbox
-                  checked={field.value as CheckedState}
-                  onCheckedChange={field.onChange}
-                  disabled={Boolean(isNotSet)}
-                />
-                <p className='text-sm'>Final</p>
-              </label>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name={`${option.name}_isNotSet`}
-            render={({ field }) => (
-              <label
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 4,
-                }}
-              >
-                <Checkbox
-                  checked={field.value as CheckedState}
-                  onCheckedChange={(checked) => {
-                    field.onChange(checked);
-                    if (checked) {
-                      form.setValue(
-                        option.name,
-                        option.type === 'BOOLEAN'
-                          ? false
-                          : option.type === 'ENUM_LIST'
-                            ? parseStoredPluginOptionValue(
-                                option.defaultValue,
-                                option.type
-                              )
-                            : (option.defaultValue ?? '')
-                      );
-                    }
-                  }}
-                />
-                <p className='text-sm'>Undefined</p>
-              </label>
-            )}
-          />
-        </div>
-        <FormDescription>
-          {option.description}
-          {option.type === 'SECRET' && (
-            <>
-              <br />
-              <span className='text-red-500'>
-                This must be the name of a secret available in the config secret
-                provider, not a secret configured on the organization, product,
-                or repository levels.
-              </span>
-            </>
-          )}
-        </FormDescription>
-        <FormMessage />
-      </FormItem>
+              <FormField
+                control={form.control}
+                name={`${option.name}_isFinal`}
+                render={({ field }) => (
+                  <label
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 4,
+                    }}
+                  >
+                    <Checkbox
+                      checked={field.value as CheckedState}
+                      onCheckedChange={field.onChange}
+                      disabled={Boolean(isNotSet)}
+                    />
+                    <p className='text-sm'>Final</p>
+                  </label>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name={`${option.name}_isNotSet`}
+                render={({ field }) => (
+                  <label
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 4,
+                    }}
+                  >
+                    <Checkbox
+                      checked={field.value as CheckedState}
+                      onCheckedChange={(checked) => {
+                        field.onChange(checked);
+                        if (checked) {
+                          form.setValue(
+                            option.name,
+                            option.type === 'BOOLEAN'
+                              ? false
+                              : option.type === 'ENUM_LIST'
+                                ? parseStoredPluginOptionValue(
+                                    option.defaultValue,
+                                    option.type
+                                  )
+                                : (option.defaultValue ?? '')
+                          );
+                        }
+                      }}
+                    />
+                    <p className='text-sm'>Undefined</p>
+                  </label>
+                )}
+              />
+            </div>
+            <FormDescription>
+              {option.description}
+              {option.type === 'SECRET' && (
+                <>
+                  <br />
+                  <span className='text-red-500'>
+                    This must be the name of a secret available in the config
+                    secret provider, not a secret configured on the
+                    organization, product, or repository levels.
+                  </span>
+                </>
+              )}
+            </FormDescription>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
     );
   });
 }

--- a/ui/src/routes/admin/plugins/$pluginType/$pluginId/edit-template/$templateName/index.tsx
+++ b/ui/src/routes/admin/plugins/$pluginType/$pluginId/edit-template/$templateName/index.tsx
@@ -45,13 +45,9 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import {
-  Form,
-  FormDescription,
-  FormItem,
-  FormLabel,
-} from '@/components/ui/form';
+import { Form } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import { ApiError } from '@/lib/api-error';
 import { queryClient } from '@/lib/query-client';
 import { toast, toastError } from '@/lib/toast';
@@ -195,11 +191,13 @@ const EditTemplate = () => {
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)}>
           <CardContent className='space-y-4'>
-            <FormItem>
-              <FormLabel>Template Name</FormLabel>
-              <Input value={params.templateName} disabled />
-              <FormDescription>The name of the template.</FormDescription>
-            </FormItem>
+            <div className='grid gap-2'>
+              <Label htmlFor='template-name'>Template Name</Label>
+              <Input id='template-name' value={params.templateName} disabled />
+              <p className='text-muted-foreground text-sm'>
+                The name of the template.
+              </p>
+            </div>
             {plugin.options && (
               <PluginOptionFormFields
                 options={plugin.options}


### PR DESCRIPTION
Also plugin template create/edit forms use a wrong semantic order of form components, which breaks them with stricter type checking that was introduced in #5679. This PR fixes the order of the form components in those forms.

The UI codebase has been scanned for other possible broken forms, and none have been found.

Please see the commit for details.