### PR TITLE
fix(ui): Sort packages/vulnerabilities search tables by package identifier

### DIFF
--- a/ui/src/helpers/identifier-conversion.ts
+++ b/ui/src/helpers/identifier-conversion.ts
@@ -20,6 +20,7 @@
 import { PackageURL } from 'packageurl-js';
 
 import { Identifier } from '@/api';
+import type { PackageIdType } from '@/schemas';
 
 export function identifierToPurl(pkg: Identifier | undefined | null): string {
   if (!pkg) {
@@ -35,4 +36,34 @@ export function identifierToString(pkg: Identifier | undefined | null): string {
   }
   const { type, namespace, name, version } = pkg;
   return `${type}:${namespace}:${name}:${version}`;
+}
+
+type PackageIdentifier = {
+  packageId?: Identifier | null;
+  purl?: string | null;
+};
+
+/** Return the package identifier matching the configured display format. */
+export function getPackageIdString(
+  pkg: PackageIdentifier,
+  packageIdType: PackageIdType
+): string {
+  return packageIdType === 'PURL'
+    ? (pkg.purl ?? '')
+    : identifierToString(pkg.packageId);
+}
+
+/** Compare packages by the identifiers displayed in package columns. */
+export function comparePackageIds(
+  pkgA: PackageIdentifier,
+  pkgB: PackageIdentifier,
+  packageIdType: PackageIdType
+): number {
+  const idA = getPackageIdString(pkgA, packageIdType);
+  const idB = getPackageIdString(pkgB, packageIdType);
+
+  return idA.localeCompare(idB, undefined, {
+    numeric: true,
+    sensitivity: 'base',
+  });
 }

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/search-package/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/search-package/index.tsx
@@ -40,7 +40,10 @@ import {
   EMPTY_SORTING_STATE,
   updateColumnSorting,
 } from '@/helpers/handle-multisort';
-import { identifierToString } from '@/helpers/identifier-conversion';
+import {
+  comparePackageIds,
+  getPackageIdString,
+} from '@/helpers/identifier-conversion';
 import {
   createAppColumnHelper,
   selectNoTableState,
@@ -98,13 +101,13 @@ function SearchPackageComponent() {
         );
       },
     }),
