### PR TITLE
Add Koin compiler plugin

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -32,6 +32,7 @@ repositories {
 dependencies {
     implementation(libs.kotlinxSerializationJson)
     implementation(libs.plugin.detekt)
+    implementation(libs.plugin.koinCompiler)
     implementation(libs.plugin.kotlin)
     implementation(libs.plugin.mavenPublish)
     implementation(libs.plugin.tinyJib)

--- a/buildSrc/src/main/kotlin/ort-server-koin-conventions.gradle.kts
+++ b/buildSrc/src/main/kotlin/ort-server-koin-conventions.gradle.kts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+plugins {
+    id("io.insert-koin.compiler.plugin")
+}
+
+koinCompiler {
+    // Disable compile time checks during the migration to the compiler plugin DSL.
+    compileSafety = false
+
+    // Downgrade informational messages from WARNING to INFO as `allWarningsAsErrors` is on.
+    logSeverity = "INFO"
+
+    // Silence the advertisement for Kotzilla MCP.
+    aiAssist = false
+}

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -27,6 +27,7 @@ plugins {
     application
 
     // Apply precompiled plugins.
+    id("ort-server-koin-conventions")
     id("ort-server-kotlin-jvm-application-conventions")
 
     // Apply third-party plugins.

--- a/dao/build.gradle.kts
+++ b/dao/build.gradle.kts
@@ -24,6 +24,7 @@ plugins {
     `java-test-fixtures`
 
     // Apply precompiled plugins.
+    id("ort-server-koin-conventions")
     id("ort-server-kotlin-jvm-conventions")
     id("ort-server-publication-conventions")
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,6 +20,7 @@
 buildConfigPlugin = "6.0.10"
 detektPlugin = "2.0.0-alpha.6"
 gitSemverPlugin = "0.19.5"
+koinCompilerPlugin = "1.1.0"
 tinyJibPlugin = "0.3.4"
 kotlinPlugin = "2.4.10"
 kotlinxCoroutines = "1.11.0"
@@ -77,6 +78,7 @@ tinyJib = { id = "tel.schich.tinyjib", version.ref = "tinyJibPlugin" }
 [libraries]
 # These are Maven coordinates for Gradle plugins, which is necessary to use them in precompiled plugin scripts.
 plugin-detekt = { module = "dev.detekt:detekt-gradle-plugin", version.ref = "detektPlugin" }
+plugin-koinCompiler = { module = "io.insert-koin:koin-compiler-gradle-plugin", version.ref = "koinCompilerPlugin" }
 plugin-kotlin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlinPlugin" }
 plugin-mavenPublish = { module = "com.vanniktech:gradle-maven-publish-plugin", version.ref = "mavenPublishPlugin" }
 plugin-tinyJib = { module = "tel.schich.tinyjib:tel.schich.tinyjib.gradle.plugin", version.ref = "tinyJibPlugin" }

--- a/orchestrator/build.gradle.kts
+++ b/orchestrator/build.gradle.kts
@@ -24,6 +24,7 @@ val dockerBaseImageTag = project.property("dockerBaseImageTag") as String
 
 plugins {
     // Apply precompiled plugins.
+    id("ort-server-koin-conventions")
     id("ort-server-kotlin-jvm-application-conventions")
 }
 

--- a/tasks/build.gradle.kts
+++ b/tasks/build.gradle.kts
@@ -24,6 +24,7 @@ val dockerBaseImageTag = project.property("dockerBaseImageTag") as String
 
 plugins {
     // Apply precompiled plugins.
+    id("ort-server-koin-conventions")
     id("ort-server-kotlin-jvm-application-conventions")
 }
 

--- a/transport/spi/build.gradle.kts
+++ b/transport/spi/build.gradle.kts
@@ -22,6 +22,7 @@ plugins {
     `java-test-fixtures`
 
     // Apply precompiled plugins.
+    id("ort-server-koin-conventions")
     id("ort-server-kotlin-jvm-conventions")
     id("ort-server-publication-conventions")
 

--- a/workers/advisor/build.gradle.kts
+++ b/workers/advisor/build.gradle.kts
@@ -27,6 +27,7 @@ plugins {
     application
 
     // Apply precompiled plugins.
+    id("ort-server-koin-conventions")
     id("ort-server-kotlin-jvm-application-conventions")
 }
 

--- a/workers/analyzer/build.gradle.kts
+++ b/workers/analyzer/build.gradle.kts
@@ -27,6 +27,7 @@ plugins {
     application
 
     // Apply precompiled plugins.
+    id("ort-server-koin-conventions")
     id("ort-server-kotlin-jvm-application-conventions")
 
     // Apply third-party plugins.

--- a/workers/config/build.gradle.kts
+++ b/workers/config/build.gradle.kts
@@ -27,6 +27,7 @@ plugins {
     application
 
     // Apply precompiled plugins.
+    id("ort-server-koin-conventions")
     id("ort-server-kotlin-jvm-application-conventions")
 
     id("ort-server-publication-conventions")

--- a/workers/evaluator/build.gradle.kts
+++ b/workers/evaluator/build.gradle.kts
@@ -27,6 +27,7 @@ plugins {
     application
 
     // Apply precompiled plugins.
+    id("ort-server-koin-conventions")
     id("ort-server-kotlin-jvm-application-conventions")
 }
 

--- a/workers/notifier/build.gradle.kts
+++ b/workers/notifier/build.gradle.kts
@@ -27,6 +27,7 @@ plugins {
     application
 
     // Apply precompiled plugins.
+    id("ort-server-koin-conventions")
     id("ort-server-kotlin-jvm-application-conventions")
 }
 

--- a/workers/reporter/build.gradle.kts
+++ b/workers/reporter/build.gradle.kts
@@ -27,6 +27,7 @@ plugins {
     application
 
     // Apply precompiled plugins.
+    id("ort-server-koin-conventions")
     id("ort-server-kotlin-jvm-application-conventions")
 }
 

--- a/workers/scanner/build.gradle.kts
+++ b/workers/scanner/build.gradle.kts
@@ -27,6 +27,7 @@ plugins {
     application
 
     // Apply precompiled plugins.
+    id("ort-server-koin-conventions")
     id("ort-server-kotlin-jvm-application-conventions")
 }
 


### PR DESCRIPTION
See the commit messages for details.

Compile time safety checks will be enabled in separate PRs. This PR already provides the benefit that at least some of the Koin calls are transformed at compile time instead of using reflection at runtime.