### PR TITLE
fix(resolutions): Escape the message of managed resolutions

### DIFF
--- a/services/ort-run/src/main/kotlin/OrtServerMappings.kt
+++ b/services/ort-run/src/main/kotlin/OrtServerMappings.kt
@@ -606,7 +606,9 @@ fun RuleViolation.mapToOrt() =
 
 fun RuleViolationResolution.mapToOrt() =
     OrtRuleViolationResolution(
-        message = message,
+        // ORT interprets the message as a regex, while Server-managed resolutions are exact string matches.
+        // Therefore, the message must be escaped.
+        message = message.takeUnless { source == ResolutionSource.SERVER } ?: Regex.escape(message),
         reason = reason.mapToOrt(),
         comment = comment
     )

--- a/services/ort-run/src/main/kotlin/OrtServerMappings.kt
+++ b/services/ort-run/src/main/kotlin/OrtServerMappings.kt
@@ -74,6 +74,7 @@ import org.eclipse.apoapsis.ortserver.model.runs.repository.PathInclude
 import org.eclipse.apoapsis.ortserver.model.runs.repository.ProvenanceSnippetChoices
 import org.eclipse.apoapsis.ortserver.model.runs.repository.RepositoryAnalyzerConfiguration
 import org.eclipse.apoapsis.ortserver.model.runs.repository.RepositoryConfiguration
+import org.eclipse.apoapsis.ortserver.model.runs.repository.ResolutionSource
 import org.eclipse.apoapsis.ortserver.model.runs.repository.Resolutions
 import org.eclipse.apoapsis.ortserver.model.runs.repository.RuleViolationResolution
 import org.eclipse.apoapsis.ortserver.model.runs.repository.RuleViolationResolutionReason
@@ -320,7 +321,9 @@ fun Issue.mapToOrt() = OrtIssue(
 )
 
 fun IssueResolution.mapToOrt() = OrtIssueResolution(
-    message = message,
+    // ORT interprets the message as a regex, while Server-managed resolutions are exact string matches.
+    // Therefore, the message must be escaped.
+    message = message.takeUnless { source == ResolutionSource.SERVER } ?: Regex.escape(message),
     reason = reason.mapToOrt(),
     comment = comment
 )

--- a/workers/common/src/test/kotlin/resolutions/OrtServerResolutionProviderTest.kt
+++ b/workers/common/src/test/kotlin/resolutions/OrtServerResolutionProviderTest.kt
@@ -23,9 +23,11 @@ import com.github.michaelbull.result.Ok
 
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldBeSingleton
 import io.kotest.matchers.maps.beEmpty
 import io.kotest.matchers.maps.containExactly
 import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
 
 import io.mockk.every
 import io.mockk.mockk
