### PR TITLE
Update test images with Renovate

### DIFF
--- a/clients/keycloak/build.gradle.kts
+++ b/clients/keycloak/build.gradle.kts
@@ -48,5 +48,7 @@ dependencies {
     testFixturesApi(libs.kotestFrameworkEngine)
     testFixturesApi(libs.testContainersKeycloak)
 
+    testFixturesImplementation(projects.utils.test)
+
     testFixturesImplementation(libs.kotlinxSerializationJson)
 }

--- a/clients/keycloak/src/testFixtures/kotlin/SharedKeycloakTestContainer.kt
+++ b/clients/keycloak/src/testFixtures/kotlin/SharedKeycloakTestContainer.kt
@@ -21,6 +21,8 @@ package org.eclipse.apoapsis.ortserver.clients.keycloak.test
 
 import dasniko.testcontainers.keycloak.KeycloakContainer
 
+import org.eclipse.apoapsis.ortserver.utils.test.Images
+
 /**
  * A singleton that manages a shared [KeycloakContainer] across all test specs within a JVM process. The container is
  * started lazily on the first access to [container] and stopped via a JVM shutdown hook when the process exits.
@@ -31,7 +33,7 @@ import dasniko.testcontainers.keycloak.KeycloakContainer
  */
 internal object SharedKeycloakTestContainer {
     private val containerLazy: Lazy<KeycloakContainer> = lazy {
-        KeycloakContainer("quay.io/keycloak/keycloak:26.6.0").also { it.start() }
+        KeycloakContainer(Images.KEYCLOAK).also { it.start() }
     }
 
     val container: KeycloakContainer by containerLazy

--- a/dao/build.gradle.kts
+++ b/dao/build.gradle.kts
@@ -66,6 +66,7 @@ dependencies {
     testFixturesApi(projects.model)
 
     testFixturesImplementation(projects.config.configSpi)
+    testFixturesImplementation(projects.utils.test)
 
     testFixturesImplementation(libs.flywayCore)
     testFixturesImplementation(libs.hikari)

--- a/dao/src/testFixtures/kotlin/DatabaseTestExtension.kt
+++ b/dao/src/testFixtures/kotlin/DatabaseTestExtension.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.withContext
 
 import org.eclipse.apoapsis.ortserver.dao.connect
 import org.eclipse.apoapsis.ortserver.dao.migrate
+import org.eclipse.apoapsis.ortserver.utils.test.Images
 
 import org.flywaydb.core.Flyway
 import org.flywaydb.core.api.configuration.FluentConfiguration
@@ -55,7 +56,7 @@ import org.testcontainers.postgresql.PostgreSQLContainer
  * see [this Kotest issue](https://github.com/kotest/kotest/issues/3555).
  */
 open class DatabaseTestExtension : BeforeSpecListener, AfterSpecListener, BeforeEachListener, AfterEachListener {
-    private val postgres = PostgreSQLContainer("postgres:15.19").apply {
+    private val postgres = PostgreSQLContainer(Images.POSTGRES).apply {
         startupAttempts = 1
     }
 

--- a/dao/src/testFixtures/kotlin/DatabaseTestExtension.kt
+++ b/dao/src/testFixtures/kotlin/DatabaseTestExtension.kt
@@ -55,7 +55,7 @@ import org.testcontainers.postgresql.PostgreSQLContainer
  * see [this Kotest issue](https://github.com/kotest/kotest/issues/3555).
  */
 open class DatabaseTestExtension : BeforeSpecListener, AfterSpecListener, BeforeEachListener, AfterEachListener {
-    private val postgres = PostgreSQLContainer("postgres:15").apply {
+    private val postgres = PostgreSQLContainer("postgres:15.19").apply {
         startupAttempts = 1
     }
 

--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,14 @@
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?\\s*\\nARG \\w+_VERSION=(?<currentValue>\\S+)"
       ]
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/utils/test/src/commonMain/kotlin/Images\\.kt$/"],
+      "matchStrings": [
+        "const val \\w+ = \"(?<depName>[^\"]+):(?<currentValue>[^\":]+)\""
+      ],
+      "datasourceTemplate": "docker"
     }
   ],
   "packageRules": [

--- a/secrets/vault/src/test/kotlin/VaultTestContainer.kt
+++ b/secrets/vault/src/test/kotlin/VaultTestContainer.kt
@@ -64,7 +64,7 @@ class VaultTestContainer {
         private const val ROLE_NAME = "test-server"
 
         /** The name of the docker image for the vault test container. */
-        private val image = DockerImageName.parse("hashicorp/vault:1.13").asCompatibleSubstituteFor("vault")
+        private val image = DockerImageName.parse("hashicorp/vault:1.13.13").asCompatibleSubstituteFor("vault")
 
         /**
          * Obtain the [VaultCredentials] to construct an authorized token for the test Vault container. Use [client]

--- a/secrets/vault/src/test/kotlin/VaultTestContainer.kt
+++ b/secrets/vault/src/test/kotlin/VaultTestContainer.kt
@@ -42,6 +42,7 @@ import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.config.ConfigSecretProviderFactoryForTesting
 import org.eclipse.apoapsis.ortserver.secrets.vault.model.VaultCredentials
 import org.eclipse.apoapsis.ortserver.utils.logging.runBlocking
+import org.eclipse.apoapsis.ortserver.utils.test.Images
 
 import org.testcontainers.utility.DockerImageName
 import org.testcontainers.vault.VaultContainer
@@ -64,7 +65,7 @@ class VaultTestContainer {
         private const val ROLE_NAME = "test-server"
 
         /** The name of the docker image for the vault test container. */
-        private val image = DockerImageName.parse("hashicorp/vault:1.13.13").asCompatibleSubstituteFor("vault")
+        private val image = DockerImageName.parse(Images.VAULT).asCompatibleSubstituteFor("vault")
 
         /**
          * Obtain the [VaultCredentials] to construct an authorized token for the test Vault container. Use [client]

--- a/storage/azure-blob/src/test/kotlin/AzureBlobStorageProviderTest.kt
+++ b/storage/azure-blob/src/test/kotlin/AzureBlobStorageProviderTest.kt
@@ -32,10 +32,9 @@ import org.eclipse.apoapsis.ortserver.storage.Key
 import org.eclipse.apoapsis.ortserver.storage.Storage
 import org.eclipse.apoapsis.ortserver.storage.Storage.Companion.dataString
 import org.eclipse.apoapsis.ortserver.storage.StorageException
+import org.eclipse.apoapsis.ortserver.utils.test.Images
 
 import org.testcontainers.containers.GenericContainer
-
-private const val AZURITE_IMAGE = "mcr.microsoft.com/azure-storage/azurite:3.35.0"
 
 // Default account name and key, see https://github.com/Azure/Azurite/blob/main/README.md#default-storage-account.
 private const val ACCOUNT_NAME = "devstoreaccount1"
@@ -47,7 +46,7 @@ private const val CONTAINER = "test"
 class AzureBlobStorageProviderTest : WordSpec({
     val azuriteContainer = install(
         TestContainerSpecExtension(
-            GenericContainer(AZURITE_IMAGE)
+            GenericContainer(Images.AZURITE)
                 // Skip the API version check to work around https://github.com/Azure/Azurite/issues/2623.
                 .withCommand("azurite-blob", "--skipApiVersionCheck", "--blobHost", "0.0.0.0")
                 .withExposedPorts(10000)

--- a/storage/s3/src/test/kotlin/S3StorageTest.kt
+++ b/storage/s3/src/test/kotlin/S3StorageTest.kt
@@ -45,6 +45,7 @@ import org.eclipse.apoapsis.ortserver.storage.Key
 import org.eclipse.apoapsis.ortserver.storage.Storage
 import org.eclipse.apoapsis.ortserver.storage.Storage.Companion.dataString
 import org.eclipse.apoapsis.ortserver.storage.StorageException
+import org.eclipse.apoapsis.ortserver.utils.test.Images
 
 import org.testcontainers.localstack.LocalStackContainer
 import org.testcontainers.utility.DockerImageName
@@ -52,7 +53,7 @@ import org.testcontainers.utility.DockerImageName
 class S3StorageTest : WordSpec({
     val localStackContainer = install(
         TestContainerSpecExtension(
-            LocalStackContainer(DockerImageName.parse(LOCALSTACK_IMAGE)).withServices("s3")
+            LocalStackContainer(DockerImageName.parse(Images.LOCALSTACK)).withServices("s3")
         )
     )
 
@@ -271,7 +272,6 @@ class S3StorageTest : WordSpec({
     }
 })
 
-internal const val LOCALSTACK_IMAGE = "localstack/localstack:3.4.0"
 internal const val S3_REGION = "eu-central-1"
 internal const val TEST_BUCKET_NAME = "test-bucket"
 

--- a/transport/activemqartemis/src/test/kotlin/ArtemisTestContainer.kt
+++ b/transport/activemqartemis/src/test/kotlin/ArtemisTestContainer.kt
@@ -25,13 +25,13 @@ import io.kotest.extensions.testcontainers.TestContainerSpecExtension
 
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.transport.testing.createConfigManager
+import org.eclipse.apoapsis.ortserver.utils.test.Images
 
 import org.slf4j.LoggerFactory
 
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.output.Slf4jLogConsumer
 
-private const val ARTEMIS_CONTAINER = "apache/artemis:2.55.0"
 private const val ARTEMIS_PORT = 61616
 
 /**
@@ -41,7 +41,7 @@ private const val ARTEMIS_PORT = 61616
 fun Spec.startArtemisContainer(consumerName: String, transportType: String): ConfigManager {
     val artemisContainer = install(
         TestContainerSpecExtension(
-            GenericContainer(ARTEMIS_CONTAINER).apply {
+            GenericContainer(Images.ARTEMIS).apply {
                 startupAttempts = 1
                 withExposedPorts(ARTEMIS_PORT)
                 withLogConsumer(Slf4jLogConsumer(LoggerFactory.getLogger("artemis")))

--- a/transport/activemqartemis/src/test/kotlin/ArtemisTestContainer.kt
+++ b/transport/activemqartemis/src/test/kotlin/ArtemisTestContainer.kt
@@ -31,7 +31,7 @@ import org.slf4j.LoggerFactory
 import org.testcontainers.containers.GenericContainer
 import org.testcontainers.containers.output.Slf4jLogConsumer
 
-private const val ARTEMIS_CONTAINER = "quay.io/arkmq-org/activemq-artemis-broker:artemis.2.50.0"
+private const val ARTEMIS_CONTAINER = "apache/artemis:2.55.0"
 private const val ARTEMIS_PORT = 61616
 
 /**
@@ -39,13 +39,11 @@ private const val ARTEMIS_PORT = 61616
  * and [transportType]. The resulting [ConfigManager] can be used to connect to the broker in the container.
  */
 fun Spec.startArtemisContainer(consumerName: String, transportType: String): ConfigManager {
-    val containerEnv = mapOf("AMQ_USER" to "admin", "AMQ_PASSWORD" to "admin")
     val artemisContainer = install(
         TestContainerSpecExtension(
             GenericContainer(ARTEMIS_CONTAINER).apply {
                 startupAttempts = 1
                 withExposedPorts(ARTEMIS_PORT)
-                withEnv(containerEnv)
                 withLogConsumer(Slf4jLogConsumer(LoggerFactory.getLogger("artemis")))
             }
         )
@@ -55,6 +53,7 @@ fun Spec.startArtemisContainer(consumerName: String, transportType: String): Con
         consumerName = consumerName,
         transportType = transportType,
         transportName = "activeMQ",
-        serverUri = "amqp://${artemisContainer.host}:${artemisContainer.firstMappedPort}"
+        serverUri = "amqp://${artemisContainer.host}:${artemisContainer.firstMappedPort}" +
+                "?jms.username=artemis&jms.password=artemis"
     )
 }

--- a/transport/rabbitmq/src/test/kotlin/RabbitMqTestContainer.kt
+++ b/transport/rabbitmq/src/test/kotlin/RabbitMqTestContainer.kt
@@ -36,7 +36,7 @@ import org.testcontainers.rabbitmq.RabbitMQContainer
 fun Spec.startRabbitMqContainer(consumerName: String, transportType: String): ConfigManager {
     val rabbitMq = install(
         TestContainerSpecExtension(
-            RabbitMQContainer("rabbitmq")
+            RabbitMQContainer("rabbitmq:4.3.4")
         )
     )
 

--- a/transport/rabbitmq/src/test/kotlin/RabbitMqTestContainer.kt
+++ b/transport/rabbitmq/src/test/kotlin/RabbitMqTestContainer.kt
@@ -26,6 +26,7 @@ import io.kotest.extensions.testcontainers.TestContainerSpecExtension
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.config.ConfigSecretProviderFactoryForTesting
 import org.eclipse.apoapsis.ortserver.transport.testing.createConfigManager
+import org.eclipse.apoapsis.ortserver.utils.test.Images
 
 import org.testcontainers.rabbitmq.RabbitMQContainer
 
@@ -36,7 +37,7 @@ import org.testcontainers.rabbitmq.RabbitMQContainer
 fun Spec.startRabbitMqContainer(consumerName: String, transportType: String): ConfigManager {
     val rabbitMq = install(
         TestContainerSpecExtension(
-            RabbitMQContainer("rabbitmq:4.3.4")
+            RabbitMQContainer(Images.RABBITMQ)
         )
     )
 

--- a/transport/sqs/src/test/kotlin/SqsConfigManager.kt
+++ b/transport/sqs/src/test/kotlin/SqsConfigManager.kt
@@ -26,6 +26,7 @@ import io.kotest.extensions.testcontainers.TestContainerSpecExtension
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.config.ConfigSecretProviderFactoryForTesting
 import org.eclipse.apoapsis.ortserver.transport.testing.createConfigManager
+import org.eclipse.apoapsis.ortserver.utils.test.Images
 
 import org.testcontainers.localstack.LocalStackContainer
 import org.testcontainers.utility.DockerImageName
@@ -36,7 +37,7 @@ import org.testcontainers.utility.DockerImageName
 fun Spec.createSqsConfigManager(consumerName: String, transportType: String): ConfigManager {
     val localStack = install(
         TestContainerSpecExtension(
-            LocalStackContainer(DockerImageName.parse("localstack/localstack:3.4.0")).withServices("sqs")
+            LocalStackContainer(DockerImageName.parse(Images.LOCALSTACK)).withServices("sqs")
         )
     )
 

--- a/utils/test/src/commonMain/kotlin/Images.kt
+++ b/utils/test/src/commonMain/kotlin/Images.kt
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.utils.test
+
+/**
+ * A central place to define Docker images used by test containers throughout the code base. Keeping the images in a
+ * single location makes it easier to automatically update them with Renovate.
+ */
+object Images {
+    const val ARTEMIS = "apache/artemis:2.55.0"
+    const val AZURITE = "mcr.microsoft.com/azure-storage/azurite:3.35.0"
+    const val KEYCLOAK = "quay.io/keycloak/keycloak:26.6.0"
+    const val LOCALSTACK = "localstack/localstack:3.4.0"
+    const val POSTGRES = "postgres:15.19"
+    const val RABBITMQ = "rabbitmq:4.3.4"
+    const val VAULT = "hashicorp/vault:1.13.13"
+}


### PR DESCRIPTION
Automate updating the Docker images used in tests with Renovate. Also pin all image versions to prevent unintended upgrades that could potentially break tests. See the commit messages for details.