### PR TITLE
ci(renovate): Override default `ignorePaths`

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,11 @@
   "extends": [
     "github>eclipse-apoapsis/renovate"
   ],
+  "ignorePaths": [
+    "**/node_modules/**",
+    "**/src/test/**",
+    "**/tests/**"
+  ],
   "customManagers": [
     {
       "customType": "regex",


### PR DESCRIPTION
The default ignore paths [1] imported by the `config:recommended` preset ignore all files matching `**/test/**`. Therefore, the custom manager introduced in f0388a8 does not match any files.

Replace this pattern with `**/src/test/*` to match the Kotlin test directories but not the `utils/test` directory. Apart from that, keep only those of the default patterns which are relevant for this project.

[1]: https://docs.renovatebot.com/presets-default/#ignoremodulesandtests