### PR TITLE
ui: Add tests for create run form, plugin options form, and some table components

### DIFF
--- a/ui/tests/unit/components/create-run-job-fields.test.tsx
+++ b/ui/tests/unit/components/create-run-job-fields.test.tsx
@@ -1,0 +1,193 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import type { ReactNode } from 'react';
+import type { UseFormReturn } from 'react-hook-form';
+import { describe, expect, it } from 'vitest';
+
+import {
+  defaultValues,
+  type CreateRunFormValues,
+} from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components';
+import {
+  AdvisorFields,
+  EvaluatorFields,
+  NotifierFields,
+  ReporterFields,
+  ScannerFields,
+} from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components';
+import {
+  createPluginDescriptor,
+  createPluginSecrets,
+} from '../fixtures/create-run';
+import { renderWithForm } from '../fixtures/form-harness';
+
+const advisorPlugins = [
+  createPluginDescriptor({
+    id: 'OSV',
+    type: 'ADVISOR',
+    displayName: 'OSV',
+  }),
+];
+const scannerPlugins = [
+  createPluginDescriptor({
+    id: 'ScanCode',
+    type: 'SCANNER',
+    displayName: 'ScanCode',
+  }),
+];
+const reporterPlugins = ['CycloneDX', 'SpdxDocument', 'WebApp'].map((id) =>
+  createPluginDescriptor({ id, type: 'REPORTER', displayName: id })
+);
+const packageConfigurationProviderPlugins = [
+  createPluginDescriptor({
+    id: 'OrtConfig',
+    type: 'PACKAGE_CONFIGURATION_PROVIDER',
+    displayName: 'ORT configuration',
+  }),
+];
+const secrets = createPluginSecrets();
+const formDefaultValues = defaultValues(
+  null,
+  advisorPlugins,
+  scannerPlugins,
+  true,
+  [],
+  packageConfigurationProviderPlugins
+);
+const onToggle = () => {};
+
+type JobFieldsTestCase = {
+  name: string;
+  sectionValue: string;
+  trigger: string;
+  contentLabel: string;
+  render: (form: UseFormReturn<CreateRunFormValues>) => ReactNode;
+};
+
+const testCases: JobFieldsTestCase[] = [
+  {
+    name: 'advisor',
+    sectionValue: 'advisor',
+    trigger: 'Advisor',
+    contentLabel: 'Skip excluded',
+    render: (form) => (
+      <AdvisorFields
+        form={form}
+        value='advisor'
+        onToggle={onToggle}
+        advisorPlugins={advisorPlugins}
+        secrets={secrets}
+        isSuperuser
+      />
+    ),
+  },
+  {
+    name: 'evaluator',
+    sectionValue: 'evaluator',
+    trigger: 'Evaluator',
+    contentLabel: 'Package configuration providers',
+    render: (form) => (
+      <EvaluatorFields
+        form={form}
+        value='evaluator'
+        onToggle={onToggle}
+        isSuperuser
+        packageConfigurationProviderPlugins={
+          packageConfigurationProviderPlugins
+        }
+        secrets={secrets}
+        isRerun={false}
+      />
+    ),
+  },
+  {
+    name: 'notifier',
+    sectionValue: 'notifier',
+    trigger: 'Notifier',
+    contentLabel: 'Recipient addresses',
+    render: (form) => (
+      <NotifierFields
+        form={form}
+        value='notifier'
+        onToggle={onToggle}
+        isSuperuser
+      />
+    ),
+  },
+  {
+    name: 'reporter',
+    sectionValue: 'reporter',
+    trigger: 'Reporter',
+    contentLabel: 'Report formats',
+    render: (form) => (
+      <ReporterFields
+        form={form}
+        value='reporter'
+        onToggle={onToggle}
+        reporterPlugins={reporterPlugins}
+        isSuperuser
+        packageConfigurationProviderPlugins={
+          packageConfigurationProviderPlugins
+        }
+        secrets={secrets}
+        isRerun={false}
+      />
+    ),
+  },
+  {
+    name: 'scanner',
+    sectionValue: 'scanner',
+    trigger: 'Scanner',
+    contentLabel: 'Skip concluded',
+    render: (form) => (
+      <ScannerFields
+        form={form}
+        value='scanner'
+        onToggle={onToggle}
+        scannerPlugins={scannerPlugins}
+        secrets={secrets}
+        isSuperuser
+      />
+    ),
+  },
+];
+
+describe('create run job fields', () => {
+  it.each(testCases)(
+    'renders the $name controls inside an open accordion',
+    ({ sectionValue, trigger, contentLabel, render }) => {
+      const markup = renderWithForm(render, {
+        defaultValues: formDefaultValues,
+        openAccordion: sectionValue,
+      });
+
+      const triggerIndex = markup.indexOf(`>${trigger}<`);
+      const switchIndexes = [...markup.matchAll(/role="switch"/g)].map(
+        (match) => match.index
+      );
+
+      expect(triggerIndex).toBeGreaterThan(-1);
+      expect(markup).toContain('data-state="open"');
+      expect(markup).toContain(contentLabel);
+      expect(switchIndexes.some((index) => index < triggerIndex)).toBe(true);
+      expect(switchIndexes.some((index) => index > triggerIndex)).toBe(true);
+    }
+  );
+});

