### PR TITLE
test(dao): Use the Kotest Koin extension

### DIFF
--- a/dao/build.gradle.kts
+++ b/dao/build.gradle.kts
@@ -59,7 +59,9 @@ dependencies {
 
     testImplementation(testFixtures(projects.config.configSpi))
 
+    testImplementation(libs.koin.test)
     testImplementation(libs.kotest.assertions.core)
+    testImplementation(libs.kotest.extensions.koin)
     testImplementation(libs.kotest.runner.junit5)
     testImplementation(libs.mockk)
     testImplementation(libs.testContainers.postgresql)

--- a/dao/src/test/kotlin/DatabaseTest.kt
+++ b/dao/src/test/kotlin/DatabaseTest.kt
@@ -23,6 +23,7 @@ import com.typesafe.config.ConfigFactory
 
 import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.koin.KoinExtension
 
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.config.ConfigSecretProviderFactoryForTesting
@@ -35,69 +36,67 @@ import org.jetbrains.exposed.v1.jdbc.Database
 import org.jetbrains.exposed.v1.jdbc.insert
 import org.jetbrains.exposed.v1.jdbc.transactions.transaction
 
-import org.koin.core.context.startKoin
-import org.koin.core.context.stopKoin
 import org.koin.dsl.module
+import org.koin.test.KoinTest
+import org.koin.test.inject
 
-class DatabaseTest : WordSpec({
-    tags(Integration)
+val testModule = module {
+    includes(databaseModule(startEager = false))
 
-    val dbExtension = extension(DatabaseTestExtension())
+    single { ConfigManager.create(get()) }
+}
 
-    afterEach {
-        stopKoin()
-    }
+class DatabaseTest : KoinTest, WordSpec() {
+    init {
+        tags(Integration)
 
-    "databaseModule" should {
-        "add a working database to the Koin context" {
-            val postgres = dbExtension.postgres
+        val dbExtension = extension(DatabaseTestExtension())
+        extension(KoinExtension(testModule))
 
-            val secretsMap = mapOf(
-                "database.username" to postgres.username,
-                "database.password" to postgres.password
-            )
+        "databaseModule" should {
+            "add a working database to the Koin context" {
+                val postgres = dbExtension.postgres
 
-            val secretConfigMap = mapOf(
-                ConfigManager.SECRET_PROVIDER_NAME_PROPERTY to ConfigSecretProviderFactoryForTesting.NAME,
-                ConfigSecretProviderFactoryForTesting.SECRETS_PROPERTY to secretsMap
-            )
-
-            val config = ConfigFactory.parseMap(
-                mapOf(
-                    "database.host" to postgres.host,
-                    "database.port" to postgres.firstMappedPort,
-                    "database.name" to postgres.databaseName,
-                    "database.schema" to TEST_DB_SCHEMA,
-                    "database.connectionTimeout" to 30000,
-                    "database.idleTimeout" to 600000,
-                    "database.keepaliveTime" to 0,
-                    "database.maxLifetime" to 1800000,
-                    "database.maximumPoolSize" to 5,
-                    "database.minimumIdle" to 1,
-                    "database.sslMode" to "disable",
-                    ConfigManager.CONFIG_MANAGER_SECTION to secretConfigMap
+                val secretsMap = mapOf(
+                    "database.username" to postgres.username,
+                    "database.password" to postgres.password
                 )
-            )
 
-            val baseModule = module {
-                single { config }
-                single { ConfigManager.create(get()) }
-            }
+                val secretConfigMap = mapOf(
+                    ConfigManager.SECRET_PROVIDER_NAME_PROPERTY to ConfigSecretProviderFactoryForTesting.NAME,
+                    ConfigSecretProviderFactoryForTesting.SECRETS_PROPERTY to secretsMap
+                )
 
-            val app = startKoin {
-                modules(baseModule, databaseModule())
-            }
+                val config = ConfigFactory.parseMap(
+                    mapOf(
+                        "database.host" to postgres.host,
+                        "database.port" to postgres.firstMappedPort,
+                        "database.name" to postgres.databaseName,
+                        "database.schema" to TEST_DB_SCHEMA,
+                        "database.connectionTimeout" to 30000,
+                        "database.idleTimeout" to 600000,
+                        "database.keepaliveTime" to 0,
+                        "database.maxLifetime" to 1800000,
+                        "database.maximumPoolSize" to 5,
+                        "database.minimumIdle" to 1,
+                        "database.sslMode" to "disable",
+                        ConfigManager.CONFIG_MANAGER_SECTION to secretConfigMap
+                    )
+                )
 
-            val db = app.koin.get<Database>()
+                getKoin().declare(config)
 
-            shouldNotThrowAny {
-                transaction(db) {
-                    OrganizationsTable.insert {
-                        it[name] = "name"
-                        it[description] = "description"
+                val db by inject<Database>()
+
+                shouldNotThrowAny {
+                    transaction(db) {
+                        OrganizationsTable.insert {
+                            it[name] = "name"
+                            it[description] = "description"
+                        }
                     }
                 }
             }
         }
     }
-})
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -109,6 +109,7 @@ konform = { module = "io.konform:konform", version.ref = "konform" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
 kotest-assertions-ktor = { module = "io.kotest.extensions:kotest-assertions-ktor", version.ref = "kotestAssertionsKtor" }
 kotest-assertions-table = { module = "io.kotest:kotest-assertions-table", version.ref = "kotest" }
+kotest-extensions-koin = { module = "io.kotest:kotest-extensions-koin", version.ref = "kotest" }
 kotest-extensions-testcontainers = { module = "io.kotest:kotest-extensions-testcontainers", version.ref = "kotest" }
 kotest-framework-engine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
 kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }


### PR DESCRIPTION
Migrate `DatabaseTest` to use Kotest's Koin extension [1]. To be able to use the helper functions of the `KoinTest` interface, the test code has to be moved to the init function.

[1]: https://kotest.io/docs/extensions/koin.html