### PR TITLE
Add filtering and sorting to rule violations endpoint

### DIFF
--- a/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
+++ b/api/v1/mapping/src/commonMain/kotlin/ApiMappings.kt
@@ -870,7 +870,13 @@ fun ApiPackageFilters.mapToModel(): PackageFilters =
         isDirectDependency = isDirectDependency
     )
 
-fun ApiRuleViolationFilters.mapToModel(): RuleViolationFilters = RuleViolationFilters(resolved = resolved)
+fun ApiRuleViolationFilters.mapToModel(): RuleViolationFilters = RuleViolationFilters(
+    resolved = resolved,
+    identifier = identifier?.mapToModel { it },
+    purl = purl?.mapToModel { it },
+    severity = severity?.mapToModel { severities -> severities.mapTo(mutableSetOf()) { it.mapToModel() } },
+    rule = rule?.mapToModel { it }
+)
 
 fun ApiVulnerabilityFilters.mapToModel(): VulnerabilityFilters = VulnerabilityFilters(
     resolved = resolved,

--- a/api/v1/model/src/commonMain/kotlin/RuleViolation.kt
+++ b/api/v1/model/src/commonMain/kotlin/RuleViolation.kt
@@ -63,5 +63,17 @@ data class RuleViolationFilters(
      * Filter to only return resolved rule violations. Null if both, resolved an unresolved rule violations should be
      * returned.
      */
-    val resolved: Boolean? = null
+    val resolved: Boolean? = null,
+
+    /** Substring filter for the package identifier. */
+    val identifier: FilterOperatorAndValue<String>? = null,
+
+    /** Substring filter for the effective package purl. */
+    val purl: FilterOperatorAndValue<String>? = null,
+
+    /** Set of [Severity] values to filter with. */
+    val severity: FilterOperatorAndValue<Set<Severity>>? = null,
+
+    /** Set of rule names to filter with. */
+    val rule: FilterOperatorAndValue<Set<String>>? = null
 )

--- a/core/src/main/kotlin/api/RunsRoute.kt
+++ b/core/src/main/kotlin/api/RunsRoute.kt
@@ -67,6 +67,7 @@ import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunPackageLicenses
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunPackages
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunProjects
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunReport
+import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunRuleViolationRules
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunRuleViolations
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunStatistics
 import org.eclipse.apoapsis.ortserver.core.apiDocs.getRunVulnerabilities
@@ -272,6 +273,12 @@ fun Route.runs() = route("runs") {
                 )
 
                 call.respond(HttpStatusCode.OK, pagedResponse)
+            }
+
+            route("rules") {
+                get(getRunRuleViolationRules, requireRunPermission()) {
+                    call.respond(HttpStatusCode.OK, ruleViolationService.getRulesForOrtRunId(call.ortRun.id))
+                }
             }
         }
 
@@ -561,7 +568,11 @@ private fun ApplicationCall.packageFilters(): PackageFilters =
  */
 private fun ApplicationCall.ruleViolationFilters(): RuleViolationFilters =
     RuleViolationFilters(
-        resolved = parameters["resolved"]?.lowercase()?.toBooleanStrictOrNull()
+        resolved = parameters["resolved"]?.lowercase()?.toBooleanStrictOrNull(),
+        identifier = parameters["identifier"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) },
+        purl = parameters["purl"]?.let { FilterOperatorAndValue(ComparisonOperator.ILIKE, it) },
+        severity = severityFilter(),
+        rule = stringSetFilter("rule")
     )
 
 /**

--- a/core/src/main/kotlin/api/RunsRoute.kt
+++ b/core/src/main/kotlin/api/RunsRoute.kt
@@ -523,9 +523,10 @@ private fun ApplicationCall.filters(): OrtRunFilters =
  * null. Otherwise, it is interpreted as a comma-delimited list of license strings to filter the result by. If the
  * first item on the list is a minus, the provided licenses will be excluded from the result.
  */
-private fun ApplicationCall.declaredLicense(): FilterOperatorAndValue<Set<String>>? = licenseFilter("declaredLicense")
+private fun ApplicationCall.declaredLicense(): FilterOperatorAndValue<Set<String>>? =
+    stringSetFilter("declaredLicense")
 