--- a/ui/tests/unit/components/data-table-cards.test.tsx
+++ b/ui/tests/unit/components/data-table-cards.test.tsx
@@ -1,0 +1,181 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import type { LinkOptions } from '@tanstack/react-router';
+import type { SortingState } from '@tanstack/react-table';
+import type { ReactNode } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { DataTableCardsHeader } from '@/components/data-table-cards/data-table-cards-header';
+import { DataTableCardsSort } from '@/components/data-table-cards/data-table-cards-sort';
+import {
+  selectNoTableState,
+  useAppTable,
+  type AppColumnDef,
+  type AppReactTable,
+} from '@/hooks/use-app-table';
+
+type TestRow = {
+  filter: string;
+  sort: string;
+};
+
+type TableHarnessOptions = {
+  columns: AppColumnDef<TestRow>[];
+  columnVisibility: Record<string, boolean>;
+  sorting: SortingState | undefined;
+};
+
+const data: TestRow[] = [{ filter: 'filter value', sort: 'sort value' }];
+
+const hiddenFilterColumn: AppColumnDef<TestRow> = {
+  accessorKey: 'filter',
+  header: 'Hidden filter',
+  enableSorting: false,
+  meta: {
+    filter: {
+      filterVariant: 'text',
+      setFilterValue: () => {},
+    },
+  },
+};
+
+const hiddenSortColumn: AppColumnDef<TestRow> = {
+  accessorKey: 'sort',
+  header: 'Hidden sort',
+  enableColumnFilter: false,
+};
+
+const setSortingOptions = (): LinkOptions => ({ to: '/' });
+
+function renderWithTable(
+  children: (table: AppReactTable<TestRow>) => ReactNode,
+  { columns, columnVisibility, sorting }: TableHarnessOptions
+) {
+  function TableHarness() {
+    const table = useAppTable(
+      {
+        data,
+        columns,
+        state: {
+          columnVisibility,
+          sorting,
+        },
+      },
+      selectNoTableState
+    );
+
+    return children(table);
+  }
+
+  return renderToStaticMarkup(<TableHarness />);
+}
+
+describe('DataTableCardsHeader', () => {
+  it('renders hidden column filters and sorting controls', () => {
+    const markup = renderWithTable(
+      (table) => (
+        <DataTableCardsHeader
+          table={table}
+          setSortingOptions={setSortingOptions}
+        />
+      ),
+      {
+        columns: [hiddenFilterColumn, hiddenSortColumn],
+        columnVisibility: { filter: false, sort: false },
+        sorting: [],
+      }
+    );
+
+    expect(markup).toContain('Hidden filter');
+    expect(markup).toContain('>Sort<');
+  });
+});
+
+// Dropdown content stays closed during static rendering, so its real Link
+// descendants are not mounted and do not require a router or a Link mock.
+describe('DataTableCardsSort', () => {
+  it('renders nothing without sorting link options', () => {
+    const markup = renderWithTable(
+      (table) => <DataTableCardsSort table={table} />,
+      {
+        columns: [hiddenSortColumn],
+        columnVisibility: { sort: false },
+        sorting: [],
+      }
+    );
+
+    expect(markup).toBe('');
+  });
+
+  it('renders nothing without sortable hidden columns', () => {
+    const markup = renderWithTable(
+      (table) => (
+        <DataTableCardsSort
+          table={table}
+          setSortingOptions={setSortingOptions}
+        />
+      ),
+      {
+        columns: [hiddenFilterColumn],
+        columnVisibility: { filter: false },
+        sorting: [],
+      }
+    );
+
+    expect(markup).toBe('');
+  });
+
+  it('renders the sort trigger for a sortable hidden column', () => {
+    const markup = renderWithTable(
+      (table) => (
+        <DataTableCardsSort
+          table={table}
+          setSortingOptions={setSortingOptions}
+        />
+      ),
+      {
+        columns: [hiddenSortColumn],
+        columnVisibility: { sort: false },
+        sorting: [],
+      }
+    );
+
+    expect(markup).toContain('>Sort<');
+  });
+
+  it('renders with undefined sorting state', () => {
+    const markup = renderWithTable(
+      (table) => (
+        <DataTableCardsSort
+          table={table}
+          setSortingOptions={setSortingOptions}
+        />
+      ),
+      {
+        columns: [hiddenSortColumn],
+        columnVisibility: { sort: false },
+        sorting: undefined,
+      }
+    );
+
+    expect(markup).toContain('>Sort<');
+  });
+});

