### PR TITLE
feat(analyzer)!: Allow overriding of the repository configuration

### DIFF
--- a/workers/analyzer/src/main/kotlin/AnalyzerRunner.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerRunner.kt
@@ -39,6 +39,7 @@ import org.ossreviewtoolkit.analyzer.determineEnabledPackageManagers
 import org.ossreviewtoolkit.model.OrtResult
 import org.ossreviewtoolkit.model.ResolvedPackageCurations
 import org.ossreviewtoolkit.model.config.AnalyzerConfiguration
+import org.ossreviewtoolkit.model.config.RepositoryAnalyzerConfiguration
 import org.ossreviewtoolkit.model.config.RepositoryConfiguration
 import org.ossreviewtoolkit.model.readValue
 import org.ossreviewtoolkit.model.readValueOrNull
@@ -233,17 +234,6 @@ class AnalyzerRunner(
      * invoked directly.
      */
     internal fun runInProcess(inputDir: File, config: AnalyzerRunnerConfig): OrtResult {
-        val ortPackageManagerOptions =
-            config.packageManagerOptions?.map { entry -> entry.key to entry.value.mapToOrt() }?.toMap()
-
-        val analyzerConfigFromJob = AnalyzerConfiguration(
-            config.allowDynamicVersions,
-            config.enabledPackageManagers ?: AnalyzerConfiguration().enabledPackageManagers,
-            config.disabledPackageManagers,
-            ortPackageManagerOptions,
-            config.skipExcluded ?: false
-        )
-
         val repositoryConfigPath = config.repositoryConfigPath ?: ORT_REPO_CONFIG_FILENAME
         val repositoryConfigFile = inputDir.resolve(repositoryConfigPath)
 
@@ -256,8 +246,7 @@ class AnalyzerRunner(
         val repositoryConfiguration = repositoryConfigFile.takeIf { it.isFile }?.readValueOrNull()
             ?: RepositoryConfiguration()
 
-        val analyzerConfig = repositoryConfiguration.analyzer?.let { analyzerConfigFromJob.merge(it) }
-            ?: analyzerConfigFromJob
+        val analyzerConfig = config.merge(repositoryConfiguration.analyzer ?: RepositoryAnalyzerConfiguration())
 
         val analyzer = Analyzer(analyzerConfig)
 
@@ -320,4 +309,53 @@ class AnalyzerRunner(
 
         return ortResult
     }
+}
+
+/**
+ * Merge this [AnalyzerRunnerConfig] with the [fileConfig] read from the repository configuration file into an
+ * [AnalyzerConfiguration] to be used for the analyzer run. In contrast to [AnalyzerConfiguration.merge], where the
+ * repository configuration file takes precedence, values defined in this [AnalyzerRunnerConfig] take precedence
+ * over the values from [fileConfig].
+ */
+internal fun AnalyzerRunnerConfig.merge(fileConfig: RepositoryAnalyzerConfiguration): AnalyzerConfiguration {
+    val ortPackageManagerOptions = packageManagerOptions?.mapValues { it.value.mapToOrt() }
+    val filePackageManagers = fileConfig.packageManagers
+
+    val mergedPackageManagers = when {
+        ortPackageManagerOptions == null -> filePackageManagers
+
+        filePackageManagers == null -> ortPackageManagerOptions
+
+        else -> {
+            val keys = sortedSetOf(String.CASE_INSENSITIVE_ORDER).apply {
+                addAll(ortPackageManagerOptions.keys)
+                addAll(filePackageManagers.keys)
+            }
+
+            val fromJob = ortPackageManagerOptions.toSortedMap(String.CASE_INSENSITIVE_ORDER)
+            val fromFile = filePackageManagers.toSortedMap(String.CASE_INSENSITIVE_ORDER)
+
+            keys.associateWithTo(sortedMapOf(String.CASE_INSENSITIVE_ORDER)) { key ->
+                val configFromJob = fromJob[key]
+                val configFromFile = fromFile[key]
+
+                when {
+                    configFromFile == null -> checkNotNull(configFromJob)
+                    configFromJob == null -> configFromFile
+                    else -> configFromFile.merge(configFromJob)
+                }
+            }
+        }
+    }
+
+    return AnalyzerConfiguration(
+        // TODO: allowDynamicVersions is not nullable in AnalyzerConfiguration. Therefore, the value is always taken,
+        //       and a fallback to the value from the repository configuration file is not possible.
+        allowDynamicVersions = allowDynamicVersions,
+        enabledPackageManagers = enabledPackageManagers ?: fileConfig.enabledPackageManagers
+            ?: AnalyzerConfiguration().enabledPackageManagers,
+        disabledPackageManagers = disabledPackageManagers ?: fileConfig.disabledPackageManagers,
+        packageManagers = mergedPackageManagers,
+        skipExcluded = skipExcluded ?: fileConfig.skipExcluded ?: false
+    )
 }

--- a/workers/analyzer/src/test/kotlin/AnalyzerRunnerTest.kt
+++ b/workers/analyzer/src/test/kotlin/AnalyzerRunnerTest.kt
@@ -27,6 +27,7 @@ import io.kotest.core.spec.style.WordSpec
 import io.kotest.engine.spec.tempdir
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.maps.beEmpty
 import io.kotest.matchers.maps.shouldContainAll
 import io.kotest.matchers.nulls.shouldNotBeNull
@@ -79,6 +80,7 @@ import org.ossreviewtoolkit.model.config.LicenseFindingCuration
 import org.ossreviewtoolkit.model.config.LicenseFindingCurationReason
 import org.ossreviewtoolkit.model.config.PackageConfiguration
 import org.ossreviewtoolkit.model.config.PackageLicenseChoice
+import org.ossreviewtoolkit.model.config.PackageManagerConfiguration as OrtPackageManagerConfiguration
 import org.ossreviewtoolkit.model.config.PathExclude
 import org.ossreviewtoolkit.model.config.PathExcludeReason
 import org.ossreviewtoolkit.model.config.RepositoryAnalyzerConfiguration
@@ -112,6 +114,18 @@ private val testRunnerConfig = AnalyzerRunnerConfig(
             options = mapOf("foo" to "bar")
         )
     ),
+    repositoryConfigPath = null,
+    keepAliveWorker = false,
+    keepAlivePhases = emptySet()
+)
+
+/** An [AnalyzerRunnerConfig] with all optional properties set to `null`, to be used as a base for merge tests. */
+private val emptyRunnerConfig = AnalyzerRunnerConfig(
+    allowDynamicVersions = false,
+    skipExcluded = null,
+    enabledPackageManagers = null,
+    disabledPackageManagers = null,
+    packageManagerOptions = null,
     repositoryConfigPath = null,
     keepAliveWorker = false,
     keepAlivePhases = emptySet()
@@ -389,6 +403,160 @@ class AnalyzerRunnerTest : WordSpec({
             }
 
             exception.message shouldContain "The forked process died"
+        }
+
+        "override the repository configuration with the run configuration" {
+            val inputDir = File("src/test/resources/runConfigOverrideProject/").absoluteFile
+            val config = testRunnerConfig.copy(skipExcluded = true)
+
+            val result = run(inputDir = inputDir, config = config)
+
+            result.getProjects(omitExcluded = false) shouldHaveSize 1
+        }
+    }
+
+    "AnalyzerRunnerConfig.merge" should {
+        "prefer properties from the runner config over the file config" {
+            val runnerConfig = emptyRunnerConfig.copy(
+                allowDynamicVersions = true,
+                enabledPackageManagers = listOf("Maven"),
+                disabledPackageManagers = listOf("Gradle"),
+                skipExcluded = true
+            )
+            val fileConfig = RepositoryAnalyzerConfiguration(
+                allowDynamicVersions = false,
+                enabledPackageManagers = listOf("Gradle"),
+                disabledPackageManagers = listOf("NPM"),
+                skipExcluded = false
+            )
+
+            val merged = runnerConfig.merge(fileConfig)
+
+            merged.allowDynamicVersions shouldBe true
+            merged.enabledPackageManagers shouldBe listOf("Maven")
+            merged.disabledPackageManagers shouldBe listOf("Gradle")
+            merged.skipExcluded shouldBe true
+        }
+
+        "fall back to the file config for properties not set in the runner config" {
+            val fileConfig = RepositoryAnalyzerConfiguration(
+                enabledPackageManagers = listOf("Gradle"),
+                disabledPackageManagers = listOf("NPM"),
+                skipExcluded = true
+            )
+
+            val merged = emptyRunnerConfig.merge(fileConfig)
+
+            merged.enabledPackageManagers shouldBe listOf("Gradle")
+            merged.disabledPackageManagers shouldBe listOf("NPM")
+            merged.skipExcluded shouldBe true
+        }
+
+        "fall back to the ORT defaults for properties not set in either config" {
+            val merged = emptyRunnerConfig.merge(RepositoryAnalyzerConfiguration())
+
+            merged.enabledPackageManagers shouldBe AnalyzerConfiguration().enabledPackageManagers
+            merged.disabledPackageManagers shouldBe null
+
+            merged.skipExcluded shouldBe false
+        }
+
+        "return null package manager options if neither config defines any" {
+            val merged = emptyRunnerConfig.merge(RepositoryAnalyzerConfiguration())
+
+            merged.packageManagers shouldBe null
+        }
+
+        "use the package manager options from the file config if the runner config does not define any" {
+            val fileOptions = mapOf(
+                "Maven" to OrtPackageManagerConfiguration(options = mapOf("file" to "value"))
+            )
+            val fileConfig = RepositoryAnalyzerConfiguration(packageManagers = fileOptions)
+
+            emptyRunnerConfig.merge(fileConfig).packageManagers shouldBe fileOptions
+        }
+
+        "use the package manager options from the runner config if the file config does not define any" {
+            val runnerConfig = emptyRunnerConfig.copy(
+                packageManagerOptions = mapOf(
+                    "Maven" to PackageManagerConfiguration(options = mapOf("job" to "value"))
+                )
+            )
+
+            val merged = runnerConfig.merge(RepositoryAnalyzerConfiguration())
+
+            merged.packageManagers shouldBe mapOf(
+                "Maven" to OrtPackageManagerConfiguration(options = mapOf("job" to "value"))
+            )
+        }
+
+        "combine package manager options for different package managers from both configs" {
+            val runnerConfig = emptyRunnerConfig.copy(
+                packageManagerOptions = mapOf(
+                    "Maven" to PackageManagerConfiguration(options = mapOf("job" to "value"))
+                )
+            )
+            val fileConfig = RepositoryAnalyzerConfiguration(
+                packageManagers = mapOf(
+                    "NPM" to OrtPackageManagerConfiguration(options = mapOf("file" to "value"))
+                )
+            )
+
+            val merged = runnerConfig.merge(fileConfig).packageManagers
+
+            merged shouldBe mapOf(
+                "Maven" to OrtPackageManagerConfiguration(options = mapOf("job" to "value")),
+                "NPM" to OrtPackageManagerConfiguration(options = mapOf("file" to "value"))
+            )
+        }
+
+        "merge the options of the same package manager, preferring the runner config's options on conflicts" {
+            val runnerConfig = emptyRunnerConfig.copy(
+                packageManagerOptions = mapOf(
+                    "Maven" to PackageManagerConfiguration(
+                        mustRunAfter = listOf("Gradle"),
+                        options = mapOf("shared" to "fromJob", "job" to "onlyJob")
+                    )
+                )
+            )
+            val fileConfig = RepositoryAnalyzerConfiguration(
+                packageManagers = mapOf(
+                    "Maven" to OrtPackageManagerConfiguration(
+                        mustRunAfter = listOf("NPM"),
+                        options = mapOf("shared" to "fromFile", "file" to "onlyFile")
+                    )
+                )
+            )
+
+            val merged = runnerConfig.merge(fileConfig).packageManagers
+
+            merged shouldBe mapOf(
+                "Maven" to OrtPackageManagerConfiguration(
+                    mustRunAfter = listOf("Gradle"),
+                    options = mapOf("shared" to "fromJob", "file" to "onlyFile", "job" to "onlyJob")
+                )
+            )
+        }
+
+        "merge package manager options case-insensitively" {
+            val runnerConfig = emptyRunnerConfig.copy(
+                packageManagerOptions = mapOf(
+                    "maven" to PackageManagerConfiguration(options = mapOf("job" to "value"))
+                )
+            )
+            val fileConfig = RepositoryAnalyzerConfiguration(
+                packageManagers = mapOf(
+                    "Maven" to OrtPackageManagerConfiguration(options = mapOf("file" to "value"))
+                )
+            )
+
+            val merged = runnerConfig.merge(fileConfig).packageManagers
+
+            merged.shouldNotBeNull()
+            merged.keys shouldHaveSize 1
+            merged["MAVEN"] shouldBe OrtPackageManagerConfiguration(
+                options = mapOf("file" to "value", "job" to "value")
+            )
         }
     }
 

