### PR TITLE
fix(ui): Keep empty table sorting state stable

### DIFF
--- a/ui/src/helpers/handle-multisort.ts
+++ b/ui/src/helpers/handle-multisort.ts
@@ -20,6 +20,14 @@
 import { SortingState } from '@tanstack/react-table';
 
 /**
+ * A stable empty sorting state for controlled TanStack tables.
+ *
+ * Recreating an empty array during every render can make TanStack Table continuously reset its derived state when
+ * another controlled state, such as row expansion, changes.
+ */
+export const EMPTY_SORTING_STATE: SortingState = [];
+
+/**
  * Handle multi-sorting of table columns.
  *
  * @param columns Current sorting state of the table.

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/search-package/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/search-package/index.tsx
@@ -43,7 +43,10 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { updateColumnSorting } from '@/helpers/handle-multisort';
+import {
+  EMPTY_SORTING_STATE,
+  updateColumnSorting,
+} from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-conversion';
 import { toastError } from '@/lib/toast';
 import {
@@ -166,7 +169,7 @@ function SearchPackageComponent() {
         pageIndex,
         pageSize,
       },
-      sorting: sortBy ?? [],
+      sorting: sortBy ?? EMPTY_SORTING_STATE,
     },
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/search-vulnerability/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/search-vulnerability/index.tsx
@@ -43,7 +43,10 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { updateColumnSorting } from '@/helpers/handle-multisort';
+import {
+  EMPTY_SORTING_STATE,
+  updateColumnSorting,
+} from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-conversion';
 import { toastError } from '@/lib/toast';
 import {
@@ -175,7 +178,7 @@ function SearchVulnerabilityComponent() {
         pageIndex,
         pageSize,
       },
-      sorting: sortBy ?? [],
+      sorting: sortBy ?? EMPTY_SORTING_STATE,
     },
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/detected-license-packages-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/detected-license-packages-table.tsx
@@ -39,6 +39,7 @@ import { LoadingIndicator } from '@/components/loading-indicator';
 import { Button } from '@/components/ui/button';
 import {
   convertToBackendSorting,
+  EMPTY_SORTING_STATE,
   updateColumnSorting,
 } from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-conversion';
@@ -199,7 +200,7 @@ export const DetectedLicensePackagesTable = ({
         pageIndex: packagePageIndex,
         pageSize: packagePageSize,
       },
-      sorting: packageSortBy ?? [],
+      sorting: packageSortBy ?? EMPTY_SORTING_STATE,
       expanded: packageExpanded,
       columnFilters: [{ id: packageColumnId, value: packageIdFilter }],
     },

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/license-findings-view.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/license-findings-view.tsx
@@ -47,6 +47,7 @@ import {
 } from '@/components/ui/card';
 import {
   convertToBackendSorting,
+  EMPTY_SORTING_STATE,
   updateColumnSorting,
 } from '@/helpers/handle-multisort';
 import { toastError } from '@/lib/toast';
@@ -217,7 +218,7 @@ export const LicenseFindingsView = () => {
         pageIndex,
         pageSize,
       },
-      sorting: search.sortBy ?? [],
+      sorting: search.sortBy ?? EMPTY_SORTING_STATE,
       expanded,
       columnFilters: [{ id: 'license', value: detectedLicenses }],
     },

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
@@ -72,6 +72,7 @@ import {
 import { getIssueSeverityBackgroundColor } from '@/helpers/get-status-class';
 import {
   convertToBackendSorting,
+  EMPTY_SORTING_STATE,
   updateColumnSorting,
 } from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-conversion';
@@ -568,7 +569,7 @@ const PackagesComponent = () => {
         pageIndex,
         pageSize,
       },
-      sorting: search.sortBy ?? [],
+      sorting: search.sortBy ?? EMPTY_SORTING_STATE,
       expanded: expanded,
       columnFilters: [
         { id: 'isDirectDependency', value: search.isDirectDependency },

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
@@ -56,7 +56,10 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { updateColumnSorting } from '@/helpers/handle-multisort';
+import {
+  EMPTY_SORTING_STATE,
+  updateColumnSorting,
+} from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-conversion';
 import { ACTION_COLUMN_SIZE, ALL_ITEMS } from '@/lib/constants';
 import { routePrefetchStaleTime } from '@/lib/query-client';
@@ -443,7 +446,7 @@ const ProjectsComponent = () => {
         declaredLicense: false,
         definitionFilePath: false,
       },
-      sorting: sortBy ?? [],
+      sorting: sortBy ?? EMPTY_SORTING_STATE,
       expanded: expanded,
     },
     onExpandedChange: setExpanded,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/provenance-snippet-findings-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/provenance-snippet-findings-table.tsx
@@ -37,6 +37,7 @@ import { LoadingIndicator } from '@/components/loading-indicator';
 import { Button } from '@/components/ui/button';
 import {
   convertToBackendSorting,
+  EMPTY_SORTING_STATE,
   updateColumnSorting,
 } from '@/helpers/handle-multisort';
 import { toastError } from '@/lib/toast';
@@ -163,7 +164,7 @@ export const ProvenanceSnippetFindingsTable = ({
         pageIndex: findingsPageIndex,
         pageSize: findingsPageSize,
       },
-      sorting: search.findingsSortBy ?? [],
+      sorting: search.findingsSortBy ?? EMPTY_SORTING_STATE,
       expanded,
     },
     onExpandedChange: setExpanded,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/snippet-finding-snippets-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/snippet-finding-snippets-table.tsx
@@ -34,6 +34,7 @@ import { SpdxExpressionBadgeGroup } from '@/components/licenses';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import {
   convertToBackendSorting,
+  EMPTY_SORTING_STATE,
   updateColumnSorting,
 } from '@/helpers/handle-multisort';
 import { toastError } from '@/lib/toast';
@@ -183,7 +184,7 @@ export const SnippetFindingSnippetsTable = ({
         pageIndex: snippetsPageIndex,
         pageSize: snippetsPageSize,
       },
-      sorting: search.snippetsSortBy ?? [],
+      sorting: search.snippetsSortBy ?? EMPTY_SORTING_STATE,
       columnVisibility: {
         purl: false,
         license: false,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/snippet-findings-view.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/snippet-findings-view.tsx
@@ -49,6 +49,7 @@ import {
 } from '@/components/ui/card';
 import {
   convertToBackendSorting,
+  EMPTY_SORTING_STATE,
   updateColumnSorting,
 } from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-conversion';
@@ -254,7 +255,7 @@ export const SnippetFindingsView = () => {
         pageIndex,
         pageSize,
       },
-      sorting: search.sortBy ?? [],
+      sorting: search.sortBy ?? EMPTY_SORTING_STATE,
       expanded,
       columnVisibility: {
         type: false,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
@@ -81,6 +81,7 @@ import {
 } from '@/helpers/get-status-class';
 import {
   convertToBackendSorting,
+  EMPTY_SORTING_STATE,
   updateColumnSorting,
 } from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-conversion';
@@ -594,7 +595,7 @@ const VulnerabilitiesComponent = () => {
         advisorName: false,
         summary: false,
       },
-      sorting: sortBy ?? [],
+      sorting: sortBy ?? EMPTY_SORTING_STATE,
       expanded: expanded,
     },
     onExpandedChange: setExpanded,

--- a/ui/src/routes/organizations/$orgId/products/$productId/search-package/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/search-package/index.tsx
@@ -46,7 +46,10 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { updateColumnSorting } from '@/helpers/handle-multisort';
+import {
+  EMPTY_SORTING_STATE,
+  updateColumnSorting,
+} from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-conversion';
 import { toastError } from '@/lib/toast';
 import {
@@ -197,7 +200,7 @@ function SearchPackageComponent() {
         pageIndex,
         pageSize,
       },
-      sorting: sortBy ?? [],
+      sorting: sortBy ?? EMPTY_SORTING_STATE,
     },
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/ui/src/routes/organizations/$orgId/products/$productId/search-vulnerability/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/search-vulnerability/index.tsx
@@ -46,7 +46,10 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { updateColumnSorting } from '@/helpers/handle-multisort';
+import {
+  EMPTY_SORTING_STATE,
+  updateColumnSorting,
+} from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-conversion';
 import { toastError } from '@/lib/toast';
 import {
@@ -206,7 +209,7 @@ function SearchVulnerabilityComponent() {
         pageIndex,
         pageSize,
       },
-      sorting: sortBy ?? [],
+      sorting: sortBy ?? EMPTY_SORTING_STATE,
     },
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
@@ -69,6 +69,7 @@ import {
 import { getVulnerabilityRatingBackgroundColor } from '@/helpers/get-status-class';
 import {
   convertToBackendSorting,
+  EMPTY_SORTING_STATE,
   updateColumnSorting,
 } from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-conversion';
@@ -500,7 +501,7 @@ const ProductVulnerabilitiesComponent = () => {
         externalId: false,
         summary: false,
       },
-      sorting: sortBy ?? [],
+      sorting: sortBy ?? EMPTY_SORTING_STATE,
       expanded: expanded,
     },
     onExpandedChange: setExpanded,

--- a/ui/src/routes/organizations/$orgId/search-package/index.tsx
+++ b/ui/src/routes/organizations/$orgId/search-package/index.tsx
@@ -47,7 +47,10 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { updateColumnSorting } from '@/helpers/handle-multisort';
+import {
+  EMPTY_SORTING_STATE,
+  updateColumnSorting,
+} from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-conversion';
 import { toastError } from '@/lib/toast';
 import {
@@ -223,7 +226,7 @@ function SearchPackageComponent() {
         pageIndex,
         pageSize,
       },
-      sorting: sortBy ?? [],
+      sorting: sortBy ?? EMPTY_SORTING_STATE,
     },
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/ui/src/routes/organizations/$orgId/search-vulnerability/index.tsx
+++ b/ui/src/routes/organizations/$orgId/search-vulnerability/index.tsx
@@ -47,7 +47,10 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
-import { updateColumnSorting } from '@/helpers/handle-multisort';
+import {
+  EMPTY_SORTING_STATE,
+  updateColumnSorting,
+} from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-conversion';
 import { toastError } from '@/lib/toast';
 import {
@@ -235,7 +238,7 @@ function SearchVulnerabilityComponent() {
         pageIndex,
         pageSize,
       },
-      sorting: sortBy ?? [],
+      sorting: sortBy ?? EMPTY_SORTING_STATE,
     },
     getCoreRowModel: getCoreRowModel(),
     getPaginationRowModel: getPaginationRowModel(),

--- a/ui/src/routes/organizations/$orgId/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/vulnerabilities/index.tsx
@@ -69,6 +69,7 @@ import {
 import { getVulnerabilityRatingBackgroundColor } from '@/helpers/get-status-class';
 import {
   convertToBackendSorting,
+  EMPTY_SORTING_STATE,
   updateColumnSorting,
 } from '@/helpers/handle-multisort';
 import { identifierToString } from '@/helpers/identifier-conversion';
@@ -494,7 +495,7 @@ const OrganizationVulnerabilitiesComponent = () => {
         externalId: false,
         summary: false,
       },
-      sorting: search.sortBy ?? [],
+      sorting: search.sortBy ?? EMPTY_SORTING_STATE,
       expanded: expanded,
     },
     onExpandedChange: setExpanded,


### PR DESCRIPTION
The hotfix merged today defaulted optional sorting state with inline empty arrays. This creates a new array on every render, which makes TanStack Table continuously reset its derived state when another controlled state, such as row expansion, changes. Expanding a project card could therefore hang the browser.

Use a shared empty sorting state so that its reference stays stable across renders in all affected tables.

The fix has been verified manually (by accessing all tables and clicking subrows open where they exist), but what's really missing from the UI is proper component testing, so that may very well be a topic of a future PR.

Please see the commit for details.