--- a/ui/tests/unit/components/environment-definition-fields.test.tsx
+++ b/ui/tests/unit/components/environment-definition-fields.test.tsx
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { ENVIRONMENT_DEFINITION_SCHEMAS } from '@/lib/environment-definition-fields';
+import { defaultValues } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components';
+import { PackageManagerField } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components';
+import { EnvironmentDefinitionsFields } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/environment-definitions';
+import { renderWithForm } from '../fixtures/form-harness';
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@tanstack/react-router')>();
+
+  return {
+    ...actual,
+    useParams: () => ({}),
+    useRouter: () => ({
+      options: {
+        context: {
+          permissions: {
+            organization: undefined,
+            product: undefined,
+            repository: undefined,
+          },
+        },
+      },
+    }),
+  };
+});
+
+vi.mock('@/hooks/use-infrastructure-services', () => ({
+  useInfrastructureServices: () => ({
+    items: [],
+    totalCount: 0,
+    isPending: false,
+    isError: false,
+    error: null,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: () => {},
+  }),
+}));
+
+const baseDefaultValues = defaultValues(null, [], [], false, [], []);
+const conanDefaultEntry = ENVIRONMENT_DEFINITION_SCHEMAS.find(
+  (schema) => schema.key === 'conan'
+)?.defaultEntries[0];
+
+if (!conanDefaultEntry) {
+  throw new Error('The Conan environment definition requires a default entry.');
+}
+
+const populatedDefaultValues = {
+  ...baseDefaultValues,
+  jobConfigs: {
+    ...baseDefaultValues.jobConfigs,
+    analyzer: {
+      ...baseDefaultValues.jobConfigs.analyzer,
+      environmentDefinitions: {
+        conan: [conanDefaultEntry],
+      },
+    },
+  },
+};
+
+const packageManagerDefaultValues = {
+  ...baseDefaultValues,
+  jobConfigs: {
+    ...baseDefaultValues.jobConfigs,
+    analyzer: {
+      ...baseDefaultValues.jobConfigs.analyzer,
+      packageManagers: {
+        ...baseDefaultValues.jobConfigs.analyzer.packageManagers,
+        Conan: {
+          ...baseDefaultValues.jobConfigs.analyzer.packageManagers.Conan,
+          options: [{ key: 'remote', value: 'central' }],
+        },
+      },
+    },
+  },
+};
+
+const renderEnvironmentDefinitions = (
+  defaultValues: typeof baseDefaultValues
+) =>
+  renderWithForm((form) => <EnvironmentDefinitionsFields form={form} />, {
+    defaultValues,
+  });
+
+describe('EnvironmentDefinitionsFields', () => {
+  it('renders an empty environment definition list', () => {
+    const markup = renderEnvironmentDefinitions(baseDefaultValues);
+
+    expect(markup).toContain('Environment configuration');
+    expect(markup).toContain('Add environment configuration');
+    expect(markup).not.toContain('>Package manager<');
+  });
+
+  it('binds the package manager label to the selector', () => {
+    const markup = renderEnvironmentDefinitions(populatedDefaultValues);
+    const selectorId = 'environment-definition-conan-0';
+
+    expect(markup).toContain('Conan #1');
+    expect(markup).toMatch(
+      new RegExp(`<label[^>]*for="${selectorId}"[^>]*>Package manager</label>`)
+    );
+    expect(markup).toMatch(new RegExp(`<button[^>]*id="${selectorId}"`));
+    expect(markup).toContain('Remote name');
+  });
+});
+
+describe('PackageManagerField', () => {
+  it('renders controls inside an open package manager accordion', () => {
+    const markup = renderWithForm(
+      (form) => <PackageManagerField form={form} />,
+      { defaultValues: packageManagerDefaultValues }
+    );
+
+    expect(markup).toContain('Enabled package managers');
+    expect(markup).toContain('data-state="open"');
+    expect(markup).toContain('Options:');
+    expect(markup).toContain('>Key<');
+    expect(markup).toContain('>Value<');
+    expect(markup).toContain('Must run after');
+  });
+});

