### PR TITLE
test(dao): Improve the `DatabaseTest`

### DIFF
--- a/dao/build.gradle.kts
+++ b/dao/build.gradle.kts
@@ -62,6 +62,7 @@ dependencies {
     testImplementation(libs.kotestAssertionsCore)
     testImplementation(libs.kotestRunnerJunit5)
     testImplementation(libs.mockk)
+    testImplementation(libs.testContainersPostgresql)
 
     testFixturesApi(projects.model)
 

--- a/dao/src/test/kotlin/DataSourceConfigTest.kt
+++ b/dao/src/test/kotlin/DataSourceConfigTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.dao
+
+import com.typesafe.config.ConfigFactory
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import org.eclipse.apoapsis.ortserver.config.ConfigManager
+import org.eclipse.apoapsis.ortserver.config.ConfigSecretProviderFactoryForTesting
+
+class DataSourceConfigTest : WordSpec({
+    "create" should {
+        "create a DataSourceConfig from the ConfigManager" {
+            val dataSourceConfig = DataSourceConfig(
+                host = "host",
+                port = 5432,
+                name = "myTestDataSource",
+                schema = "myTestSchema",
+                username = "scott",
+                password = "tiger",
+                connectionTimeout = 30000L,
+                idleTimeout = 600000L,
+                keepaliveTime = 0L,
+                maxLifetime = 1800000L,
+                maximumPoolSize = 12,
+                minimumIdle = 5,
+                sslMode = "myTestSSLMode",
+                sslCert = "myTestSSLCert",
+                sslKey = "myTestSSLKey",
+                sslRootCert = "myTestSSLRootCert",
+                initSqlStatement = "SET search_path TO test,public;"
+            )
+
+            val secretsMap = mapOf(
+                "database.username" to dataSourceConfig.username,
+                "database.password" to dataSourceConfig.password
+            )
+
+            val secretProviderConfig = mapOf(
+                ConfigManager.SECRET_PROVIDER_NAME_PROPERTY to ConfigSecretProviderFactoryForTesting.NAME,
+                ConfigSecretProviderFactoryForTesting.SECRETS_PROPERTY to secretsMap
+            )
+
+            val config = ConfigFactory.parseMap(
+                mapOf(
+                    "database.host" to dataSourceConfig.host,
+                    "database.port" to dataSourceConfig.port,
+                    "database.name" to dataSourceConfig.name,
+                    "database.schema" to dataSourceConfig.schema,
+                    "database.connectionTimeout" to dataSourceConfig.connectionTimeout,
+                    "database.idleTimeout" to dataSourceConfig.idleTimeout,
+                    "database.keepaliveTime" to dataSourceConfig.keepaliveTime,
+                    "database.maxLifetime" to dataSourceConfig.maxLifetime,
+                    "database.maximumPoolSize" to dataSourceConfig.maximumPoolSize,
+                    "database.minimumIdle" to dataSourceConfig.minimumIdle,
+                    "database.sslMode" to dataSourceConfig.sslMode,
+                    "database.sslCert" to dataSourceConfig.sslCert,
+                    "database.sslKey" to dataSourceConfig.sslKey,
+                    "database.sslRootCert" to dataSourceConfig.sslRootCert,
+                    "database.initSqlStatement" to dataSourceConfig.initSqlStatement,
+                    ConfigManager.CONFIG_MANAGER_SECTION to secretProviderConfig
+                )
+            )
+
+            val configManager = ConfigManager.create(config)
+
+            DataSourceConfig.create(configManager) shouldBe dataSourceConfig
+        }
+    }
+})

--- a/dao/src/test/kotlin/DatabaseTest.kt
+++ b/dao/src/test/kotlin/DatabaseTest.kt
@@ -21,103 +21,82 @@ package org.eclipse.apoapsis.ortserver.dao
 
 import com.typesafe.config.ConfigFactory
 
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.WordSpec
-
-import io.mockk.every
-import io.mockk.mockk
-import io.mockk.mockkStatic
-import io.mockk.unmockkAll
-import io.mockk.verify
-
-import javax.sql.DataSource
 
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.config.ConfigSecretProviderFactoryForTesting
+import org.eclipse.apoapsis.ortserver.dao.repositories.organization.OrganizationsTable
+import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
+import org.eclipse.apoapsis.ortserver.dao.test.TEST_DB_SCHEMA
+import org.eclipse.apoapsis.ortserver.utils.test.Integration
 
 import org.jetbrains.exposed.v1.jdbc.Database
+import org.jetbrains.exposed.v1.jdbc.insert
+import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
 import org.koin.dsl.module
 
 class DatabaseTest : WordSpec({
+    tags(Integration)
+
+    val dbExtension = extension(DatabaseTestExtension())
+
     afterEach {
-        unmockkAll()
+        stopKoin()
     }
 
     "databaseModule" should {
-        "return a module that connects to the database" {
-            val dbConfig = DataSourceConfig(
-                host = "host",
-                port = 5432,
-                name = "myTestDataSource",
-                schema = "myTestSchema",
-                username = "scott",
-                password = "tiger",
-                connectionTimeout = 30000L,
-                idleTimeout = 600000L,
-                keepaliveTime = 0L,
-                maxLifetime = 1800000L,
-                maximumPoolSize = 12,
-                minimumIdle = 5,
-                sslMode = "myTestSSLMode",
-                sslCert = "myTestSSLCert",
-                sslKey = "myTestSSLKey",
-                sslRootCert = "myTestSSLRootCert",
-                initSqlStatement = "SET search_path TO test,public;"
-            )
+        "add a working database to the Koin context" {
+            val postgres = dbExtension.postgres
 
             val secretsMap = mapOf(
-                "database.username" to dbConfig.username,
-                "database.password" to dbConfig.password
+                "database.username" to postgres.username,
+                "database.password" to postgres.password
             )
+
             val secretConfigMap = mapOf(
                 ConfigManager.SECRET_PROVIDER_NAME_PROPERTY to ConfigSecretProviderFactoryForTesting.NAME,
                 ConfigSecretProviderFactoryForTesting.SECRETS_PROPERTY to secretsMap
             )
+
             val config = ConfigFactory.parseMap(
                 mapOf(
-                    "database.host" to dbConfig.host,
-                    "database.port" to dbConfig.port,
-                    "database.name" to dbConfig.name,
-                    "database.schema" to dbConfig.schema,
-                    "database.connectionTimeout" to dbConfig.connectionTimeout,
-                    "database.idleTimeout" to dbConfig.idleTimeout,
-                    "database.keepaliveTime" to dbConfig.keepaliveTime,
-                    "database.maxLifetime" to dbConfig.maxLifetime,
-                    "database.maximumPoolSize" to dbConfig.maximumPoolSize,
-                    "database.minimumIdle" to dbConfig.minimumIdle,
-                    "database.sslMode" to dbConfig.sslMode,
-                    "database.sslCert" to dbConfig.sslCert,
-                    "database.sslKey" to dbConfig.sslKey,
-                    "database.sslRootCert" to dbConfig.sslRootCert,
-                    "database.initSqlStatement" to dbConfig.initSqlStatement,
+                    "database.host" to postgres.host,
+                    "database.port" to postgres.firstMappedPort,
+                    "database.name" to postgres.databaseName,
+                    "database.schema" to TEST_DB_SCHEMA,
+                    "database.connectionTimeout" to 30000,
+                    "database.idleTimeout" to 600000,
+                    "database.keepaliveTime" to 0,
+                    "database.maxLifetime" to 1800000,
+                    "database.maximumPoolSize" to 5,
+                    "database.minimumIdle" to 1,
+                    "database.sslMode" to "disable",
                     ConfigManager.CONFIG_MANAGER_SECTION to secretConfigMap
                 )
             )
-
-            val dataSource = mockk<DataSource>()
-            val database = mockk<Database>()
-            mockkStatic(::createDataSource)
-            mockkStatic(DataSource::connect)
-            every { createDataSource(dbConfig) } returns dataSource
-            every { dataSource.connect() } returns database
 
             val baseModule = module {
                 single { config }
                 single { ConfigManager.create(get()) }
             }
 
-            startKoin {
+            val app = startKoin {
                 modules(baseModule, databaseModule())
             }
 
-            try {
-                verify {
-                    createDataSource(dbConfig)
+            val db = app.koin.get<Database>()
+
+            shouldNotThrowAny {
+                transaction(db) {
+                    OrganizationsTable.insert {
+                        it[name] = "name"
+                        it[description] = "description"
+                    }
                 }
-            } finally {
-                stopKoin()
             }
         }
     }

--- a/dao/src/testFixtures/kotlin/DatabaseTestExtension.kt
+++ b/dao/src/testFixtures/kotlin/DatabaseTestExtension.kt
@@ -56,7 +56,7 @@ import org.testcontainers.postgresql.PostgreSQLContainer
  * see [this Kotest issue](https://github.com/kotest/kotest/issues/3555).
  */
 open class DatabaseTestExtension : BeforeSpecListener, AfterSpecListener, BeforeEachListener, AfterEachListener {
-    private val postgres = PostgreSQLContainer(Images.POSTGRES).apply {
+    internal val postgres = PostgreSQLContainer(Images.POSTGRES).apply {
         startupAttempts = 1
     }
 
@@ -91,7 +91,7 @@ open class DatabaseTestExtension : BeforeSpecListener, AfterSpecListener, Before
     }
 }
 
-private const val TEST_DB_SCHEMA = "ort_server_test"
+internal const val TEST_DB_SCHEMA = "ort_server_test"
 
 private fun clean(dataSource: DataSource) {
     Flyway(getTestFlywayConfig(dataSource)).clean()


### PR DESCRIPTION
Previously, the `DatabaseTest` had two issues:

- It was only implicitly validated that the `DataSourceConfig` was parsed correctly from the `ConfigManager` by using it as an argument in `mockk` calls. If there was an error with parsing the config, the resulting test error would not have pointed directly to the issue.
- The test only verified that the `createDatabaseConfig` function was called by mocking it, not that it worked correctly and that its return value was actually used for anything.

To improve this, split this test into two separate tests:
- `DataSourceConfigTest` to validate that parsing the config from the `ConfigManager` works correctly.
- `DatabaseTest` to actually verify that a working database is created without mocking anything.