### PR TITLE
fix(ui): Support enum list options when creating runs

### DIFF
--- a/ui/src/components/form/plugin-multi-select-field.tsx
+++ b/ui/src/components/form/plugin-multi-select-field.tsx
@@ -56,6 +56,9 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input.tsx';
 import { Label } from '@/components/ui/label';
+import MultipleSelector, {
+  Option as MultipleSelectorOption,
+} from '@/components/ui/multiple-selector';
 import {
   Select,
   SelectContent,
@@ -68,6 +71,19 @@ import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group.tsx';
 import { cn } from '@/lib/utils';
 
 export type ScannerScope = 'both' | 'packages' | 'projects';
+
+function parsePluginOptionList(value: unknown): string[] {
+  if (Array.isArray(value)) return value as string[];
+
+  if (typeof value === 'string') {
+    return value
+      .split(',')
+      .map((entry) => entry.trim())
+      .filter(Boolean);
+  }
+
+  return [];
+}
 
 type SortablePluginListItemProps = {
   id: string;
@@ -418,6 +434,30 @@ export const PluginMultiSelectField = <
                                   ))}
                                 </SelectContent>
                               </Select>
+                            ) : option.type === 'ENUM_LIST' ? (
+                              <MultipleSelector
+                                className='min-w-[280px]'
+                                placeholder='Select values'
+                                hidePlaceholderWhenSelected
+                                value={parsePluginOptionList(
+                                  field.value
+                                ).map<MultipleSelectorOption>((entry) => ({
+                                  value: entry,
+                                  label: entry,
+                                }))}
+                                options={(
+                                  option.enumEntries ?? []
+                                ).map<MultipleSelectorOption>((entry) => ({
+                                  value: entry,
+                                  label: entry,
+                                }))}
+                                onChange={(selected) => {
+                                  field.onChange(
+                                    selected.map((entry) => entry.value)
+                                  );
+                                }}
+                                disabled={option.isFixed}
+                              />
                             ) : option.isRequired ? (
                               <Input
                                 {...field}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/plugin-utils.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/plugin-utils.ts
@@ -42,6 +42,17 @@ function optionTypeToZodType(type: PluginOptionType): ZodType {
       }, z.boolean());
     case 'ENUM':
       return z.string();
+    case 'ENUM_LIST':
+      // Preprocess to coerce the comma-separated representation used by the API
+      // into the array representation used by the form.
+      return z.preprocess((val) => {
+        if (typeof val === 'string')
+          return val
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean);
+        return val;
+      }, z.array(z.string()));
     case 'INTEGER':
       return z.coerce.string();
     case 'LONG':
@@ -96,7 +107,12 @@ export function validateRequiredPluginOptions(
       const section = option.type === 'SECRET' ? 'secrets' : 'options';
       const value = pluginConfig?.[section]?.[option.name];
 
-      if (value === undefined || value === null || value === '') {
+      if (
+        value === undefined ||
+        value === null ||
+        value === '' ||
+        (Array.isArray(value) && value.length === 0)
+      ) {
         ctx.addIssue({
           code: 'invalid_type',
           expected: 'string',
@@ -275,7 +291,10 @@ export function getPluginDefaultValues(
             return;
           } else if (option.type === 'BOOLEAN') {
             options[option.name] = option.defaultValue === 'true';
-          } else if (option.type === 'STRING_LIST') {
+          } else if (
+            option.type === 'ENUM_LIST' ||
+            option.type === 'STRING_LIST'
+          ) {
             options[option.name] =
               typeof option.defaultValue === 'string'
                 ? option.defaultValue

--- a/ui/tests/unit/logic/run-schema.test.ts
+++ b/ui/tests/unit/logic/run-schema.test.ts
@@ -83,6 +83,84 @@ describe('createRunFormSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('accepts enum list plugin options', () => {
+    const scannerPlugin = createPluginDescriptor({
+      id: 'Scanner',
+      options: [
+        {
+          name: 'rules',
+          description: 'Enabled rules.',
+          type: 'ENUM_LIST',
+          enumEntries: ['copyright', 'license'],
+          isFixed: false,
+          isNullable: false,
+          isRequired: true,
+        },
+      ],
+    });
+    const schema = createRunFormSchema([], [scannerPlugin], [], []);
+    const formData = createValidFormData();
+    formData.jobConfigs.scanner.scanners = ['Scanner'];
+    formData.jobConfigs.scanner.config = {
+      Scanner: {
+        options: {
+          rules: 'copyright, license',
+        },
+        secrets: {},
+      },
+    };
+
+    const result = schema.safeParse(formData);
+
+    expect(result.success).toBe(true);
+    const parsedConfig = result.data?.jobConfigs.scanner.config as
+      Record<string, { options?: Record<string, unknown> }> | undefined;
+    expect(parsedConfig?.Scanner?.options?.rules).toEqual([
+      'copyright',
+      'license',
+    ]);
+  });
+
+  it('rejects an empty required enum list plugin option', () => {
+    const scannerPlugin = createPluginDescriptor({
+      id: 'Scanner',
+      options: [
+        {
+          name: 'rules',
+          description: 'Enabled rules.',
+          type: 'ENUM_LIST',
+          enumEntries: ['copyright', 'license'],
+          isFixed: false,
+          isNullable: false,
+          isRequired: true,
+        },
+      ],
+    });
+    const schema = createRunFormSchema([], [scannerPlugin], [], []);
+    const formData = createValidFormData();
+    formData.jobConfigs.scanner.scanners = ['Scanner'];
+    formData.jobConfigs.scanner.config = {
+      Scanner: {
+        options: {
+          rules: [] as unknown as string,
+        },
+        secrets: {},
+      },
+    };
+
+    const result = schema.safeParse(formData);
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.map((issue) => issue.path)).toContainEqual([
+      'jobConfigs',
+      'scanner',
+      'config',
+      'Scanner',
+      'options',
+      'rules',
+    ]);
+  });
+
   it('validates reporter package configuration providers when evaluator is disabled', () => {
     const schema = createRunFormSchema(
       [],


### PR DESCRIPTION
[1] added support to plugin template forms, while [2] added only `ENUM`  support to the run form and deferred `ENUM_LIST`.

The gap became a blocking regression 2 days ago when [3] upgraded ORT to 92.1.0. That release added ScanOSS's `chosenSnippetModel` as `ENUM_LIST`, causing schema creation to fail for every create or rerun page.

Parse enum list values from the API, initialize defaults, validate required lists, and render them as a multi-select field. Add regression tests for parsing and required option validation.

[1]: https://github.com/eclipse-apoapsis/ort-server/pull/5450
[2]: https://github.com/eclipse-apoapsis/ort-server/pull/5459
[3]: https://github.com/eclipse-apoapsis/ort-server/pull/5691