### PR TITLE
refactor(workers): Remove unused `secretResolverService` argument

### DIFF
--- a/workers/common/src/main/kotlin/context/WorkerContextModule.kt
+++ b/workers/common/src/main/kotlin/context/WorkerContextModule.kt
@@ -36,24 +36,18 @@ import org.koin.dsl.module
 /**
  * Return a [Module] with bean definitions required to obtain a [WorkerContextFactory] and other functionality that is
  * typically needed by workers. Workers requiring a [WorkerContext] can integrate this module and then obtain a
- * factory via injection. Per default, the module provides a [SecretResolverService] that queries the configured
- * secret storage. It is possible to override this by passing in a non-null [secretResolverService]. This is useful to
- * restrict the access to secrets in some scenarios.
+ * factory via injection.
  */
-fun workerContextModule(secretResolverService: SecretResolverService? = null): Module = module {
+fun workerContextModule(): Module = module {
     single<OrtRunRepository> { DaoOrtRunRepository(get()) }
     single<RepositoryRepository> { DaoRepositoryRepository(get()) }
 
-    if (secretResolverService != null) {
-        single { secretResolverService }
-    } else {
-        single<SecretRepository> { DaoSecretRepository(get()) }
-        single {
-            val secretStorage = SecretStorage.createStorage(get())
-            SecretService(get(), get(), secretStorage)
-        }
-        single { SecretResolverService.wrapSecretService(get()) }
+    single<SecretRepository> { DaoSecretRepository(get()) }
+    single {
+        val secretStorage = SecretStorage.createStorage(get())
+        SecretService(get(), get(), secretStorage)
     }
+    single { SecretResolverService.wrapSecretService(get()) }
 
     singleOf(::WorkerContextFactory)
     singleOf(::AdminConfigService)

--- a/workers/common/src/test/kotlin/context/WorkerContextModuleTest.kt
+++ b/workers/common/src/test/kotlin/context/WorkerContextModuleTest.kt
@@ -60,20 +60,6 @@ class WorkerContextModuleTest : KoinTest, StringSpec() {
                 secretResolverService.getSecretValue(secret) shouldBe secretValue
             }
         }
-
-        "A custom secret resolver service should be returned" {
-            val secret = mockk<Secret>()
-            val secretValue = SecretValue("The correctly resolved secret value")
-            val resolverService = mockk<SecretResolverService> {
-                every { getSecretValue(secret) } returns secretValue
-            }
-
-            runModuleTest(workerContextModule(resolverService)) {
-                val secretResolverService = get<SecretResolverService>()
-
-                secretResolverService.getSecretValue(secret) shouldBe secretValue
-            }
-        }
     }
 
     /**


### PR DESCRIPTION
Remove the argument from the `workerContextModule` function because it was only used by a test that verified that the argument works.