@@ -196,7 +198,7 @@ class OrtServerResolutionProviderTest : WordSpec({
                     comment = "matching repository configuration issue resolution"
                 ),
                 IssueResolution(
-                    message = "match",
+                    message = Regex.escape("match"),
                     reason = IssueResolutionReason.CANT_FIX_ISSUE,
                     comment = "matching managed issue resolution"
                 )
@@ -303,7 +305,7 @@ class OrtServerResolutionProviderTest : WordSpec({
             provider.getResolutionsFor(Issue(source = "source", message = literalMessage)) should
                     containExactlyInAnyOrder(
                         IssueResolution(
-                            message = literalMessage,
+                            message = Regex.escape(literalMessage),
                             reason = IssueResolutionReason.CANT_FIX_ISSUE,
                             comment = "matching managed issue resolution"
                         )
@@ -406,7 +408,7 @@ class OrtServerResolutionProviderTest : WordSpec({
             val managedResolutions = Resolutions(
                 issues = listOf(
                     IssueResolution(
-                        message = "match",
+                        message = Regex.escape("match"),
                         reason = IssueResolutionReason.CANT_FIX_ISSUE,
                         comment = "matching managed issue resolution"
                     ),
@@ -450,6 +452,37 @@ class OrtServerResolutionProviderTest : WordSpec({
             )
 
             provider.getResolutionsFor(issue) should containExactlyInAnyOrder(expectedMatchingResolutions)
+        }
+
+        "escape the messages from server issue resolutions" {
+            val issueMessage = "IOException: Could not resolve provenance for package " +
+                    "'Maven:org.apache.commons:commons-configuration2:2.15.1' " +
+                    "for source code origins [ARTIFACT, VCS].\n" +
+                    "Resolution of ARTIFACT failed with:\n" +
+                    "IOException: Could not verify existence of source artifact at " +
+                    "https://non-existing.repo.org/maven2/org/apache/commons/commons-configuration2/2.15.1/" +
+                    "commons-configuration2-2.15.1-sources.jar. HTTP request got response 403."
+            val issue = Issue(source = "source", message = issueMessage)
+
+            val provider = OrtServerResolutionProvider(
+                globalResolutions = Resolutions(),
+                repositoryConfigurationResolutions = Resolutions(),
+                managedIssueResolutions = listOf(
+                    ServerIssueResolution(
+                        message = issueMessage,
+                        messageHash = calculateResolutionMessageHash(issueMessage),
+                        reason = ServerIssueResolutionReason.CANT_FIX_ISSUE,
+                        comment = "matching managed issue resolution",
+                        source = ResolutionSource.SERVER
+                    )
+                ),
+                managedRuleViolationResolutions = emptyList(),
+                managedVulnerabilityResolutions = emptyList()
+            )
+
+            provider.getResolutionsFor(issue).shouldBeSingleton { resolution ->
+                resolution.matches(issue) shouldBe true
+            }
         }
 
         "return matching rule violation resolutions from all three sources" {

--- a/workers/common/src/test/kotlin/resolutions/OrtServerResolutionProviderTest.kt
+++ b/workers/common/src/test/kotlin/resolutions/OrtServerResolutionProviderTest.kt
@@ -229,7 +229,7 @@ class OrtServerResolutionProviderTest : WordSpec({
                     comment = "matching repository configuration rule violation resolution"
                 ),
                 RuleViolationResolution(
-                    message = "match",
+                    message = Regex.escape("match"),
                     reason = RuleViolationResolutionReason.CANT_FIX_EXCEPTION,
                     comment = "matching managed rule violation resolution"
                 )
@@ -365,7 +365,7 @@ class OrtServerResolutionProviderTest : WordSpec({
                 )
             ) should containExactlyInAnyOrder(
                 RuleViolationResolution(
-                    message = literalMessage,
+                    message = Regex.escape(literalMessage),
                     reason = RuleViolationResolutionReason.CANT_FIX_EXCEPTION,
                     comment = "matching managed rule violation resolution"
                 )
@@ -553,13 +553,46 @@ class OrtServerResolutionProviderTest : WordSpec({
                 globalResolutions.ruleViolations.first(),
                 repositoryConfigurationResolutions.ruleViolations.first(),
                 RuleViolationResolution(
-                    message = "match",
+                    message = Regex.escape("match"),
                     reason = RuleViolationResolutionReason.CANT_FIX_EXCEPTION,
                     comment = "matching managed rule violation resolution"
                 )
             )
 
             provider.getResolutionsFor(ruleViolation) should containExactlyInAnyOrder(expectedMatchingResolutions)
+        }
+
+        "escape the messages from server rule violation resolutions" {
+            val ruleViolationMessage = "License *GPL-2.0-only* found in files [source1, source2]."
+            val ruleViolation = RuleViolation(
+                rule = "rule",
+                pkg = null,
+                license = null,
+                licenseSources = enumSetOf(),
+                severity = Severity.WARNING,
+                message = ruleViolationMessage,
+                howToFix = ""
+            )
+
+            val provider = OrtServerResolutionProvider(
+                globalResolutions = Resolutions(),
+                repositoryConfigurationResolutions = Resolutions(),
+                managedIssueResolutions = emptyList(),
+                managedRuleViolationResolutions = listOf(
+                    ServerRuleViolationResolution(
+                        message = ruleViolationMessage,
+                        messageHash = calculateResolutionMessageHash(ruleViolationMessage),
+                        reason = ServerRuleViolationResolutionReason.CANT_FIX_EXCEPTION,
+                        comment = "matching managed rule violation resolution",
+                        source = ResolutionSource.SERVER
+                    )
+                ),
+                managedVulnerabilityResolutions = emptyList()
+            )
+
+            provider.getResolutionsFor(ruleViolation).shouldBeSingleton { resolution ->
+                resolution.matches(ruleViolation) shouldBe true
+            }
         }
 
         "return matching vulnerability resolutions from all three sources" {


### PR DESCRIPTION
The issue and rule violation resolutions managed by ORT Server do an exact match against the
message. The corresponding ORT resolutions in contrast interpret the message as
a regular expression. Therefore, when ORT Server resolutions are
converted to ORT resolutions, the message must be escaped. Otherwise,
special characters are interpreted by the Regex logic or could even cause
syntax errors.
