### PR TITLE
hotfix: Default controlled table sorting state

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/search-package/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/search-package/index.tsx
@@ -166,7 +166,7 @@ function SearchPackageComponent() {
         pageIndex,
         pageSize,
       },
-      sorting: sortBy,
+      sorting: sortBy ?? [],
     },
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/search-vulnerability/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/search-vulnerability/index.tsx
@@ -175,7 +175,7 @@ function SearchVulnerabilityComponent() {
         pageIndex,
         pageSize,
       },
-      sorting: sortBy,
+      sorting: sortBy ?? [],
     },
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/detected-license-packages-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/detected-license-packages-table.tsx
@@ -199,7 +199,7 @@ export const DetectedLicensePackagesTable = ({
         pageIndex: packagePageIndex,
         pageSize: packagePageSize,
       },
-      sorting: packageSortBy,
+      sorting: packageSortBy ?? [],
       expanded: packageExpanded,
       columnFilters: [{ id: packageColumnId, value: packageIdFilter }],
     },

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/license-findings-view.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/license-findings-view.tsx
@@ -217,7 +217,7 @@ export const LicenseFindingsView = () => {
         pageIndex,
         pageSize,
       },
-      sorting: search.sortBy,
+      sorting: search.sortBy ?? [],
       expanded,
       columnFilters: [{ id: 'license', value: detectedLicenses }],
     },

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
@@ -568,7 +568,7 @@ const PackagesComponent = () => {
         pageIndex,
         pageSize,
       },
-      sorting: search.sortBy,
+      sorting: search.sortBy ?? [],
       expanded: expanded,
       columnFilters: [
         { id: 'isDirectDependency', value: search.isDirectDependency },

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
@@ -443,7 +443,7 @@ const ProjectsComponent = () => {
         declaredLicense: false,
         definitionFilePath: false,
       },
-      sorting: sortBy,
+      sorting: sortBy ?? [],
       expanded: expanded,
     },
     onExpandedChange: setExpanded,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/provenance-snippet-findings-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/provenance-snippet-findings-table.tsx
@@ -163,7 +163,7 @@ export const ProvenanceSnippetFindingsTable = ({
         pageIndex: findingsPageIndex,
         pageSize: findingsPageSize,
       },
-      sorting: search.findingsSortBy,
+      sorting: search.findingsSortBy ?? [],
       expanded,
     },
     onExpandedChange: setExpanded,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/snippet-finding-snippets-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/snippet-finding-snippets-table.tsx
@@ -183,7 +183,7 @@ export const SnippetFindingSnippetsTable = ({
         pageIndex: snippetsPageIndex,
         pageSize: snippetsPageSize,
       },
-      sorting: search.snippetsSortBy,
+      sorting: search.snippetsSortBy ?? [],
       columnVisibility: {
         purl: false,
         license: false,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/snippet-findings-view.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/snippet-findings-view.tsx
@@ -254,7 +254,7 @@ export const SnippetFindingsView = () => {
         pageIndex,
         pageSize,
       },
-      sorting: search.sortBy,
+      sorting: search.sortBy ?? [],
       expanded,
       columnVisibility: {
         type: false,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
@@ -594,7 +594,7 @@ const VulnerabilitiesComponent = () => {
         advisorName: false,
         summary: false,
       },
-      sorting: sortBy,
+      sorting: sortBy ?? [],
       expanded: expanded,
     },
     onExpandedChange: setExpanded,

--- a/ui/src/routes/organizations/$orgId/products/$productId/search-package/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/search-package/index.tsx
@@ -197,7 +197,7 @@ function SearchPackageComponent() {
         pageIndex,
         pageSize,
       },
-      sorting: sortBy,
+      sorting: sortBy ?? [],
     },
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/ui/src/routes/organizations/$orgId/products/$productId/search-vulnerability/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/search-vulnerability/index.tsx
@@ -206,7 +206,7 @@ function SearchVulnerabilityComponent() {
         pageIndex,
         pageSize,
       },
-      sorting: sortBy,
+      sorting: sortBy ?? [],
     },
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
@@ -500,7 +500,7 @@ const ProductVulnerabilitiesComponent = () => {
         externalId: false,
         summary: false,
       },
-      sorting: sortBy,
+      sorting: sortBy ?? [],
       expanded: expanded,
     },
     onExpandedChange: setExpanded,

--- a/ui/src/routes/organizations/$orgId/search-package/index.tsx
+++ b/ui/src/routes/organizations/$orgId/search-package/index.tsx
@@ -223,7 +223,7 @@ function SearchPackageComponent() {
         pageIndex,
         pageSize,
       },
-      sorting: sortBy,
+      sorting: sortBy ?? [],
     },
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/ui/src/routes/organizations/$orgId/search-vulnerability/index.tsx
+++ b/ui/src/routes/organizations/$orgId/search-vulnerability/index.tsx
@@ -235,7 +235,7 @@ function SearchVulnerabilityComponent() {
         pageIndex,
         pageSize,
       },
-      sorting: sortBy,
+      sorting: sortBy ?? [],
     },
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/ui/src/routes/organizations/$orgId/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/vulnerabilities/index.tsx
@@ -494,7 +494,7 @@ const OrganizationVulnerabilitiesComponent = () => {
         externalId: false,
         summary: false,
       },
-      sorting: search.sortBy,
+      sorting: search.sortBy ?? [],
       expanded: expanded,
     },
     onExpandedChange: setExpanded,


### PR DESCRIPTION
Sorting search parameters are optional, but the routes passed them directly into controlled table state. This left `sorting` undefined when no sort was selected.

#5679 removed a guard around `sorting.length` because the table types declare that state as an array. This revealed that the routes did not uphold that contract at runtime. Fix by defaulting optional sorting values to an empty array.

Note: it would be a smaller code change to make the fix in `schemas/index.ts` by always defaulting an undefined sorting schema to `[]` but that would make the non-sorted routes look ugly (they would always have `?sortBy=[]`) instead of `undefined` which disappears from the URL. It is the usual convention for TanStack Router to allow truly undefined route search parameters - they just need to be defaulted for tables, as in this PR.

Please see the commit for details.