--- a/ui/tests/unit/components/plugin-option-form-fields.test.tsx
+++ b/ui/tests/unit/components/plugin-option-form-fields.test.tsx
@@ -1,0 +1,156 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { renderToStaticMarkup } from 'react-dom/server';
+import {
+  FormProvider,
+  useForm,
+  type DefaultValues,
+  type FieldValues,
+} from 'react-hook-form';
+import { describe, expect, it } from 'vitest';
+
+import type { PluginOption, PluginOptionType } from '@/api';
+import { PluginOptionFormFields } from '@/routes/admin/plugins/$pluginType/$pluginId/-components/plugin-option-form-fields';
+
+function createPluginOption(
+  type: PluginOptionType,
+  overrides: Partial<PluginOption> = {}
+): PluginOption {
+  return {
+    name: `${type.toLowerCase()}Option`,
+    type,
+    description: `${type} option description`,
+    enumEntries:
+      type === 'ENUM' || type === 'ENUM_LIST' ? ['Alpha', 'Beta'] : undefined,
+    isNullable: false,
+    isRequired: true,
+    ...overrides,
+  };
+}
+
+function renderPluginOptions(
+  options: PluginOption[],
+  defaultValues: DefaultValues<FieldValues>
+) {
+  function FormHarness() {
+    const form = useForm<FieldValues>({ defaultValues });
+
+    return (
+      <FormProvider {...form}>
+        <PluginOptionFormFields options={options} form={form} />
+      </FormProvider>
+    );
+  }
+
+  return renderToStaticMarkup(<FormHarness />);
+}
+
+type OptionTestCase = {
+  type: PluginOptionType;
+  value: unknown;
+  overrides?: Partial<PluginOption>;
+  expectedMarkup: string;
+};
+
+const optionTestCases: OptionTestCase[] = [
+  {
+    type: 'BOOLEAN',
+    value: true,
+    expectedMarkup: 'role="switch"',
+  },
+  {
+    type: 'ENUM',
+    value: 'Alpha',
+    expectedMarkup: 'role="combobox"',
+  },
+  {
+    type: 'ENUM_LIST',
+    value: ['Alpha'],
+    expectedMarkup: 'cmdk-input=""',
+  },
+  {
+    type: 'INTEGER',
+    value: 7,
+    expectedMarkup: 'type="number"',
+  },
+  {
+    type: 'LONG',
+    value: 9,
+    expectedMarkup: 'type="number"',
+  },
+  {
+    type: 'SECRET',
+    value: 'secret-name',
+    overrides: { isRequired: false },
+    expectedMarkup: 'placeholder="(optional)"',
+  },
+  {
+    type: 'STRING',
+    value: 'text value',
+    expectedMarkup: 'type="text"',
+  },
+  {
+    type: 'STRING_LIST',
+    value: 'first,second',
+    overrides: { isRequired: false },
+    expectedMarkup: 'placeholder="(optional)"',
+  },
+];
+
+describe('PluginOptionFormFields', () => {
+  it.each(optionTestCases)(
+    'renders the control for a $type option',
+    ({ type, value, overrides, expectedMarkup }) => {
+      const option = createPluginOption(type, overrides);
+      const markup = renderPluginOptions([option], {
+        [option.name]: value,
+        [`${option.name}_isFinal`]: false,
+        [`${option.name}_isNotSet`]: false,
+      });
+
+      expect(markup).toContain(option.name);
+      expect(markup).toContain(type);
+      expect(markup).toContain(option.description);
+      expect(markup).toContain(expectedMarkup);
+      expect(markup).toContain('Final');
+      expect(markup).toContain('Undefined');
+
+      if (type === 'SECRET') {
+        expect(markup).toContain(
+          'This must be the name of a secret available in the config secret provider'
+        );
+      }
+    }
+  );
+
+  it('renders values and final state from an existing template', () => {
+    const option = createPluginOption('STRING', { name: 'existingOption' });
+    const markup = renderPluginOptions([option], {
+      existingOption: 'configured value',
+      existingOption_isFinal: true,
+      existingOption_isNotSet: false,
+    });
+
+    expect(markup).toContain('value="configured value"');
+    expect(markup).toContain('data-state="checked"');
+    expect(markup).toContain('Final');
+    expect(markup).toContain('Undefined');
+  });
+});