-    columnHelper.accessor('packageId', {
+    columnHelper.accessor((row) => getPackageIdString(row, packageIdType), {
+      id: 'packageId',
       header: 'Matching Package',
+      sortFn: (rowA, rowB) =>
+        comparePackageIds(rowA.original, rowB.original, packageIdType),
       cell: function CellComponent({ row }) {
-        const id =
-          packageIdType === 'PURL'
-            ? row.original.purl
-            : identifierToString(row.original.packageId);
+        const id = getPackageIdString(row.original, packageIdType);
         return (
           <Link
             className='font-semibold text-blue-400 hover:underline'
@@ -116,11 +119,11 @@ function SearchPackageComponent() {
               runIndex: row.original.ortRunIndex.toString(),
             }}
             search={{
-              pkgId: id ?? undefined,
+              pkgId: id || undefined,
               marked: '0',
             }}
           >
-            <BreakableString text={id ?? ''} />
+            <BreakableString text={id} />
           </Link>
         );
       },

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/search-vulnerability/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/search-vulnerability/index.tsx
@@ -40,7 +40,10 @@ import {
   EMPTY_SORTING_STATE,
   updateColumnSorting,
 } from '@/helpers/handle-multisort';
-import { identifierToString } from '@/helpers/identifier-conversion';
+import {
+  comparePackageIds,
+  getPackageIdString,
+} from '@/helpers/identifier-conversion';
 import {
   createAppColumnHelper,
   selectNoTableState,
@@ -98,23 +101,20 @@ function SearchVulnerabilityComponent() {
         );
       },
     }),
-    columnHelper.accessor('packageId', {
+    columnHelper.accessor((row) => getPackageIdString(row, packageIdType), {
+      id: 'packageId',
       header: 'Package',
+      sortFn: (rowA, rowB) =>
+        comparePackageIds(rowA.original, rowB.original, packageIdType),
       cell: function CellComponent({ row }) {
-        const id =
-          packageIdType === 'PURL'
-            ? row.original.purl
-            : identifierToString(row.original.packageId);
-        return <BreakableString text={id ?? ''} />;
+        const id = getPackageIdString(row.original, packageIdType);
+        return <BreakableString text={id} />;
       },
     }),
     columnHelper.accessor('externalId', {
       header: 'Vulnerability',
       cell: function CellComponent({ row }) {
-        const id =
-          packageIdType === 'PURL'
-            ? row.original.purl
-            : identifierToString(row.original.packageId);
+        const id = getPackageIdString(row.original, packageIdType);
         return (
           <Link
             className='font-semibold text-blue-400 hover:underline'
@@ -126,7 +126,7 @@ function SearchVulnerabilityComponent() {
               runIndex: row.original.ortRunIndex.toString(),
             }}
             search={{
-              pkgId: id ?? undefined,
+              pkgId: id || undefined,
               externalId: row.original.externalId,
             }}
           >

--- a/ui/src/routes/organizations/$orgId/products/$productId/search-package/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/search-package/index.tsx
@@ -43,7 +43,10 @@ import {
   EMPTY_SORTING_STATE,
   updateColumnSorting,
 } from '@/helpers/handle-multisort';
-import { identifierToString } from '@/helpers/identifier-conversion';
+import {
+  comparePackageIds,
+  getPackageIdString,
+} from '@/helpers/identifier-conversion';
 import {
   createAppColumnHelper,
   selectNoTableState,
@@ -129,13 +132,13 @@ function SearchPackageComponent() {
         );
       },
     }),
-    columnHelper.accessor('packageId', {
+    columnHelper.accessor((row) => getPackageIdString(row, packageIdType), {
+      id: 'packageId',
       header: 'Matching Package',
+      sortFn: (rowA, rowB) =>
+        comparePackageIds(rowA.original, rowB.original, packageIdType),
       cell: function CellComponent({ row }) {
-        const id =
-          packageIdType === 'PURL'
-            ? row.original.purl
-            : identifierToString(row.original.packageId);
+        const id = getPackageIdString(row.original, packageIdType);
         return (
           <Link
             className='font-semibold text-blue-400 hover:underline'
@@ -147,11 +150,11 @@ function SearchPackageComponent() {
               runIndex: row.original.ortRunIndex.toString(),
             }}
             search={{
-              pkgId: id ?? undefined,
+              pkgId: id || undefined,
               marked: '0',
             }}
           >
-            <BreakableString text={id ?? ''} />
+            <BreakableString text={id} />
           </Link>
         );
       },

--- a/ui/src/routes/organizations/$orgId/products/$productId/search-vulnerability/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/search-vulnerability/index.tsx
@@ -43,7 +43,10 @@ import {
   EMPTY_SORTING_STATE,
   updateColumnSorting,
 } from '@/helpers/handle-multisort';
-import { identifierToString } from '@/helpers/identifier-conversion';
+import {
+  comparePackageIds,
+  getPackageIdString,
+} from '@/helpers/identifier-conversion';
 import {
   createAppColumnHelper,
   selectNoTableState,
@@ -129,23 +132,20 @@ function SearchVulnerabilityComponent() {
         );
       },
     }),
-    columnHelper.accessor('packageId', {
+    columnHelper.accessor((row) => getPackageIdString(row, packageIdType), {
+      id: 'packageId',
       header: 'Package',
+      sortFn: (rowA, rowB) =>
+        comparePackageIds(rowA.original, rowB.original, packageIdType),
       cell: function CellComponent({ row }) {
-        const id =
-          packageIdType === 'PURL'
-            ? row.original.purl
-            : identifierToString(row.original.packageId);
-        return <BreakableString text={id ?? ''} />;
+        const id = getPackageIdString(row.original, packageIdType);
+        return <BreakableString text={id} />;
       },
     }),
     columnHelper.accessor('externalId', {
       header: 'Vulnerability',
       cell: function CellComponent({ row }) {
-        const id =
-          packageIdType === 'PURL'
-            ? row.original.purl
-            : identifierToString(row.original.packageId);
+        const id = getPackageIdString(row.original, packageIdType);
         return (
           <Link
             className='font-semibold text-blue-400 hover:underline'
@@ -157,7 +157,7 @@ function SearchVulnerabilityComponent() {
               runIndex: row.original.ortRunIndex.toString(),
             }}
             search={{
-              pkgId: id ?? undefined,
+              pkgId: id || undefined,
               externalId: row.original.externalId,
             }}
           >

--- a/ui/src/routes/organizations/$orgId/search-package/index.tsx
+++ b/ui/src/routes/organizations/$orgId/search-package/index.tsx
@@ -44,7 +44,10 @@ import {
   EMPTY_SORTING_STATE,
   updateColumnSorting,
 } from '@/helpers/handle-multisort';
-import { identifierToString } from '@/helpers/identifier-conversion';
+import {
+  comparePackageIds,
+  getPackageIdString,
+} from '@/helpers/identifier-conversion';
 import {
   createAppColumnHelper,
   selectNoTableState,
@@ -155,13 +158,13 @@ function SearchPackageComponent() {
         );
       },
     }),
-    columnHelper.accessor('packageId', {
+    columnHelper.accessor((row) => getPackageIdString(row, packageIdType), {
+      id: 'packageId',
       header: 'Matching Package',
+      sortFn: (rowA, rowB) =>
+        comparePackageIds(rowA.original, rowB.original, packageIdType),
       cell: function CellComponent({ row }) {
-        const id =
-          packageIdType === 'PURL'
-            ? row.original.purl
-            : identifierToString(row.original.packageId);
+        const id = getPackageIdString(row.original, packageIdType);
         return (
           <Link
             className='font-semibold text-blue-400 hover:underline'
@@ -173,11 +176,11 @@ function SearchPackageComponent() {
               runIndex: row.original.ortRunIndex.toString(),
             }}
             search={{
-              pkgId: id ?? undefined,
+              pkgId: id || undefined,
               marked: '0',
             }}
           >
-            <BreakableString text={id ?? ''} />
+            <BreakableString text={id} />
           </Link>
         );
       },

--- a/ui/src/routes/organizations/$orgId/search-vulnerability/index.tsx
+++ b/ui/src/routes/organizations/$orgId/search-vulnerability/index.tsx
@@ -44,7 +44,10 @@ import {
   EMPTY_SORTING_STATE,
   updateColumnSorting,
 } from '@/helpers/handle-multisort';
-import { identifierToString } from '@/helpers/identifier-conversion';
+import {
+  comparePackageIds,
+  getPackageIdString,
+} from '@/helpers/identifier-conversion';
 import {
   createAppColumnHelper,
   selectNoTableState,
@@ -158,23 +161,20 @@ function SearchVulnerabilityComponent() {
         );
       },
     }),
-    columnHelper.accessor('packageId', {
+    columnHelper.accessor((row) => getPackageIdString(row, packageIdType), {
+      id: 'packageId',
       header: 'Package',
+      sortFn: (rowA, rowB) =>
+        comparePackageIds(rowA.original, rowB.original, packageIdType),
       cell: function CellComponent({ row }) {
-        const id =
-          packageIdType === 'PURL'
-            ? row.original.purl
-            : identifierToString(row.original.packageId);
-        return <BreakableString text={id ?? ''} />;
+        const id = getPackageIdString(row.original, packageIdType);
+        return <BreakableString text={id} />;
       },
     }),
     columnHelper.accessor('externalId', {
       header: 'Vulnerability',
       cell: function CellComponent({ row }) {
-        const id =
-          packageIdType === 'PURL'
-            ? row.original.purl
-            : identifierToString(row.original.packageId);
+        const id = getPackageIdString(row.original, packageIdType);
         return (
           <Link
             className='font-semibold text-blue-400 hover:underline'
@@ -186,7 +186,7 @@ function SearchVulnerabilityComponent() {
               runIndex: row.original.ortRunIndex.toString(),
             }}
             search={{
-              pkgId: id ?? undefined,
+              pkgId: id || undefined,
               externalId: row.original.externalId,
             }}
           >

--- a/ui/tests/unit/logic/identifier-conversion.test.ts
+++ b/ui/tests/unit/logic/identifier-conversion.test.ts
@@ -20,6 +20,8 @@
 import { expect, it } from 'vitest';
 
 import {
+  comparePackageIds,
+  getPackageIdString,
   identifierToPurl,
   identifierToString,
 } from '@/helpers/identifier-conversion';
@@ -41,4 +43,35 @@ it('identifierToString', () => {
   expect(identifierToString(id)).toBe(
     'Maven:com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava'
   );
+});
+
+it('getPackageIdString returns the configured identifier type', () => {
+  const pkg = {
+    packageId: id,
+    purl: 'pkg:maven/com.google.guava/listenablefuture@9999.0',
+  };
+
+  expect(getPackageIdString(pkg, 'ORT_ID')).toBe(
+    'Maven:com.google.guava:listenablefuture:9999.0-empty-to-avoid-conflict-with-guava'
+  );
+  expect(getPackageIdString(pkg, 'PURL')).toBe(
+    'pkg:maven/com.google.guava/listenablefuture@9999.0'
+  );
+});
+
+it.each([
+  [
+    'ORT_ID' as const,
+    { packageId: { ...id, version: '2' }, purl: null },
+    { packageId: { ...id, version: '10' }, purl: null },
+  ],
+  [
+    'PURL' as const,
+    { packageId: null, purl: 'pkg:maven/example/pkg@2' },
+    { packageId: null, purl: 'pkg:maven/example/pkg@10' },
+  ],
+])('comparePackageIds naturally sorts %s values', (packageIdType, two, ten) => {
+  expect(comparePackageIds(two, ten, packageIdType)).toBeLessThan(0);
+  expect(comparePackageIds(ten, two, packageIdType)).toBeGreaterThan(0);
+  expect(comparePackageIds(two, two, packageIdType)).toBe(0);
 });

--- a/ui/tests/unit/logic/use-app-table.test.ts
+++ b/ui/tests/unit/logic/use-app-table.test.ts
@@ -17,9 +17,16 @@
  * License-Filename: LICENSE
  */
 
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
 import { expect, it } from 'vitest';
 
-import { appTableFeatures } from '@/hooks/use-app-table';
+import {
+  appTableFeatures,
+  selectNoTableState,
+  useAppTable,
+  type AppColumnDef,
+} from '@/hooks/use-app-table';
 
 it('registers only the required table features and row models', () => {
   expect(Object.keys(appTableFeatures).sort()).toEqual([
@@ -33,4 +40,42 @@ it('registers only the required table features and row models', () => {
     'rowSortingFeature',
     'sortedRowModel',
   ]);
+});
+
+it('sorts client-side rows by a controlled string accessor', () => {
+  type PackageRow = { packageId: string };
+
+  const data: PackageRow[] = [
+    { packageId: 'pkg:z' },
+    { packageId: 'pkg:a' },
+    { packageId: 'pkg:m' },
+  ];
+  const columns: AppColumnDef<PackageRow>[] = [{ accessorKey: 'packageId' }];
+  let sortedPackageIds: string[] = [];
+
+  function TestTable() {
+    const table = useAppTable(
+      {
+        data,
+        columns,
+        state: {
+          pagination: { pageIndex: 0, pageSize: 10 },
+          sorting: [{ id: 'packageId', desc: false }],
+        },
+        manualPagination: false,
+        manualSorting: false,
+      },
+      selectNoTableState
+    );
+
+    sortedPackageIds = table
+      .getRowModel()
+      .rows.map((row) => row.original.packageId);
+
+    return null;
+  }
+
+  renderToStaticMarkup(createElement(TestTable));
+
+  expect(sortedPackageIds).toEqual(['pkg:a', 'pkg:m', 'pkg:z']);
 });


### PR DESCRIPTION
This PR fixes sorting by package identifier in package/vulnerability search tables (it has probably been broken from the beginning).

There are seven other UI tables which duplicate the same PURL vs. ORT ID selection, but they already use primitive string accessors, so they don't have the same sorting bug. This PR won't touch those tables. For future note, if it is decided they also should be refactored for slight code alignment, here's the list of the tables:
- All three vulnerability tables
- ORT run's packages, issues, rule violations, and detected-license packages

Please see the commits for details.

