### PR TITLE
test(transport): Stop SQS receivers after each test

### DIFF
--- a/transport/spi/src/testFixtures/kotlin/Utils.kt
+++ b/transport/spi/src/testFixtures/kotlin/Utils.kt
@@ -28,9 +28,11 @@ import java.util.concurrent.BlockingQueue
 import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.TimeUnit
 
-import kotlin.concurrent.thread
-
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.launch
 
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.model.orchestrator.OrchestratorMessage
@@ -64,13 +66,37 @@ fun createConfigManager(
 }
 
 /**
- * Start a receiver that is initialized from the given [configManager]. Since the receiver blocks, this has to be done
- * in a separate thread. Return a queue that can be polled to obtain the received messages.
+ * A handle to a receiver started via [startReceiver]. It acts as the [BlockingQueue] the received messages are put
+ * into, and additionally allows to [stop] the receiver again.
+ */
+class ReceiverHandle internal constructor(
+    private val job: Job,
+    queue: BlockingQueue<Message<OrchestratorMessage>>
+) : BlockingQueue<Message<OrchestratorMessage>> by queue {
+    /**
+     * Stop this receiver and wait until it has terminated. Tests that share a queue between test cases must do this
+     * at the end of each test case; otherwise the still running receiver of an already finished test case competes
+     * for the messages that are meant for the next test case.
+     *
+     * This requires a receiver that suspends while waiting for messages. That is the case for SQS, which checks
+     * `coroutineContext.isActive` in its receive loop, and for RabbitMQ, which collects a cancellable flow. It does
+     * not work for Artemis, whose receive loop does not check whether it is still active and blocks in a JMS
+     * `receive()` call that cannot be interrupted from the outside.
+     */
+    suspend fun stop() {
+        job.cancelAndJoin()
+    }
+}
+
+/**
+ * Start a receiver that is initialized from the given [configManager]. Since the receiver runs until it is stopped,
+ * this has to be done in a separate coroutine. Return a [ReceiverHandle] that can be polled to obtain the received
+ * messages and that allows to stop the receiver again.
  */
 fun startReceiver(
     configManager: ConfigManager,
     result: EndpointHandlerResult = EndpointHandlerResult.CONTINUE
-): LinkedBlockingQueue<Message<OrchestratorMessage>> {
+): ReceiverHandle {
     val queue = LinkedBlockingQueue<Message<OrchestratorMessage>>()
 
     fun handler(message: Message<OrchestratorMessage>): EndpointHandlerResult {
@@ -78,14 +104,11 @@ fun startReceiver(
         return result
     }
 
-    thread {
-        @Suppress("ForbiddenMethodCall")
-        runBlocking {
-            MessageReceiverFactory.createReceiver(OrchestratorEndpoint, configManager, ::handler)
-        }
+    val job = CoroutineScope(Dispatchers.IO).launch {
+        MessageReceiverFactory.createReceiver(OrchestratorEndpoint, configManager, ::handler)
     }
 
-    return queue
+    return ReceiverHandle(job, queue)
 }
 
 /**

--- a/transport/sqs/src/test/kotlin/SqsMessageReceiverFactoryTest.kt
+++ b/transport/sqs/src/test/kotlin/SqsMessageReceiverFactoryTest.kt
@@ -38,6 +38,7 @@ import org.eclipse.apoapsis.ortserver.model.orchestrator.OrchestratorMessage
 import org.eclipse.apoapsis.ortserver.transport.EndpointHandlerResult
 import org.eclipse.apoapsis.ortserver.transport.MessageHeader
 import org.eclipse.apoapsis.ortserver.transport.json.JsonSerializer
+import org.eclipse.apoapsis.ortserver.transport.testing.ReceiverHandle
 import org.eclipse.apoapsis.ortserver.transport.testing.TEST_QUEUE_NAME
 import org.eclipse.apoapsis.ortserver.transport.testing.checkMessage
 import org.eclipse.apoapsis.ortserver.transport.testing.startReceiver
@@ -63,17 +64,33 @@ class SqsMessageReceiverFactoryTest : StringSpec({
         client.sendMessage(request)
     }
 
+    // All tests use the same queue name, so a receiver that is still running after its test has finished competes
+    // for the messages of the following tests. Keep track of the started receivers to be able to stop them again.
+    val receivers = mutableListOf<ReceiverHandle>()
+
+    fun startTestReceiver(result: EndpointHandlerResult = EndpointHandlerResult.CONTINUE) =
+        startReceiver(configManager, result).also { receivers += it }
+
     beforeTest {
         client.createQueue(CreateQueueRequest { queueName = TEST_QUEUE_NAME })
         queueResponse = client.getQueueUrl(GetQueueUrlRequest { queueName = TEST_QUEUE_NAME })
     }
 
     afterTest {
+        // Stopping the receivers is what isolates the tests from each other. Deleting and recreating the queue does
+        // not achieve this, because the recreated queue has the same name and therefore the same URL, so a receiver
+        // that is still running simply continues to poll it.
+        receivers.forEach { receiver -> receiver.stop() }
+        receivers.clear()
+
+        // Deleting the queue is still needed to discard messages that no test has consumed. Stopping a receiver can
+        // leave behind a message that SQS has already handed out, but that was neither processed nor deleted. Such a
+        // message becomes visible again after the visibility timeout and would then show up in a later test.
         client.deleteQueue(DeleteQueueRequest { this.queueUrl = queueResponse.queueUrl })
     }
 
     "Messages can be received via the SQS transport" {
-        val messageQueue = startReceiver(configManager)
+        val messageQueue = startTestReceiver()
 
         val traceId1 = "trace1"
         val ortRunId1 = 1L
@@ -91,7 +108,7 @@ class SqsMessageReceiverFactoryTest : StringSpec({
     }
 
     "Exceptions during message receiving are handled" {
-        val messageQueue = startReceiver(configManager)
+        val messageQueue = startTestReceiver()
 
         val traceId = "validTraceId"
         val ortRunId = 10L
@@ -104,7 +121,7 @@ class SqsMessageReceiverFactoryTest : StringSpec({
     }
 
     "Messages can have empty trace IDs" {
-        val messageQueue = startReceiver(configManager)
+        val messageQueue = startTestReceiver()
 
         val traceId = EMPTY_VALUE
         val ortRunId = 10L
@@ -116,7 +133,7 @@ class SqsMessageReceiverFactoryTest : StringSpec({
     }
 
     "Message receiving is stopped when the handler returns STOP" {
-        val messageQueue = startReceiver(configManager, EndpointHandlerResult.STOP)
+        val messageQueue = startTestReceiver(EndpointHandlerResult.STOP)
 
         val traceId1 = "trace1"
         val ortRunId1 = 1L


### PR DESCRIPTION
The SQS receiver tests share one queue, and every test started a receiver that was never stopped again. A leftover receiver could pick up a message meant for a later test and put it into its own abandoned queue. The message was then gone from SQS, and the waiting test failed on a timeout. This made the `test` job in `build-and-test.yml` fail often, usually passing on a rerun, in essence making the test task very flaky.

`startReceiver` now returns a `ReceiverHandle` that still behaves like the `BlockingQueue` holding the received messages, but also offers a `stop` function. The SQS test stops the receivers it started in `afterTest`, before the queue is deleted.

Bug was reproduced with 4/10 runs failing before the fix, and 0/25 after the fix.