### PR TITLE
Align license-findings table's license filtering with packages/projects tables

### DIFF
--- a/components/license-findings/backend/build.gradle.kts
+++ b/components/license-findings/backend/build.gradle.kts
@@ -36,6 +36,7 @@ dependencies {
 
     routesApi(projects.components.authorization.authorizationBackend)
 
+    routesImplementation(projects.api.v1.apiV1Mapping)
     routesImplementation(projects.shared.apiMappings)
     routesImplementation(projects.shared.ktorUtils)
 

--- a/components/license-findings/backend/src/main/kotlin/LicenseFindingService.kt
+++ b/components/license-findings/backend/src/main/kotlin/LicenseFindingService.kt
@@ -62,12 +62,14 @@ class LicenseFindingService(private val db: Database) {
      * Return the detected licenses for the ORT run with the given [ortRunId].
      *
      * The result contains one entry per detected license together with the number of distinct packages that contain the
-     * license. The result can be filtered by [licenseFilter], and paged and sorted according to [parameters].
+     * license. [licenseFilter] selects exact license expressions, while [licenseSearch] applies a case-insensitive
+     * substring search. The result is paged and sorted according to [parameters].
      */
     fun getDetectedLicensesForRun(
         ortRunId: Long,
         parameters: ListQueryParameters,
-        licenseFilter: FilterOperatorAndValue<String>?
+        licenseFilter: FilterOperatorAndValue<Set<String>>?,
+        licenseSearch: String?
     ): ListQueryResult<DetectedLicense> = db.blockingQuery {
         val licenseFindingsJoin = buildLicenseFindingsJoin()
         val packageCount = Count(IdentifiersTable.id, distinct = true)
@@ -82,6 +84,7 @@ class LicenseFindingService(private val db: Database) {
         licenseFilter?.let {
             query.andWhere { LicenseFindingsTable.license.applyFilter(it.operator, it.value) }
         }
+        licenseSearch?.let { query.andWhere { LicenseFindingsTable.license.applyILike(it) } }
 
         parameters.sortFields.forEach { orderField ->
             val sortOrder = orderField.direction.toSortOrder()

--- a/components/license-findings/backend/src/routes/kotlin/routes/GetRunDetectedLicenses.kt
+++ b/components/license-findings/backend/src/routes/kotlin/routes/GetRunDetectedLicenses.kt
@@ -23,12 +23,11 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 
+import org.eclipse.apoapsis.ortserver.api.v1.mapping.mapToModel as mapApiFilterToModel
 import org.eclipse.apoapsis.ortserver.components.authorization.routes.get
 import org.eclipse.apoapsis.ortserver.components.licensefindings.DetectedLicense
 import org.eclipse.apoapsis.ortserver.components.licensefindings.LicenseFindingService
 import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
-import org.eclipse.apoapsis.ortserver.model.util.ComparisonOperator
-import org.eclipse.apoapsis.ortserver.model.util.FilterOperatorAndValue
 import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToApi
 import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToModel
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse
@@ -39,6 +38,7 @@ import org.eclipse.apoapsis.ortserver.shared.ktorutils.jsonBody
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.pagingOptions
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireIdParameter
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.standardListQueryParameters
+import org.eclipse.apoapsis.ortserver.shared.ktorutils.stringSetFilter
 
 internal fun Route.getRunDetectedLicenses(
     service: LicenseFindingService,
@@ -54,11 +54,11 @@ internal fun Route.getRunDetectedLicenses(
                 description = "The ID of the ORT run."
             }
             queryParameter<String>("license") {
-                description = "Filter by license. Uses a case-insensitive substring match by default."
+                description = "Filter by exact license expressions. Multiple values can be separated by commas. " +
+                    "Include '-' to exclude the provided values."
             }
-            queryParameter<String>("licenseMatchType") {
-                description = "How to match the license filter: 'substring' performs a case-insensitive substring " +
-                    "match (the default), while 'exact' performs case-sensitive equality."
+            queryParameter<String>("licenseSearch") {
+                description = "Search licenses using a case-insensitive substring match."
             }
             standardListQueryParameters()
         }
@@ -83,35 +83,17 @@ internal fun Route.getRunDetectedLicenses(
                     }
                 }
             }
-            HttpStatusCode.BadRequest to {
-                description = "If 'licenseMatchType' has an unsupported value."
-            }
         }
     }, requireRunReadPermission(ortRunRepository)) {
         val runId = call.requireIdParameter("runId")
 
         ortRunRepository.get(runId) ?: return@get call.respond(HttpStatusCode.NotFound)
 
-        val licenseFilter = call.parameters["license"]?.let { value ->
-            val matchType = call.parameters["licenseMatchType"] ?: "substring"
-            val operator = when (matchType) {
-                "substring" -> ComparisonOperator.ILIKE
-
-                "exact" -> ComparisonOperator.EQUALS
-
-                else -> return@get call.respond(
-                    HttpStatusCode.BadRequest,
-                    "Unsupported 'licenseMatchType' value '$matchType'. Supported values are 'substring' and 'exact'."
-                )
-            }
-
-            FilterOperatorAndValue(operator, value)
-        }
-
         val result = service.getDetectedLicensesForRun(
             ortRunId = runId,
             parameters = call.pagingOptions(SortProperty("license", SortDirection.ASCENDING)).mapToModel(),
-            licenseFilter = licenseFilter
+            licenseFilter = call.stringSetFilter("license")?.mapApiFilterToModel { it },
+            licenseSearch = call.parameters["licenseSearch"]
         )
 
         call.respond(HttpStatusCode.OK, result.mapToApi { it })

--- a/components/license-findings/backend/src/test/kotlin/LicenseFindingServiceTest.kt
+++ b/components/license-findings/backend/src/test/kotlin/LicenseFindingServiceTest.kt
@@ -79,6 +79,7 @@ class LicenseFindingServiceTest : WordSpec() {
                 val result = service.getDetectedLicensesForRun(
                     seed.otherOrtRunId + 999L,
                     ListQueryParameters(sortFields = listOf(OrderField("license", OrderDirection.ASCENDING))),
+                    null,
                     null
                 )
 
@@ -90,6 +91,7 @@ class LicenseFindingServiceTest : WordSpec() {
                 val result = service.getDetectedLicensesForRun(
                     seed.ortRunId,
                     ListQueryParameters(sortFields = listOf(OrderField("license", OrderDirection.ASCENDING))),
+                    null,
                     null
                 )
 
@@ -101,30 +103,33 @@ class LicenseFindingServiceTest : WordSpec() {
                 )
             }
 
-            "apply licenseFilter ILIKE" {
+            "filter by one exact license" {
                 val result = service.getDetectedLicensesForRun(
                     seed.ortRunId,
                     ListQueryParameters(sortFields = listOf(OrderField("license", OrderDirection.ASCENDING))),
-                    FilterOperatorAndValue(ComparisonOperator.ILIKE, "apache")
-                )
-
-                result.totalCount shouldBe 1
-                result.data should containExactly(DetectedLicense("Apache-2.0", 2))
-            }
-
-            "not include scan results from a different scanner run sharing the same package provenance" {
-                val cross = seedCrossRunData(fixtures, db)
-
-                val result = service.getDetectedLicensesForRun(
-                    cross.ortRunId2,
-                    ListQueryParameters(sortFields = listOf(OrderField("license", OrderDirection.ASCENDING))),
+                    FilterOperatorAndValue(ComparisonOperator.IN, setOf("MIT")),
                     null
                 )
 
-                result.data.map { it.license } should containExactly("MIT")
+                result.data should containExactly(DetectedLicense("MIT", 1))
             }
 
-            "apply an EQUALS licenseFilter" {
+            "filter by multiple exact licenses" {
+                val result = service.getDetectedLicensesForRun(
+                    seed.ortRunId,
+                    ListQueryParameters(sortFields = listOf(OrderField("license", OrderDirection.ASCENDING))),
+                    FilterOperatorAndValue(ComparisonOperator.IN, setOf("MIT", "Apache-2.0")),
+                    null
+                )
+
+                result.totalCount shouldBe 2
+                result.data should containExactly(
+                    DetectedLicense("Apache-2.0", 2),
+                    DetectedLicense("MIT", 1)
+                )
+            }
+
+            "search licenses by a case-insensitive substring" {
                 addLicenseFindings(
                     db,
                     seed.scannerRunId,
@@ -135,16 +140,52 @@ class LicenseFindingServiceTest : WordSpec() {
                 val result = service.getDetectedLicensesForRun(
                     seed.ortRunId,
                     ListQueryParameters(sortFields = listOf(OrderField("license", OrderDirection.ASCENDING))),
-                    FilterOperatorAndValue(ComparisonOperator.EQUALS, "MIT")
+                    null,
+                    "mit"
                 )
 
-                result.data should containExactly(DetectedLicense("MIT", 1))
+                result.data should containExactly(
+                    DetectedLicense("MIT", 1),
+                    DetectedLicense("MIT OR Apache-2.0", 1)
+                )
+            }
+
+            "combine exact filtering and substring search" {
+                addLicenseFindings(
+                    db,
+                    seed.scannerRunId,
+                    Identifier("Maven", "com.example", "mit-or-apache", "1.0"),
+                    listOf("MIT OR Apache-2.0")
+                )
+
+                val result = service.getDetectedLicensesForRun(
+                    seed.ortRunId,
+                    ListQueryParameters(sortFields = listOf(OrderField("license", OrderDirection.ASCENDING))),
+                    FilterOperatorAndValue(ComparisonOperator.IN, setOf("MIT", "MIT OR Apache-2.0")),
+                    "apache"
+                )
+
+                result.data should containExactly(DetectedLicense("MIT OR Apache-2.0", 1))
+            }
+
+            "not include scan results from a different scanner run sharing the same package provenance" {
+                val cross = seedCrossRunData(fixtures, db)
+
+                val result = service.getDetectedLicensesForRun(
+                    cross.ortRunId2,
+                    ListQueryParameters(sortFields = listOf(OrderField("license", OrderDirection.ASCENDING))),
+                    null,
+                    null
+                )
+
+                result.data.map { it.license } should containExactly("MIT")
             }
 
             "sort by packageCount descending without throwing" {
                 val result = service.getDetectedLicensesForRun(
                     seed.ortRunId,
                     ListQueryParameters(sortFields = listOf(OrderField("packageCount", OrderDirection.DESCENDING))),
+                    null,
                     null
                 )
 
@@ -155,6 +196,7 @@ class LicenseFindingServiceTest : WordSpec() {
                 val result = service.getDetectedLicensesForRun(
                     seed.ortRunId,
                     ListQueryParameters(sortFields = listOf(OrderField("license", OrderDirection.ASCENDING))),
+                    null,
                     null
                 )
 
@@ -165,6 +207,7 @@ class LicenseFindingServiceTest : WordSpec() {
                 val result = service.getDetectedLicensesForRun(
                     seed.ortRunId,
                     ListQueryParameters(sortFields = listOf(OrderField("license", OrderDirection.ASCENDING))),
+                    null,
                     null
                 )
 
@@ -183,6 +226,7 @@ class LicenseFindingServiceTest : WordSpec() {
                         limit = 1,
                         offset = 1
                     ),
+                    null,
                     null
                 )
 

--- a/components/license-findings/backend/src/test/kotlin/routes/GetRunDetectedLicensesIntegrationTest.kt
+++ b/components/license-findings/backend/src/test/kotlin/routes/GetRunDetectedLicensesIntegrationTest.kt
@@ -69,54 +69,23 @@ class GetRunDetectedLicensesIntegrationTest : LicenseFindingIntegrationTest({
             }
         }
 
-        "use substring matching by default for the license query parameter" {
-            addLicenseFindings(
-                dbExtension.db,
-                seeded.scannerRunId,
-                Identifier("Maven", "com.example", "mit-or-apache", "1.0"),
-                listOf("MIT OR Apache-2.0")
-            )
-
+        "filter by multiple exact license expressions" {
             licenseFindingTestApplication { client ->
                 val response = client.get("/runs/${seeded.ortRunId}/detected-licenses") {
-                    parameter("license", "mit")
+                    parameter("license", "MIT,Apache-2.0")
                 }
 
                 response.status shouldBe HttpStatusCode.OK
                 val body = response.body<PagedResponse<DetectedLicense>>()
                 body.pagination.totalCount shouldBe 2
                 body.data should containExactly(
-                    DetectedLicense("MIT", 1),
-                    DetectedLicense("MIT OR Apache-2.0", 1)
+                    DetectedLicense("Apache-2.0", 2),
+                    DetectedLicense("MIT", 1)
                 )
             }
         }
 
-        "support explicit substring matching for the license query parameter" {
-            addLicenseFindings(
-                dbExtension.db,
-                seeded.scannerRunId,
-                Identifier("Maven", "com.example", "mit-or-apache", "1.0"),
-                listOf("MIT OR Apache-2.0")
-            )
-
-            licenseFindingTestApplication { client ->
-                val response = client.get("/runs/${seeded.ortRunId}/detected-licenses") {
-                    parameter("license", "mit")
-                    parameter("licenseMatchType", "substring")
-                }
-
-                response.status shouldBe HttpStatusCode.OK
-                val body = response.body<PagedResponse<DetectedLicense>>()
-                body.pagination.totalCount shouldBe 2
-                body.data should containExactly(
-                    DetectedLicense("MIT", 1),
-                    DetectedLicense("MIT OR Apache-2.0", 1)
-                )
-            }
-        }
-
-        "support exact matching for the license query parameter" {
+        "not match a longer expression when filtering by one exact license" {
             addLicenseFindings(
                 dbExtension.db,
                 seeded.scannerRunId,
@@ -127,7 +96,6 @@ class GetRunDetectedLicensesIntegrationTest : LicenseFindingIntegrationTest({
             licenseFindingTestApplication { client ->
                 val response = client.get("/runs/${seeded.ortRunId}/detected-licenses") {
                     parameter("license", "MIT")
-                    parameter("licenseMatchType", "exact")
                 }
 
                 response.status shouldBe HttpStatusCode.OK
@@ -137,16 +105,42 @@ class GetRunDetectedLicensesIntegrationTest : LicenseFindingIntegrationTest({
             }
         }
 
-        "return 400 for an unsupported license match type" {
+        "search by a case-insensitive license substring" {
+            addLicenseFindings(
+                dbExtension.db,
+                seeded.scannerRunId,
+                Identifier("Maven", "com.example", "mit-or-apache", "1.0"),
+                listOf("MIT OR Apache-2.0")
+            )
+
             licenseFindingTestApplication { client ->
                 val response = client.get("/runs/${seeded.ortRunId}/detected-licenses") {
-                    parameter("license", "MIT")
-                    parameter("licenseMatchType", "unsupported")
+                    parameter("licenseSearch", "mit")
                 }
 
-                response.status shouldBe HttpStatusCode.BadRequest
-                response.body<String>() shouldBe
-                    "Unsupported 'licenseMatchType' value 'unsupported'. Supported values are 'substring' and 'exact'."
+                response.status shouldBe HttpStatusCode.OK
+                val body = response.body<PagedResponse<DetectedLicense>>()
+                body.pagination.totalCount shouldBe 2
+                body.data should containExactly(
+                    DetectedLicense("MIT", 1),
+                    DetectedLicense("MIT OR Apache-2.0", 1)
+                )
+            }
+        }
+
+        "exclude exact license expressions" {
+            licenseFindingTestApplication { client ->
+                val response = client.get("/runs/${seeded.ortRunId}/detected-licenses") {
+                    parameter("license", "-,MIT")
+                }
+
+                response.status shouldBe HttpStatusCode.OK
+                val body = response.body<PagedResponse<DetectedLicense>>()
+                body.pagination.totalCount shouldBe 2
+                body.data should containExactly(
+                    DetectedLicense("Apache-2.0", 2),
+                    DetectedLicense("BSD-3-Clause", 1)
+                )
             }
         }
 

--- a/core/src/main/kotlin/api/RunsRoute.kt
+++ b/core/src/main/kotlin/api/RunsRoute.kt
@@ -106,6 +106,7 @@ import org.eclipse.apoapsis.ortserver.shared.apimodel.SortProperty
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.pagingOptions
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireIdParameter
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireParameter
+import org.eclipse.apoapsis.ortserver.shared.ktorutils.stringSetFilter
 
 import org.koin.ktor.ext.inject
 
@@ -552,16 +553,6 @@ private fun ApplicationCall.filters(): OrtRunFilters =
  */
 private fun ApplicationCall.declaredLicense(): FilterOperatorAndValue<Set<String>>? =
     stringSetFilter("declaredLicense")
-
-private fun ApplicationCall.stringSetFilter(parameterName: String): FilterOperatorAndValue<Set<String>>? {
-    val parts = parameters[parameterName]?.split(',')?.toSet() ?: return null
-
-    return if ("-" in parts) {
-        FilterOperatorAndValue(ComparisonOperator.NOT_IN, parts - "-")
-    } else {
-        FilterOperatorAndValue(ComparisonOperator.IN, parts)
-    }
-}
 
 private fun ApplicationCall.severityFilter(): FilterOperatorAndValue<Set<Severity>>? =
     parameters["severity"]?.let { value ->

--- a/shared/ktor-utils/build.gradle.kts
+++ b/shared/ktor-utils/build.gradle.kts
@@ -29,6 +29,7 @@ plugins {
 group = "org.eclipse.apoapsis.ortserver.shared"
 
 dependencies {
+    api(projects.api.v1.apiV1Model)
     api(projects.shared.apiModel)
 
     api(ktorLibs.server.core)

--- a/shared/ktor-utils/src/main/kotlin/ParameterHelpers.kt
+++ b/shared/ktor-utils/src/main/kotlin/ParameterHelpers.kt
@@ -23,6 +23,8 @@ import io.ktor.server.application.ApplicationCall
 import io.ktor.server.plugins.MissingRequestParameterException
 import io.ktor.server.plugins.ParameterConversionException
 
+import org.eclipse.apoapsis.ortserver.api.v1.model.ComparisonOperator
+import org.eclipse.apoapsis.ortserver.api.v1.model.FilterOperatorAndValue
 import org.eclipse.apoapsis.ortserver.shared.apimodel.FilterOptions
 
 /**
@@ -48,6 +50,20 @@ fun ApplicationCall.requireIdParameter(name: String): Long {
     val id = requireParameter(name).toLongOrNull()
 
     return if (id != null && id > 0) id else throw ParameterConversionException(name, "ID")
+}
+
+/**
+ * Get a comma-separated string set filter from this [ApplicationCall], or return null if the parameter is absent.
+ * If the filter contains `-`, exclude the remaining values instead of including them.
+ */
+fun ApplicationCall.stringSetFilter(parameterName: String): FilterOperatorAndValue<Set<String>>? {
+    val parts = parameters[parameterName]?.split(',')?.toSet() ?: return null
+
+    return if ("-" in parts) {
+        FilterOperatorAndValue(ComparisonOperator.NOT_IN, parts - "-")
+    } else {
+        FilterOperatorAndValue(ComparisonOperator.IN, parts)
+    }
 }
 
 /**

--- a/shared/ktor-utils/src/test/kotlin/ParameterHelpersTest.kt
+++ b/shared/ktor-utils/src/test/kotlin/ParameterHelpersTest.kt
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.shared.ktorutils
+
+import io.kotest.assertions.ktor.client.shouldHaveStatus
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import io.ktor.client.request.get
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.response.respond
+import io.ktor.server.routing.get
+import io.ktor.server.testing.testApplication
+
+import org.eclipse.apoapsis.ortserver.api.v1.model.ComparisonOperator
+import org.eclipse.apoapsis.ortserver.api.v1.model.FilterOperatorAndValue
+import org.eclipse.apoapsis.ortserver.utils.test.Integration
+
+class ParameterHelpersTest : WordSpec({
+    tags(Integration)
+
+    "ApplicationCall.stringSetFilter" should {
+        "return null when the parameter is absent" {
+            testStringSetFilter(null, null)
+        }
+
+        "include comma-separated values" {
+            testStringSetFilter(
+                "?filter=MIT,Apache-2.0",
+                FilterOperatorAndValue(ComparisonOperator.IN, setOf("MIT", "Apache-2.0"))
+            )
+        }
+
+        "exclude values when the parameter contains a minus" {
+            testStringSetFilter(
+                "?filter=-,MIT,Apache-2.0",
+                FilterOperatorAndValue(ComparisonOperator.NOT_IN, setOf("MIT", "Apache-2.0"))
+            )
+        }
+
+        "deduplicate values" {
+            testStringSetFilter(
+                "?filter=MIT,Apache-2.0,MIT",
+                FilterOperatorAndValue(ComparisonOperator.IN, setOf("MIT", "Apache-2.0"))
+            )
+        }
+    }
+})
+
+private fun testStringSetFilter(query: String?, expected: FilterOperatorAndValue<Set<String>>?) {
+    testApplication {
+        routing {
+            get("/test") {
+                call.stringSetFilter("filter") shouldBe expected
+                call.respond(HttpStatusCode.OK)
+            }
+        }
+
+        client.get("/test${query.orEmpty()}") shouldHaveStatus HttpStatusCode.OK
+    }
+}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/license-findings-state.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/license-findings-state.ts
@@ -27,7 +27,7 @@ export const getMarkerExpandedState = (marker?: string): ExpandedState =>
 export const getDetectedLicenseQueryFilter = (
   marked: string | undefined,
   license: string | undefined
-) => (marked ? { license: marked, licenseMatchType: 'exact' } : { license });
+) => (marked ? { license: marked } : { license });
 
 export const getPackageIdentifierQueryFilter = (
   packageMarked: string | undefined,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/license-findings-view.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/license-findings-view.tsx
@@ -112,7 +112,7 @@ export const LicenseFindingsView = () => {
       path: { runId: ortRun.id },
       query: {
         limit: DROPDOWN_PAGE_SIZE,
-        license: debouncedLicenseSearchTerm || undefined,
+        licenseSearch: debouncedLicenseSearchTerm || undefined,
       },
     }),
     { enabled: licenseFilterOpen }

--- a/ui/tests/unit/logic/license-findings-state.test.ts
+++ b/ui/tests/unit/logic/license-findings-state.test.ts
@@ -28,16 +28,21 @@ import {
 } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/license-findings-state';
 
 describe('license findings deep-link state', () => {
-  it('uses an exact license filter for a marked license', () => {
-    expect(
-      getDetectedLicenseQueryFilter('MIT', 'MIT,MIT AND Apache-2.0')
-    ).toEqual({ license: 'MIT', licenseMatchType: 'exact' });
+  it('uses a marked license instead of the interactive filter', () => {
+    const filter = getDetectedLicenseQueryFilter(
+      'MIT',
+      'MIT,MIT AND Apache-2.0'
+    );
+
+    expect(filter).toEqual({ license: 'MIT' });
+    expect(filter).not.toHaveProperty('licenseMatchType');
   });
 
-  it('keeps normal license filters when no license is marked', () => {
-    expect(getDetectedLicenseQueryFilter(undefined, 'MIT,Apache-2.0')).toEqual({
-      license: 'MIT,Apache-2.0',
-    });
+  it('keeps comma-separated interactive license filters', () => {
+    const filter = getDetectedLicenseQueryFilter(undefined, 'MIT,Apache-2.0');
+
+    expect(filter).toEqual({ license: 'MIT,Apache-2.0' });
+    expect(filter).not.toHaveProperty('licenseMatchType');
   });
 
   it('uses stable marker values as expanded row IDs', () => {


### PR DESCRIPTION
The filtering logic differed from eg. packages table's filtering with declared license, which broke the filtering, returning an empty set when multiple detected licenses were selected from the dropdown.

Please see the commits for details.