--- a/ui/tests/unit/fixtures/create-run.ts
+++ b/ui/tests/unit/fixtures/create-run.ts
@@ -17,7 +17,19 @@
  * License-Filename: LICENSE
  */
 
-import type { OrtRun, PreconfiguredPluginDescriptor } from '@/api';
+import type {
+  OrganizationPermission,
+  OrtRun,
+  PreconfiguredPluginDescriptor,
+  ProductPermission,
+  RepositoryPermission,
+  Secret,
+} from '@/api';
+import {
+  OrganizationPermissions,
+  ProductPermissions,
+  RepositoryPermissions,
+} from '@/lib/permissions';
 import type { DeepPartial } from './deep-partial';
 
 /**
@@ -25,16 +37,76 @@ import type { DeepPartial } from './deep-partial';
  * override only the fields they assert on (typically `id`, `type`, `options`).
  */
 export const createPluginDescriptor = (
-  overrides: Partial<PreconfiguredPluginDescriptor> = {}
-): PreconfiguredPluginDescriptor => ({
-  id: 'TestPlugin',
-  type: 'SCANNER',
-  displayName: 'Test Plugin',
-  summary: 'A test plugin.',
-  description: 'A test plugin.',
-  options: [],
-  ...overrides,
+  overrides: DeepPartial<PreconfiguredPluginDescriptor> = {}
+): PreconfiguredPluginDescriptor =>
+  ({
+    id: 'TestPlugin',
+    type: 'SCANNER',
+    displayName: 'Test Plugin',
+    summary: 'A test plugin.',
+    description: 'A test plugin.',
+    options: [],
+    ...overrides,
+  }) as PreconfiguredPluginDescriptor;
+
+/** Build the permission context expected by create-run field components. */
+export const createPermissions = (
+  overrides: DeepPartial<{
+    organization: {
+      id: number;
+      isSuperuser: boolean;
+      permissions: OrganizationPermission[];
+    };
+    product: {
+      id: number;
+      isSuperuser: boolean;
+      permissions: ProductPermission[];
+    };
+    repository: {
+      id: number;
+      isSuperuser: boolean;
+      permissions: RepositoryPermission[];
+    };
+  }> = {}
+) => ({
+  organization: new OrganizationPermissions(
+    overrides.organization?.id ?? 1,
+    overrides.organization?.isSuperuser ?? false,
+    overrides.organization?.permissions ?? []
+  ),
+  product: new ProductPermissions(
+    overrides.product?.id ?? 2,
+    overrides.product?.isSuperuser ?? false,
+    overrides.product?.permissions ?? []
+  ),
+  repository: new RepositoryPermissions(
+    overrides.repository?.id ?? 3,
+    overrides.repository?.isSuperuser ?? false,
+    overrides.repository?.permissions ?? []
+  ),
 });
+
+/** Build secrets offered to plugin option fields. */
+export const createPluginSecrets = (
+  overrides: DeepPartial<Secret>[] = [{}]
+): Secret[] =>
+  overrides.map((secret, index) => ({
+    name: secret.name ?? `test-secret-${index + 1}`,
+    description: secret.description,
+  }));
+
+/** Build package curation provider plugins for analyzer field tests. */
+export const createPackageCurationProviderPlugins = (
+  overrides: DeepPartial<PreconfiguredPluginDescriptor>[] = [{}]
+): PreconfiguredPluginDescriptor[] =>
+  overrides.map((plugin, index) =>
+    createPluginDescriptor({
+      id: `PackageCurationProvider${index + 1}`,
+      type: 'PACKAGE_CURATION_PROVIDER',
+      displayName: `Package Curation Provider ${index + 1}`,
+      ...plugin,
+    })
+  );
 
 /**
  * Builds a minimal {@link OrtRun} for tests that only read `revision`, `path`,

--- a/ui/tests/unit/fixtures/form-harness.tsx
+++ b/ui/tests/unit/fixtures/form-harness.tsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import type { ReactNode } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import {
+  FormProvider,
+  useForm,
+  type DefaultValues,
+  type UseFormReturn,
+} from 'react-hook-form';
+
+import { Accordion } from '@/components/ui/accordion';
+import type { CreateRunFormValues } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components';
+
+type FormHarnessOptions = {
+  defaultValues: DefaultValues<CreateRunFormValues>;
+  openAccordion?: string;
+};
+
+export function renderWithForm(
+  children: (form: UseFormReturn<CreateRunFormValues>) => ReactNode,
+  { defaultValues, openAccordion }: FormHarnessOptions
+) {
+  function FormHarness() {
+    const form = useForm<CreateRunFormValues>({ defaultValues });
+    const content = children(form);
+
+    return (
+      <FormProvider {...form}>
+        {openAccordion ? (
+          <Accordion type='multiple' defaultValue={[openAccordion]}>
+            {content}
+          </Accordion>
+        ) : (
+          content
+        )}
+      </FormProvider>
+    );
+  }
+
+  return renderToStaticMarkup(<FormHarness />);
+}


### PR DESCRIPTION
Use current test harness to add tests for some UI components that previously had no render test coverage, and which caused regressions (they needed quick hotfixing in #5684, #5686, and #5694).