--- a/workers/analyzer/src/test/resources/runConfigOverrideProject/.ort.yml
+++ b/workers/analyzer/src/test/resources/runConfigOverrideProject/.ort.yml
@@ -1,0 +1,10 @@
+---
+analyzer:
+  allow_dynamic_versions: true
+  skip_excluded: false
+excludes:
+  paths:
+    - pattern: "**/test"
+      reason: TEST_OF
+      comment: >-
+        This path should not be analyzed.

--- a/workers/analyzer/src/test/resources/runConfigOverrideProject/pom.xml
+++ b/workers/analyzer/src/test/resources/runConfigOverrideProject/pom.xml
@@ -1,0 +1,34 @@
+<!--
+  ~ Copyright (C) 2022 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ License-Filename: LICENSE
+  -->
+
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.mycompany.app</groupId>
+    <artifactId>my-app</artifactId>
+    <version>1</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.vdurmont</groupId>
+            <artifactId>semver4j</artifactId>
+            <version>3.1.0</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/workers/analyzer/src/test/resources/runConfigOverrideProject/test/pom.xml
+++ b/workers/analyzer/src/test/resources/runConfigOverrideProject/test/pom.xml
@@ -1,0 +1,34 @@
+<!--
+  ~ Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~     https://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  ~
+  ~ SPDX-License-Identifier: Apache-2.0
+  ~ License-Filename: LICENSE
+  -->
+
+<project>
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.mycompany.app</groupId>
+    <artifactId>my-other-app</artifactId>
+    <version>1.0.1</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.20.0</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
So far, analyzer-related options in the repository configuration took precedence over options in the `AnalyzerJobConfiguration`. This was contrary to the handling of the environment configuration where the options in the job configuration could override the options in `.env.ort.yml`. Revert the priority, so that it is possible to override settings from `.ort.yml` when triggering a run. This also simplifies testing of options: The `.ort.yml` file in the repository defines default values, but those can now be overridden on a per-run basis.

The existing merge logic in ORT gave priority to the repository configuration. Therefore, add a new merge function with corresponding tests.