-private fun ApplicationCall.licenseFilter(parameterName: String): FilterOperatorAndValue<Set<String>>? {
+private fun ApplicationCall.stringSetFilter(parameterName: String): FilterOperatorAndValue<Set<String>>? {
     val parts = parameters[parameterName]?.split(',')?.toSet() ?: return null
 
     return if ("-" in parts) {
@@ -534,6 +535,15 @@ private fun ApplicationCall.licenseFilter(parameterName: String): FilterOperator
         FilterOperatorAndValue(ComparisonOperator.IN, parts)
     }
 }
+
+private fun ApplicationCall.severityFilter(): FilterOperatorAndValue<Set<Severity>>? =
+    parameters["severity"]?.let { value ->
+        val parts = value.split(',')
+        val operator = if (parts.first() == "-") ComparisonOperator.NOT_IN else ComparisonOperator.IN
+        val severities = if (operator == ComparisonOperator.NOT_IN) parts.drop(1) else parts
+
+        FilterOperatorAndValue(operator, severities.mapTo(mutableSetOf()) { findByName<Severity>(it) })
+    }
 
 /**
  * Extract the package filters from this [ApplicationCall].
@@ -557,16 +567,8 @@ private fun ApplicationCall.ruleViolationFilters(): RuleViolationFilters =
 /**
  * Extract the issue filters from this [ApplicationCall].
  */
-private fun ApplicationCall.issueFilters(): IssueFilter {
-    val severity: FilterOperatorAndValue<Set<Severity>>? = parameters["severity"]?.let { value ->
-        val parts = value.split(',')
-        val operator = if (parts.first() == "-") ComparisonOperator.NOT_IN else ComparisonOperator.IN
-        val severities = if (operator == ComparisonOperator.NOT_IN) parts.drop(1) else parts
-
-        FilterOperatorAndValue(operator, severities.mapTo(mutableSetOf()) { findByName<Severity>(it) })
-    }
-
-    return IssueFilter(
+private fun ApplicationCall.issueFilters(): IssueFilter =
+    IssueFilter(
         resolved = parameters["resolved"]?.lowercase()?.toBooleanStrictOrNull(),
         identifier = parameters["identifier"]?.let {
             FilterOperatorAndValue(ComparisonOperator.ILIKE, it)
@@ -574,9 +576,8 @@ private fun ApplicationCall.issueFilters(): IssueFilter {
         purl = parameters["purl"]?.let {
             FilterOperatorAndValue(ComparisonOperator.ILIKE, it)
         },
-        severity = severity
+        severity = severityFilter()
     )
-}
 
 /**
  * Extract the vulnerability filters from this [ApplicationCall].

--- a/core/src/main/kotlin/apiDocs/RunsDocs.kt
+++ b/core/src/main/kotlin/apiDocs/RunsDocs.kt
@@ -437,11 +437,35 @@ val getRunVulnerabilityAdvisors: RouteConfig.() -> Unit = {
 val getRunRuleViolations: RouteConfig.() -> Unit = {
     operationId = "getRunRuleViolations"
     summary = "Get the rule violations found in an ORT run"
+    description = "Supported sort fields are 'identifier', 'purl', 'status', 'severity', and 'rule'."
     tags = listOf("Runs")
 
     request {
         pathParameter<Long>("runId") {
             description = "The ID of the ORT run."
+        }
+
+        queryParameter<String>("identifier") {
+            description = "Defines an ORT package identifier to filter the results by. Uses a case-insensitive " +
+                    "substring match against the full ORT coordinates."
+        }
+
+        queryParameter<String>("purl") {
+            description = "Defines a package purl to filter the results by. Uses a case-insensitive substring match " +
+                    "against the effective purl, where a curated purl takes precedence over the analyzer purl."
+        }
+
+        queryParameter<String>("severity") {
+            description = "Defines the severities to filter the results by. This is a comma-separated string with " +
+                    "the following allowed severities: " + Severity.entries.joinToString { "'$it'" } +
+                    " (ignoring case). Add a minus as the first item to exclude rule violations with the specified " +
+                    "severities, e.g. '-,HINT,WARNING'."
+        }
+
+        queryParameter<String>("rule") {
+            description = "Defines the exact rule names to filter the results by as a comma-separated string. Add a " +
+                    "minus as the first item to exclude rule violations with the specified rules, e.g. " +
+                    "'-,Unmapped declared license found'."
         }
 
         queryParameter<Boolean>("resolved") {
@@ -529,6 +553,34 @@ val getRunRuleViolations: RouteConfig.() -> Unit = {
                         `licenseSource` property containing only the first license source if available. This is
                         deprecated, and clients should migrate to using the `licenseSources` property.
                     """.trimIndent()
+                }
+            }
+        }
+
+        HttpStatusCode.NotFound to {
+            description = "The ORT run does not exist."
+        }
+    }
+}
+
+val getRunRuleViolationRules: RouteConfig.() -> Unit = {
+    operationId = "getRunRuleViolationRules"
+    summary = "Get the rules found in an ORT run"
+    description = "Returns the distinct rule names found in the run, sorted case-insensitively by name."
+    tags = listOf("Runs")
+
+    request {
+        pathParameter<Long>("runId") {
+            description = "The ID of the ORT run."
+        }
+    }
+
+    response {
+        HttpStatusCode.OK to {
+            description = "Success."
+            jsonBody<List<String>> {
+                example("Get rules for an ORT run") {
+                    value = listOf("LicenseRule", "VulnerabilityRule")
                 }
             }
         }

--- a/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
@@ -350,6 +350,100 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
         return IssueRouteScenario(ortRun, resolvedIssue, unresolvedIssue, resolvedPackage.purl)
     }
 
+    data class RuleViolationRouteScenario(
+        val ortRun: OrtRun,
+        val resolvedViolation: RuleViolation,
+        val warningViolation: RuleViolation,
+        val hintViolation: RuleViolation,
+        val resolvedViolationPurl: String
+    )
+
+    fun createRuleViolationRouteScenario(includeDuplicateRule: Boolean = false): RuleViolationRouteScenario {
+        val ortRun = dbExtension.fixtures.createOrtRun(
+            repositoryId = repositoryId,
+            revision = "revision",
+            jobConfigurations = JobConfigurations()
+        )
+        val resolvedPackage = dbExtension.fixtures.generatePackage(
+            Identifier("Maven", "com.example", "alpha-lib", "1.0")
+        )
+        val warningPackage = dbExtension.fixtures.generatePackage(
+            Identifier("NPM", "org.example", "beta-lib", "2.0")
+        )
+        val hintPackage = dbExtension.fixtures.generatePackage(
+            Identifier("PyPI", "", "gamma-lib", "3.0")
+        )
+        val resolvedViolation = RuleViolation(
+            rule = "zebra-rule",
+            id = resolvedPackage.identifier,
+            license = "MIT",
+            licenseSources = setOf(LicenseSource.DECLARED),
+            severity = Severity.ERROR,
+            message = "resolved alpha violation",
+            howToFix = "Fix alpha"
+        )
+        val warningViolation = RuleViolation(
+            rule = "middle-rule",
+            id = warningPackage.identifier,
+            license = "Apache-2.0",
+            licenseSources = setOf(LicenseSource.CONCLUDED),
+            severity = Severity.WARNING,
+            message = "unresolved beta violation",
+            howToFix = "Fix beta"
+        )
+        val hintViolation = RuleViolation(
+            rule = "Alpha-rule",
+            id = hintPackage.identifier,
+            license = "BSD-2-Clause",
+            licenseSources = setOf(LicenseSource.DETECTED),
+            severity = Severity.HINT,
+            message = "unresolved gamma violation",
+            howToFix = "Fix gamma"
+        )
+
+        val analyzerJob = dbExtension.fixtures.createAnalyzerJob(ortRun.id)
+        dbExtension.fixtures.createAnalyzerRun(
+            analyzerJob.id,
+            packages = setOf(resolvedPackage, warningPackage, hintPackage)
+        )
+
+        val evaluatorJob = dbExtension.fixtures.createEvaluatorJob(
+            ortRunId = ortRun.id,
+            configuration = EvaluatorJobConfiguration()
+        )
+        val violations = listOf(resolvedViolation, warningViolation, hintViolation).toMutableList()
+        if (includeDuplicateRule) {
+            violations += hintViolation.copy(message = "another violation from the same rule")
+        }
+
+        dbExtension.fixtures.evaluatorRunRepository.create(
+            evaluatorJobId = evaluatorJob.id,
+            startTime = Clock.System.now().toDatabasePrecision(),
+            endTime = Clock.System.now().toDatabasePrecision(),
+            environment = Environment.EMPTY,
+            violations = violations
+        )
+
+        val resolution = RuleViolationResolution(
+            message = resolvedViolation.message,
+            reason = RuleViolationResolutionReason.CANT_FIX_EXCEPTION,
+            comment = "Known violation",
+            source = ResolutionSource.REPOSITORY_FILE
+        )
+        dbExtension.fixtures.resolvedConfigurationRepository.addResolutions(
+            ortRun.id,
+            ResolvedItemsResult(ruleViolations = mapOf(resolvedViolation to listOf(resolution)))
+        )
+
+        return RuleViolationRouteScenario(
+            ortRun,
+            resolvedViolation,
+            warningViolation,
+            hintViolation,
+            resolvedPackage.purl
+        )
+    }
+
     "GET /runs/{runId}" should {
         "return the requested ORT run" {
             integrationTestApplication {
@@ -2679,6 +2773,220 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
                     ApiLicenseSource.DECLARED,
                     ApiLicenseSource.DETECTED
                 )
+            }
+        }
+
+        "handle a non-existing ORT run" {
+            integrationTestApplication {
+                superuserClient.get("/api/v1/runs/12345/rule-violations") shouldHaveStatus HttpStatusCode.NotFound
+            }
+        }
+
+        "filter rule violations by identifier and analyzer PURL" {
+            integrationTestApplication {
+                val scenario = createRuleViolationRouteScenario()
+                val baseUrl = "/api/v1/runs/${scenario.ortRun.id}/rule-violations"
+
+                val identifierResponse = superuserClient.get("$baseUrl?identifier=ALPHA-LIB")
+                val purlResponse = superuserClient.get("$baseUrl?purl=ALPHA-LIB")
+
+                identifierResponse shouldHaveStatus HttpStatusCode.OK
+                identifierResponse.body<PagedResponse<ApiRuleViolation>>().data.shouldBeSingleton {
+                    it.message shouldBe scenario.resolvedViolation.message
+                }
+                purlResponse shouldHaveStatus HttpStatusCode.OK
+                purlResponse.body<PagedResponse<ApiRuleViolation>>().data.shouldBeSingleton {
+                    it.message shouldBe scenario.resolvedViolation.message
+                    it.purl shouldBe scenario.resolvedViolationPurl
+                }
+            }
+        }
+
+        "include or exclude rule violations by severity and rule" {
+            integrationTestApplication {
+                val scenario = createRuleViolationRouteScenario()
+                val baseUrl = "/api/v1/runs/${scenario.ortRun.id}/rule-violations"
+
+                val includedSeverities = superuserClient.get("$baseUrl?severity=error,warning")
+                val excludedSeverity = superuserClient.get("$baseUrl?severity=-,warning")
+                val includedRules = superuserClient.get("$baseUrl?rule=zebra-rule,middle-rule")
+                val excludedRule = superuserClient.get("$baseUrl?rule=-,middle-rule")
+
+                includedSeverities.body<PagedResponse<ApiRuleViolation>>().data.map { it.message }
+                    .shouldContainExactlyInAnyOrder(
+                        scenario.resolvedViolation.message,
+                        scenario.warningViolation.message
+                    )
+                excludedSeverity.body<PagedResponse<ApiRuleViolation>>().data.map { it.message }
+                    .shouldContainExactlyInAnyOrder(
+                        scenario.resolvedViolation.message,
+                        scenario.hintViolation.message
+                    )
+                includedRules.body<PagedResponse<ApiRuleViolation>>().data.map { it.message }
+                    .shouldContainExactlyInAnyOrder(
+                        scenario.resolvedViolation.message,
+                        scenario.warningViolation.message
+                    )
+                excludedRule.body<PagedResponse<ApiRuleViolation>>().data.map { it.message }
+                    .shouldContainExactlyInAnyOrder(
+                        scenario.resolvedViolation.message,
+                        scenario.hintViolation.message
+                    )
+            }
+        }
+
+        "combine filters before pagination and counting" {
+            integrationTestApplication {
+                val scenario = createRuleViolationRouteScenario()
+                val response = superuserClient.get(
+                    "/api/v1/runs/${scenario.ortRun.id}/rule-violations" +
+                            "?identifier=example&purl=pkg:&severity=error,warning&rule=zebra-rule,middle-rule" +
+                            "&sort=identifier&limit=1&offset=1"
+                )
+
+                response shouldHaveStatus HttpStatusCode.OK
+                val body = response.body<PagedResponse<ApiRuleViolation>>()
+                body.pagination.totalCount shouldBe 2
+                body.pagination.limit shouldBe 1
+                body.pagination.offset shouldBe 1
+                body.data.shouldBeSingleton {
+                    it.message shouldBe scenario.warningViolation.message
+                }
+            }
+        }
+
+        "reject an invalid severity" {
+            integrationTestApplication {
+                val scenario = createRuleViolationRouteScenario()
+                superuserClient.get(
+                    "/api/v1/runs/${scenario.ortRun.id}/rule-violations?severity=critical"
+                ) shouldHaveStatus HttpStatusCode.BadRequest
+            }
+        }
+
+        "sort rule violations by all table fields in both directions" {
+            integrationTestApplication {
+                val scenario = createRuleViolationRouteScenario()
+                val identifierOrder = listOf(
+                    scenario.resolvedViolation.message,
+                    scenario.warningViolation.message,
+                    scenario.hintViolation.message
+                )
+                val expectedAscending = mapOf(
+                    "identifier" to identifierOrder,
+                    "purl" to identifierOrder,
+                    "status" to identifierOrder,
+                    "severity" to listOf(
+                        scenario.hintViolation.message,
+                        scenario.warningViolation.message,
+                        scenario.resolvedViolation.message
+                    ),
+                    "rule" to listOf(
+                        scenario.hintViolation.message,
+                        scenario.warningViolation.message,
+                        scenario.resolvedViolation.message
+                    )
+                )
+                val expectedDescending = expectedAscending.mapValues { (field, messages) ->
+                    if (field == "status") {
+                        listOf(
+                            scenario.warningViolation.message,
+                            scenario.hintViolation.message,
+                            scenario.resolvedViolation.message
+                        )
+                    } else {
+                        messages.reversed()
+                    }
+                }
+                val baseUrl = "/api/v1/runs/${scenario.ortRun.id}/rule-violations"
+
+                expectedAscending.forEach { (field, expectedMessages) ->
+                    val ascendingResponse = superuserClient.get("$baseUrl?sort=$field")
+                    val descendingResponse = superuserClient.get("$baseUrl?sort=-$field")
+
+                    ascendingResponse shouldHaveStatus HttpStatusCode.OK
+                    ascendingResponse.body<PagedResponse<ApiRuleViolation>>().data.map { it.message } shouldBe
+                        expectedMessages
+                    descendingResponse shouldHaveStatus HttpStatusCode.OK
+                    descendingResponse.body<PagedResponse<ApiRuleViolation>>().data.map { it.message } shouldBe
+                        expectedDescending.getValue(field)
+                }
+            }
+        }
+
+        "apply sorting with filtering and pagination" {
+            integrationTestApplication {
+                val scenario = createRuleViolationRouteScenario()
+                val response = superuserClient.get(
+                    "/api/v1/runs/${scenario.ortRun.id}/rule-violations" +
+                            "?severity=hint,warning,error&sort=severity&limit=1&offset=1"
+                )
+
+                response shouldHaveStatus HttpStatusCode.OK
+                val body = response.body<PagedResponse<ApiRuleViolation>>()
+                body.pagination.totalCount shouldBe 3
+                body.data.shouldBeSingleton {
+                    it.message shouldBe scenario.warningViolation.message
+                }
+            }
+        }
+
+        "reject an unsupported sort field" {
+            integrationTestApplication {
+                val scenario = createRuleViolationRouteScenario()
+                superuserClient.get(
+                    "/api/v1/runs/${scenario.ortRun.id}/rule-violations?sort=message"
+                ) shouldHaveStatus HttpStatusCode.BadRequest
+            }
+        }
+    }
+
+    "GET /runs/{runId}/rule-violations/rules" should {
+        "return distinct sorted rules scoped to the run" {
+            integrationTestApplication {
+                val scenario = createRuleViolationRouteScenario(includeDuplicateRule = true)
+                createRuleViolationRouteScenario()
+
+                val response = superuserClient.get(
+                    "/api/v1/runs/${scenario.ortRun.id}/rule-violations/rules"
+                )
+
+                response shouldHaveStatus HttpStatusCode.OK
+                response.body<List<String>>() shouldBe listOf("Alpha-rule", "middle-rule", "zebra-rule")
+            }
+        }
+
+        "return an empty list if the run has no violations" {
+            integrationTestApplication {
+                val ortRun = dbExtension.fixtures.createOrtRun(
+                    repositoryId = repositoryId,
+                    revision = "revision",
+                    jobConfigurations = JobConfigurations()
+                )
+
+                val response = superuserClient.get("/api/v1/runs/${ortRun.id}/rule-violations/rules")
+
+                response shouldHaveStatus HttpStatusCode.OK
+                response.body<List<String>>() should beEmpty()
+            }
+        }
+
+        "handle a non-existing ORT run" {
+            integrationTestApplication {
+                superuserClient.get("/api/v1/runs/12345/rule-violations/rules") shouldHaveStatus
+                    HttpStatusCode.NotFound
+            }
+        }
+
+        "require RepositoryPermission.READ_ORT_RUNS" {
+            val ortRun = dbExtension.fixtures.createOrtRun(
+                repositoryId = repositoryId,
+                revision = "revision",
+                jobConfigurations = JobConfigurations()
+            )
+
+            requestShouldRequireRole(RepositoryRole.READER, hierarchyId) {
+                get("/api/v1/runs/${ortRun.id}/rule-violations/rules")
             }
         }
     }

--- a/model/src/commonMain/kotlin/runs/RuleViolation.kt
+++ b/model/src/commonMain/kotlin/runs/RuleViolation.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.model.runs
 import org.eclipse.apoapsis.ortserver.model.Severity
 import org.eclipse.apoapsis.ortserver.model.runs.repository.AppliedRuleViolationResolution
 import org.eclipse.apoapsis.ortserver.model.runs.repository.RuleViolationResolution
+import org.eclipse.apoapsis.ortserver.model.util.FilterOperatorAndValue
 
 /**
  * A data class describing a rule violation that occurred during an ORT run.
@@ -47,9 +48,18 @@ data class RuleViolation(
  * Filters to apply when querying for rule violations.
  */
 data class RuleViolationFilters(
-    /**
-     * Filter to only return resolved rule violations. Null if both, resolved an unresolved rule violations should be
-     * returned.
-     */
-    val resolved: Boolean? = null
+    /** Filter by resolution status. Null if both resolved and unresolved rule violations should be returned. */
+    val resolved: Boolean? = null,
+
+    /** Filter rule violations by their package identifier. */
+    val identifier: FilterOperatorAndValue<String>? = null,
+
+    /** Filter rule violations by their package PURL. */
+    val purl: FilterOperatorAndValue<String>? = null,
+
+    /** Filter rule violations by their [Severity]. */
+    val severity: FilterOperatorAndValue<Set<Severity>>? = null,
+
+    /** Filter rule violations by their rule name. */
+    val rule: FilterOperatorAndValue<Set<String>>? = null
 )

--- a/services/ort-run/src/main/kotlin/RuleViolationService.kt
+++ b/services/ort-run/src/main/kotlin/RuleViolationService.kt
@@ -32,7 +32,10 @@ import org.eclipse.apoapsis.ortserver.dao.repositories.evaluatorrun.ResolvedRule
 import org.eclipse.apoapsis.ortserver.dao.repositories.evaluatorrun.RuleViolationsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.repositoryconfiguration.RuleViolationResolutionsTable
 import org.eclipse.apoapsis.ortserver.dao.tables.shared.IdentifiersTable
+import org.eclipse.apoapsis.ortserver.dao.utils.applyFilter
+import org.eclipse.apoapsis.ortserver.dao.utils.applyILike
 import org.eclipse.apoapsis.ortserver.dao.utils.calculateResolutionMessageHash
+import org.eclipse.apoapsis.ortserver.dao.utils.severitySortRank
 import org.eclipse.apoapsis.ortserver.model.CountByCategory
 import org.eclipse.apoapsis.ortserver.model.RepositoryId
 import org.eclipse.apoapsis.ortserver.model.Severity
@@ -43,6 +46,7 @@ import org.eclipse.apoapsis.ortserver.model.runs.RuleViolationFilters
 import org.eclipse.apoapsis.ortserver.model.runs.repository.AppliedRuleViolationResolution
 import org.eclipse.apoapsis.ortserver.model.runs.repository.ResolutionSource
 import org.eclipse.apoapsis.ortserver.model.runs.repository.RuleViolationResolution
+import org.eclipse.apoapsis.ortserver.model.util.ComparisonOperator
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
 import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
@@ -50,20 +54,36 @@ import org.eclipse.apoapsis.ortserver.model.util.OrderField
 import org.eclipse.apoapsis.ortserver.services.ResourceNotFoundException
 import org.eclipse.apoapsis.ortserver.services.utils.toSortOrder
 
+import org.jetbrains.exposed.v1.core.Case
 import org.jetbrains.exposed.v1.core.Count
+import org.jetbrains.exposed.v1.core.ExpressionWithColumnType
 import org.jetbrains.exposed.v1.core.JoinType
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.alias
 import org.jetbrains.exposed.v1.core.and
+import org.jetbrains.exposed.v1.core.concat
+import org.jetbrains.exposed.v1.core.dao.id.EntityID
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.core.inList
 import org.jetbrains.exposed.v1.core.inSubQuery
 import org.jetbrains.exposed.v1.core.innerJoin
+import org.jetbrains.exposed.v1.core.isNotNull
+import org.jetbrains.exposed.v1.core.isNull
 import org.jetbrains.exposed.v1.core.not
+import org.jetbrains.exposed.v1.core.or
+import org.jetbrains.exposed.v1.core.stringLiteral
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.Query
 import org.jetbrains.exposed.v1.jdbc.andWhere
 import org.jetbrains.exposed.v1.jdbc.select
+
+private class RuleViolationQueryContext(
+    val query: Query,
+    val identifierExpression: ExpressionWithColumnType<String>,
+    val purlColumn: ExpressionWithColumnType<String>,
+    val statusExpression: ExpressionWithColumnType<String>
+)
 
 /**
  * A service to interact with rule violations.
@@ -73,6 +93,7 @@ class RuleViolationService(
     private val ortRunService: OrtRunService,
     private val ruleViolationResolutionService: RuleViolationResolutionService
 ) {
+    /** Return a page of rule violations for the given ORT run after applying the requested filters. */
     fun listForOrtRunId(
         ortRunId: Long,
         parameters: ListQueryParameters = ListQueryParameters.DEFAULT,
@@ -83,10 +104,10 @@ class RuleViolationService(
         )
 
         return db.blockingQuery {
-            val query = buildListForOrtRunIdQuery(ortRunId, ruleViolationFilter)
+            val context = buildListForOrtRunIdQueryContext(ortRunId, ruleViolationFilter)
 
-            val totalCount = query.count()
-            val ruleViolationIds = fetchPagedRuleViolationIds(query, parameters)
+            val totalCount = context.query.count()
+            val ruleViolationIds = fetchPagedRuleViolationIds(context, parameters)
 
             if (ruleViolationIds.isEmpty()) {
                 return@blockingQuery ListQueryResult(emptyList(), parameters, totalCount)
@@ -113,17 +134,62 @@ class RuleViolationService(
         }
     }
 
-    private fun buildListForOrtRunIdQuery(ortRunId: Long, ruleViolationFilter: RuleViolationFilters): Query {
-        val query = RuleViolationsTable
+    private fun buildListForOrtRunIdQueryContext(
+        ortRunId: Long,
+        ruleViolationFilter: RuleViolationFilters
+    ): RuleViolationQueryContext {
+        val riOrtRunId = EvaluatorJobsTable.ortRunId.alias("rule_violation_ri_ort_run_id")
+
+        // Null identifier IDs are excluded from the pairs query before this is passed to the shared PURL builder.
+        @Suppress("UNCHECKED_CAST")
+        val identifierId = RuleViolationsTable.identifierId as ExpressionWithColumnType<EntityID<Long>>
+        val riIdentifierId = identifierId.alias("rule_violation_ri_identifier_id")
+        val runIdPairs = RuleViolationsTable
             .innerJoin(EvaluatorRunsRuleViolationsTable)
             .innerJoin(EvaluatorRunsTable)
             .innerJoin(EvaluatorJobsTable)
-            .select(RuleViolationsTable.id)
-            .where { EvaluatorJobsTable.ortRunId eq ortRunId }
+            .select(riOrtRunId, riIdentifierId)
+            .where {
+                (EvaluatorJobsTable.ortRunId eq ortRunId) and RuleViolationsTable.identifierId.isNotNull()
+            }
+            .withDistinct()
+            .alias("rule_violation_run_identifier_pairs")
+
+        val purls = buildPurlByRunIdentifier(
+            runIdPairs,
+            runIdPairs[riOrtRunId],
+            runIdPairs[riIdentifierId]
+        )
+        val purlColumn = purls.alias[purls.purl]
+
+        val identifierExpression = concat(
+            IdentifiersTable.type,
+            stringLiteral(":"),
+            IdentifiersTable.namespace,
+            stringLiteral(":"),
+            IdentifiersTable.name,
+            stringLiteral(":"),
+            IdentifiersTable.version
+        )
 
         val resolvedRuleViolationIdsSubquery = ResolvedRuleViolationsTable
             .select(ResolvedRuleViolationsTable.ruleViolationId)
             .where { ResolvedRuleViolationsTable.ortRunId eq ortRunId }
+        val statusExpression = Case()
+            .When(RuleViolationsTable.id inSubQuery resolvedRuleViolationIdsSubquery, stringLiteral("Resolved"))
+            .Else(stringLiteral("Unresolved"))
+
+        val query = RuleViolationsTable
+            .innerJoin(EvaluatorRunsRuleViolationsTable)
+            .innerJoin(EvaluatorRunsTable)
+            .innerJoin(EvaluatorJobsTable)
+            .join(IdentifiersTable, JoinType.LEFT, RuleViolationsTable.identifierId, IdentifiersTable.id)
+            .join(purls.alias, JoinType.LEFT) {
+                (EvaluatorJobsTable.ortRunId eq purls.alias[purls.ortRunId]) and
+                    (RuleViolationsTable.identifierId eq purls.alias[purls.identifierId])
+            }
+            .select(RuleViolationsTable.id)
+            .where { EvaluatorJobsTable.ortRunId eq ortRunId }
 
         when (ruleViolationFilter.resolved) {
             true -> query.andWhere { RuleViolationsTable.id inSubQuery resolvedRuleViolationIdsSubquery }
@@ -131,10 +197,38 @@ class RuleViolationService(
             null -> {}
         }
 
-        return query
+        ruleViolationFilter.identifier?.let { filter ->
+            require(filter.operator == ComparisonOperator.ILIKE) {
+                "Unsupported operator for identifier filter: ${filter.operator}"
+            }
+
+            query.andWhere { identifierExpression.applyILike(filter.value) }
+        }
+
+        ruleViolationFilter.purl?.let { filter ->
+            require(filter.operator == ComparisonOperator.ILIKE) {
+                "Unsupported operator for PURL filter: ${filter.operator}"
+            }
+
+            query.andWhere { purlColumn.applyILike(filter.value) }
+        }
+
+        ruleViolationFilter.severity?.let { filter ->
+            query.andWhere { RuleViolationsTable.severity.applyFilter(filter.operator, filter.value) }
+        }
+
+        ruleViolationFilter.rule?.let { filter ->
+            query.andWhere { RuleViolationsTable.rule.applyFilter(filter.operator, filter.value) }
+        }
+
+        return RuleViolationQueryContext(query, identifierExpression, purlColumn, statusExpression)
     }
 
-    private fun fetchPagedRuleViolationIds(query: Query, parameters: ListQueryParameters): List<Long> {
+    private fun fetchPagedRuleViolationIds(
+        context: RuleViolationQueryContext,
+        parameters: ListQueryParameters
+    ): List<Long> {
+        val query = context.query
         val sortFields = parameters.sortFields.ifEmpty {
             listOf(OrderField("rule", OrderDirection.ASCENDING))
         }
@@ -143,8 +237,30 @@ class RuleViolationService(
             val sortOrder = orderField.direction.toSortOrder()
 
             when (orderField.name) {
+                "identifier" -> {
+                    query.orderBy(IdentifiersTable.type to sortOrder)
+                    query.orderBy(IdentifiersTable.namespace to sortOrder)
+                    query.orderBy(IdentifiersTable.name to sortOrder)
+                    query.orderBy(IdentifiersTable.version to sortOrder)
+                }
+
+                "purl" -> {
+                    val purlWithIdentifierFallback = Case()
+                        .When(
+                            context.purlColumn.isNull() or (context.purlColumn eq ""),
+                            context.identifierExpression
+                        )
+                        .Else(context.purlColumn)
+
+                    query.orderBy(purlWithIdentifierFallback to sortOrder)
+                }
+
+                "status" -> query.orderBy(context.statusExpression to sortOrder)
+
+                "severity" -> query.orderBy(RuleViolationsTable.severity.severitySortRank() to sortOrder)
+
                 "rule" -> query.orderBy(RuleViolationsTable.rule to sortOrder)
-                "severity" -> query.orderBy(RuleViolationsTable.severity to sortOrder)
+
                 else -> throw QueryParametersException("Unknown sort field '${orderField.name}'.")
             }
         }

--- a/services/ort-run/src/main/kotlin/RuleViolationService.kt
+++ b/services/ort-run/src/main/kotlin/RuleViolationService.kt
@@ -93,6 +93,25 @@ class RuleViolationService(
     private val ortRunService: OrtRunService,
     private val ruleViolationResolutionService: RuleViolationResolutionService
 ) {
+    /** Return the distinct rule names found in the given ORT run, sorted case-insensitively. */
+    fun getRulesForOrtRunId(ortRunId: Long): List<String> {
+        if (ortRunService.getOrtRun(ortRunId) == null) {
+            throw ResourceNotFoundException("ORT run with ID $ortRunId not found.")
+        }
+
+        return db.blockingQuery {
+            RuleViolationsTable
+                .innerJoin(EvaluatorRunsRuleViolationsTable)
+                .innerJoin(EvaluatorRunsTable)
+                .innerJoin(EvaluatorJobsTable)
+                .select(RuleViolationsTable.rule)
+                .where { EvaluatorJobsTable.ortRunId eq ortRunId }
+                .withDistinct()
+                .map { it[RuleViolationsTable.rule] }
+                .sortedWith(String.CASE_INSENSITIVE_ORDER)
+        }
+    }
+
     /** Return a page of rule violations for the given ORT run after applying the requested filters. */
     fun listForOrtRunId(
         ortRunId: Long,

--- a/services/ort-run/src/test/kotlin/RuleViolationServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/RuleViolationServiceTest.kt
@@ -21,6 +21,7 @@ package org.eclipse.apoapsis.ortserver.services.ortrun
 
 import com.github.michaelbull.result.Ok
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactlyInAnyOrder
@@ -30,6 +31,7 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 
 import io.mockk.every
 import io.mockk.mockk
@@ -60,9 +62,15 @@ import org.eclipse.apoapsis.ortserver.model.runs.repository.PackageCurationData
 import org.eclipse.apoapsis.ortserver.model.runs.repository.ResolutionSource
 import org.eclipse.apoapsis.ortserver.model.runs.repository.RuleViolationResolution
 import org.eclipse.apoapsis.ortserver.model.runs.repository.RuleViolationResolutionReason
+import org.eclipse.apoapsis.ortserver.model.util.ComparisonOperator
+import org.eclipse.apoapsis.ortserver.model.util.FilterOperatorAndValue
+import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
+import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
+import org.eclipse.apoapsis.ortserver.model.util.OrderField
 
 import org.jetbrains.exposed.v1.jdbc.Database
 
+@Suppress("LargeClass")
 class RuleViolationServiceTest : WordSpec() {
     private val dbExtension = extension(DatabaseTestExtension())
 
@@ -196,6 +204,205 @@ class RuleViolationServiceTest : WordSpec() {
                 resultsUnresolved shouldHaveSize 2
                 resultsUnresolved[0].rule shouldBe "Rule-2"
                 resultsUnresolved[1].rule shouldBe "Rule-3-no-id"
+
+                val statusAscending = service.listForOrtRunId(
+                    ortRun.id,
+                    ListQueryParameters(
+                        sortFields = listOf(OrderField("status", OrderDirection.ASCENDING))
+                    )
+                ).data
+                val statusDescending = service.listForOrtRunId(
+                    ortRun.id,
+                    ListQueryParameters(
+                        sortFields = listOf(OrderField("status", OrderDirection.DESCENDING))
+                    )
+                ).data
+                val combinedFilters = service.listForOrtRunId(
+                    ortRun.id,
+                    ruleViolationFilter = RuleViolationFilters(
+                        resolved = true,
+                        identifier = FilterOperatorAndValue(ComparisonOperator.ILIKE, "LOG4J-CORE"),
+                        severity = FilterOperatorAndValue(ComparisonOperator.IN, setOf(Severity.WARNING)),
+                        rule = FilterOperatorAndValue(ComparisonOperator.IN, setOf("Rule-1"))
+                    )
+                )
+
+                statusAscending.map { it.rule } shouldBe listOf("Rule-1", "Rule-2", "Rule-3-no-id")
+                statusDescending.map { it.rule } shouldBe listOf("Rule-2", "Rule-3-no-id", "Rule-1")
+                combinedFilters.data.map { it.rule } shouldBe listOf("Rule-1")
+            }
+
+            "filter by identifier, severity, and rule" {
+                val ortRun = createRuleViolationEntries()
+
+                val identifierResult = service.listForOrtRunId(
+                    ortRun.id,
+                    ruleViolationFilter = RuleViolationFilters(
+                        identifier = FilterOperatorAndValue(ComparisonOperator.ILIKE, "LOGGING.LOG4J:LOG4J-CO")
+                    )
+                )
+                val severityResult = service.listForOrtRunId(
+                    ortRun.id,
+                    ruleViolationFilter = RuleViolationFilters(
+                        severity = FilterOperatorAndValue(
+                            ComparisonOperator.IN,
+                            setOf(Severity.HINT, Severity.ERROR)
+                        )
+                    )
+                )
+                val excludedSeverityResult = service.listForOrtRunId(
+                    ortRun.id,
+                    ruleViolationFilter = RuleViolationFilters(
+                        severity = FilterOperatorAndValue(
+                            ComparisonOperator.NOT_IN,
+                            setOf(Severity.HINT, Severity.ERROR)
+                        )
+                    )
+                )
+                val ruleResult = service.listForOrtRunId(
+                    ortRun.id,
+                    ruleViolationFilter = RuleViolationFilters(
+                        rule = FilterOperatorAndValue(ComparisonOperator.IN, setOf("Rule-1", "Rule-3-no-id"))
+                    )
+                )
+                val excludedRuleResult = service.listForOrtRunId(
+                    ortRun.id,
+                    ruleViolationFilter = RuleViolationFilters(
+                        rule = FilterOperatorAndValue(ComparisonOperator.NOT_IN, setOf("Rule-1", "Rule-2"))
+                    )
+                )
+
+                identifierResult.data.map { it.rule } shouldBe listOf("Rule-1")
+                severityResult.data.map { it.rule } shouldBe listOf("Rule-2", "Rule-3-no-id")
+                excludedSeverityResult.data.map { it.rule } shouldBe listOf("Rule-1")
+                ruleResult.data.map { it.rule } shouldBe listOf("Rule-1", "Rule-3-no-id")
+                excludedRuleResult.data.map { it.rule } shouldBe listOf("Rule-3-no-id")
+            }
+
+            "compose filters and count before pagination" {
+                val violations = listOf(
+                    RuleViolation(
+                        "Matching-1",
+                        Identifier("Maven", "com.example", "alpha", "1.0"),
+                        null,
+                        emptySet(),
+                        Severity.WARNING,
+                        "Message-1",
+                        "Fix"
+                    ),
+                    RuleViolation(
+                        "Matching-2",
+                        Identifier("Maven", "com.example", "beta", "1.0"),
+                        null,
+                        emptySet(),
+                        Severity.WARNING,
+                        "Message-2",
+                        "Fix"
+                    ),
+                    RuleViolation(
+                        "Other",
+                        Identifier("Maven", "org.example", "gamma", "1.0"),
+                        null,
+                        emptySet(),
+                        Severity.ERROR,
+                        "Message-3",
+                        "Fix"
+                    )
+                )
+                val ortRun = createRuleViolationEntries(ruleViolations = violations)
+
+                val result = service.listForOrtRunId(
+                    ortRun.id,
+                    parameters = ListQueryParameters(limit = 1, offset = 1),
+                    ruleViolationFilter = RuleViolationFilters(
+                        identifier = FilterOperatorAndValue(ComparisonOperator.ILIKE, "maven:com.example"),
+                        severity = FilterOperatorAndValue(ComparisonOperator.IN, setOf(Severity.WARNING)),
+                        rule = FilterOperatorAndValue(
+                            ComparisonOperator.IN,
+                            setOf("Matching-1", "Matching-2")
+                        )
+                    )
+                )
+
+                result.totalCount shouldBe 2
+                result.data.map { it.rule } shouldBe listOf("Matching-2")
+            }
+
+            "reject unsupported filter operators" {
+                val ortRun = createRuleViolationEntries()
+
+                shouldThrow<IllegalArgumentException> {
+                    service.listForOrtRunId(
+                        ortRun.id,
+                        ruleViolationFilter = RuleViolationFilters(
+                            identifier = FilterOperatorAndValue(ComparisonOperator.EQUALS, "Maven")
+                        )
+                    )
+                }.message shouldContain "Unsupported operator for identifier filter"
+
+                shouldThrow<IllegalArgumentException> {
+                    service.listForOrtRunId(
+                        ortRun.id,
+                        ruleViolationFilter = RuleViolationFilters(
+                            purl = FilterOperatorAndValue(ComparisonOperator.EQUALS, "pkg:maven")
+                        )
+                    )
+                }.message shouldContain "Unsupported operator for PURL filter"
+
+                shouldThrow<IllegalArgumentException> {
+                    service.listForOrtRunId(
+                        ortRun.id,
+                        ruleViolationFilter = RuleViolationFilters(
+                            severity = FilterOperatorAndValue(ComparisonOperator.EQUALS, setOf(Severity.ERROR))
+                        )
+                    )
+                }.message shouldContain "Unsupported operator for collections"
+            }
+
+            "sort identifier, severity, and rule in both directions" {
+                val ortRun = createRuleViolationEntries()
+
+                fun sorted(field: String, direction: OrderDirection) = service.listForOrtRunId(
+                    ortRun.id,
+                    ListQueryParameters(sortFields = listOf(OrderField(field, direction)))
+                ).data.map { it.rule }
+
+                sorted("identifier", OrderDirection.ASCENDING) shouldBe
+                    listOf("Rule-2", "Rule-1", "Rule-3-no-id")
+                sorted("identifier", OrderDirection.DESCENDING) shouldBe
+                    listOf("Rule-3-no-id", "Rule-1", "Rule-2")
+                sorted("severity", OrderDirection.ASCENDING) shouldBe
+                    listOf("Rule-3-no-id", "Rule-1", "Rule-2")
+                sorted("severity", OrderDirection.DESCENDING) shouldBe
+                    listOf("Rule-2", "Rule-1", "Rule-3-no-id")
+                sorted("rule", OrderDirection.ASCENDING) shouldBe
+                    listOf("Rule-1", "Rule-2", "Rule-3-no-id")
+                sorted("rule", OrderDirection.DESCENDING) shouldBe
+                    listOf("Rule-3-no-id", "Rule-2", "Rule-1")
+            }
+
+            "sort by multiple fields before pagination and use the ID as a tie-breaker" {
+                val violations = listOf(
+                    RuleViolation("Same", null, null, emptySet(), Severity.ERROR, "First", "Fix"),
+                    RuleViolation("Same", null, null, emptySet(), Severity.ERROR, "Second", "Fix"),
+                    RuleViolation("Alpha", null, null, emptySet(), Severity.ERROR, "Third", "Fix"),
+                    RuleViolation("Beta", null, null, emptySet(), Severity.HINT, "Fourth", "Fix")
+                )
+                val ortRun = createRuleViolationEntries(ruleViolations = violations)
+
+                val result = service.listForOrtRunId(
+                    ortRun.id,
+                    ListQueryParameters(
+                        limit = 2,
+                        offset = 1,
+                        sortFields = listOf(
+                            OrderField("severity", OrderDirection.DESCENDING),
+                            OrderField("rule", OrderDirection.ASCENDING)
+                        )
+                    )
+                )
+
+                result.data.map { it.message } shouldBe listOf("First", "Second")
             }
 
             "return new resolutions which were created after the run" {
@@ -392,6 +599,49 @@ class RuleViolationServiceTest : WordSpec() {
 
                 results[3].rule shouldBe "Rule-4-project-id"
                 results[3].purl should beNull()
+
+                val analyzerPurlResult = service.listForOrtRunId(
+                    ortRun.id,
+                    ruleViolationFilter = RuleViolationFilters(
+                        purl = FilterOperatorAndValue(
+                            ComparisonOperator.ILIKE,
+                            pkg2.purl.uppercase().substringAfter("PKG:").substringBefore('@')
+                        )
+                    )
+                )
+                val curatedPurlResult = service.listForOrtRunId(
+                    ortRun.id,
+                    ruleViolationFilter = RuleViolationFilters(
+                        purl = FilterOperatorAndValue(ComparisonOperator.ILIKE, "CURAT")
+                    )
+                )
+                val replacedAnalyzerPurlResult = service.listForOrtRunId(
+                    ortRun.id,
+                    ruleViolationFilter = RuleViolationFilters(
+                        purl = FilterOperatorAndValue(ComparisonOperator.ILIKE, pkg1.purl)
+                    )
+                )
+                val nonPackageResult = service.listForOrtRunId(
+                    ortRun.id,
+                    ruleViolationFilter = RuleViolationFilters(
+                        purl = FilterOperatorAndValue(ComparisonOperator.ILIKE, "does-not-match")
+                    )
+                )
+                val purlAscending = service.listForOrtRunId(
+                    ortRun.id,
+                    ListQueryParameters(sortFields = listOf(OrderField("purl", OrderDirection.ASCENDING)))
+                ).data.map { it.rule }
+                val purlDescending = service.listForOrtRunId(
+                    ortRun.id,
+                    ListQueryParameters(sortFields = listOf(OrderField("purl", OrderDirection.DESCENDING)))
+                ).data.map { it.rule }
+
+                analyzerPurlResult.data.shouldBeSingleton { it.purl shouldBe pkg2.purl }
+                curatedPurlResult.data.shouldBeSingleton { it.purl shouldBe "curated" }
+                replacedAnalyzerPurlResult.data should beEmpty()
+                nonPackageResult.data should beEmpty()
+                purlAscending shouldBe listOf("Rule-3-no-id", "Rule-1", "Rule-4-project-id", "Rule-2")
+                purlDescending shouldBe listOf("Rule-2", "Rule-4-project-id", "Rule-1", "Rule-3-no-id")
             }
         }
 

--- a/services/ort-run/src/test/kotlin/RuleViolationServiceTest.kt
+++ b/services/ort-run/src/test/kotlin/RuleViolationServiceTest.kt
@@ -26,6 +26,7 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldBeSingleton
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.nulls.beNull
@@ -111,6 +112,38 @@ class RuleViolationServiceTest : WordSpec() {
             }
 
             service = RuleViolationService(db, ortRunService, ruleViolationResolutionService)
+        }
+
+        "getRulesForOrtRunId" should {
+            "return distinct case-insensitively sorted rules for the given ORT run" {
+                val repositoryId = fixtures.createRepository().id
+                val ruleViolations = generateRuleViolations()
+                val ortRun = createRuleViolationEntries(
+                    repositoryId,
+                    listOf(
+                        ruleViolations[0].copy(rule = "zeta"),
+                        ruleViolations[1].copy(rule = "alpha"),
+                        ruleViolations[2].copy(rule = "Beta"),
+                        ruleViolations[0].copy(rule = "alpha", message = "Another message")
+                    )
+                )
+
+                createRuleViolationEntries(
+                    repositoryId,
+                    listOf(ruleViolations[0].copy(rule = "A rule from another run"))
+                )
+
+                service.getRulesForOrtRunId(ortRun.id) shouldContainExactly listOf("alpha", "Beta", "zeta")
+            }
+
+            "return an empty list when the ORT run has no rule violations" {
+                val repositoryId = fixtures.createRepository().id
+                val ortRunWithoutEvaluatorResult = fixtures.createOrtRun(repositoryId)
+                val ortRunWithoutViolations = createRuleViolationEntries(repositoryId, emptyList())
+
+                service.getRulesForOrtRunId(ortRunWithoutEvaluatorResult.id) should beEmpty()
+                service.getRulesForOrtRunId(ortRunWithoutViolations.id) should beEmpty()
+            }
         }
 
         "listForOrtRunId" should {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
@@ -17,26 +17,24 @@
  * License-Filename: LICENSE
  */
 
-import { useSuspenseQuery } from '@tanstack/react-query';
+import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import {
   createColumnHelper,
   ExpandedState,
   getCoreRowModel,
   getExpandedRowModel,
-  getFilteredRowModel,
-  getPaginationRowModel,
-  getSortedRowModel,
   Row,
   useReactTable,
 } from '@tanstack/react-table';
 import { ChevronDown, ChevronUp } from 'lucide-react';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 import z from 'zod';
 
 import { RuleViolation, Severity } from '@/api';
 import {
   getRepositoryRunOptions,
+  getRunRuleViolationRulesOptions,
   getRunRuleViolationsOptions,
 } from '@/api/@tanstack/react-query.gen';
 import { zSeverity } from '@/api/zod.gen';
@@ -72,15 +70,18 @@ import {
   getResolvedBackgroundColor,
   getRuleViolationSeverityBackgroundColor,
 } from '@/helpers/get-status-class';
-import { updateColumnSorting } from '@/helpers/handle-multisort';
+import {
+  convertToBackendSorting,
+  updateColumnSorting,
+} from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-conversion';
 import {
   getResolutionAccordionDefaultValue,
   getResolutionAccordionLabel,
   getResolvedStatus,
 } from '@/helpers/resolutions';
-import { compareSeverity } from '@/helpers/sorting-functions';
-import { ACTION_COLUMN_SIZE, ALL_ITEMS } from '@/lib/constants';
+import { ACTION_COLUMN_SIZE } from '@/lib/constants';
+import { toastError } from '@/lib/toast';
 import {
   ItemResolved,
   itemResolvedSchema,
@@ -95,6 +96,13 @@ import {
 import { useUserSettingsStore } from '@/store/user-settings.store';
 
 const defaultPageSize = 10;
+const supportedSortColumns = new Set([
+  'identifier',
+  'purl',
+  'status',
+  'severity',
+  'rule',
+]);
 
 const columnHelper = createColumnHelper<RuleViolation>();
 
@@ -208,27 +216,72 @@ const RuleViolationsComponent = () => {
     }),
   });
 
-  const { data: ruleViolations } = useSuspenseQuery({
+  const pageIndex = search.page ? search.page - 1 : 0;
+  const pageSize = search.pageSize ? search.pageSize : defaultPageSize;
+  const severity = search.severity;
+  const itemStatus = search.itemResolved;
+  const packageIdentifier = search.pkgId;
+  const selectedRules = search.rule;
+  const columnId = packageIdType === 'ORT_ID' ? 'identifier' : 'purl';
+  const resolved =
+    itemStatus?.length === 1 ? itemStatus[0] === 'Resolved' : undefined;
+  const sortBy =
+    search.sortBy?.filter((sort) => supportedSortColumns.has(sort.id)) ?? [];
+
+  const columnFilters = [
+    { id: 'severity', value: severity },
+    { id: 'status', value: itemStatus },
+    { id: columnId, value: packageIdentifier },
+    { id: 'rule', value: selectedRules },
+  ].filter(({ value }) => value !== undefined);
+
+  const {
+    data: totalRuleViolations,
+    isPending: totalIsPending,
+    isError: totalIsError,
+    error: totalError,
+  } = useQuery({
     ...getRunRuleViolationsOptions({
       path: { runId: ortRun.id },
-      query: { limit: ALL_ITEMS },
+      query: { limit: 1 },
     }),
   });
 
-  const ruleOptions = useMemo(
-    () =>
-      [
-        ...new Set(
-          ruleViolations.data.map((ruleViolation) => ruleViolation.rule)
-        ),
-      ]
-        .sort((a, b) => a.localeCompare(b))
-        .map((rule) => ({
-          label: rule,
-          value: rule,
-        })),
-    [ruleViolations.data]
-  );
+  const {
+    data: availableRules,
+    isPending: rulesIsPending,
+    isError: rulesIsError,
+    error: rulesError,
+  } = useQuery({
+    ...getRunRuleViolationRulesOptions({
+      path: { runId: ortRun.id },
+    }),
+  });
+
+  const {
+    data: ruleViolations,
+    isPending,
+    isError,
+    error,
+  } = useQuery({
+    ...getRunRuleViolationsOptions({
+      path: { runId: ortRun.id },
+      query: {
+        limit: pageSize,
+        offset: pageIndex * pageSize,
+        sort: convertToBackendSorting(sortBy),
+        resolved,
+        severity: severity?.join(','),
+        rule: selectedRules?.join(','),
+        ...(packageIdType === 'ORT_ID'
+          ? { identifier: packageIdentifier }
+          : { purl: packageIdentifier }),
+      },
+    }),
+  });
+
+  const ruleOptions =
+    availableRules?.map((rule) => ({ label: rule, value: rule })) ?? [];
 
   const columns = [
     columnHelper.display({
@@ -305,11 +358,8 @@ const RuleViolationsComponent = () => {
         return getResolvedStatus(ruleViolation);
       },
       {
-        id: 'itemStatus',
+        id: 'status',
         header: 'Status',
-        filterFn: (row, _columnId, filterValue): boolean => {
-          return filterValue.includes(getResolvedStatus(row.original));
-        },
         meta: {
           filter: {
             filterVariant: 'select',
@@ -332,12 +382,6 @@ const RuleViolationsComponent = () => {
     ),
     columnHelper.accessor('severity', {
       header: 'Severity',
-      filterFn: (row, _columnId, filterValue): boolean => {
-        return filterValue.includes(row.original.severity);
-      },
-      sortingFn: (rowA, rowB) => {
-        return compareSeverity(rowA.original.severity, rowB.original.severity);
-      },
       meta: {
         filter: {
           filterVariant: 'select',
@@ -360,9 +404,6 @@ const RuleViolationsComponent = () => {
 
     columnHelper.accessor('rule', {
       header: 'Rule',
-      filterFn: (row, _columnId, filterValue): boolean => {
-        return filterValue.includes(row.original.rule);
-      },
       meta: {
         filter: {
           filterVariant: 'select',
@@ -381,62 +422,6 @@ const RuleViolationsComponent = () => {
       },
     }),
   ];
-
-  // Memoize the search parameters to prevent unnecessary re-rendering
-
-  const pageIndex = useMemo(
-    () => (search.page ? search.page - 1 : 0),
-    [search.page]
-  );
-
-  const pageSize = useMemo(
-    () => (search.pageSize ? search.pageSize : defaultPageSize),
-    [search.pageSize]
-  );
-
-  const severity = useMemo(
-    () => (search.severity ? search.severity : undefined),
-    [search.severity]
-  );
-
-  const itemStatus = useMemo(
-    () => (search.itemResolved ? search.itemResolved : undefined),
-    [search.itemResolved]
-  );
-
-  const packageIdentifier = useMemo(
-    () => (search.pkgId ? search.pkgId : undefined),
-    [search.pkgId]
-  );
-
-  const rules = useMemo(
-    () => (search.rule ? search.rule : undefined),
-    [search.rule]
-  );
-
-  const columnId = packageIdType === 'ORT_ID' ? 'identifier' : 'purl';
-
-  const columnFilters = useMemo(() => {
-    const filters = [];
-    if (severity) {
-      filters.push({ id: 'severity', value: severity });
-    }
-    if (itemStatus) {
-      filters.push({ id: 'itemStatus', value: itemStatus });
-    }
-    if (packageIdentifier) {
-      filters.push({ id: columnId, value: packageIdentifier });
-    }
-    if (rules) {
-      filters.push({ id: 'rule', value: rules });
-    }
-    return filters;
-  }, [severity, itemStatus, packageIdentifier, rules, columnId]);
-
-  const sortBy = useMemo(
-    () => (search.sortBy ? search.sortBy : undefined),
-    [search.sortBy]
-  );
 
   const renderSubComponent = useCallback(
     ({ row }: { row: Row<RuleViolation> }) => {
@@ -502,8 +487,11 @@ const RuleViolationsComponent = () => {
   );
 
   const table = useReactTable({
-    data: ruleViolations.data,
+    data: ruleViolations?.data || [],
     columns,
+    pageCount: Math.ceil(
+      (ruleViolations?.pagination.totalCount ?? 0) / pageSize
+    ),
     state: {
       pagination: {
         pageIndex,
@@ -513,7 +501,7 @@ const RuleViolationsComponent = () => {
       columnVisibility: {
         [columnId]: false,
         severity: false,
-        itemStatus: false,
+        status: false,
         rule: false,
       },
       sorting: sortBy,
@@ -522,13 +510,23 @@ const RuleViolationsComponent = () => {
     onExpandedChange: setExpanded,
     getCoreRowModel: getCoreRowModel(),
     getExpandedRowModel: getExpandedRowModel(),
-    getFilteredRowModel: getFilteredRowModel(),
-    getPaginationRowModel: getPaginationRowModel(),
-    getSortedRowModel: getSortedRowModel(),
     getRowCanExpand: () => true,
+    manualFiltering: true,
+    manualPagination: true,
+    manualSorting: true,
   });
+
+  if (isPending || totalIsPending || rulesIsPending) {
+    return <LoadingIndicator />;
+  }
+
+  if (isError || totalIsError || rulesIsError) {
+    toastError('Unable to load data', error || totalError || rulesError);
+    return;
+  }
+
   const filtersInUse = table.getState().columnFilters.length > 0;
-  const matching = `, ${table.getPrePaginationRowModel().rows.length} matching filters`;
+  const matching = `, ${ruleViolations.pagination.totalCount} matching filters`;
   const evaluatorWasIncludedInRun = ortRun.jobs.evaluator != null;
   const noResultsContent = !evaluatorWasIncludedInRun ? (
     <div className='text-muted-foreground text-sm'>
@@ -541,7 +539,7 @@ const RuleViolationsComponent = () => {
     <Card className='h-fit'>
       <CardHeader>
         <CardTitle>
-          Rule Violations ({ruleViolations.pagination.totalCount} in total
+          Rule Violations ({totalRuleViolations.pagination.totalCount} in total
           {filtersInUse && matching})
         </CardTitle>
         <CardDescription>
@@ -571,7 +569,12 @@ const RuleViolationsComponent = () => {
               to: Route.to,
               search: {
                 ...search,
-                sortBy: updateColumnSorting(search.sortBy, sortBy),
+                sortBy: updateColumnSorting(
+                  search.sortBy?.filter((sort) =>
+                    supportedSortColumns.has(sort.id)
+                  ),
+                  sortBy
+                ),
               },
             };
           }}


### PR DESCRIPTION
This PR adds back-end filtering and sorting to rule violations endpoint and converts the rule violations table in the UI to use server-side data manipulation, as described in #5349.

Please see the commits for details.