### PR TITLE
ui: Start migrating the UI tables to TanStack Table v9

### DIFF
--- a/ui/eslint.config.js
+++ b/ui/eslint.config.js
@@ -65,7 +65,7 @@ export default defineConfig([
       // value that is never nullish, so that the checks that do matter stand
       // out.
       '@typescript-eslint/no-unnecessary-condition': 'error',
-      // Silence the warnings about useReactTable() hook, because React Compiler
+      // Silence the warnings about useLegacyTable() hook, because React Compiler
       // is not used in this project.
       'react-hooks/incompatible-library': 'off',
     },

--- a/ui/package.json
+++ b/ui/package.json
@@ -43,7 +43,7 @@
     "@tanstack/react-query-devtools": "5.101.4",
     "@tanstack/react-router": "1.170.25",
     "@tanstack/react-router-devtools": "1.167.1",
-    "@tanstack/react-table": "8.21.3",
+    "@tanstack/react-table": "9.1.2",
     "ae-cvss-calculator": "1.0.13",
     "axios": "1.19.0",
     "class-variance-authority": "0.7.1",

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -84,8 +84,8 @@ importers:
         specifier: 1.167.1
         version: 1.167.1(@tanstack/react-router@1.170.25(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(@tanstack/router-core@1.171.21)(csstype@3.2.3)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       '@tanstack/react-table':
-        specifier: 8.21.3
-        version: 8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: 9.1.2
+        version: 9.1.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       ae-cvss-calculator:
         specifier: 1.0.13
         version: 1.0.13
@@ -1363,18 +1363,23 @@ packages:
       react: '>=18.0.0 || >=19.0.0'
       react-dom: '>=18.0.0 || >=19.0.0'
 
+  '@tanstack/react-store@0.11.1':
+    resolution: {integrity: sha512-HaIGKI3YLmjBYIvy5DFDY23oNaYZIsTZfngey07Uh5iLVJgM3bIGCnZeOFOqzjFld9JHWcaHJnasD/bKoGKwJQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   '@tanstack/react-store@0.9.3':
     resolution: {integrity: sha512-y2iHd/N9OkoQbFJLUX1T9vbc2O9tjH0pQRgTcx1/Nz4IlwLvkgpuglXUx+mXt0g5ZDFrEeDnONPqkbfxXJKwRg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  '@tanstack/react-table@8.21.3':
-    resolution: {integrity: sha512-5nNMTSETP4ykGegmVkhjcS8tTLW6Vl4axfEGQN3v0zdHYbK4UfoqfPChclTrJ4EoK9QynqAu9oUf8VEmrpZ5Ww==}
-    engines: {node: '>=12'}
+  '@tanstack/react-table@9.1.2':
+    resolution: {integrity: sha512-YQPZFJ1nIi/bjjwsPZVouABgahDcl7Gdm33CdTStUJBn0DjEVJ2uhSTVmIoWt9MVKdQziXGAsXipSzy949Hygg==}
+    engines: {node: '>=20'}
     peerDependencies:
-      react: '>=16.8'
-      react-dom: '>=16.8'
+      react: '>=18'
 
   '@tanstack/router-cli@1.167.27':
     resolution: {integrity: sha512-Ezgr3ipytBLNW0xG3St84DQCGJBLoueLy9lGgdT0CLsQK8IbX+Ri/sls8sJSA7eGiy46hdz0YWey1h2X1nAqMg==}
@@ -1428,12 +1433,15 @@ packages:
     resolution: {integrity: sha512-Gu0Sm3HOKv9Elh4hMxJzSiKcSRU63Ex3KIKTrS8YlRcbYPnrpsymXO+sLteyJMvYDQ3HstrMjSwy8YIcRS30Vw==}
     engines: {node: '>=20.19'}
 
+  '@tanstack/store@0.11.1':
+    resolution: {integrity: sha512-mzTOBhypOuDJAy/D8n2MfUZ1HFkXnmSETviRyhqEC8LUE7/IZQExOTxMANj3KjTofYTkFNpBY67qaVrT41YccA==}
+
   '@tanstack/store@0.9.3':
     resolution: {integrity: sha512-8reSzl/qGWGGVKhBoxXPMWzATSbZLZFWhwBAFO9NAyp0TxzfBP0mIrGb8CP8KrQTmvzXlR/vFPPUrHTLBGyFyw==}
 
-  '@tanstack/table-core@8.21.3':
-    resolution: {integrity: sha512-ldZXEhOBb8Is7xLs01fR3YEc3DERiz5silj8tnGkFZytt1abEvl/GhUmCE0PMLaMPTa3Jk4HbKmRlHmu+gCftg==}
-    engines: {node: '>=12'}
+  '@tanstack/table-core@9.1.2':
+    resolution: {integrity: sha512-ONpWQeass1sfg80CWF1NSwQ8r3GiqxA2lT/EdqIcrDEPZ0Z+0mM94eQoFYLPN0Kztzj8TQVb2+PrSZSItqA61g==}
+    engines: {node: '>=20'}
 
   '@tanstack/virtual-file-routes@1.162.0':
     resolution: {integrity: sha512-uhOeFyxLcU41HzvrxsGpiWdcMbScY1EDgbZ5K7DVRMYInbLYWAC0EA/kx9wXAoSM8q82bUG2hRl8+EAjE6XAbA==}
@@ -4265,6 +4273,13 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
+  '@tanstack/react-store@0.11.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@tanstack/store': 0.11.1
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      use-sync-external-store: 1.6.0(react@19.2.8)
+
   '@tanstack/react-store@0.9.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@tanstack/store': 0.9.3
@@ -4272,11 +4287,13 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       use-sync-external-store: 1.6.0(react@19.2.8)
 
-  '@tanstack/react-table@8.21.3(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+  '@tanstack/react-table@9.1.2(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
-      '@tanstack/table-core': 8.21.3
+      '@tanstack/react-store': 0.11.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@tanstack/table-core': 9.1.2
       react: 19.2.8
-      react-dom: 19.2.8(react@19.2.8)
+    transitivePeerDependencies:
+      - react-dom
 
   '@tanstack/router-cli@1.167.27':
     dependencies:
@@ -4355,9 +4372,13 @@ snapshots:
       - vite-plugin-solid
       - webpack
 
+  '@tanstack/store@0.11.1': {}
+
   '@tanstack/store@0.9.3': {}
 
-  '@tanstack/table-core@8.21.3': {}
+  '@tanstack/table-core@9.1.2':
+    dependencies:
+      '@tanstack/store': 0.11.1
 
   '@tanstack/virtual-file-routes@1.162.0': {}
 

--- a/ui/src/@types/@tanstack/react-table.d.ts
+++ b/ui/src/@types/@tanstack/react-table.d.ts
@@ -19,21 +19,28 @@
 
 import '@tanstack/react-table';
 
+import type { CellData, RowData, TableFeatures } from '@tanstack/react-table';
+
 import type { FilterOption } from '@/components/data-table/filter-multi-select';
 import type { InfiniteList } from '@/lib/infinite-list';
 
 declare module '@tanstack/react-table' {
   // Extend the ColumnMeta interface to include properties needed for filtering
-  // Disable no-unused-vars for TData, it is needed here to ensure the extended
-  // interface matches the original one.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  interface ColumnMeta<TData extends RowData, TValue> {
+  // Disable no-unused-vars for TFeatures and TData, they are needed here to
+  // ensure the extended interface matches the original one.
+  /* eslint-disable @typescript-eslint/no-unused-vars */
+  interface ColumnMeta<
+    in out TFeatures extends TableFeatures,
+    in out TData extends RowData,
+    TValue extends CellData = CellData,
+  > {
     filter?: Filter<TValue>;
     /** Column takes this percentage of total table width (e.g., 30 = 30%) */
     widthPercentage?: number;
     /** Column expands to fill remaining available space */
     isGrow?: boolean;
   }
+  /* eslint-enable @typescript-eslint/no-unused-vars */
 
   // Define the different filter variants
 

--- a/ui/src/components/data-table-cards/data-table-cards-header.tsx
+++ b/ui/src/components/data-table-cards/data-table-cards-header.tsx
@@ -18,20 +18,21 @@
  */
 
 import { LinkOptions } from '@tanstack/react-router';
-import { Table } from '@tanstack/react-table';
+import type { RowData } from '@tanstack/react-table';
+import type { LegacyReactTable } from '@tanstack/react-table/legacy';
 
 import { DataTableCardsSort } from '@/components/data-table-cards/data-table-cards-sort';
 import { DataTableFilter } from '@/components/data-table/data-table-filter';
 
-interface DataTableCardsHeaderProps<TData> {
-  table: Table<TData>;
+interface DataTableCardsHeaderProps<TData extends RowData> {
+  table: LegacyReactTable<TData>;
   setSortingOptions?: (sorting: {
     id: string;
     desc: boolean | undefined;
   }) => LinkOptions;
 }
 
-export function DataTableCardsHeader<TData>({
+export function DataTableCardsHeader<TData extends RowData>({
   table,
   setSortingOptions,
 }: DataTableCardsHeaderProps<TData>) {

--- a/ui/src/components/data-table-cards/data-table-cards-sort.tsx
+++ b/ui/src/components/data-table-cards/data-table-cards-sort.tsx
@@ -18,7 +18,8 @@
  */
 
 import { Link, LinkOptions } from '@tanstack/react-router';
-import { Table } from '@tanstack/react-table';
+import type { RowData } from '@tanstack/react-table';
+import type { LegacyReactTable } from '@tanstack/react-table/legacy';
 import { ChevronDown, ChevronsUpDown, ChevronUp } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
@@ -37,15 +38,15 @@ import {
 } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 
-interface DataTableCardsSortProps<TData> {
-  table: Table<TData>;
+interface DataTableCardsSortProps<TData extends RowData> {
+  table: LegacyReactTable<TData>;
   setSortingOptions?: (sorting: {
     id: string;
     desc: boolean | undefined;
   }) => LinkOptions;
 }
 
-export function DataTableCardsSort<TData>({
+export function DataTableCardsSort<TData extends RowData>({
   table,
   setSortingOptions,
 }: DataTableCardsSortProps<TData>) {

--- a/ui/src/components/data-table-cards/data-table-cards.tsx
+++ b/ui/src/components/data-table-cards/data-table-cards.tsx
@@ -18,7 +18,11 @@
  */
 
 import { LinkOptions } from '@tanstack/react-router';
-import { Row, type Table as TanstackTable } from '@tanstack/react-table';
+import type { RowData } from '@tanstack/react-table';
+import type {
+  LegacyRow,
+  LegacyReactTable as TanstackTable,
+} from '@tanstack/react-table/legacy';
 import React from 'react';
 
 import { DataTableCardsHeader } from '@/components/data-table-cards/data-table-cards-header';
@@ -29,10 +33,10 @@ import { useTableSizing } from '@/hooks/use-table-sizing';
 import { cn } from '@/lib/utils';
 
 interface DataTableCardsProps<
-  TData,
+  TData extends RowData,
 > extends React.HTMLAttributes<HTMLDivElement> {
   table: TanstackTable<TData>;
-  renderSubComponent?: (props: { row: Row<TData> }) => React.ReactElement;
+  renderSubComponent?: (props: { row: LegacyRow<TData> }) => React.ReactElement;
   noResultsContent?: React.ReactNode;
   setCurrentPageOptions: (page: number) => LinkOptions;
   setPageSizeOptions: (pageSize: number) => LinkOptions;
@@ -42,7 +46,7 @@ interface DataTableCardsProps<
   }) => LinkOptions;
 }
 
-export function DataTableCards<TData>({
+export function DataTableCards<TData extends RowData>({
   table,
   renderSubComponent,
   noResultsContent,

--- a/ui/src/components/data-table/data-table-body.tsx
+++ b/ui/src/components/data-table/data-table-body.tsx
@@ -17,20 +17,21 @@
  * License-Filename: LICENSE
  */
 
-import { flexRender, Row } from '@tanstack/react-table';
+import { flexRender, type RowData } from '@tanstack/react-table';
+import type { LegacyRow } from '@tanstack/react-table/legacy';
 import React, { Fragment } from 'react';
 
 import { TableBody, TableCell, TableRow } from '@/components/ui/table';
 
-interface DataTableBodyProps<TData> {
-  rows: Row<TData>[];
-  renderSubComponent?: (props: { row: Row<TData> }) => React.ReactElement;
+interface DataTableBodyProps<TData extends RowData> {
+  rows: LegacyRow<TData>[];
+  renderSubComponent?: (props: { row: LegacyRow<TData> }) => React.ReactElement;
   columnSizing?: Record<string, number>;
   columnCount: number;
   noResultsContent?: React.ReactNode;
 }
 
-export function DataTableBody<TData>({
+export function DataTableBody<TData extends RowData>({
   rows,
   renderSubComponent,
   columnSizing,

--- a/ui/src/components/data-table/data-table-filter.tsx
+++ b/ui/src/components/data-table/data-table-filter.tsx
@@ -18,13 +18,14 @@
  */
 
 import {
-  Column,
   InfiniteSelectFilter,
   RegexFilter,
+  RowData,
   SelectFilter,
   SingleSelectFilter,
   TextFilter,
 } from '@tanstack/react-table';
+import type { LegacyColumn } from '@tanstack/react-table/legacy';
 
 import { FilterInfiniteMultiSelect } from '@/components/data-table/filter-infinite-multi-select';
 import { FilterMultiSelect } from '@/components/data-table/filter-multi-select';
@@ -32,12 +33,12 @@ import { FilterRegex } from '@/components/data-table/filter-regex';
 import { FilterSingleSelect } from '@/components/data-table/filter-single-select';
 import { FilterText } from '@/components/data-table/filter-text';
 
-interface DataTableFilterProps<TData, TValue> {
-  column: Column<TData, TValue>;
+interface DataTableFilterProps<TData extends RowData, TValue> {
+  column: LegacyColumn<TData, TValue>;
   showTitle?: boolean; // Whether to show the title next to the filter icon
 }
 
-export function DataTableFilter<TData, TValue>({
+export function DataTableFilter<TData extends RowData, TValue>({
   column,
   showTitle,
 }: DataTableFilterProps<TData, TValue>) {

--- a/ui/src/components/data-table/data-table-header.tsx
+++ b/ui/src/components/data-table/data-table-header.tsx
@@ -18,7 +18,8 @@
  */
 
 import { Link, LinkOptions } from '@tanstack/react-router';
-import { flexRender, Header } from '@tanstack/react-table';
+import { flexRender, type RowData } from '@tanstack/react-table';
+import type { LegacyHeader } from '@tanstack/react-table/legacy';
 import { ChevronDown, ChevronsUpDown, ChevronUp } from 'lucide-react';
 
 import { DataTableFilter } from '@/components/data-table/data-table-filter';
@@ -30,8 +31,8 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 
-interface DataTableHeaderProps<TData> {
-  headers: Header<TData, unknown>[];
+interface DataTableHeaderProps<TData extends RowData> {
+  headers: LegacyHeader<TData, unknown>[];
   setSortingOptions?: (sorting: {
     id: string;
     desc: boolean | undefined;
@@ -39,7 +40,7 @@ interface DataTableHeaderProps<TData> {
   columnSizing?: Record<string, number>;
 }
 
-export function DataTableHeader<TData>({
+export function DataTableHeader<TData extends RowData>({
   headers,
   setSortingOptions,
   columnSizing,

--- a/ui/src/components/data-table/data-table.tsx
+++ b/ui/src/components/data-table/data-table.tsx
@@ -18,7 +18,11 @@
  */
 
 import { LinkOptions } from '@tanstack/react-router';
-import { Row, type Table as TanstackTable } from '@tanstack/react-table';
+import type { RowData } from '@tanstack/react-table';
+import type {
+  LegacyRow,
+  LegacyReactTable as TanstackTable,
+} from '@tanstack/react-table/legacy';
 import React from 'react';
 
 import { DataTablePagination } from '@/components/data-table/data-table-pagination';
@@ -31,9 +35,11 @@ import { DataTableHeader } from './data-table-header';
 export const DEFAULT_PAGE = 1;
 export const DEFAULT_PAGE_SIZE = 10;
 
-interface DataTableProps<TData> extends React.HTMLAttributes<HTMLDivElement> {
+interface DataTableProps<
+  TData extends RowData,
+> extends React.HTMLAttributes<HTMLDivElement> {
   table: TanstackTable<TData>;
-  renderSubComponent?: (props: { row: Row<TData> }) => React.ReactElement;
+  renderSubComponent?: (props: { row: LegacyRow<TData> }) => React.ReactElement;
   noResultsContent?: React.ReactNode;
   setCurrentPageOptions: (page: number) => LinkOptions;
   setPageSizeOptions: (pageSize: number) => LinkOptions;
@@ -46,7 +52,7 @@ interface DataTableProps<TData> extends React.HTMLAttributes<HTMLDivElement> {
   }) => LinkOptions;
 }
 
-export function DataTable<TData>({
+export function DataTable<TData extends RowData>({
   table,
   renderSubComponent,
   noResultsContent,

--- a/ui/src/components/data-table/mark-items.tsx
+++ b/ui/src/components/data-table/mark-items.tsx
@@ -18,7 +18,8 @@
  */
 
 import { Link, LinkOptions } from '@tanstack/react-router';
-import { Row } from '@tanstack/react-table';
+import type { RowData } from '@tanstack/react-table';
+import type { LegacyRow } from '@tanstack/react-table/legacy';
 import { Link as Chain } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
@@ -28,15 +29,18 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 
-interface MarkItemsProps<TData> {
-  row: Row<TData>;
+interface MarkItemsProps<TData extends RowData> {
+  row: LegacyRow<TData>;
   /**
    * A function to provide `LinkOptions` for a link to set marked item in the URL.
    */
   setMarked: (marked: string) => LinkOptions;
 }
 
-export function MarkItems<TData>({ row, setMarked }: MarkItemsProps<TData>) {
+export function MarkItems<TData extends RowData>({
+  row,
+  setMarked,
+}: MarkItemsProps<TData>) {
   // Copy the URL with marked item to clipboard.
   // Because TanStack Router updates the URL asynchronously,
   // a small delay is used before copying to ensure the new

--- a/ui/src/components/ui/user-group-row-actions.tsx
+++ b/ui/src/components/ui/user-group-row-actions.tsx
@@ -17,7 +17,7 @@
  * License-Filename: LICENSE
  */
 
-import { Row } from '@tanstack/react-table';
+import type { LegacyRow } from '@tanstack/react-table/legacy';
 import { Eye, Pen, Shield } from 'lucide-react';
 
 import { UserGroup, UserWithGroups } from '@/api';
@@ -30,7 +30,7 @@ import {
 } from '@/components/ui/dropdown-menu.tsx';
 
 type UserGroupRowActionsProps = {
-  row: Row<UserWithGroups>;
+  row: LegacyRow<UserWithGroups>;
   onJoinAdminsGroup: (user: UserWithGroups) => Promise<void>;
   onJoinWritersGroup: (user: UserWithGroups) => Promise<void>;
   onJoinReadersGroup: (user: UserWithGroups) => Promise<void>;

--- a/ui/src/hooks/use-table-sizing.ts
+++ b/ui/src/hooks/use-table-sizing.ts
@@ -17,7 +17,8 @@
  * License-Filename: LICENSE
  */
 
-import { Table } from '@tanstack/react-table';
+import type { RowData } from '@tanstack/react-table';
+import type { LegacyTable } from '@tanstack/react-table/legacy';
 import { useLayoutEffect, useRef, useState } from 'react';
 
 const DEFAULT_MIN_SIZE = 40;
@@ -148,7 +149,9 @@ export function calculateColumnSizing(
  * }
  * ```
  */
-export function useTableSizing<TData>(table: Table<TData>) {
+export function useTableSizing<TData extends RowData>(
+  table: LegacyTable<TData>
+) {
   const containerRef = useRef<HTMLDivElement>(null);
   const tableRef = useRef(table);
   const lastWidthRef = useRef<number>(0);

--- a/ui/src/routes/admin/runs/index.tsx
+++ b/ui/src/routes/admin/runs/index.tsx
@@ -25,10 +25,10 @@ import {
 } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import {
-  createColumnHelper,
   getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { Repeat, View } from 'lucide-react';
 import z from 'zod';
 
@@ -75,7 +75,7 @@ import {
 const defaultPageSize = 10;
 const pollInterval = config.pollInterval;
 
-const columnHelper = createColumnHelper<OrtRunSummary>();
+const columnHelper = legacyCreateColumnHelper<OrtRunSummary>();
 
 const RunsComponent = () => {
   const search = Route.useSearch();
@@ -86,7 +86,7 @@ const RunsComponent = () => {
 
   const columnFilters = status ? [{ id: 'status', value: status }] : [];
 
-  const columns = [
+  const columns = columnHelper.columns([
     columnHelper.display({
       id: 'repository',
       header: 'Repository',
@@ -324,7 +324,7 @@ const RunsComponent = () => {
       size: 70,
       enableColumnFilter: false,
     }),
-  ];
+  ]);
 
   const { data: runs } = useQuery({
     ...getRunsOptions({
@@ -344,7 +344,7 @@ const RunsComponent = () => {
     refetchInterval: pollInterval,
   });
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: data?.data || [],
     columns,
     pageCount: Math.ceil((data?.pagination.totalCount ?? 0) / pageSize),

--- a/ui/src/routes/admin/users/index.tsx
+++ b/ui/src/routes/admin/users/index.tsx
@@ -24,11 +24,11 @@ import {
 } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import {
-  createColumnHelper,
   getCoreRowModel,
   getPaginationRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { ShieldCheck, ShieldMinus, ShieldPlus, UserPlus } from 'lucide-react';
 
 import { UserWithSuperuserStatus } from '@/api';
@@ -64,9 +64,9 @@ import { paginationSearchParameterSchema } from '@/schemas';
 
 const defaultPageSize = 10;
 
-const columnHelper = createColumnHelper<UserWithSuperuserStatus>();
+const columnHelper = legacyCreateColumnHelper<UserWithSuperuserStatus>();
 
-const columns = [
+const columns = columnHelper.columns([
   columnHelper.accessor('user.username', {
     header: 'Username',
     cell: ({ row }) => <TooltipIfTruncated text={row.original.user.username} />,
@@ -199,7 +199,7 @@ const columns = [
       );
     },
   }),
-];
+]);
 
 const Users = () => {
   const search = Route.useSearch();
@@ -211,7 +211,7 @@ const Users = () => {
     staleTime: routePrefetchStaleTime,
   });
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: users,
     columns,
 

--- a/ui/src/routes/organizations/$orgId/-components/organization-product-table.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-product-table.tsx
@@ -20,10 +20,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { getRouteApi, Link } from '@tanstack/react-router';
 import {
-  createColumnHelper,
   getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { Loader2 } from 'lucide-react';
 import { useMemo } from 'react';
 
@@ -44,7 +44,7 @@ import { LastRunStatus } from '../products/$productId/-components/last-run-statu
 import { TotalRuns } from '../products/$productId/-components/total-runs';
 import { ProductItemCounts } from './product-item-counts';
 
-const columnHelper = createColumnHelper<Product>();
+const columnHelper = legacyCreateColumnHelper<Product>();
 
 const routeApi = getRouteApi('/organizations/$orgId/');
 
@@ -91,180 +91,183 @@ export const OrganizationProductTable = () => {
   });
 
   const columns = useMemo(
-    () => [
-      columnHelper.accessor('name', {
-        id: 'product',
-        header: 'Products',
-        size: 300,
-        cell: ({ row }) => (
-          <>
-            <div className='flex items-center gap-1.5'>
-              <Link
-                className='font-semibold text-blue-400 hover:underline'
-                to={`/organizations/$orgId/products/$productId`}
-                params={{
-                  orgId: row.original.organizationId.toString(),
-                  productId: row.original.id.toString(),
-                }}
-              >
-                {row.original.name}
-              </Link>
-              {organization && (
-                <ProductFavoriteButton
-                  organization={organization}
-                  organizationId={row.original.organizationId}
-                  product={row.original}
-                  size='xs'
-                  variant='ghost'
-                  className='size-6 p-0'
-                />
-              )}
-            </div>
-            <div className='text-muted-foreground text-sm md:inline'>
-              {row.original.description}
-            </div>
-          </>
-        ),
-        meta: {
-          filter: {
-            filterVariant: 'regex',
-            setFilterValue: (value: string | undefined) => {
-              navigate({
-                search: { ...search, page: 1, filter: value },
-              });
+    () =>
+      columnHelper.columns([
+        columnHelper.accessor('name', {
+          id: 'product',
+          header: 'Products',
+          size: 300,
+          cell: ({ row }) => (
+            <>
+              <div className='flex items-center gap-1.5'>
+                <Link
+                  className='font-semibold text-blue-400 hover:underline'
+                  to={`/organizations/$orgId/products/$productId`}
+                  params={{
+                    orgId: row.original.organizationId.toString(),
+                    productId: row.original.id.toString(),
+                  }}
+                >
+                  {row.original.name}
+                </Link>
+                {organization && (
+                  <ProductFavoriteButton
+                    organization={organization}
+                    organizationId={row.original.organizationId}
+                    product={row.original}
+                    size='xs'
+                    variant='ghost'
+                    className='size-6 p-0'
+                  />
+                )}
+              </div>
+              <div className='text-muted-foreground text-sm md:inline'>
+                {row.original.description}
+              </div>
+            </>
+          ),
+          meta: {
+            filter: {
+              filterVariant: 'regex',
+              setFilterValue: (value: string | undefined) => {
+                navigate({
+                  search: { ...search, page: 1, filter: value },
+                });
+              },
             },
           },
-        },
-      }),
-      columnHelper.display({
-        id: 'runs',
-        header: 'Runs',
-        size: 50,
-        cell: function CellComponent({ row }) {
-          const { data, isPending, isError } = useQuery({
-            ...getProductRepositoriesOptions({
-              path: { productId: row.original.id },
-              query: { limit: 1 },
-            }),
-          });
+        }),
+        columnHelper.display({
+          id: 'runs',
+          header: 'Runs',
+          size: 50,
+          cell: function CellComponent({ row }) {
+            const { data, isPending, isError } = useQuery({
+              ...getProductRepositoriesOptions({
+                path: { productId: row.original.id },
+                query: { limit: 1 },
+              }),
+            });
 
-          if (isPending)
+            if (isPending)
+              return (
+                <>
+                  <span className='sr-only'>Loading...</span>
+                  <Loader2 size={16} className='mx-3 animate-spin' />
+                </>
+              );
+
+            if (isError) return <span>Error loading data.</span>;
+
+            if (data.pagination.totalCount === 1 && data.data[0])
+              return <TotalRuns repoId={data.data[0].id} />;
+            else return <span>-</span>;
+          },
+          enableColumnFilter: false,
+        }),
+        columnHelper.display({
+          id: 'runStatus',
+          header: 'Last Run Status',
+          cell: function CellComponent({ row }) {
+            const { data, isPending, isError } = useQuery({
+              ...getProductRepositoriesOptions({
+                path: { productId: row.original.id },
+                query: { limit: 1 },
+              }),
+            });
+
+            if (isPending)
+              return (
+                <>
+                  <span className='sr-only'>Loading...</span>
+                  <Loader2 size={16} className='mx-3 animate-spin' />
+                </>
+              );
+
+            if (isError) return <span>Error loading data.</span>;
+
             return (
-              <>
-                <span className='sr-only'>Loading...</span>
-                <Loader2 size={16} className='mx-3 animate-spin' />
-              </>
-            );
-
-          if (isError) return <span>Error loading data.</span>;
-
-          if (data.pagination.totalCount === 1 && data.data[0])
-            return <TotalRuns repoId={data.data[0].id} />;
-          else return <span>-</span>;
-        },
-        enableColumnFilter: false,
-      }),
-      columnHelper.display({
-        id: 'runStatus',
-        header: 'Last Run Status',
-        cell: function CellComponent({ row }) {
-          const { data, isPending, isError } = useQuery({
-            ...getProductRepositoriesOptions({
-              path: { productId: row.original.id },
-              query: { limit: 1 },
-            }),
-          });
-
-          if (isPending)
-            return (
-              <>
-                <span className='sr-only'>Loading...</span>
-                <Loader2 size={16} className='mx-3 animate-spin' />
-              </>
-            );
-
-          if (isError) return <span>Error loading data.</span>;
-
-          return (
-            <div className='flex flex-col gap-1'>
-              {data.pagination.totalCount === 1 && data.data[0] ? (
-                <LastRunStatus repoId={data.data[0].id} />
-              ) : (
-                <span>Contains {data.pagination.totalCount} repositories</span>
-              )}
-              <div className='flex'>
-                <ProductItemCounts productId={row.original.id} />
+              <div className='flex flex-col gap-1'>
+                {data.pagination.totalCount === 1 && data.data[0] ? (
+                  <LastRunStatus repoId={data.data[0].id} />
+                ) : (
+                  <span>
+                    Contains {data.pagination.totalCount} repositories
+                  </span>
+                )}
+                <div className='flex'>
+                  <ProductItemCounts productId={row.original.id} />
+                </div>
               </div>
-            </div>
-          );
-        },
-        enableColumnFilter: false,
-      }),
-      columnHelper.display({
-        id: 'lastRunDate',
-        header: 'Last Run Date',
-        cell: function CellComponent({ row }) {
-          const { data, isPending, isError } = useQuery({
-            ...getProductRepositoriesOptions({
-              path: { productId: row.original.id },
-              query: { limit: 1 },
-            }),
-          });
-
-          if (isPending)
-            return (
-              <>
-                <span className='sr-only'>Loading...</span>
-                <Loader2 size={16} className='mx-3 animate-spin' />
-              </>
             );
+          },
+          enableColumnFilter: false,
+        }),
+        columnHelper.display({
+          id: 'lastRunDate',
+          header: 'Last Run Date',
+          cell: function CellComponent({ row }) {
+            const { data, isPending, isError } = useQuery({
+              ...getProductRepositoriesOptions({
+                path: { productId: row.original.id },
+                query: { limit: 1 },
+              }),
+            });
 
-          if (isError) return <span>Error loading data.</span>;
+            if (isPending)
+              return (
+                <>
+                  <span className='sr-only'>Loading...</span>
+                  <Loader2 size={16} className='mx-3 animate-spin' />
+                </>
+              );
 
-          if (data.pagination.totalCount === 1 && data.data[0])
-            return <LastRunDate repoId={data.data[0].id} />;
-          else return null;
-        },
-        meta: {
-          widthPercentage: 12,
-        },
-        enableColumnFilter: false,
-      }),
-      columnHelper.display({
-        id: 'jobStatus',
-        header: 'Last Job Status',
-        cell: function CellComponent({ row }) {
-          const { data, isPending, isError } = useQuery({
-            ...getProductRepositoriesOptions({
-              path: { productId: row.original.id },
-              query: { limit: 1 },
-            }),
-          });
+            if (isError) return <span>Error loading data.</span>;
 
-          if (isPending)
-            return (
-              <>
-                <span className='sr-only'>Loading...</span>
-                <Loader2 size={16} className='mx-3 animate-spin' />
-              </>
-            );
+            if (data.pagination.totalCount === 1 && data.data[0])
+              return <LastRunDate repoId={data.data[0].id} />;
+            else return null;
+          },
+          meta: {
+            widthPercentage: 12,
+          },
+          enableColumnFilter: false,
+        }),
+        columnHelper.display({
+          id: 'jobStatus',
+          header: 'Last Job Status',
+          cell: function CellComponent({ row }) {
+            const { data, isPending, isError } = useQuery({
+              ...getProductRepositoriesOptions({
+                path: { productId: row.original.id },
+                query: { limit: 1 },
+              }),
+            });
 
-          if (isError) return <span>Error loading data.</span>;
+            if (isPending)
+              return (
+                <>
+                  <span className='sr-only'>Loading...</span>
+                  <Loader2 size={16} className='mx-3 animate-spin' />
+                </>
+              );
 
-          if (data.pagination.totalCount === 1 && data.data[0])
-            return <LastJobStatus repoId={data.data[0].id} />;
-          else return null;
-        },
-        meta: {
-          widthPercentage: 8,
-        },
-        enableColumnFilter: false,
-      }),
-    ],
+            if (isError) return <span>Error loading data.</span>;
+
+            if (data.pagination.totalCount === 1 && data.data[0])
+              return <LastJobStatus repoId={data.data[0].id} />;
+            else return null;
+          },
+          meta: {
+            widthPercentage: 8,
+          },
+          enableColumnFilter: false,
+        }),
+      ]),
     [navigate, organization, search]
   );
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: products?.data || [],
     columns,
     pageCount: Math.ceil((products?.pagination.totalCount ?? 0) / pageSize),

--- a/ui/src/routes/organizations/$orgId/infrastructure-services/index.tsx
+++ b/ui/src/routes/organizations/$orgId/infrastructure-services/index.tsx
@@ -19,12 +19,13 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { CellContext } from '@tanstack/react-table';
 import {
-  CellContext,
-  ColumnDef,
   getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  LegacyColumnDef,
+  LegacyFeatures,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { EditIcon, PlusIcon } from 'lucide-react';
 
 import { InfrastructureService } from '@/api';
@@ -59,7 +60,9 @@ import { paginationSearchParameterSchema } from '@/schemas';
 
 const defaultPageSize = 10;
 
-const ActionCell = ({ row }: CellContext<InfrastructureService, unknown>) => {
+const ActionCell = ({
+  row,
+}: CellContext<LegacyFeatures, InfrastructureService, unknown>) => {
   const params = Route.useParams();
   const queryClient = useQueryClient();
 
@@ -141,7 +144,7 @@ const InfrastructureServices = () => {
     }),
   });
 
-  const columns: ColumnDef<InfrastructureService>[] = [
+  const columns: LegacyColumnDef<InfrastructureService>[] = [
     {
       accessorKey: 'details',
       header: undefined,
@@ -196,7 +199,7 @@ const InfrastructureServices = () => {
     },
   ];
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: infraServices?.data || [],
     columns,
     pageCount: Math.ceil(

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repository-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repository-table.tsx
@@ -20,10 +20,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { getRouteApi, Link } from '@tanstack/react-router';
 import {
-  createColumnHelper,
   getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { useMemo } from 'react';
 
 import { Repository } from '@/api';
@@ -43,7 +43,7 @@ import { LastRunStatus } from './last-run-status';
 import { RepositoryItemCounts } from './repository-item-counts';
 import { TotalRuns } from './total-runs';
 
-const columnHelper = createColumnHelper<Repository>();
+const columnHelper = legacyCreateColumnHelper<Repository>();
 
 const routeApi = getRouteApi('/organizations/$orgId/products/$productId/');
 
@@ -96,132 +96,133 @@ export const ProductRepositoryTable = () => {
   });
 
   const columns = useMemo(
-    () => [
-      columnHelper.accessor(
-        (repository) => `${repository.name ?? ''} ${repository.url}`.trim(),
-        {
-          id: 'repository',
-          header: 'Repositories',
-          size: 300,
-          cell: ({ row }) => {
-            const linkParams = {
-              orgId: row.original.organizationId.toString(),
-              productId: row.original.productId.toString(),
-              repoId: row.original.id.toString(),
-            };
+    () =>
+      columnHelper.columns([
+        columnHelper.accessor(
+          (repository) => `${repository.name ?? ''} ${repository.url}`.trim(),
+          {
+            id: 'repository',
+            header: 'Repositories',
+            size: 300,
+            cell: ({ row }) => {
+              const linkParams = {
+                orgId: row.original.organizationId.toString(),
+                productId: row.original.productId.toString(),
+                repoId: row.original.id.toString(),
+              };
 
-            return (
-              <>
-                <div className='flex flex-wrap items-center gap-1.5'>
-                  <Link
-                    className='font-semibold text-blue-400 hover:underline'
-                    to={
-                      '/organizations/$orgId/products/$productId/repositories/$repoId'
-                    }
-                    params={linkParams}
-                  >
-                    {row.original.name || row.original.url}
-                  </Link>
-                  {organization && product && (
-                    <RepositoryFavoriteButton
-                      organization={organization}
-                      organizationId={row.original.organizationId}
-                      product={product}
-                      productId={row.original.productId}
-                      repository={row.original}
-                      size='xs'
-                      variant='ghost'
-                      className='size-6 p-0'
-                    />
+              return (
+                <>
+                  <div className='flex flex-wrap items-center gap-1.5'>
+                    <Link
+                      className='font-semibold text-blue-400 hover:underline'
+                      to={
+                        '/organizations/$orgId/products/$productId/repositories/$repoId'
+                      }
+                      params={linkParams}
+                    >
+                      {row.original.name || row.original.url}
+                    </Link>
+                    {organization && product && (
+                      <RepositoryFavoriteButton
+                        organization={organization}
+                        organizationId={row.original.organizationId}
+                        product={product}
+                        productId={row.original.productId}
+                        repository={row.original}
+                        size='xs'
+                        variant='ghost'
+                        className='size-6 p-0'
+                      />
+                    )}
+                  </div>
+                  {row.original.name && (
+                    <Link
+                      className='block font-semibold text-blue-400 hover:underline'
+                      to={
+                        '/organizations/$orgId/products/$productId/repositories/$repoId'
+                      }
+                      params={linkParams}
+                    >
+                      {row.original.url}
+                    </Link>
                   )}
-                </div>
-                {row.original.name && (
-                  <Link
-                    className='block font-semibold text-blue-400 hover:underline'
-                    to={
-                      '/organizations/$orgId/products/$productId/repositories/$repoId'
-                    }
-                    params={linkParams}
-                  >
-                    {row.original.url}
-                  </Link>
-                )}
-                <div className='text-muted-foreground text-sm md:inline'>
-                  {row.original.type}
-                  {row.original.description
-                    ? ` | ${row.original.description}`
-                    : ''}
-                </div>
-              </>
-            );
-          },
-          meta: {
-            filter: {
-              filterVariant: 'regex',
-              setFilterValue: (value: string | undefined) => {
-                navigate({
-                  search: { ...search, page: 1, filter: value },
-                });
+                  <div className='text-muted-foreground text-sm md:inline'>
+                    {row.original.type}
+                    {row.original.description
+                      ? ` | ${row.original.description}`
+                      : ''}
+                  </div>
+                </>
+              );
+            },
+            meta: {
+              filter: {
+                filterVariant: 'regex',
+                setFilterValue: (value: string | undefined) => {
+                  navigate({
+                    search: { ...search, page: 1, filter: value },
+                  });
+                },
               },
             },
-          },
-        }
-      ),
-      columnHelper.display({
-        id: 'runs',
-        header: 'Runs',
-        size: 50,
-        cell: ({ row }) => (
-          <Link
-            to='/organizations/$orgId/products/$productId/repositories/$repoId/runs'
-            params={{
-              orgId: row.original.organizationId.toString(),
-              productId: row.original.productId.toString(),
-              repoId: row.original.id.toString(),
-            }}
-            className='font-semibold text-blue-400 hover:underline'
-          >
-            <TotalRuns repoId={row.original.id} />
-          </Link>
+          }
         ),
-        enableColumnFilter: false,
-      }),
-      columnHelper.display({
-        id: 'runStatus',
-        header: 'Last Run Status',
-        cell: ({ row }) => (
-          <div className='flex flex-col gap-1'>
-            <LastRunStatus repoId={row.original.id} />
-            <div className='flex'>
-              <RepositoryItemCounts repoId={row.original.id} />
+        columnHelper.display({
+          id: 'runs',
+          header: 'Runs',
+          size: 50,
+          cell: ({ row }) => (
+            <Link
+              to='/organizations/$orgId/products/$productId/repositories/$repoId/runs'
+              params={{
+                orgId: row.original.organizationId.toString(),
+                productId: row.original.productId.toString(),
+                repoId: row.original.id.toString(),
+              }}
+              className='font-semibold text-blue-400 hover:underline'
+            >
+              <TotalRuns repoId={row.original.id} />
+            </Link>
+          ),
+          enableColumnFilter: false,
+        }),
+        columnHelper.display({
+          id: 'runStatus',
+          header: 'Last Run Status',
+          cell: ({ row }) => (
+            <div className='flex flex-col gap-1'>
+              <LastRunStatus repoId={row.original.id} />
+              <div className='flex'>
+                <RepositoryItemCounts repoId={row.original.id} />
+              </div>
             </div>
-          </div>
-        ),
-        enableColumnFilter: false,
-      }),
-      columnHelper.display({
-        id: 'lastRunDate',
-        header: 'Last Run Date',
-        cell: ({ row }) => <LastRunDate repoId={row.original.id} />,
-        meta: {
-          widthPercentage: 12,
-        },
-        enableColumnFilter: false,
-      }),
-      columnHelper.display({
-        id: 'jobStatus',
-        header: 'Last Job Status',
-        cell: ({ row }) => <LastJobStatus repoId={row.original.id} />,
-        meta: {
-          widthPercentage: 8,
-        },
-        enableColumnFilter: false,
-      }),
-    ],
+          ),
+          enableColumnFilter: false,
+        }),
+        columnHelper.display({
+          id: 'lastRunDate',
+          header: 'Last Run Date',
+          cell: ({ row }) => <LastRunDate repoId={row.original.id} />,
+          meta: {
+            widthPercentage: 12,
+          },
+          enableColumnFilter: false,
+        }),
+        columnHelper.display({
+          id: 'jobStatus',
+          header: 'Last Job Status',
+          cell: ({ row }) => <LastJobStatus repoId={row.original.id} />,
+          meta: {
+            widthPercentage: 8,
+          },
+          enableColumnFilter: false,
+        }),
+      ]),
     [navigate, organization, product, search]
   );
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: repositories?.data || [],
     columns,
     pageCount: Math.ceil((repositories?.pagination.totalCount ?? 0) / pageSize),

--- a/ui/src/routes/organizations/$orgId/products/$productId/infrastructure-services/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/infrastructure-services/index.tsx
@@ -19,12 +19,13 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { CellContext } from '@tanstack/react-table';
 import {
-  CellContext,
-  ColumnDef,
   getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  LegacyColumnDef,
+  LegacyFeatures,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { EditIcon, PlusIcon } from 'lucide-react';
 
 import { InfrastructureService } from '@/api';
@@ -59,7 +60,9 @@ import { paginationSearchParameterSchema } from '@/schemas';
 
 const defaultPageSize = 10;
 
-const ActionCell = ({ row }: CellContext<InfrastructureService, unknown>) => {
+const ActionCell = ({
+  row,
+}: CellContext<LegacyFeatures, InfrastructureService, unknown>) => {
   const params = Route.useParams();
   const queryClient = useQueryClient();
 
@@ -145,7 +148,7 @@ const InfrastructureServices = () => {
     }),
   });
 
-  const columns: ColumnDef<InfrastructureService>[] = [
+  const columns: LegacyColumnDef<InfrastructureService>[] = [
     {
       accessorKey: 'details',
       header: undefined,
@@ -200,7 +203,7 @@ const InfrastructureServices = () => {
     },
   ];
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: infraServices?.data || [],
     columns,
     pageCount: Math.ceil(

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/repository-runs-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/repository-runs-table.tsx
@@ -25,10 +25,10 @@ import {
 } from '@tanstack/react-query';
 import { Link } from '@tanstack/react-router';
 import {
-  createColumnHelper,
   getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { GitCompare, Repeat, View } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
@@ -101,7 +101,7 @@ type RunComparisonContext = {
 
 const pollInterval = config.pollInterval;
 
-const columnHelper = createColumnHelper<OrtRunSummary>();
+const columnHelper = legacyCreateColumnHelper<OrtRunSummary>();
 
 const SummaryCard = ({
   summary,
@@ -302,148 +302,152 @@ const RunIndexCell = ({
 const createColumns = (
   favoriteContext: FavoriteContext,
   comparison: RunComparisonContext
-) => [
-  columnHelper.accessor('index', {
-    header: 'Index',
-    size: 70,
-    cell: ({ row }) => (
-      <RunIndexCell favoriteContext={favoriteContext} summary={row.original} />
-    ),
-    enableColumnFilter: false,
-  }),
-  columnHelper.display({
-    id: 'card',
-    header: 'Run Details',
-    cell: ({ row }) => (
-      <SummaryCard summary={row.original} comparison={comparison} />
-    ),
-    meta: {
-      isGrow: true,
-    },
-    enableColumnFilter: false,
-  }),
-  columnHelper.display({
-    id: 'actions',
-    header: 'Actions',
-    size: 70,
-    cell: function Row({ row }) {
-      const queryClient = useQueryClient();
+) =>
+  columnHelper.columns([
+    columnHelper.accessor('index', {
+      header: 'Index',
+      size: 70,
+      cell: ({ row }) => (
+        <RunIndexCell
+          favoriteContext={favoriteContext}
+          summary={row.original}
+        />
+      ),
+      enableColumnFilter: false,
+    }),
+    columnHelper.display({
+      id: 'card',
+      header: 'Run Details',
+      cell: ({ row }) => (
+        <SummaryCard summary={row.original} comparison={comparison} />
+      ),
+      meta: {
+        isGrow: true,
+      },
+      enableColumnFilter: false,
+    }),
+    columnHelper.display({
+      id: 'actions',
+      header: 'Actions',
+      size: 70,
+      cell: function Row({ row }) {
+        const queryClient = useQueryClient();
 
-      const repository = useSuspenseQuery({
-        ...getRepositoryOptions({
-          path: {
-            repositoryId: row.original.repositoryId,
+        const repository = useSuspenseQuery({
+          ...getRepositoryOptions({
+            path: {
+              repositoryId: row.original.repositoryId,
+            },
+          }),
+        });
+
+        const { isAllowed: canTriggerRun } = useRepositoryPermission(
+          row.original.repositoryId,
+          'TRIGGER_ORT_RUN'
+        );
+
+        const { isAllowed: canDeleteRun } = useRepositoryPermission(
+          row.original.repositoryId,
+          'DELETE'
+        );
+
+        const { mutateAsync: deleteRun } = useMutation({
+          ...deleteRepositoryRunMutation(),
+          onSuccess() {
+            toast.info('Delete Run', {
+              description: `Run "${row.original.index}" deleted successfully.`,
+            });
+            runDeleted(
+              queryClient,
+              row.original.repositoryId,
+              row.original.index
+            );
           },
-        }),
-      });
-
-      const { isAllowed: canTriggerRun } = useRepositoryPermission(
-        row.original.repositoryId,
-        'TRIGGER_ORT_RUN'
-      );
-
-      const { isAllowed: canDeleteRun } = useRepositoryPermission(
-        row.original.repositoryId,
-        'DELETE'
-      );
-
-      const { mutateAsync: deleteRun } = useMutation({
-        ...deleteRepositoryRunMutation(),
-        onSuccess() {
-          toast.info('Delete Run', {
-            description: `Run "${row.original.index}" deleted successfully.`,
-          });
-          runDeleted(
-            queryClient,
-            row.original.repositoryId,
-            row.original.index
-          );
-        },
-        onError(error: ApiError) {
-          toastError(error.message, error);
-        },
-      });
-
-      async function handleDelete() {
-        await deleteRun({
-          path: {
-            ortRunIndex: row.original.index,
-            repositoryId: row.original.repositoryId,
+          onError(error: ApiError) {
+            toastError(error.message, error);
           },
         });
-      }
 
-      return (
-        <div className='flex flex-col items-center gap-2'>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button variant='outline' asChild size='sm' className='w-10'>
-                <Link
-                  to={
-                    '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex'
-                  }
-                  params={{
-                    orgId: row.original.organizationId.toString(),
-                    productId: row.original.productId.toString(),
-                    repoId: row.original.repositoryId.toString(),
-                    runIndex: row.original.index.toString(),
-                  }}
+        async function handleDelete() {
+          await deleteRun({
+            path: {
+              ortRunIndex: row.original.index,
+              repositoryId: row.original.repositoryId,
+            },
+          });
+        }
+
+        return (
+          <div className='flex flex-col items-center gap-2'>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant='outline' asChild size='sm' className='w-10'>
+                  <Link
+                    to={
+                      '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex'
+                    }
+                    params={{
+                      orgId: row.original.organizationId.toString(),
+                      productId: row.original.productId.toString(),
+                      repoId: row.original.repositoryId.toString(),
+                      runIndex: row.original.index.toString(),
+                    }}
+                  >
+                    <View className='h-4 w-4' />
+                  </Link>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>View the details of this run</TooltipContent>
+            </Tooltip>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant='outline'
+                  asChild
+                  size='sm'
+                  className='w-10'
+                  disabled={canTriggerRun === false}
                 >
-                  <View className='h-4 w-4' />
-                </Link>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>View the details of this run</TooltipContent>
-          </Tooltip>
-          <Tooltip>
-            <TooltipTrigger asChild>
-              <Button
-                variant='outline'
-                asChild
-                size='sm'
-                className='w-10'
-                disabled={canTriggerRun === false}
-              >
-                <Link
-                  to='/organizations/$orgId/products/$productId/repositories/$repoId/create-run'
-                  params={{
-                    orgId: row.original.organizationId.toString(),
-                    productId: row.original.productId.toString(),
-                    repoId: row.original.repositoryId.toString(),
-                  }}
-                  search={{
-                    rerunIndex: row.original.index,
-                  }}
-                >
-                  <Repeat className='h-4 w-4' />
-                </Link>
-              </Button>
-            </TooltipTrigger>
-            <TooltipContent>
-              {canTriggerRun !== false
-                ? 'Create a new run based on this run'
-                : 'Insufficient permissions.'}
-            </TooltipContent>
-          </Tooltip>
-          <DeleteDialog
-            thingName={
-              <>
-                run with index{' '}
-                <span className='font-bold'>{row.original.index}</span>
-                from repository{' '}
-                <span className='font-bold'>{repository.data.url}</span>
-              </>
-            }
-            uiComponent={<DeleteIconButton />}
-            onDelete={handleDelete}
-            disabled={canDeleteRun === false}
-          />
-        </div>
-      );
-    },
-    enableColumnFilter: false,
-  }),
-];
+                  <Link
+                    to='/organizations/$orgId/products/$productId/repositories/$repoId/create-run'
+                    params={{
+                      orgId: row.original.organizationId.toString(),
+                      productId: row.original.productId.toString(),
+                      repoId: row.original.repositoryId.toString(),
+                    }}
+                    search={{
+                      rerunIndex: row.original.index,
+                    }}
+                  >
+                    <Repeat className='h-4 w-4' />
+                  </Link>
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {canTriggerRun !== false
+                  ? 'Create a new run based on this run'
+                  : 'Insufficient permissions.'}
+              </TooltipContent>
+            </Tooltip>
+            <DeleteDialog
+              thingName={
+                <>
+                  run with index{' '}
+                  <span className='font-bold'>{row.original.index}</span>
+                  from repository{' '}
+                  <span className='font-bold'>{repository.data.url}</span>
+                </>
+              }
+              uiComponent={<DeleteIconButton />}
+              onDelete={handleDelete}
+              disabled={canDeleteRun === false}
+            />
+          </div>
+        );
+      },
+      enableColumnFilter: false,
+    }),
+  ]);
 
 export const RepositoryRunsTable = ({
   orgId,
@@ -548,7 +552,7 @@ export const RepositoryRunsTable = ({
     refetchInterval: pollInterval,
   });
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: runs?.data || [],
     columns,
     pageCount: Math.ceil((runs?.pagination.totalCount ?? 0) / pageSize),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/infrastructure-services/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/infrastructure-services/index.tsx
@@ -19,12 +19,13 @@
 
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { CellContext } from '@tanstack/react-table';
 import {
-  CellContext,
-  ColumnDef,
   getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  LegacyColumnDef,
+  LegacyFeatures,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { EditIcon, PlusIcon } from 'lucide-react';
 
 import { InfrastructureService } from '@/api';
@@ -59,7 +60,9 @@ import { paginationSearchParameterSchema } from '@/schemas';
 
 const defaultPageSize = 10;
 
-const ActionCell = ({ row }: CellContext<InfrastructureService, unknown>) => {
+const ActionCell = ({
+  row,
+}: CellContext<LegacyFeatures, InfrastructureService, unknown>) => {
   const params = Route.useParams();
   const queryClient = useQueryClient();
 
@@ -150,7 +153,7 @@ const InfrastructureServices = () => {
     }),
   });
 
-  const columns: ColumnDef<InfrastructureService>[] = [
+  const columns: LegacyColumnDef<InfrastructureService>[] = [
     {
       accessorKey: 'details',
       header: undefined,
@@ -205,7 +208,7 @@ const InfrastructureServices = () => {
     },
   ];
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: infraServices?.data || [],
     columns,
     pageCount: Math.ceil(

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/search-package/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/search-package/index.tsx
@@ -20,12 +20,12 @@
 import { useQuery } from '@tanstack/react-query';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import {
-  createColumnHelper,
   getCoreRowModel,
   getPaginationRowModel,
   getSortedRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { useMemo } from 'react';
 import z from 'zod';
 
@@ -57,7 +57,7 @@ import {
 import { useUserSettingsStore } from '@/store/user-settings.store';
 
 const defaultPageSize = 10;
-const columnHelper = createColumnHelper<RunWithPackage>();
+const columnHelper = legacyCreateColumnHelper<RunWithPackage>();
 
 function SearchPackageComponent() {
   const params = Route.useParams();
@@ -66,7 +66,7 @@ function SearchPackageComponent() {
   const identifier = search.pkgId ?? '';
   const packageIdType = useUserSettingsStore((state) => state.packageIdType);
 
-  const columns = [
+  const columns = columnHelper.columns([
     columnHelper.accessor('createdAt', {
       header: 'Created At',
       cell: ({ row }) => (
@@ -127,7 +127,7 @@ function SearchPackageComponent() {
         );
       },
     }),
-  ];
+  ]);
 
   const pageIndex = useMemo(
     () => (search.page ? search.page - 1 : 0),
@@ -161,7 +161,7 @@ function SearchPackageComponent() {
     enabled: identifier !== '',
   });
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: runsWithPackage || [],
     columns,
     state: {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/search-vulnerability/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/search-vulnerability/index.tsx
@@ -20,12 +20,12 @@
 import { useQuery } from '@tanstack/react-query';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import {
-  createColumnHelper,
   getCoreRowModel,
   getPaginationRowModel,
   getSortedRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { useMemo } from 'react';
 import z from 'zod';
 
@@ -57,7 +57,7 @@ import {
 import { useUserSettingsStore } from '@/store/user-settings.store';
 
 const defaultPageSize = 10;
-const columnHelper = createColumnHelper<RunWithVulnerability>();
+const columnHelper = legacyCreateColumnHelper<RunWithVulnerability>();
 
 function SearchVulnerabilityComponent() {
   const params = Route.useParams();
@@ -66,7 +66,7 @@ function SearchVulnerabilityComponent() {
   const externalId = search.externalId ?? '';
   const packageIdType = useUserSettingsStore((state) => state.packageIdType);
 
-  const columns = [
+  const columns = columnHelper.columns([
     columnHelper.accessor('createdAt', {
       header: 'Created At',
       cell: ({ row }) => (
@@ -137,7 +137,7 @@ function SearchVulnerabilityComponent() {
         );
       },
     }),
-  ];
+  ]);
 
   const pageIndex = useMemo(
     () => (search.page ? search.page - 1 : 0),
@@ -170,7 +170,7 @@ function SearchVulnerabilityComponent() {
     enabled: externalId !== '',
   });
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: runsWithVulnerability || [],
     columns,
     state: {

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/secrets/index.tsx
@@ -24,12 +24,13 @@ import {
   useSuspenseQuery,
 } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { CellContext } from '@tanstack/react-table';
 import {
-  CellContext,
-  ColumnDef,
   getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  LegacyColumnDef,
+  LegacyFeatures,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { EditIcon, PlusIcon } from 'lucide-react';
 import z from 'zod';
 
@@ -77,7 +78,7 @@ import {
 
 const defaultPageSize = 5;
 
-const ActionCell = ({ row }: CellContext<Secret, unknown>) => {
+const ActionCell = ({ row }: CellContext<LegacyFeatures, Secret, unknown>) => {
   const params = Route.useParams();
   const queryClient = useQueryClient();
 
@@ -137,7 +138,7 @@ const ActionCell = ({ row }: CellContext<Secret, unknown>) => {
   );
 };
 
-const baseColumns: ColumnDef<Secret>[] = [
+const baseColumns: LegacyColumnDef<Secret>[] = [
   {
     accessorKey: 'name',
     header: 'Name',
@@ -150,7 +151,7 @@ const baseColumns: ColumnDef<Secret>[] = [
   },
 ];
 
-const columns: ColumnDef<Secret>[] = [
+const columns: LegacyColumnDef<Secret>[] = [
   ...baseColumns,
   {
     id: 'actions',
@@ -254,7 +255,7 @@ const RepositorySecrets = () => {
     }),
   });
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: secrets?.data || [],
     columns,
     pageCount: Math.ceil((secrets?.pagination.totalCount ?? 0) / pageSize),
@@ -268,7 +269,7 @@ const RepositorySecrets = () => {
     manualPagination: true,
   });
 
-  const productTable = useReactTable({
+  const productTable = useLegacyTable({
     data: productSecrets?.data || [],
     columns: baseColumns,
     pageCount: Math.ceil(
@@ -284,7 +285,7 @@ const RepositorySecrets = () => {
     manualPagination: true,
   });
 
-  const orgTable = useReactTable({
+  const orgTable = useLegacyTable({
     data: orgSecrets?.data || [],
     columns: baseColumns,
     pageCount: Math.ceil(

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/-components/repository-users-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/-components/repository-users-table.tsx
@@ -20,10 +20,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getRouteApi } from '@tanstack/react-router';
 import {
-  createColumnHelper,
   getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { Eye, FileOutput, Pen, Shield } from 'lucide-react';
 
 import { UserWithGroups } from '@/api';
@@ -47,9 +47,9 @@ import { useUser } from '@/hooks/use-user.ts';
 import { ApiError } from '@/lib/api-error';
 import { toast, toastError } from '@/lib/toast';
 
-const columnHelper = createColumnHelper<UserWithGroups>();
+const columnHelper = legacyCreateColumnHelper<UserWithGroups>();
 
-const columns = [
+const columns = columnHelper.columns([
   columnHelper.accessor('user.username', {
     header: 'Username',
     cell: ({ row }) => <>{row.original.user.username}</>,
@@ -245,7 +245,7 @@ const columns = [
       );
     },
   }),
-];
+]);
 
 const routeApi = getRouteApi(
   '/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users'
@@ -268,7 +268,7 @@ export const RepositoryUsersTable = () => {
     }),
   });
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: usersWithGroups?.data || [],
     columns: columns,
     pageCount: Math.ceil(

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/issues/index.tsx
@@ -19,14 +19,14 @@
 
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { ExpandedState } from '@tanstack/react-table';
 import {
-  createColumnHelper,
-  ExpandedState,
   getCoreRowModel,
   getExpandedRowModel,
-  Row,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  LegacyRow,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import z from 'zod';
@@ -103,7 +103,7 @@ const supportedSortColumns = new Set([
   'source',
 ]);
 
-const columnHelper = createColumnHelper<Issue>();
+const columnHelper = legacyCreateColumnHelper<Issue>();
 
 // Component to render a single issue card in the list.
 const IssueCard = ({ issue }: { issue: Issue }) => {
@@ -201,7 +201,7 @@ const IssuesComponent = () => {
   const navigate = Route.useNavigate();
   const packageIdType = useUserSettingsStore((state) => state.packageIdType);
 
-  const columns = [
+  const columns = columnHelper.columns([
     columnHelper.display({
       id: 'details',
       header: 'Details',
@@ -329,7 +329,7 @@ const IssuesComponent = () => {
       header: 'Source',
       enableColumnFilter: false,
     }),
-  ];
+  ]);
 
   const pageIndex = search.page ? search.page - 1 : 0;
   const pageSize = search.pageSize ? search.pageSize : defaultPageSize;
@@ -391,7 +391,7 @@ const IssuesComponent = () => {
   });
 
   const renderSubComponent = useCallback(
-    ({ row }: { row: Row<Issue> }) => {
+    ({ row }: { row: LegacyRow<Issue> }) => {
       const issue = row.original;
 
       return (
@@ -436,7 +436,7 @@ const IssuesComponent = () => {
     search.marked ? { [search.marked]: true } : {}
   );
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: issues?.data || [],
     columns,
     pageCount: Math.ceil((issues?.pagination.totalCount ?? 0) / pageSize),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/detected-license-findings-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/detected-license-findings-table.tsx
@@ -20,10 +20,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { useSearch } from '@tanstack/react-router';
 import {
-  createColumnHelper,
   getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 
 import { LicenseFinding } from '@/api';
 import { getRunDetectedLicenseFindingsOptions } from '@/api/@tanstack/react-query.gen';
@@ -40,7 +40,7 @@ import { buildSwhBrowseUrl } from '@/lib/software-heritage';
 import { toastError } from '@/lib/toast';
 import { formatLineNumber } from '@/lib/utils';
 
-const findingColumnHelper = createColumnHelper<LicenseFinding>();
+const findingColumnHelper = legacyCreateColumnHelper<LicenseFinding>();
 const defaultPageSize = 10;
 const licenseFindingsRoutePath =
   '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/';
@@ -81,7 +81,7 @@ export const DetectedLicenseFindingsTable = ({
     }),
   });
 
-  const findingColumns = [
+  const findingColumns = findingColumnHelper.columns([
     findingColumnHelper.accessor('path', {
       id: 'path',
       header: 'Path',
@@ -155,9 +155,9 @@ export const DetectedLicenseFindingsTable = ({
         widthPercentage: 15,
       },
     }),
-  ];
+  ]);
 
-  const findingsTable = useReactTable({
+  const findingsTable = useLegacyTable({
     data: findings?.data || [],
     columns: findingColumns,
     pageCount: Math.ceil(

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/detected-license-packages-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/detected-license-packages-table.tsx
@@ -19,14 +19,14 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate, useSearch } from '@tanstack/react-router';
+import { ExpandedState } from '@tanstack/react-table';
 import {
-  createColumnHelper,
-  ExpandedState,
   getCoreRowModel,
   getExpandedRowModel,
-  Row,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  LegacyRow,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
@@ -54,7 +54,7 @@ import {
   getPackageIdentifierQueryFilter,
 } from './license-findings-state';
 
-const packageColumnHelper = createColumnHelper<PackageIdentifier>();
+const packageColumnHelper = legacyCreateColumnHelper<PackageIdentifier>();
 const defaultPageSize = 10;
 const licenseFindingsRoutePath =
   '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/';
@@ -80,7 +80,7 @@ const PackageIdCell = ({
 };
 
 type DetectedLicensePackagesTableProps = {
-  row: Row<DetectedLicense>;
+  row: LegacyRow<DetectedLicense>;
   runId: number;
 };
 
@@ -125,7 +125,7 @@ export const DetectedLicensePackagesTable = ({
     }),
   });
 
-  const packageColumns = [
+  const packageColumns = packageColumnHelper.columns([
     packageColumnHelper.display({
       id: 'details',
       header: 'Details',
@@ -187,9 +187,9 @@ export const DetectedLicensePackagesTable = ({
         },
       }
     ),
-  ];
+  ]);
 
-  const packageTable = useReactTable({
+  const packageTable = useLegacyTable({
     data: packages?.data || [],
     columns: packageColumns,
     pageCount: Math.ceil(

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/license-findings-view.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/license-findings-view.tsx
@@ -19,14 +19,14 @@
 
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate, useParams, useSearch } from '@tanstack/react-router';
+import { ExpandedState } from '@tanstack/react-table';
 import {
-  createColumnHelper,
-  ExpandedState,
   getCoreRowModel,
   getExpandedRowModel,
-  Row,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  LegacyRow,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useEffect, useRef, useState } from 'react';
 
@@ -64,7 +64,7 @@ import {
   getMarkerExpandedState,
 } from './license-findings-state';
 
-const licenseColumnHelper = createColumnHelper<DetectedLicense>();
+const licenseColumnHelper = legacyCreateColumnHelper<DetectedLicense>();
 const defaultPageSize = 10;
 const licenseFindingsRoutePath =
   '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/';
@@ -73,7 +73,7 @@ const renderSubComponent = ({
   row,
   runId,
 }: {
-  row: Row<DetectedLicense>;
+  row: LegacyRow<DetectedLicense>;
   runId: number;
 }) => <DetectedLicensePackagesTable row={row} runId={runId} />;
 
@@ -148,7 +148,7 @@ export const LicenseFindingsView = () => {
     }),
   });
 
-  const columns = [
+  const columns = licenseColumnHelper.columns([
     licenseColumnHelper.display({
       id: 'details',
       header: 'Details',
@@ -226,9 +226,9 @@ export const LicenseFindingsView = () => {
         widthPercentage: 14,
       },
     }),
-  ];
+  ]);
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: detectedLicenseFindings.data,
     columns,
     pageCount: Math.ceil(

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
@@ -470,6 +470,7 @@ const PackagesComponent = () => {
     columnHelper.accessor(() => search.isDirectDependency, {
       id: 'isDirectDependency',
       header: 'Dependency Type',
+      enableSorting: false,
       meta: {
         filter: {
           filterVariant: 'single-select',

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/packages/index.tsx
@@ -19,14 +19,14 @@
 
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
+import { ExpandedState } from '@tanstack/react-table';
 import {
-  createColumnHelper,
-  ExpandedState,
   getCoreRowModel,
   getExpandedRowModel,
-  Row,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  LegacyRow,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useState } from 'react';
 import z from 'zod';
@@ -92,7 +92,7 @@ import { useUserSettingsStore } from '@/store/user-settings.store';
 
 const defaultPageSize = 10;
 
-const columnHelper = createColumnHelper<Package>();
+const columnHelper = legacyCreateColumnHelper<Package>();
 
 const LicenseList = ({ licenses }: { licenses: string[] }) => (
   <div className='flex flex-wrap gap-1'>
@@ -205,7 +205,7 @@ const renderSubComponent = ({
   packageIdType,
   runId,
 }: {
-  row: Row<Package>;
+  row: LegacyRow<Package>;
   packageIdType?: PackageIdType;
   runId: number;
 }) => {
@@ -420,7 +420,7 @@ const PackagesComponent = () => {
     }),
   });
 
-  const columns = [
+  const columns = columnHelper.columns([
     // Leftmost action column.
     columnHelper.display({
       id: 'details',
@@ -552,7 +552,7 @@ const PackagesComponent = () => {
         },
       }
     ),
-  ];
+  ]);
 
   const columnId = packageIdType === 'ORT_ID' ? 'identifier' : 'purl';
 
@@ -560,7 +560,7 @@ const PackagesComponent = () => {
     search.marked ? { [search.marked]: true } : {}
   );
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: packages.data,
     columns,
     pageCount: Math.ceil(packages.pagination.totalCount / pageSize),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/projects/index.tsx
@@ -19,14 +19,14 @@
 
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
+import { ExpandedState } from '@tanstack/react-table';
 import {
-  createColumnHelper,
-  ExpandedState,
   getCoreRowModel,
   getExpandedRowModel,
-  Row,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  LegacyRow,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import z from 'zod';
@@ -81,7 +81,7 @@ const supportedSortColumns = new Set([
   'definitionFilePath',
 ]);
 
-const columnHelper = createColumnHelper<Project>();
+const columnHelper = legacyCreateColumnHelper<Project>();
 
 const LicenseList = ({ licenses }: { licenses: string[] }) => (
   <div className='flex flex-wrap gap-1'>
@@ -143,7 +143,7 @@ const renderSubComponent = ({
   row,
   runId,
 }: {
-  row: Row<Project>;
+  row: LegacyRow<Project>;
   runId: number;
 }) => {
   const project = row.original;
@@ -328,7 +328,7 @@ const ProjectsComponent = () => {
     staleTime: routePrefetchStaleTime,
   });
 
-  const columns = [
+  const columns = columnHelper.columns([
     columnHelper.display({
       id: 'details',
       header: 'Details',
@@ -442,13 +442,13 @@ const ProjectsComponent = () => {
         },
       },
     }),
-  ];
+  ]);
 
   const [expanded, setExpanded] = useState<ExpandedState>(
     search.marked ? { [search.marked]: true } : {}
   );
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: projects?.data || [],
     columns,
     pageCount: Math.ceil((projects?.pagination.totalCount ?? 0) / pageSize),

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/rule-violations/index.tsx
@@ -19,14 +19,14 @@
 
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { ExpandedState } from '@tanstack/react-table';
 import {
-  createColumnHelper,
-  ExpandedState,
   getCoreRowModel,
   getExpandedRowModel,
-  Row,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  LegacyRow,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import z from 'zod';
@@ -104,7 +104,7 @@ const supportedSortColumns = new Set([
   'rule',
 ]);
 
-const columnHelper = createColumnHelper<RuleViolation>();
+const columnHelper = legacyCreateColumnHelper<RuleViolation>();
 
 // Component to render a single rule violation card in the list.
 const RuleViolationCard = ({
@@ -283,7 +283,7 @@ const RuleViolationsComponent = () => {
   const ruleOptions =
     availableRules?.map((rule) => ({ label: rule, value: rule })) ?? [];
 
-  const columns = [
+  const columns = columnHelper.columns([
     columnHelper.display({
       id: 'details',
       header: 'Details',
@@ -421,10 +421,10 @@ const RuleViolationsComponent = () => {
         },
       },
     }),
-  ];
+  ]);
 
   const renderSubComponent = useCallback(
-    ({ row }: { row: Row<RuleViolation> }) => {
+    ({ row }: { row: LegacyRow<RuleViolation> }) => {
       const ruleViolation = row.original;
 
       return (
@@ -486,7 +486,7 @@ const RuleViolationsComponent = () => {
     search.marked ? { [search.marked]: true } : {}
   );
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: ruleViolations?.data || [],
     columns,
     pageCount: Math.ceil(

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/provenance-snippet-findings-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/provenance-snippet-findings-table.tsx
@@ -19,13 +19,13 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { useNavigate, useSearch } from '@tanstack/react-router';
+import { ExpandedState } from '@tanstack/react-table';
 import {
-  createColumnHelper,
-  ExpandedState,
   getCoreRowModel,
   getExpandedRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useState } from 'react';
 
@@ -44,7 +44,7 @@ import { toastError } from '@/lib/toast';
 import { formatLineNumber } from '@/lib/utils';
 import { SnippetFindingSnippetsTable } from './snippet-finding-snippets-table';
 
-const findingColumnHelper = createColumnHelper<SnippetFinding>();
+const findingColumnHelper = legacyCreateColumnHelper<SnippetFinding>();
 const defaultPageSize = 10;
 const snippetFindingsRoutePath =
   '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/';
@@ -83,7 +83,7 @@ export const ProvenanceSnippetFindingsTable = ({
     }),
   });
 
-  const findingColumns = [
+  const findingColumns = findingColumnHelper.columns([
     findingColumnHelper.display({
       id: 'details',
       header: 'Details',
@@ -151,9 +151,9 @@ export const ProvenanceSnippetFindingsTable = ({
         widthPercentage: 14,
       },
     }),
-  ];
+  ]);
 
-  const findingsTable = useReactTable({
+  const findingsTable = useLegacyTable({
     data: findings?.data || [],
     columns: findingColumns,
     pageCount: Math.ceil(

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/snippet-finding-snippets-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/snippet-finding-snippets-table.tsx
@@ -20,10 +20,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { useSearch } from '@tanstack/react-router';
 import {
-  createColumnHelper,
   getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 
 import { SnippetSource } from '@/api';
 import { getRunSnippetFindingSnippetsOptions } from '@/api/@tanstack/react-query.gen';
@@ -40,7 +40,7 @@ import {
 import { toastError } from '@/lib/toast';
 import { formatLineNumber } from '@/lib/utils';
 
-const snippetColumnHelper = createColumnHelper<SnippetSource>();
+const snippetColumnHelper = legacyCreateColumnHelper<SnippetSource>();
 const defaultPageSize = 10;
 const snippetFindingsRoutePath =
   '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/';
@@ -154,7 +154,7 @@ export const SnippetFindingSnippetsTable = ({
     }),
   });
 
-  const snippetColumns = [
+  const snippetColumns = snippetColumnHelper.columns([
     snippetColumnHelper.display({
       id: 'card',
       cell: ({ row }) => <SnippetSourceCard snippet={row.original} />,
@@ -171,9 +171,9 @@ export const SnippetFindingSnippetsTable = ({
       id: 'score',
       header: 'Score',
     }),
-  ];
+  ]);
 
-  const snippetsTable = useReactTable({
+  const snippetsTable = useLegacyTable({
     data: snippets?.data || [],
     columns: snippetColumns,
     pageCount: Math.ceil(

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/snippet-findings-view.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/snippet-findings-view.tsx
@@ -19,13 +19,13 @@
 
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { useNavigate, useParams, useSearch } from '@tanstack/react-router';
+import { ExpandedState } from '@tanstack/react-table';
 import {
-  createColumnHelper,
-  ExpandedState,
   getCoreRowModel,
   getExpandedRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useState } from 'react';
 
@@ -60,7 +60,8 @@ import {
   getSnippetFindingProvenancesQuery,
 } from './snippet-findings-state';
 
-const provenanceColumnHelper = createColumnHelper<SnippetFindingProvenance>();
+const provenanceColumnHelper =
+  legacyCreateColumnHelper<SnippetFindingProvenance>();
 const defaultPageSize = 10;
 const snippetFindingsRoutePath =
   '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/';
@@ -177,7 +178,7 @@ export const SnippetFindingsView = () => {
     }),
   });
 
-  const columns = [
+  const columns = provenanceColumnHelper.columns([
     provenanceColumnHelper.display({
       id: 'details',
       header: 'Details',
@@ -233,9 +234,9 @@ export const SnippetFindingsView = () => {
       id: 'version',
       header: 'Version',
     }),
-  ];
+  ]);
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: provenances.data,
     columns,
     pageCount: getSnippetFindingProvenancePageCount(

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/vulnerabilities/index.tsx
@@ -19,14 +19,14 @@
 
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { ExpandedState } from '@tanstack/react-table';
 import {
-  createColumnHelper,
-  ExpandedState,
   getCoreRowModel,
   getExpandedRowModel,
-  Row,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  LegacyRow,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { PackageURL } from 'packageurl-js';
 import { useCallback, useState } from 'react';
@@ -121,7 +121,7 @@ const supportedSortColumns = new Set([
   'rating',
 ]);
 
-const columnHelper = createColumnHelper<VulnerabilityWithDetails>();
+const columnHelper = legacyCreateColumnHelper<VulnerabilityWithDetails>();
 
 // Component to render a single vulnerability card in the list.
 const VulnerabilityCard = ({
@@ -246,7 +246,7 @@ const VulnerabilitiesComponent = () => {
     }),
   });
 
-  const columns = [
+  const columns = columnHelper.columns([
     columnHelper.display({
       id: 'details',
       header: 'Details',
@@ -414,7 +414,7 @@ const VulnerabilitiesComponent = () => {
         enableColumnFilter: false,
       }
     ),
-  ];
+  ]);
 
   const columnId = packageIdType === 'ORT_ID' ? 'identifier' : 'purl';
 
@@ -453,7 +453,7 @@ const VulnerabilitiesComponent = () => {
   });
 
   const renderSubComponent = useCallback(
-    ({ row }: { row: Row<VulnerabilityWithDetails> }) => {
+    ({ row }: { row: LegacyRow<VulnerabilityWithDetails> }) => {
       const vulnerability = row.original.vulnerability;
       let pkgVersion;
       try {
@@ -582,7 +582,7 @@ const VulnerabilitiesComponent = () => {
     search.marked ? { [search.marked]: true } : {}
   );
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: vulnerabilities.data,
     columns,
     pageCount: Math.ceil(vulnerabilities.pagination.totalCount / pageSize),

--- a/ui/src/routes/organizations/$orgId/products/$productId/search-package/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/search-package/index.tsx
@@ -20,12 +20,12 @@
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import {
-  createColumnHelper,
   getCoreRowModel,
   getPaginationRowModel,
   getSortedRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { useMemo } from 'react';
 import z from 'zod';
 
@@ -60,7 +60,7 @@ import {
 import { useUserSettingsStore } from '@/store/user-settings.store';
 
 const defaultPageSize = 10;
-const columnHelper = createColumnHelper<RunWithPackage>();
+const columnHelper = legacyCreateColumnHelper<RunWithPackage>();
 
 function SearchPackageComponent() {
   const params = Route.useParams();
@@ -69,7 +69,7 @@ function SearchPackageComponent() {
   const identifier = search.pkgId ?? '';
   const packageIdType = useUserSettingsStore((state) => state.packageIdType);
 
-  const columns = [
+  const columns = columnHelper.columns([
     columnHelper.accessor('createdAt', {
       header: 'Created At',
       cell: ({ row }) => (
@@ -158,7 +158,7 @@ function SearchPackageComponent() {
         );
       },
     }),
-  ];
+  ]);
 
   const pageIndex = useMemo(
     () => (search.page ? search.page - 1 : 0),
@@ -192,7 +192,7 @@ function SearchPackageComponent() {
     enabled: identifier !== '',
   });
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: runsWithPackage || [],
     columns,
     state: {

--- a/ui/src/routes/organizations/$orgId/products/$productId/search-vulnerability/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/search-vulnerability/index.tsx
@@ -20,12 +20,12 @@
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import {
-  createColumnHelper,
   getCoreRowModel,
   getPaginationRowModel,
   getSortedRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { useMemo } from 'react';
 import z from 'zod';
 
@@ -60,7 +60,7 @@ import {
 import { useUserSettingsStore } from '@/store/user-settings.store';
 
 const defaultPageSize = 10;
-const columnHelper = createColumnHelper<RunWithVulnerability>();
+const columnHelper = legacyCreateColumnHelper<RunWithVulnerability>();
 
 function SearchVulnerabilityComponent() {
   const params = Route.useParams();
@@ -69,7 +69,7 @@ function SearchVulnerabilityComponent() {
   const externalId = search.externalId ?? '';
   const packageIdType = useUserSettingsStore((state) => state.packageIdType);
 
-  const columns = [
+  const columns = columnHelper.columns([
     columnHelper.accessor('createdAt', {
       header: 'Created At',
       cell: ({ row }) => (
@@ -168,7 +168,7 @@ function SearchVulnerabilityComponent() {
         );
       },
     }),
-  ];
+  ]);
 
   const pageIndex = useMemo(
     () => (search.page ? search.page - 1 : 0),
@@ -201,7 +201,7 @@ function SearchVulnerabilityComponent() {
     enabled: externalId !== '',
   });
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: runsWithVulnerability || [],
     columns,
     state: {

--- a/ui/src/routes/organizations/$orgId/products/$productId/secrets/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/secrets/index.tsx
@@ -24,12 +24,13 @@ import {
   useSuspenseQuery,
 } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { CellContext } from '@tanstack/react-table';
 import {
-  CellContext,
-  ColumnDef,
   getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  LegacyColumnDef,
+  LegacyFeatures,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { EditIcon, PlusIcon } from 'lucide-react';
 import z from 'zod';
 
@@ -71,7 +72,7 @@ import {
 
 const defaultPageSize = 5;
 
-const ActionCell = ({ row }: CellContext<Secret, unknown>) => {
+const ActionCell = ({ row }: CellContext<LegacyFeatures, Secret, unknown>) => {
   const params = Route.useParams();
   const queryClient = useQueryClient();
 
@@ -133,7 +134,7 @@ const ActionCell = ({ row }: CellContext<Secret, unknown>) => {
   );
 };
 
-const baseColumns: ColumnDef<Secret>[] = [
+const baseColumns: LegacyColumnDef<Secret>[] = [
   {
     accessorKey: 'name',
     header: 'Name',
@@ -146,7 +147,7 @@ const baseColumns: ColumnDef<Secret>[] = [
   },
 ];
 
-const columns: ColumnDef<Secret>[] = [
+const columns: LegacyColumnDef<Secret>[] = [
   ...baseColumns,
   {
     id: 'actions',
@@ -213,7 +214,7 @@ const ProductSecrets = () => {
     }),
   });
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: secrets?.data || [],
     columns,
     pageCount: Math.ceil((secrets?.pagination.totalCount ?? 0) / pageSize),
@@ -227,7 +228,7 @@ const ProductSecrets = () => {
     manualPagination: true,
   });
 
-  const orgTable = useReactTable({
+  const orgTable = useLegacyTable({
     data: orgSecrets?.data || [],
     columns: baseColumns,
     pageCount: Math.ceil(

--- a/ui/src/routes/organizations/$orgId/products/$productId/users/-components/product-users-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/users/-components/product-users-table.tsx
@@ -20,10 +20,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getRouteApi } from '@tanstack/react-router';
 import {
-  createColumnHelper,
   getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { Eye, FileOutput, Pen, Shield } from 'lucide-react';
 
 import { UserWithGroups } from '@/api';
@@ -47,9 +47,9 @@ import { useUser } from '@/hooks/use-user.ts';
 import { ApiError } from '@/lib/api-error';
 import { toast, toastError } from '@/lib/toast';
 
-const columnHelper = createColumnHelper<UserWithGroups>();
+const columnHelper = legacyCreateColumnHelper<UserWithGroups>();
 
-const columns = [
+const columns = columnHelper.columns([
   columnHelper.accessor('user.username', {
     header: 'Username',
     cell: ({ row }) => <>{row.original.user.username}</>,
@@ -236,7 +236,7 @@ const columns = [
       );
     },
   }),
-];
+]);
 
 const routeApi = getRouteApi('/organizations/$orgId/products/$productId/users');
 
@@ -257,7 +257,7 @@ export const ProductUsersTable = () => {
     }),
   });
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: usersWithGroups?.data || [],
     columns: columns,
     pageCount: Math.ceil(

--- a/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/vulnerabilities/index.tsx
@@ -19,14 +19,14 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { ExpandedState } from '@tanstack/react-table';
 import {
-  createColumnHelper,
-  ExpandedState,
   getCoreRowModel,
   getExpandedRowModel,
-  Row,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  LegacyRow,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import z from 'zod';
@@ -88,7 +88,7 @@ import { useUserSettingsStore } from '@/store/user-settings.store';
 
 const defaultPageSize = 10;
 
-const columnHelper = createColumnHelper<VulnerabilityWithStats>();
+const columnHelper = legacyCreateColumnHelper<VulnerabilityWithStats>();
 
 // Component to render a single vulnerability card in the list.
 const VulnerabilityCard = ({
@@ -163,7 +163,11 @@ const VulnerabilityCard = ({
   );
 };
 
-const renderSubComponent = ({ row }: { row: Row<VulnerabilityWithStats> }) => {
+const renderSubComponent = ({
+  row,
+}: {
+  row: LegacyRow<VulnerabilityWithStats>;
+}) => {
   const vulnerability = row.original.vulnerability;
 
   return (
@@ -234,155 +238,156 @@ const ProductVulnerabilitiesComponent = () => {
   // Prevent infinite rerenders by providing a stable reference to columns via memoization.
   // https://tanstack.com/table/latest/docs/faq#solution-1-stable-references-with-usememo-or-usestate
   const columns = useMemo(
-    () => [
-      columnHelper.display({
-        id: 'moreInfo',
-        header: 'Details',
-        size: ACTION_COLUMN_SIZE,
-        cell: function CellComponent({ row }) {
-          return row.getCanExpand() ? (
-            <div className='flex items-center gap-1'>
-              <Button
-                variant='outline'
-                size='sm'
-                {...{
-                  onClick: row.getToggleExpandedHandler(),
-                  style: { cursor: 'pointer' },
-                }}
-              >
-                {row.getIsExpanded() ? (
-                  <ChevronUp className='h-4 w-4' />
-                ) : (
-                  <ChevronDown className='h-4 w-4' />
-                )}
-              </Button>
-              <MarkItems
-                row={row}
-                setMarked={(marked) => {
-                  return {
-                    to: Route.to,
-                    search: {
-                      ...search,
-                      // If no items are marked for inspection, remove the "marked" parameter
-                      // from search parameters.
-                      marked: marked === '' ? undefined : marked,
-                    },
-                  };
-                }}
-              />
-            </div>
-          ) : (
-            'No info'
-          );
-        },
-        enableSorting: false,
-        enableColumnFilter: false,
-      }),
-      columnHelper.display({
-        id: 'card',
-        cell: ({ row }) => (
-          <VulnerabilityCard
-            vulnerability={row.original}
-            organizationId={params.orgId}
-            productId={params.productId}
-          />
-        ),
-      }),
-      columnHelper.accessor(
-        (vuln) => {
-          if (packageIdType === 'PURL') {
-            return vuln.purl;
-          } else {
-            return identifierToString(vuln.identifier);
+    () =>
+      columnHelper.columns([
+        columnHelper.display({
+          id: 'moreInfo',
+          header: 'Details',
+          size: ACTION_COLUMN_SIZE,
+          cell: function CellComponent({ row }) {
+            return row.getCanExpand() ? (
+              <div className='flex items-center gap-1'>
+                <Button
+                  variant='outline'
+                  size='sm'
+                  {...{
+                    onClick: row.getToggleExpandedHandler(),
+                    style: { cursor: 'pointer' },
+                  }}
+                >
+                  {row.getIsExpanded() ? (
+                    <ChevronUp className='h-4 w-4' />
+                  ) : (
+                    <ChevronDown className='h-4 w-4' />
+                  )}
+                </Button>
+                <MarkItems
+                  row={row}
+                  setMarked={(marked) => {
+                    return {
+                      to: Route.to,
+                      search: {
+                        ...search,
+                        // If no items are marked for inspection, remove the "marked" parameter
+                        // from search parameters.
+                        marked: marked === '' ? undefined : marked,
+                      },
+                    };
+                  }}
+                />
+              </div>
+            ) : (
+              'No info'
+            );
+          },
+          enableSorting: false,
+          enableColumnFilter: false,
+        }),
+        columnHelper.display({
+          id: 'card',
+          cell: ({ row }) => (
+            <VulnerabilityCard
+              vulnerability={row.original}
+              organizationId={params.orgId}
+              productId={params.productId}
+            />
+          ),
+        }),
+        columnHelper.accessor(
+          (vuln) => {
+            if (packageIdType === 'PURL') {
+              return vuln.purl;
+            } else {
+              return identifierToString(vuln.identifier);
+            }
+          },
+          {
+            id: packageIdType === 'ORT_ID' ? 'identifier' : 'purl',
+            header: 'Package ID',
+            meta: {
+              filter: {
+                filterVariant: 'text',
+                setFilterValue: (value: string | undefined) => {
+                  navigate({
+                    search: { ...search, page: 1, pkgId: value },
+                  });
+                },
+              },
+            },
           }
-        },
-        {
-          id: packageIdType === 'ORT_ID' ? 'identifier' : 'purl',
-          header: 'Package ID',
+        ),
+        columnHelper.accessor('vulnerability.externalId', {
+          id: 'externalId',
+          header: 'External ID',
           meta: {
             filter: {
               filterVariant: 'text',
               setFilterValue: (value: string | undefined) => {
                 navigate({
-                  search: { ...search, page: 1, pkgId: value },
+                  search: { ...search, page: 1, externalId: value },
                 });
               },
             },
           },
-        }
-      ),
-      columnHelper.accessor('vulnerability.externalId', {
-        id: 'externalId',
-        header: 'External ID',
-        meta: {
-          filter: {
-            filterVariant: 'text',
-            setFilterValue: (value: string | undefined) => {
-              navigate({
-                search: { ...search, page: 1, externalId: value },
-              });
+        }),
+        columnHelper.accessor('rating', {
+          id: 'rating',
+          header: 'Rating',
+          meta: {
+            filter: {
+              filterVariant: 'select',
+              selectOptions: zVulnerabilityRating.options.map((rating) => ({
+                label: rating,
+                value: rating,
+              })),
+              setSelected: (ratings: VulnerabilityRating[]) => {
+                navigate({
+                  search: {
+                    ...search,
+                    page: 1,
+                    rating: ratings.length === 0 ? undefined : ratings,
+                  },
+                });
+              },
             },
           },
-        },
-      }),
-      columnHelper.accessor('rating', {
-        id: 'rating',
-        header: 'Rating',
-        meta: {
-          filter: {
-            filterVariant: 'select',
-            selectOptions: zVulnerabilityRating.options.map((rating) => ({
-              label: rating,
-              value: rating,
-            })),
-            setSelected: (ratings: VulnerabilityRating[]) => {
-              navigate({
-                search: {
-                  ...search,
-                  page: 1,
-                  rating: ratings.length === 0 ? undefined : ratings,
-                },
-              });
+        }),
+        columnHelper.accessor('repositoriesCount', {
+          id: 'repositoriesCount',
+          header: 'Repositories',
+          enableColumnFilter: false,
+        }),
+        columnHelper.accessor(() => '', {
+          id: 'advisor',
+          header: 'Advisor',
+          enableSorting: false,
+          enableColumnFilter: (advisors?.length ?? 0) > 1,
+          meta: {
+            filter: {
+              filterVariant: 'select',
+              selectOptions: (advisors ?? []).map((advisor) => ({
+                label: advisor,
+                value: advisor,
+              })),
+              setSelected: (advisors: string[]) => {
+                navigate({
+                  search: {
+                    ...search,
+                    page: 1,
+                    advisor: advisors.length === 0 ? undefined : advisors,
+                  },
+                });
+              },
             },
           },
-        },
-      }),
-      columnHelper.accessor('repositoriesCount', {
-        id: 'repositoriesCount',
-        header: 'Repositories',
-        enableColumnFilter: false,
-      }),
-      columnHelper.accessor(() => '', {
-        id: 'advisor',
-        header: 'Advisor',
-        enableSorting: false,
-        enableColumnFilter: (advisors?.length ?? 0) > 1,
-        meta: {
-          filter: {
-            filterVariant: 'select',
-            selectOptions: (advisors ?? []).map((advisor) => ({
-              label: advisor,
-              value: advisor,
-            })),
-            setSelected: (advisors: string[]) => {
-              navigate({
-                search: {
-                  ...search,
-                  page: 1,
-                  advisor: advisors.length === 0 ? undefined : advisors,
-                },
-              });
-            },
-          },
-        },
-      }),
-      columnHelper.accessor('vulnerability.summary', {
-        id: 'summary',
-        header: 'Summary',
-        enableSorting: false,
-        enableColumnFilter: false,
-      }),
-    ],
+        }),
+        columnHelper.accessor('vulnerability.summary', {
+          id: 'summary',
+          header: 'Summary',
+          enableSorting: false,
+          enableColumnFilter: false,
+        }),
+      ]),
     [advisors, navigate, packageIdType, params.orgId, params.productId, search]
   );
 
@@ -481,7 +486,7 @@ const ProductVulnerabilitiesComponent = () => {
 
   const columnId = packageIdType === 'ORT_ID' ? 'identifier' : 'purl';
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: vulnerabilities?.data || [],
     columns,
     pageCount: Math.ceil(

--- a/ui/src/routes/organizations/$orgId/search-package/index.tsx
+++ b/ui/src/routes/organizations/$orgId/search-package/index.tsx
@@ -20,12 +20,12 @@
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import {
-  createColumnHelper,
   getCoreRowModel,
   getPaginationRowModel,
   getSortedRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { useMemo } from 'react';
 import z from 'zod';
 
@@ -61,7 +61,7 @@ import {
 import { useUserSettingsStore } from '@/store/user-settings.store';
 
 const defaultPageSize = 10;
-const columnHelper = createColumnHelper<RunWithPackage>();
+const columnHelper = legacyCreateColumnHelper<RunWithPackage>();
 
 function SearchPackageComponent() {
   const params = Route.useParams();
@@ -70,7 +70,7 @@ function SearchPackageComponent() {
   const identifier = search.pkgId ?? '';
   const packageIdType = useUserSettingsStore((state) => state.packageIdType);
 
-  const columns = [
+  const columns = columnHelper.columns([
     columnHelper.accessor('createdAt', {
       header: 'Created At',
       cell: ({ row }) => (
@@ -184,7 +184,7 @@ function SearchPackageComponent() {
         );
       },
     }),
-  ];
+  ]);
 
   const pageIndex = useMemo(
     () => (search.page ? search.page - 1 : 0),
@@ -218,7 +218,7 @@ function SearchPackageComponent() {
     enabled: identifier !== '',
   });
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: runsWithPackage || [],
     columns,
     state: {

--- a/ui/src/routes/organizations/$orgId/search-vulnerability/index.tsx
+++ b/ui/src/routes/organizations/$orgId/search-vulnerability/index.tsx
@@ -20,12 +20,12 @@
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import {
-  createColumnHelper,
   getCoreRowModel,
   getPaginationRowModel,
   getSortedRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { useMemo } from 'react';
 import z from 'zod';
 
@@ -61,7 +61,7 @@ import {
 import { useUserSettingsStore } from '@/store/user-settings.store';
 
 const defaultPageSize = 10;
-const columnHelper = createColumnHelper<RunWithVulnerability>();
+const columnHelper = legacyCreateColumnHelper<RunWithVulnerability>();
 
 function SearchVulnerabilityComponent() {
   const params = Route.useParams();
@@ -70,7 +70,7 @@ function SearchVulnerabilityComponent() {
   const externalId = search.externalId ?? '';
   const packageIdType = useUserSettingsStore((state) => state.packageIdType);
 
-  const columns = [
+  const columns = columnHelper.columns([
     columnHelper.accessor('createdAt', {
       header: 'Created At',
       cell: ({ row }) => (
@@ -197,7 +197,7 @@ function SearchVulnerabilityComponent() {
         );
       },
     }),
-  ];
+  ]);
 
   const pageIndex = useMemo(
     () => (search.page ? search.page - 1 : 0),
@@ -230,7 +230,7 @@ function SearchVulnerabilityComponent() {
     enabled: externalId !== '',
   });
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: runsWithVulnerability || [],
     columns,
     state: {

--- a/ui/src/routes/organizations/$orgId/secrets/index.tsx
+++ b/ui/src/routes/organizations/$orgId/secrets/index.tsx
@@ -24,12 +24,13 @@ import {
   useSuspenseQuery,
 } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { CellContext } from '@tanstack/react-table';
 import {
-  CellContext,
-  ColumnDef,
   getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  LegacyColumnDef,
+  LegacyFeatures,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { EditIcon, PlusIcon } from 'lucide-react';
 
 import { Secret } from '@/api';
@@ -64,7 +65,7 @@ import { paginationSearchParameterSchema } from '@/schemas';
 
 const defaultPageSize = 10;
 
-const ActionCell = ({ row }: CellContext<Secret, unknown>) => {
+const ActionCell = ({ row }: CellContext<LegacyFeatures, Secret, unknown>) => {
   const params = Route.useParams();
   const queryClient = useQueryClient();
 
@@ -122,7 +123,7 @@ const ActionCell = ({ row }: CellContext<Secret, unknown>) => {
   );
 };
 
-const columns: ColumnDef<Secret>[] = [
+const columns: LegacyColumnDef<Secret>[] = [
   {
     accessorKey: 'name',
     header: 'Name',
@@ -169,7 +170,7 @@ const OrganizationSecrets = () => {
     }),
   });
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: secrets?.data || [],
     columns,
     pageCount: Math.ceil((secrets?.pagination.totalCount ?? 0) / pageSize),

--- a/ui/src/routes/organizations/$orgId/users/-components/organization-users-table.tsx
+++ b/ui/src/routes/organizations/$orgId/users/-components/organization-users-table.tsx
@@ -20,10 +20,10 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { getRouteApi } from '@tanstack/react-router';
 import {
-  createColumnHelper,
   getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { Eye, FileOutput, Pen, Shield } from 'lucide-react';
 
 import { UserWithGroups } from '@/api';
@@ -47,9 +47,9 @@ import { useUser } from '@/hooks/use-user.ts';
 import { ApiError } from '@/lib/api-error';
 import { toast, toastError } from '@/lib/toast';
 
-const columnHelper = createColumnHelper<UserWithGroups>();
+const columnHelper = legacyCreateColumnHelper<UserWithGroups>();
 
-const columns = [
+const columns = columnHelper.columns([
   columnHelper.accessor('user.username', {
     header: 'Username',
     cell: ({ row }) => <>{row.original.user.username}</>,
@@ -240,7 +240,7 @@ const columns = [
       );
     },
   }),
-];
+]);
 
 const routeApi = getRouteApi('/organizations/$orgId/users');
 
@@ -263,7 +263,7 @@ export const OrganizationUsersTable = () => {
     }),
   });
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: usersWithGroups?.data || [],
     columns: columns,
     pageCount: Math.ceil(

--- a/ui/src/routes/organizations/$orgId/vulnerabilities/index.tsx
+++ b/ui/src/routes/organizations/$orgId/vulnerabilities/index.tsx
@@ -19,14 +19,14 @@
 
 import { useQuery } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
+import { ExpandedState } from '@tanstack/react-table';
 import {
-  createColumnHelper,
-  ExpandedState,
   getCoreRowModel,
   getExpandedRowModel,
-  Row,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  LegacyRow,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { ChevronDown, ChevronUp } from 'lucide-react';
 import { useMemo, useState } from 'react';
 import z from 'zod';
@@ -88,7 +88,7 @@ import { useUserSettingsStore } from '@/store/user-settings.store';
 
 const defaultPageSize = 10;
 
-const columnHelper = createColumnHelper<VulnerabilityWithStats>();
+const columnHelper = legacyCreateColumnHelper<VulnerabilityWithStats>();
 
 // Component to render a single vulnerability card in the list.
 const VulnerabilityCard = ({
@@ -158,7 +158,11 @@ const VulnerabilityCard = ({
   );
 };
 
-const renderSubComponent = ({ row }: { row: Row<VulnerabilityWithStats> }) => {
+const renderSubComponent = ({
+  row,
+}: {
+  row: LegacyRow<VulnerabilityWithStats>;
+}) => {
   const vulnerability = row.original.vulnerability;
 
   return (
@@ -318,154 +322,155 @@ const OrganizationVulnerabilitiesComponent = () => {
   // Prevent infinite rerenders by providing a stable reference to columns via memoization.
   // https://tanstack.com/table/latest/docs/faq#solution-1-stable-references-with-usememo-or-usestate
   const columns = useMemo(
-    () => [
-      columnHelper.display({
-        id: 'moreInfo',
-        header: 'Details',
-        size: ACTION_COLUMN_SIZE,
-        cell: function CellComponent({ row }) {
-          return row.getCanExpand() ? (
-            <div className='flex items-center gap-1'>
-              <Button
-                variant='outline'
-                size='sm'
-                {...{
-                  onClick: row.getToggleExpandedHandler(),
-                  style: { cursor: 'pointer' },
-                }}
-              >
-                {row.getIsExpanded() ? (
-                  <ChevronUp className='h-4 w-4' />
-                ) : (
-                  <ChevronDown className='h-4 w-4' />
-                )}
-              </Button>
-              <MarkItems
-                row={row}
-                setMarked={(marked) => {
-                  return {
-                    to: Route.to,
-                    search: {
-                      ...search,
-                      // If no items are marked for inspection, remove the "marked" parameter
-                      // from search parameters.
-                      marked: marked === '' ? undefined : marked,
-                    },
-                  };
-                }}
-              />
-            </div>
-          ) : (
-            'No info'
-          );
-        },
-        enableSorting: false,
-        enableColumnFilter: false,
-      }),
-      columnHelper.display({
-        id: 'card',
-        cell: ({ row }) => (
-          <VulnerabilityCard
-            vulnerability={row.original}
-            organizationId={params.orgId}
-          />
-        ),
-      }),
-      columnHelper.accessor(
-        (vuln) => {
-          if (packageIdType === 'PURL') {
-            return vuln.purl;
-          } else {
-            return identifierToString(vuln.identifier);
+    () =>
+      columnHelper.columns([
+        columnHelper.display({
+          id: 'moreInfo',
+          header: 'Details',
+          size: ACTION_COLUMN_SIZE,
+          cell: function CellComponent({ row }) {
+            return row.getCanExpand() ? (
+              <div className='flex items-center gap-1'>
+                <Button
+                  variant='outline'
+                  size='sm'
+                  {...{
+                    onClick: row.getToggleExpandedHandler(),
+                    style: { cursor: 'pointer' },
+                  }}
+                >
+                  {row.getIsExpanded() ? (
+                    <ChevronUp className='h-4 w-4' />
+                  ) : (
+                    <ChevronDown className='h-4 w-4' />
+                  )}
+                </Button>
+                <MarkItems
+                  row={row}
+                  setMarked={(marked) => {
+                    return {
+                      to: Route.to,
+                      search: {
+                        ...search,
+                        // If no items are marked for inspection, remove the "marked" parameter
+                        // from search parameters.
+                        marked: marked === '' ? undefined : marked,
+                      },
+                    };
+                  }}
+                />
+              </div>
+            ) : (
+              'No info'
+            );
+          },
+          enableSorting: false,
+          enableColumnFilter: false,
+        }),
+        columnHelper.display({
+          id: 'card',
+          cell: ({ row }) => (
+            <VulnerabilityCard
+              vulnerability={row.original}
+              organizationId={params.orgId}
+            />
+          ),
+        }),
+        columnHelper.accessor(
+          (vuln) => {
+            if (packageIdType === 'PURL') {
+              return vuln.purl;
+            } else {
+              return identifierToString(vuln.identifier);
+            }
+          },
+          {
+            id: packageIdType === 'ORT_ID' ? 'identifier' : 'purl',
+            header: 'Package ID',
+            meta: {
+              filter: {
+                filterVariant: 'text',
+                setFilterValue: (value: string | undefined) => {
+                  navigate({
+                    search: { ...search, page: 1, pkgId: value },
+                  });
+                },
+              },
+            },
           }
-        },
-        {
-          id: packageIdType === 'ORT_ID' ? 'identifier' : 'purl',
-          header: 'Package ID',
+        ),
+        columnHelper.accessor('vulnerability.externalId', {
+          id: 'externalId',
+          header: 'External ID',
           meta: {
             filter: {
               filterVariant: 'text',
               setFilterValue: (value: string | undefined) => {
                 navigate({
-                  search: { ...search, page: 1, pkgId: value },
+                  search: { ...search, page: 1, externalId: value },
                 });
               },
             },
           },
-        }
-      ),
-      columnHelper.accessor('vulnerability.externalId', {
-        id: 'externalId',
-        header: 'External ID',
-        meta: {
-          filter: {
-            filterVariant: 'text',
-            setFilterValue: (value: string | undefined) => {
-              navigate({
-                search: { ...search, page: 1, externalId: value },
-              });
+        }),
+        columnHelper.accessor('rating', {
+          id: 'rating',
+          header: 'Rating',
+          meta: {
+            filter: {
+              filterVariant: 'select',
+              selectOptions: zVulnerabilityRating.options.map((rating) => ({
+                label: rating,
+                value: rating,
+              })),
+              setSelected: (ratings: VulnerabilityRating[]) => {
+                navigate({
+                  search: {
+                    ...search,
+                    page: 1,
+                    rating: ratings.length === 0 ? undefined : ratings,
+                  },
+                });
+              },
             },
           },
-        },
-      }),
-      columnHelper.accessor('rating', {
-        id: 'rating',
-        header: 'Rating',
-        meta: {
-          filter: {
-            filterVariant: 'select',
-            selectOptions: zVulnerabilityRating.options.map((rating) => ({
-              label: rating,
-              value: rating,
-            })),
-            setSelected: (ratings: VulnerabilityRating[]) => {
-              navigate({
-                search: {
-                  ...search,
-                  page: 1,
-                  rating: ratings.length === 0 ? undefined : ratings,
-                },
-              });
+        }),
+        columnHelper.accessor('repositoriesCount', {
+          id: 'repositoriesCount',
+          header: 'Repositories',
+          enableColumnFilter: false,
+        }),
+        columnHelper.accessor(() => '', {
+          id: 'advisor',
+          header: 'Advisor',
+          enableSorting: false,
+          enableColumnFilter: (advisors?.length ?? 0) > 1,
+          meta: {
+            filter: {
+              filterVariant: 'select',
+              selectOptions: (advisors ?? []).map((advisor) => ({
+                label: advisor,
+                value: advisor,
+              })),
+              setSelected: (advisors: string[]) => {
+                navigate({
+                  search: {
+                    ...search,
+                    page: 1,
+                    advisor: advisors.length === 0 ? undefined : advisors,
+                  },
+                });
+              },
             },
           },
-        },
-      }),
-      columnHelper.accessor('repositoriesCount', {
-        id: 'repositoriesCount',
-        header: 'Repositories',
-        enableColumnFilter: false,
-      }),
-      columnHelper.accessor(() => '', {
-        id: 'advisor',
-        header: 'Advisor',
-        enableSorting: false,
-        enableColumnFilter: (advisors?.length ?? 0) > 1,
-        meta: {
-          filter: {
-            filterVariant: 'select',
-            selectOptions: (advisors ?? []).map((advisor) => ({
-              label: advisor,
-              value: advisor,
-            })),
-            setSelected: (advisors: string[]) => {
-              navigate({
-                search: {
-                  ...search,
-                  page: 1,
-                  advisor: advisors.length === 0 ? undefined : advisors,
-                },
-              });
-            },
-          },
-        },
-      }),
-      columnHelper.accessor('vulnerability.summary', {
-        id: 'summary',
-        header: 'Summary',
-        enableSorting: false,
-        enableColumnFilter: false,
-      }),
-    ],
+        }),
+        columnHelper.accessor('vulnerability.summary', {
+          id: 'summary',
+          header: 'Summary',
+          enableSorting: false,
+          enableColumnFilter: false,
+        }),
+      ]),
     [advisors, packageIdType, search, navigate, params.orgId]
   );
 
@@ -475,7 +480,7 @@ const OrganizationVulnerabilitiesComponent = () => {
 
   const columnId = packageIdType === 'ORT_ID' ? 'identifier' : 'purl';
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: vulnerabilities?.data || [],
     columns,
     pageCount: Math.ceil(

--- a/ui/src/routes/organizations/index.tsx
+++ b/ui/src/routes/organizations/index.tsx
@@ -20,10 +20,10 @@
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import {
-  createColumnHelper,
   getCoreRowModel,
-  useReactTable,
-} from '@tanstack/react-table';
+  legacyCreateColumnHelper,
+  useLegacyTable,
+} from '@tanstack/react-table/legacy';
 import { PlusIcon } from 'lucide-react';
 import { useMemo } from 'react';
 import z from 'zod';
@@ -55,7 +55,7 @@ import {
 } from '@/schemas';
 import { useTablePrefsStore } from '@/store/table-prefs.store';
 
-const columnHelper = createColumnHelper<Organization>();
+const columnHelper = legacyCreateColumnHelper<Organization>();
 
 export const OrganizationsPage = () => {
   const orgPageSize = useTablePrefsStore((state) => state.orgPageSize);
@@ -101,49 +101,50 @@ export const OrganizationsPage = () => {
   });
 
   const columns = useMemo(
-    () => [
-      columnHelper.accessor('name', {
-        id: 'organization',
-        header: 'Organizations',
-        cell: ({ row }) => (
-          <>
-            <div className='flex items-center gap-1.5'>
-              <Link
-                className='font-semibold text-blue-400 hover:underline'
-                to={`/organizations/$orgId`}
-                params={{ orgId: row.original.id.toString() }}
-              >
-                {row.original.name}
-              </Link>
-              <OrganizationFavoriteButton
-                organization={row.original}
-                size='xs'
-                variant='ghost'
-                className='size-6 p-0'
-              />
-            </div>
+    () =>
+      columnHelper.columns([
+        columnHelper.accessor('name', {
+          id: 'organization',
+          header: 'Organizations',
+          cell: ({ row }) => (
+            <>
+              <div className='flex items-center gap-1.5'>
+                <Link
+                  className='font-semibold text-blue-400 hover:underline'
+                  to={`/organizations/$orgId`}
+                  params={{ orgId: row.original.id.toString() }}
+                >
+                  {row.original.name}
+                </Link>
+                <OrganizationFavoriteButton
+                  organization={row.original}
+                  size='xs'
+                  variant='ghost'
+                  className='size-6 p-0'
+                />
+              </div>
 
-            <div className='text-muted-foreground hidden text-sm md:inline'>
-              {row.original.description}
-            </div>
-          </>
-        ),
-        meta: {
-          filter: {
-            filterVariant: 'regex',
-            setFilterValue: (value: string | undefined) => {
-              navigate({
-                search: { ...search, page: 1, filter: value },
-              });
+              <div className='text-muted-foreground hidden text-sm md:inline'>
+                {row.original.description}
+              </div>
+            </>
+          ),
+          meta: {
+            filter: {
+              filterVariant: 'regex',
+              setFilterValue: (value: string | undefined) => {
+                navigate({
+                  search: { ...search, page: 1, filter: value },
+                });
+              },
             },
           },
-        },
-      }),
-    ],
+        }),
+      ]),
     [navigate, search]
   );
 
-  const table = useReactTable({
+  const table = useLegacyTable({
     data: organizations?.data || [],
     columns,
     pageCount: Math.ceil(


### PR DESCRIPTION
This PR starts migrating the UI tables by implementing a minimal "legacy migration", which unblocks updating the dependency from v8 to v9.

The compatibility layer changes rendering internals (methods now live on prototypes, and the `useLegacyTable()` hook subscribes to the whole table state). For that reason, in addition to automated testing, the PR has been verified manually by:
- accessing every UI table in the browser and verifying that the UI doesn't break
- checking server-side pagination and page-size changes on repository runs table and vulnerabilities table
- checking multi-column sorting, including the third click that removes a column from the sort
- checking sorting reset in card-table sort menu
- checking column filters and the filter variants (text, regex, select, infinite select, single select)
- checking row expansion and sub-component rendering on the packages, projects, issues, rule-violations, and license-findings tables
- verifying responsive column sizing (`useTableSizing`) after a window resize, including a table that mixes `size`, `widthPercentage`, and `isGrow` columns

NOTE: it was tested that legacy migration increases the UI bundle size by 2.4% due to TanStack Table v9 core and the legacy compatibility layer. This overhead is temporary, until the tables are migrated to the native v9 API in upcoming PRs.

Please see the commits for details. For reviewers:
- commit 1 starts migration by updating  the dependency and breaking the UI build temporarily
- commits 2-3 prepare for the migration
- commits 4-12 migrate the tables group by group (mostly mechanic replacement of methods and types). Each commit is verified by checking that the TypeScript errors vanish for touched files. Each commit also records the errors left
- commit 13 finishes migration
- commit 14 fixes an existing bug for packages table that was found while testing the migration