### PR TITLE
Page snippet provenances in the database

### DIFF
--- a/components/snippet-findings/backend/src/main/kotlin/SnippetFindingService.kt
+++ b/components/snippet-findings/backend/src/main/kotlin/SnippetFindingService.kt
@@ -40,69 +40,116 @@ import org.eclipse.apoapsis.ortserver.dao.tables.shared.VcsInfoTable
 import org.eclipse.apoapsis.ortserver.dao.utils.toSortOrder
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
-import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
 import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 
 import org.jetbrains.exposed.v1.core.Count
 import org.jetbrains.exposed.v1.core.Join
 import org.jetbrains.exposed.v1.core.JoinType
-import org.jetbrains.exposed.v1.core.Op
+import org.jetbrains.exposed.v1.core.SortOrder
+import org.jetbrains.exposed.v1.core.alias
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
-import org.jetbrains.exposed.v1.core.or
 import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.select
+import org.jetbrains.exposed.v1.jdbc.union
 
 /**
  * A service for querying snippet findings and their snippet sources for ORT runs.
  */
 class SnippetFindingService(private val db: Database) {
     /**
-     * Return all package provenances associated with the scanner run for the ORT run with the given [ortRunId].
+     * Return package provenances with snippet findings for the ORT run with the given [ortRunId].
      *
-     * Each entry carries the package identifier and provenance details (artifact or VCS). The result is paged and
-     * sorted according to [parameters].
+     * Each entry carries the package identifier, provenance details (artifact or VCS), and the number of snippet
+     * findings. The result is paged and sorted according to [parameters].
      */
     fun getProvenancesForRun(
         ortRunId: Long,
         parameters: ListQueryParameters
     ): ListQueryResult<SnippetFindingProvenance> = db.blockingQuery {
-        // Two separate queries are needed because sub-repository scan results are not linked via
-        // ScanResultPackageProvenancesTable — they can only be reached through NestedProvenancesTable.
-        val directProvenances = queryProvenances(buildDirectProvenancesJoin(), ortRunId)
-        val nestedProvenances = queryProvenances(buildNestedProvenancesJoin(), ortRunId)
+        val provenances = buildProvenancesQuery(ortRunId).alias("provenances")
 
-        // Merge, giving direct matches priority (a scan result should not appear on both paths,
-        // but deduplicate by id just to be safe).
-        val mergedProvenances = mutableMapOf<Long, SnippetFindingProvenance>()
-        (directProvenances + nestedProvenances).forEach { mergedProvenances.putIfAbsent(it.id, it) }
+        val provenanceId = provenances[provenanceIdAlias]
+        val identifierType = provenances[identifierTypeAlias]
+        val identifierNamespace = provenances[identifierNamespaceAlias]
+        val identifierName = provenances[identifierNameAlias]
+        val identifierVersion = provenances[identifierVersionAlias]
+        val artifactUrl = provenances[artifactUrlAlias]
+        val vcsType = provenances[vcsTypeAlias]
+        val vcsUrl = provenances[vcsUrlAlias]
+        val vcsRevision = provenances[vcsRevisionAlias]
 
-        // Attach snippet finding counts so callers can see how many findings each provenance has.
-        val counts = countSnippetFindingsByProvenanceId(mergedProvenances.keys.toList())
-        var result = mergedProvenances.values.map { it.copy(snippetFindingCount = counts[it.id] ?: 0L) }
+        val query = provenances
+            .join(ScanResultsTable, JoinType.INNER, provenanceId, ScanResultsTable.id)
+            .join(ScanSummariesTable, JoinType.INNER, ScanResultsTable.scanSummaryId, ScanSummariesTable.id)
+            .join(SnippetFindingsTable, JoinType.INNER, ScanSummariesTable.id, SnippetFindingsTable.scanSummaryId)
+            .select(
+                provenanceId,
+                identifierType,
+                identifierNamespace,
+                identifierName,
+                identifierVersion,
+                artifactUrl,
+                vcsType,
+                vcsUrl,
+                vcsRevision,
+                snippetFindingCountAlias
+            )
+            .groupBy(
+                provenanceId,
+                identifierType,
+                identifierNamespace,
+                identifierName,
+                identifierVersion,
+                artifactUrl,
+                vcsType,
+                vcsUrl,
+                vcsRevision
+            )
 
-        // Sort in Kotlin because the two query paths cannot share a single ORDER BY clause.
-        // TODO: Improve this to sort and page in the database because loading all rows to sort and limit them in
-        // memory is inefficient.
-        for (orderField in parameters.sortFields.reversed()) {
-            val comparator: Comparator<SnippetFindingProvenance> = when (orderField.name) {
-                "name" -> compareBy { it.identifier.name }
-                "namespace" -> compareBy { it.identifier.namespace }
-                "version" -> compareBy { it.identifier.version }
-                "type" -> compareBy { it.identifier.type }
+        val sortExpressions = parameters.sortFields.map { orderField ->
+            val sortExpression = when (orderField.name) {
+                "name" -> identifierName
+                "namespace" -> identifierNamespace
+                "version" -> identifierVersion
+                "type" -> identifierType
                 else -> throw QueryParametersException("Unsupported sort field: '${orderField.name}'.")
             }
-            result = result.sortedWith(
-                if (orderField.direction == OrderDirection.ASCENDING) comparator else comparator.reversed()
-            )
+
+            sortExpression to orderField.direction.toSortOrder()
         }
 
-        val totalCount = result.size.toLong()
-        val offset = (parameters.offset ?: 0L).toInt()
-        val limit = parameters.limit ?: ListQueryParameters.DEFAULT_LIMIT
+        val totalCount = query.count()
+
+        sortExpressions.forEach(query::orderBy)
+        query.orderBy(provenanceId to SortOrder.ASC)
+        query.limit(parameters.limit ?: ListQueryParameters.DEFAULT_LIMIT).offset(parameters.offset ?: 0L)
 
         ListQueryResult(
-            data = result.drop(offset).take(limit),
+            data = query.map { row ->
+                val rowArtifactUrl = row.getOrNull(artifactUrl)
+                val rowVcsUrl = row.getOrNull(vcsUrl)
+
+                SnippetFindingProvenance(
+                    id = row[provenanceId].value,
+                    identifier = Identifier(
+                        type = row[identifierType],
+                        namespace = row[identifierNamespace],
+                        name = row[identifierName],
+                        version = row[identifierVersion]
+                    ),
+                    provenanceType = when {
+                        rowArtifactUrl != null -> "ARTIFACT"
+                        rowVcsUrl != null -> "REPOSITORY"
+                        else -> "UNKNOWN"
+                    },
+                    snippetFindingCount = row[snippetFindingCountAlias],
+                    artifactUrl = rowArtifactUrl,
+                    vcsType = row.getOrNull(vcsType),
+                    vcsUrl = rowVcsUrl,
+                    vcsRevision = row.getOrNull(vcsRevision)
+                )
+            },
             params = parameters,
             totalCount = totalCount
         )
@@ -283,23 +330,6 @@ class SnippetFindingService(private val db: Database) {
 }
 
 /**
- * Return the number of snippet findings per scan result ID for the given [scanResultIds].
- *
- * Scan result IDs with no findings are absent from the map (callers should default to 0).
- */
-private fun countSnippetFindingsByProvenanceId(scanResultIds: List<Long>): Map<Long, Long> {
-    if (scanResultIds.isEmpty()) return emptyMap()
-    val count = Count(SnippetFindingsTable.id)
-    return SnippetFindingsTable
-        .innerJoin(ScanSummariesTable)
-        .join(ScanResultsTable, JoinType.INNER, ScanSummariesTable.id, ScanResultsTable.scanSummaryId)
-        .select(ScanResultsTable.id, count)
-        .where { scanResultIds.map { ScanResultsTable.id eq it }.reduce(Op<Boolean>::or) }
-        .groupBy(ScanResultsTable.id)
-        .associate { it[ScanResultsTable.id].value to it[count] }
-}
-
-/**
  * Build the common join for snippet findings queries.
  *
  * Goes directly from the snippet finding's scan result to the scanner run via [ScannerRunsScanResultsTable]. This
@@ -317,44 +347,35 @@ private fun buildQueryContext(): Join = SnippetFindingsTable
     .join(ScannerRunsTable, JoinType.INNER, ScannerRunsScanResultsTable.scannerRunId, ScannerRunsTable.id)
     .join(ScannerJobsTable, JoinType.INNER, ScannerRunsTable.scannerJobId, ScannerJobsTable.id)
 
+private val provenanceIdAlias = ScanResultsTable.id.alias("provenance_id")
+private val identifierTypeAlias = IdentifiersTable.type.alias("identifier_type")
+private val identifierNamespaceAlias = IdentifiersTable.namespace.alias("identifier_namespace")
+private val identifierNameAlias = IdentifiersTable.name.alias("identifier_name")
+private val identifierVersionAlias = IdentifiersTable.version.alias("identifier_version")
+private val artifactUrlAlias = ScanResultsTable.artifactUrl.alias("artifact_url")
+private val vcsTypeAlias = ScanResultsTable.vcsType.alias("vcs_type")
+private val vcsUrlAlias = ScanResultsTable.vcsUrl.alias("vcs_url")
+private val vcsRevisionAlias = ScanResultsTable.vcsRevision.alias("vcs_revision")
+private val snippetFindingCountAlias = Count(SnippetFindingsTable.id).alias("snippet_finding_count")
+
 private val provenanceColumns = listOf(
-    ScanResultsTable.id,
-    IdentifiersTable.type,
-    IdentifiersTable.namespace,
-    IdentifiersTable.name,
-    IdentifiersTable.version,
-    ScanResultsTable.artifactUrl,
-    ScanResultsTable.vcsType,
-    ScanResultsTable.vcsUrl,
-    ScanResultsTable.vcsRevision
+    provenanceIdAlias,
+    identifierTypeAlias,
+    identifierNamespaceAlias,
+    identifierNameAlias,
+    identifierVersionAlias,
+    artifactUrlAlias,
+    vcsTypeAlias,
+    vcsUrlAlias,
+    vcsRevisionAlias
 )
 
-private fun queryProvenances(join: Join, ortRunId: Long): List<SnippetFindingProvenance> =
-    join.select(provenanceColumns)
-        .where { ScannerJobsTable.ortRunId eq ortRunId }
-        .map { row ->
-            val artifactUrl = row.getOrNull(ScanResultsTable.artifactUrl)
-            val vcsUrl = row.getOrNull(ScanResultsTable.vcsUrl)
-            SnippetFindingProvenance(
-                id = row[ScanResultsTable.id].value,
-                identifier = Identifier(
-                    type = row[IdentifiersTable.type],
-                    namespace = row[IdentifiersTable.namespace],
-                    name = row[IdentifiersTable.name],
-                    version = row[IdentifiersTable.version]
-                ),
-                provenanceType = when {
-                    artifactUrl != null -> "ARTIFACT"
-                    vcsUrl != null -> "REPOSITORY"
-                    else -> "UNKNOWN"
-                },
-                snippetFindingCount = 0L, // filled in by getProvenancesForRun via countSnippetFindingsByProvenanceId
-                artifactUrl = artifactUrl,
-                vcsType = row.getOrNull(ScanResultsTable.vcsType),
-                vcsUrl = vcsUrl,
-                vcsRevision = row.getOrNull(ScanResultsTable.vcsRevision)
-            )
-        }
+private fun buildProvenancesQuery(ortRunId: Long) =
+    buildProvenancesQuery(buildDirectProvenancesJoin(), ortRunId)
+        .union(buildProvenancesQuery(buildNestedProvenancesJoin(), ortRunId))
+
+private fun buildProvenancesQuery(join: Join, ortRunId: Long) =
+    join.select(provenanceColumns).where { ScannerJobsTable.ortRunId eq ortRunId }
 
 /**
  * Build the join for scan results directly linked to a package provenance via [ScanResultPackageProvenancesTable].

--- a/components/snippet-findings/backend/src/test/kotlin/SnippetFindingServiceTest.kt
+++ b/components/snippet-findings/backend/src/test/kotlin/SnippetFindingServiceTest.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.apoapsis.ortserver.components.snippetfindings
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
@@ -28,6 +29,7 @@ import io.kotest.matchers.shouldBe
 
 import kotlin.time.Clock
 
+import org.eclipse.apoapsis.ortserver.dao.QueryParametersException
 import org.eclipse.apoapsis.ortserver.dao.blockingQuery
 import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsPackageProvenancesTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.scannerrun.ScannerRunsScanResultsTable
@@ -104,10 +106,13 @@ class SnippetFindingServiceTest : WordSpec() {
                 )
             }
 
-            "return both direct and nested sub-repository provenances" {
+            "return both direct and nested sub-repository provenances with findings" {
                 var subRepoScanResultId = -1L
                 db.blockingQuery {
-                    subRepoScanResultId = addNestedSubRepoScanResult(seed)
+                    subRepoScanResultId = addNestedSubRepoScanResult(
+                        seed,
+                        snippetFinding = SnippetFindingSeed("submodule/source.c", 4, 9)
+                    )
                 }
 
                 val result = service.getProvenancesForRun(
@@ -120,15 +125,131 @@ class SnippetFindingServiceTest : WordSpec() {
                     seed.provenanceId,
                     subRepoScanResultId
                 )
-                // Both provenances belong to the same package identifier.
                 result.data.map { it.identifier }.toSet() shouldBe setOf(
                     ApiIdentifier("Maven", "com.example", "artifact-package", "1.0")
                 )
-                // The nested provenance has the sub-repository VCS details.
                 result.data.first { it.id == subRepoScanResultId }.let { nested ->
                     nested.provenanceType shouldBe "REPOSITORY"
+                    nested.snippetFindingCount shouldBe 1
                     nested.vcsUrl shouldBe "https://example.com/scm/artifact-package-sub.git"
                     nested.vcsRevision shouldBe "fedcba9876543210"
+                }
+            }
+
+            "omit direct and nested provenances without findings" {
+                db.blockingQuery {
+                    addDirectScanResult(
+                        seed,
+                        Identifier("Maven", "com.example", "empty-package", "1.0"),
+                        findingCount = 0
+                    )
+                    addNestedSubRepoScanResult(seed)
+                }
+
+                val result = service.getProvenancesForRun(
+                    seed.ortRunId,
+                    ListQueryParameters(sortFields = listOf(OrderField("name", OrderDirection.ASCENDING)))
+                )
+
+                result.totalCount shouldBe 1
+                result.data.map { it.id } should containExactly(seed.provenanceId)
+            }
+
+            "support sorting by every identifier field" {
+                var gradleScanResultId = -1L
+                var npmScanResultId = -1L
+                db.blockingQuery {
+                    gradleScanResultId = addDirectScanResult(
+                        seed,
+                        Identifier("Gradle", "zulu", "alpha-package", "3.0")
+                    )
+                    npmScanResultId = addDirectScanResult(
+                        seed,
+                        Identifier("NPM", "alpha", "zeta-package", "2.0")
+                    )
+                }
+
+                val expectedIdsBySortField = mapOf(
+                    "type" to listOf(gradleScanResultId, seed.provenanceId, npmScanResultId),
+                    "namespace" to listOf(npmScanResultId, seed.provenanceId, gradleScanResultId),
+                    "name" to listOf(gradleScanResultId, seed.provenanceId, npmScanResultId),
+                    "version" to listOf(seed.provenanceId, npmScanResultId, gradleScanResultId)
+                )
+
+                expectedIdsBySortField.forEach { (sortField, expectedIds) ->
+                    val result = service.getProvenancesForRun(
+                        seed.ortRunId,
+                        ListQueryParameters(sortFields = listOf(OrderField(sortField, OrderDirection.ASCENDING)))
+                    )
+
+                    result.data.map { it.id } should containExactly(expectedIds)
+                }
+            }
+
+            "sort and page the combined result in the database" {
+                var firstScanResultId = -1L
+                var lastScanResultId = -1L
+                var nestedScanResultId = -1L
+                db.blockingQuery {
+                    firstScanResultId = addDirectScanResult(
+                        seed,
+                        Identifier("Maven", "com.example", "aaa-package", "1.0")
+                    )
+                    lastScanResultId = addDirectScanResult(
+                        seed,
+                        Identifier("Maven", "com.example", "zzz-package", "1.0")
+                    )
+                    nestedScanResultId = addNestedSubRepoScanResult(
+                        seed,
+                        snippetFinding = SnippetFindingSeed("submodule/source.c", 4, 9)
+                    )
+                }
+
+                val ascendingPage = service.getProvenancesForRun(
+                    seed.ortRunId,
+                    ListQueryParameters(
+                        sortFields = listOf(OrderField("name", OrderDirection.ASCENDING)),
+                        limit = 2,
+                        offset = 1
+                    )
+                )
+
+                ascendingPage.totalCount shouldBe 4
+                ascendingPage.data.map { it.id } should containExactly(seed.provenanceId, nestedScanResultId)
+
+                val descendingPage = service.getProvenancesForRun(
+                    seed.ortRunId,
+                    ListQueryParameters(
+                        sortFields = listOf(OrderField("name", OrderDirection.DESCENDING)),
+                        limit = 2
+                    )
+                )
+
+                descendingPage.totalCount shouldBe 4
+                descendingPage.data.map { it.id } should containExactly(lastScanResultId, seed.provenanceId)
+                descendingPage.data.none { it.id == firstScanResultId } shouldBe true
+            }
+
+            "preserve the total count for an offset beyond the last page" {
+                val result = service.getProvenancesForRun(
+                    seed.ortRunId,
+                    ListQueryParameters(
+                        sortFields = listOf(OrderField("name", OrderDirection.ASCENDING)),
+                        limit = 1,
+                        offset = 100
+                    )
+                )
+
+                result.totalCount shouldBe 1
+                result.data.shouldBeEmpty()
+            }
+
+            "reject unsupported sort fields" {
+                shouldThrow<QueryParametersException> {
+                    service.getProvenancesForRun(
+                        seed.ortRunId,
+                        ListQueryParameters(sortFields = listOf(OrderField("findings", OrderDirection.ASCENDING)))
+                    )
                 }
             }
 
@@ -467,6 +588,29 @@ internal fun createPackageProvenance(
     return provenance
 }
 
+internal fun addDirectScanResult(
+    seed: SeedResult,
+    identifier: Identifier,
+    findingCount: Int = 1
+): Long {
+    val artifactUrl = "https://example.com/packages/${identifier.name}-${identifier.version}.tgz"
+    val packageProvenance = createPackageProvenance(
+        seed.scannerRunId,
+        identifier,
+        RemoteArtifact(artifactUrl, artifactUrl.hashCode().toString(), "SHA-1")
+    )
+    val snippetFindings = (1..findingCount).associate { index ->
+        SnippetFindingSeed("src/${identifier.name}-$index.c", index, index + 1) to emptyList<SnippetDao>()
+    }
+
+    return createScanResultWithSnippetFindings(
+        seed.scannerRunId,
+        packageProvenance.id.value,
+        snippetFindings,
+        artifactUrl = artifactUrl
+    ).first
+}
+
 internal fun createArtifactSnippet(
     purl: String,
     path: String,
@@ -574,7 +718,8 @@ internal fun createScanResultWithSnippetFindings(
 internal fun addNestedSubRepoScanResult(
     seed: SeedResult,
     subRepoUrl: String = "https://example.com/scm/artifact-package-sub.git",
-    subRepoRevision: String = "fedcba9876543210"
+    subRepoRevision: String = "fedcba9876543210",
+    snippetFinding: SnippetFindingSeed? = null
 ): Long {
     val rootVcsInfo = VcsInfoDao.getOrPut(
         VcsInfo(RepositoryType.GIT, "https://example.com/scm/artifact-package.git", "abcdef1234567890", "")
@@ -604,6 +749,21 @@ internal fun addNestedSubRepoScanResult(
 
     // Create the scan result for the sub-repo. Intentionally NOT inserted into ScanResultPackageProvenancesTable —
     // that's what distinguishes nested sub-repo scan results from root ones.
+    val scanSummary = ScanSummaryDao.new {
+        startTime = Clock.System.now()
+        endTime = Clock.System.now()
+        hash = "sub-repo-summary-$subRepoRevision"
+    }
+
+    snippetFinding?.let { finding ->
+        SnippetFindingDao.new {
+            path = finding.path
+            startLine = finding.startLine
+            endLine = finding.endLine
+            this.scanSummary = scanSummary
+        }
+    }
+
     val subRepoScanResult = ScanResultDao.new {
         artifactUrl = null
         artifactHash = null
@@ -611,11 +771,7 @@ internal fun addNestedSubRepoScanResult(
         vcsType = "GIT"
         vcsUrl = subRepoUrl
         vcsRevision = subRepoRevision
-        scanSummary = ScanSummaryDao.new {
-            startTime = Clock.System.now()
-            endTime = Clock.System.now()
-            hash = "sub-repo-summary-$subRepoRevision"
-        }
+        this.scanSummary = scanSummary
         scannerName = "SnippetScanner"
         scannerVersion = "1.0.0"
         scannerConfiguration = "default"

--- a/components/snippet-findings/backend/src/test/kotlin/routes/GetRunSnippetFindingProvenancesIntegrationTest.kt
+++ b/components/snippet-findings/backend/src/test/kotlin/routes/GetRunSnippetFindingProvenancesIntegrationTest.kt
@@ -19,6 +19,7 @@
 
 package org.eclipse.apoapsis.ortserver.components.snippetfindings.routes
 
+import io.kotest.matchers.collections.shouldBeSingleton
 import io.kotest.matchers.shouldBe
 
 import io.ktor.client.call.body
@@ -28,7 +29,10 @@ import io.ktor.http.HttpStatusCode
 import org.eclipse.apoapsis.ortserver.components.snippetfindings.SeedResult
 import org.eclipse.apoapsis.ortserver.components.snippetfindings.SnippetFindingIntegrationTest
 import org.eclipse.apoapsis.ortserver.components.snippetfindings.SnippetFindingProvenance
+import org.eclipse.apoapsis.ortserver.components.snippetfindings.addDirectScanResult
 import org.eclipse.apoapsis.ortserver.components.snippetfindings.seedData
+import org.eclipse.apoapsis.ortserver.dao.blockingQuery
+import org.eclipse.apoapsis.ortserver.model.runs.Identifier as ModelIdentifier
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters.Companion.DEFAULT_LIMIT
 import org.eclipse.apoapsis.ortserver.shared.apimodel.Identifier
 import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse
@@ -56,12 +60,47 @@ class GetRunSnippetFindingProvenancesIntegrationTest : SnippetFindingIntegration
                     totalCount = 1,
                     sortProperties = listOf(SortProperty("name", SortDirection.ASCENDING))
                 )
-                body.data.size shouldBe 1
-                body.data[0].id shouldBe seeded.provenanceId
-                body.data[0].identifier shouldBe Identifier("Maven", "com.example", "artifact-package", "1.0")
-                body.data[0].provenanceType shouldBe "REPOSITORY"
-                body.data[0].vcsUrl shouldBe "https://example.com/scm/artifact-package.git"
-                body.data[0].vcsRevision shouldBe "abcdef1234567890"
+                body.data.shouldBeSingleton {
+                    it.id shouldBe seeded.provenanceId
+                    it.identifier shouldBe Identifier("Maven", "com.example", "artifact-package", "1.0")
+                    it.provenanceType shouldBe "REPOSITORY"
+                    it.vcsUrl shouldBe "https://example.com/scm/artifact-package.git"
+                    it.vcsRevision shouldBe "abcdef1234567890"
+                }
+            }
+        }
+
+        "page and sort only provenances with findings" {
+            var firstScanResultId = -1L
+            dbExtension.db.blockingQuery {
+                firstScanResultId = addDirectScanResult(
+                    seeded,
+                    ModelIdentifier("Maven", "com.example", "aaa-package", "1.0")
+                )
+                addDirectScanResult(
+                    seeded,
+                    ModelIdentifier("Maven", "com.example", "zzz-empty-package", "1.0"),
+                    findingCount = 0
+                )
+            }
+
+            snippetFindingTestApplication { client ->
+                val response = client.get(
+                    "/runs/${seeded.ortRunId}/snippet-findings/provenances?sort=-name&limit=1&offset=1"
+                )
+
+                response.status shouldBe HttpStatusCode.OK
+                val body = response.body<PagedResponse<SnippetFindingProvenance>>()
+                body.pagination shouldBe PagingData(
+                    limit = 1,
+                    offset = 1,
+                    totalCount = 2,
+                    sortProperties = listOf(SortProperty("name", SortDirection.DESCENDING))
+                )
+                body.data.shouldBeSingleton {
+                    it.id shouldBe firstScanResultId
+                    it.snippetFindingCount shouldBe 1
+                }
             }
         }
 

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/snippet-findings-state.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/snippet-findings-state.ts
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { SortingState } from '@tanstack/react-table';
+
+import { convertToBackendSorting } from '@/helpers/handle-multisort';
+
+export const getSnippetFindingProvenancesQuery = (
+  pageIndex: number,
+  pageSize: number,
+  sorting: SortingState | undefined
+) => ({
+  limit: pageSize,
+  offset: pageIndex * pageSize,
+  sort: convertToBackendSorting(sorting),
+});
+
+export const getSnippetFindingProvenancePageCount = (
+  totalCount: number,
+  pageSize: number
+) => Math.ceil(totalCount / pageSize);

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/snippet-findings-view.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/snippet-findings-view.tsx
@@ -48,7 +48,6 @@ import {
   CardTitle,
 } from '@/components/ui/card';
 import {
-  convertToBackendSorting,
   EMPTY_SORTING_STATE,
   updateColumnSorting,
 } from '@/helpers/handle-multisort';
@@ -56,6 +55,10 @@ import { identifierToString } from '@/helpers/identifier-conversion';
 import { ACTION_COLUMN_SIZE } from '@/lib/constants';
 import { toastError } from '@/lib/toast';
 import { ProvenanceSnippetFindingsTable } from './provenance-snippet-findings-table';
+import {
+  getSnippetFindingProvenancePageCount,
+  getSnippetFindingProvenancesQuery,
+} from './snippet-findings-state';
 
 const provenanceColumnHelper = createColumnHelper<SnippetFindingProvenance>();
 const defaultPageSize = 10;
@@ -159,13 +162,6 @@ export const SnippetFindingsView = () => {
     }),
   });
 
-  const { data: totalProvenances } = useSuspenseQuery({
-    ...getRunSnippetFindingProvenancesOptions({
-      path: { runId: ortRun.id },
-      query: { limit: 1 },
-    }),
-  });
-
   const {
     data: provenances,
     isError,
@@ -173,20 +169,13 @@ export const SnippetFindingsView = () => {
   } = useSuspenseQuery({
     ...getRunSnippetFindingProvenancesOptions({
       path: { runId: ortRun.id },
-      query: {
-        limit: totalProvenances.pagination.totalCount || 1,
-        sort: convertToBackendSorting(search.sortBy),
-      },
+      query: getSnippetFindingProvenancesQuery(
+        pageIndex,
+        pageSize,
+        search.sortBy
+      ),
     }),
   });
-
-  const provenancesWithFindings = provenances.data.filter(
-    (provenance) => provenance.snippetFindingCount > 0
-  );
-  const pagedProvenances = provenancesWithFindings.slice(
-    pageIndex * pageSize,
-    (pageIndex + 1) * pageSize
-  );
 
   const columns = [
     provenanceColumnHelper.display({
@@ -247,9 +236,12 @@ export const SnippetFindingsView = () => {
   ];
 
   const table = useReactTable({
-    data: pagedProvenances,
+    data: provenances.data,
     columns,
-    pageCount: Math.ceil(provenancesWithFindings.length / pageSize),
+    pageCount: getSnippetFindingProvenancePageCount(
+      provenances.pagination.totalCount,
+      pageSize
+    ),
     state: {
       pagination: {
         pageIndex,
@@ -282,7 +274,7 @@ export const SnippetFindingsView = () => {
       No detected snippets are available because the scanner job was not enabled
       for this run.
     </div>
-  ) : provenancesWithFindings.length === 0 ? (
+  ) : provenances.pagination.totalCount === 0 ? (
     <div className='text-muted-foreground text-sm'>
       No detected snippets were found for this run, or no snippet scanner was
       used.
@@ -293,7 +285,7 @@ export const SnippetFindingsView = () => {
     <Card className='h-fit'>
       <CardHeader>
         <CardTitle>
-          Detected Snippets ({provenancesWithFindings.length} package
+          Detected Snippets ({provenances.pagination.totalCount} package
           provenances with findings)
         </CardTitle>
         <CardDescription>

--- a/ui/tests/unit/logic/snippet-findings-state.test.ts
+++ b/ui/tests/unit/logic/snippet-findings-state.test.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  getSnippetFindingProvenancePageCount,
+  getSnippetFindingProvenancesQuery,
+} from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/snippet-findings-state';
+
+describe('snippet finding provenance table state', () => {
+  it('requests only the first page', () => {
+    expect(getSnippetFindingProvenancesQuery(0, 10, undefined)).toEqual({
+      limit: 10,
+      offset: 0,
+      sort: undefined,
+    });
+  });
+
+  it('requests only the selected page with server-side sorting', () => {
+    expect(
+      getSnippetFindingProvenancesQuery(2, 25, [
+        { id: 'type', desc: false },
+        { id: 'name', desc: true },
+      ])
+    ).toEqual({
+      limit: 25,
+      offset: 50,
+      sort: 'type,-name',
+    });
+  });
+
+  it('calculates the page count from the server total', () => {
+    expect(getSnippetFindingProvenancePageCount(0, 10)).toBe(0);
+    expect(getSnippetFindingProvenancePageCount(20, 10)).toBe(2);
+    expect(getSnippetFindingProvenancePageCount(21, 10)).toBe(3);
+  });
+});


### PR DESCRIPTION
This is the final PR for unblocking implementation of #4073 (creating an upper bound for `limit` in paged requests).

Please see the commits for details.