### PR TITLE
ui: Add remaining interactive regression tests

### DIFF
--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/create-run-form.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/create-run-form.tsx
@@ -1,0 +1,585 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Loader2, PlusIcon, TrashIcon } from 'lucide-react';
+import { useState } from 'react';
+import { useFieldArray, useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import type {
+  OrtRun,
+  PostRepositoryRun,
+  PreconfiguredPluginDescriptor,
+  Secret,
+} from '@/api';
+import { CopyToClipboard } from '@/components/copy-to-clipboard';
+import { InlineCode } from '@/components/typography.tsx';
+import { Accordion } from '@/components/ui/accordion';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+import {
+  Form,
+  FormControl,
+  FormDescription,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { Textarea } from '@/components/ui/textarea';
+import type {
+  OrganizationPermissions,
+  ProductPermissions,
+  RepositoryPermissions,
+} from '@/lib/permissions';
+import {
+  AdvisorFields,
+  AnalyzerFields,
+  EvaluatorFields,
+  NotifierFields,
+  ReporterFields,
+  ScannerFields,
+} from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components';
+import { defaultValues } from './default-values';
+import { formValuesToPayload } from './payload';
+import {
+  createRunFormSchema,
+  flattenErrors,
+  type CreateRunFormValues,
+} from './run-schema';
+
+type AccordionSection =
+  'analyzer' | 'advisor' | 'scanner' | 'evaluator' | 'reporter' | 'notifier';
+
+type CreateRunPermissions = {
+  organization: OrganizationPermissions | undefined;
+  product: ProductPermissions | undefined;
+  repository: RepositoryPermissions | undefined;
+};
+
+export type CreateRunFormProps = {
+  isSubmitting: boolean;
+  isSuperuser: boolean;
+  onSubmit: (payload: PostRepositoryRun) => Promise<void> | void;
+  permissions: CreateRunPermissions;
+  plugins: PreconfiguredPluginDescriptor[];
+  rerun: OrtRun | null;
+  secrets: Secret[];
+};
+
+export const CreateRunForm = ({
+  isSubmitting,
+  isSuperuser,
+  onSubmit,
+  permissions,
+  plugins,
+  rerun,
+  secrets,
+}: CreateRunFormProps) => {
+  const [isTest, setIsTest] = useState(false);
+  const isRerun = rerun !== null;
+  const [openAccordions, setOpenAccordions] = useState<AccordionSection[]>([]);
+
+  const advisorPlugins = plugins.filter((plugin) => plugin.type === 'ADVISOR');
+  const reporterPlugins = plugins.filter(
+    (plugin) => plugin.type === 'REPORTER'
+  );
+  const scannerPlugins = plugins.filter((plugin) => plugin.type === 'SCANNER');
+  const packageCurationProviderPlugins = plugins.filter(
+    (plugin) => plugin.type === 'PACKAGE_CURATION_PROVIDER'
+  );
+  const packageConfigurationProviderPlugins = plugins.filter(
+    (plugin) => plugin.type === 'PACKAGE_CONFIGURATION_PROVIDER'
+  );
+
+  // Manually toggle accordion open/close state
+  const toggleAccordionOpen = (value: AccordionSection) => {
+    setOpenAccordions(
+      (prev) =>
+        prev.includes(value)
+          ? prev.filter((v) => v !== value) // Close accordion if open
+          : [...prev, value] // Open accordion if closed
+    );
+  };
+
+  const formSchema = createRunFormSchema(
+    advisorPlugins,
+    scannerPlugins,
+    packageCurationProviderPlugins,
+    packageConfigurationProviderPlugins
+  );
+
+  const form = useForm<z.infer<typeof formSchema>>({
+    resolver: zodResolver(formSchema),
+    defaultValues: defaultValues(
+      rerun,
+      advisorPlugins,
+      scannerPlugins,
+      isSuperuser,
+      packageCurationProviderPlugins,
+      packageConfigurationProviderPlugins
+    ),
+  });
+
+  const watchedValues = form.watch();
+
+  const {
+    fields: parametersFields,
+    append: parametersAppend,
+    remove: parametersRemove,
+  } = useFieldArray({
+    name: 'jobConfigs.parameters',
+    control: form.control,
+  });
+
+  const {
+    fields: labelsFields,
+    append: labelsAppend,
+    remove: labelsRemove,
+  } = useFieldArray({
+    name: 'labels',
+    control: form.control,
+  });
+
+  async function submitForm(values: CreateRunFormValues) {
+    await onSubmit(formValuesToPayload(values));
+  }
+
+  const onValidationFailed = (errors: typeof form.formState.errors) => {
+    // Determine which accordions contain errors
+    const accordionsWithErrors: AccordionSection[] = [];
+
+    if (errors.jobConfigs?.analyzer) {
+      accordionsWithErrors.push('analyzer');
+    }
+    if (errors.jobConfigs?.advisor) {
+      accordionsWithErrors.push('advisor');
+    }
+    if (errors.jobConfigs?.scanner) {
+      accordionsWithErrors.push('scanner');
+    }
+    if (errors.jobConfigs?.evaluator) {
+      accordionsWithErrors.push('evaluator');
+    }
+    if (errors.jobConfigs?.reporter) {
+      accordionsWithErrors.push('reporter');
+    }
+    if (errors.jobConfigs?.notifier) {
+      accordionsWithErrors.push('notifier');
+    }
+
+    // Open the accordions with errors
+    setOpenAccordions(accordionsWithErrors);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Create a Run</CardTitle>
+      </CardHeader>
+      <Form {...form}>
+        <form
+          onSubmit={form.handleSubmit(submitForm, onValidationFailed)}
+          className='space-y-8'
+        >
+          <CardContent>
+            <FormField
+              control={form.control}
+              name='revision'
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Revision</FormLabel>
+                  <FormControl autoFocus>
+                    <Input {...field} />
+                  </FormControl>
+                  <FormDescription>
+                    The repository revision to use. Can be a branch, tag, or
+                    commit. Uses the default branch if left empty.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name='path'
+              render={({ field }) => (
+                <FormItem className='pt-4'>
+                  <FormLabel>Path</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder='(optional)' />
+                  </FormControl>
+                  <FormDescription>
+                    The path (relative to the repository root) to limit the
+                    analysis to, for example{' '}
+                    <InlineCode>path/to/source</InlineCode>.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name='jobConfigContext'
+              render={({ field }) => (
+                <FormItem className='pt-4'>
+                  <FormLabel>Configuration context</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder='(optional)' />
+                  </FormControl>
+                  <FormDescription>
+                    The context to pass to the configuration provider in use.
+                    The configuration provider is responsible for obtaining
+                    configuration for this run and uses the context in an
+                    implementation-specific way. For example, if the{' '}
+                    <InlineCode>GitHubConfigFileProvider</InlineCode> is in use,
+                    the context defines the Git revision of the configuration to
+                    check out.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name='environmentConfigPath'
+              render={({ field }) => (
+                <FormItem className='pt-4'>
+                  <FormLabel>Environment configuration path</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder='(optional)' />
+                  </FormControl>
+                  <FormDescription>
+                    The optional path to an environment configuration file. If
+                    this is not defined, the environment configuration is read
+                    from the default location
+                    <InlineCode>.ort.env.yml</InlineCode>.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name='jobConfigs.ruleSet'
+              render={({ field }) => (
+                <FormItem className='pt-4'>
+                  <FormLabel>Rule set</FormLabel>
+                  <FormControl>
+                    <Input {...field} placeholder='(optional)' />
+                  </FormControl>
+                  <FormDescription>
+                    The rule set to use for the run. This selects a set of
+                    configuration files used by the Evaluator and the Reporter,
+                    such as rules for the Evaluator or license classifications.
+                    If left empty, the default rule set is used.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+
+            <h3 className='mt-4'>Configuration parameters</h3>
+            <div className='text-sm text-gray-500'>
+              A map of key-value pairs that serve as input parameters for the
+              configuration's validation script. The script can use these
+              parameters to alter specific job configurations.
+            </div>
+            {parametersFields.map((field, index) => (
+              <div
+                key={field.id}
+                className='my-2 flex flex-row items-end space-x-2'
+              >
+                <div className='flex-auto'>
+                  <FormField
+                    control={form.control}
+                    name={`jobConfigs.parameters.${index}.key`}
+                    render={({ field }) => (
+                      <FormItem>
+                        {index === 0 && (
+                          <FormLabel className='mb-2'>Key</FormLabel>
+                        )}
+                        <FormControl>
+                          <Input {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+                <div className='flex-auto'>
+                  <FormField
+                    control={form.control}
+                    name={`jobConfigs.parameters.${index}.value`}
+                    render={({ field }) => (
+                      <FormItem>
+                        {index === 0 && (
+                          <FormLabel className='mb-2'>Value</FormLabel>
+                        )}
+                        <FormControl>
+                          <Input {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+                <Button
+                  type='button'
+                  variant='outline'
+                  size='sm'
+                  onClick={() => {
+                    parametersRemove(index);
+                  }}
+                >
+                  <TrashIcon className='h-4 w-4' />
+                </Button>
+              </div>
+            ))}
+            <Button
+              size='sm'
+              className='mt-2'
+              variant='outline'
+              type='button'
+              onClick={() => {
+                parametersAppend({ key: '', value: '' });
+              }}
+            >
+              Add parameter
+              <PlusIcon className='ml-1 h-4 w-4' />
+            </Button>
+
+            <h3 className='mt-4'>ORT labels</h3>
+            <div className='text-sm text-gray-500'>
+              A map of key-value pairs to store as labels in ORT results. ORT
+              does not interpret labels by itself, but leaves interpretation to
+              custom configuration, like evaluator rules.
+            </div>
+            {labelsFields.map((field, index) => (
+              <div
+                key={field.id}
+                className='my-2 flex flex-row items-end space-x-2'
+              >
+                <div className='flex-auto'>
+                  <FormField
+                    control={form.control}
+                    name={`labels.${index}.key`}
+                    render={({ field }) => (
+                      <FormItem>
+                        {index === 0 && (
+                          <FormLabel className='mb-2'>Key</FormLabel>
+                        )}
+                        <FormControl>
+                          <Input {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+                <div className='flex-auto'>
+                  <FormField
+                    control={form.control}
+                    name={`labels.${index}.value`}
+                    render={({ field }) => (
+                      <FormItem>
+                        {index === 0 && (
+                          <FormLabel className='mb-2'>Value</FormLabel>
+                        )}
+                        <FormControl>
+                          <Input {...field} />
+                        </FormControl>
+                        <FormMessage />
+                      </FormItem>
+                    )}
+                  />
+                </div>
+                <Button
+                  type='button'
+                  variant='outline'
+                  size='sm'
+                  onClick={() => {
+                    labelsRemove(index);
+                  }}
+                >
+                  <TrashIcon className='h-4 w-4' />
+                </Button>
+              </div>
+            ))}
+            <Button
+              size='sm'
+              className='mt-2'
+              variant='outline'
+              type='button'
+              onClick={() => {
+                labelsAppend({ key: '', value: '' });
+              }}
+            >
+              Add label
+              <PlusIcon className='ml-1 h-4 w-4' />
+            </Button>
+
+            <h3 className='mt-4'>Enable and configure jobs</h3>
+            <div className='text-sm text-gray-500'>
+              Configure the jobs to be included in the run.
+            </div>
+            <Accordion
+              type='multiple'
+              value={openAccordions}
+              onValueChange={(value) =>
+                setOpenAccordions(value as AccordionSection[])
+              }
+            >
+              <AnalyzerFields
+                form={form}
+                value='analyzer'
+                onToggle={() => toggleAccordionOpen('analyzer')}
+                isSuperuser={isSuperuser}
+                packageCurationProviderPlugins={packageCurationProviderPlugins}
+                pluginSecrets={secrets}
+                isRerun={isRerun}
+                permissions={permissions}
+              />
+              <AdvisorFields
+                form={form}
+                value='advisor'
+                onToggle={() => toggleAccordionOpen('advisor')}
+                advisorPlugins={advisorPlugins}
+                secrets={secrets}
+                isSuperuser={isSuperuser}
+              />
+              <ScannerFields
+                form={form}
+                value='scanner'
+                onToggle={() => toggleAccordionOpen('scanner')}
+                scannerPlugins={scannerPlugins}
+                secrets={secrets}
+                isSuperuser={isSuperuser}
+              />
+              <EvaluatorFields
+                form={form}
+                value='evaluator'
+                onToggle={() => toggleAccordionOpen('evaluator')}
+                isSuperuser={isSuperuser}
+                packageConfigurationProviderPlugins={
+                  packageConfigurationProviderPlugins
+                }
+                secrets={secrets}
+                isRerun={isRerun}
+              />
+              <ReporterFields
+                form={form}
+                value='reporter'
+                onToggle={() => toggleAccordionOpen('reporter')}
+                reporterPlugins={reporterPlugins}
+                isSuperuser={isSuperuser}
+                packageConfigurationProviderPlugins={
+                  packageConfigurationProviderPlugins
+                }
+                secrets={secrets}
+                isRerun={isRerun}
+              />
+              <NotifierFields
+                form={form}
+                value='notifier'
+                onToggle={() => toggleAccordionOpen('notifier')}
+                isSuperuser={isSuperuser}
+              />
+            </Accordion>
+          </CardContent>
+          <CardFooter className='flex flex-col items-start gap-4'>
+            {Object.keys(form.formState.errors).length > 0 && (
+              <p className='text-destructive text-[0.8rem] font-medium'>
+                {flattenErrors(form.formState.errors).map(
+                  ({ path, message }) => (
+                    <div key={path}>
+                      <strong>{path}:</strong> {message}
+                    </div>
+                  )
+                )}
+              </p>
+            )}
+            <div className='flex w-full items-center justify-between'>
+              <Button type='submit' disabled={isSubmitting}>
+                {isSubmitting ? (
+                  <>
+                    <span className='sr-only'>Creating run...</span>
+                    <Loader2 size={16} className='mx-3 animate-spin' />
+                  </>
+                ) : (
+                  'Create'
+                )}
+              </Button>
+              <div className='flex items-center space-x-2'>
+                <Switch
+                  id='test-form'
+                  checked={isTest}
+                  onCheckedChange={setIsTest}
+                />
+                <Label className='text-muted-foreground' htmlFor='test-form'>
+                  Show payload
+                </Label>
+              </div>
+            </div>
+            {isTest && (
+              <>
+                <h3 className='mt-4'>Form payload</h3>
+                <Label htmlFor='payload' className='text-muted-foreground'>
+                  You can copy this payload to use it when triggering runs via
+                  the API or CLI.
+                </Label>
+                <div className='relative w-full'>
+                  <Textarea
+                    id='payload'
+                    className='h-96 pr-12 font-mono'
+                    readOnly
+                    value={JSON.stringify(
+                      formValuesToPayload(watchedValues),
+                      null,
+                      2
+                    )}
+                  />
+                  <div className='absolute top-2 right-2 z-10'>
+                    <CopyToClipboard
+                      copyText={JSON.stringify(
+                        formValuesToPayload(watchedValues),
+                        null,
+                        2
+                      )}
+                    />
+                  </div>
+                </div>
+              </>
+            )}
+          </CardFooter>
+        </form>
+      </Form>
+    </Card>
+  );
+};

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/create-run-form.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/create-run-form.tsx
@@ -515,7 +515,7 @@ export const CreateRunForm = ({
           </CardContent>
           <CardFooter className='flex flex-col items-start gap-4'>
             {Object.keys(form.formState.errors).length > 0 && (
-              <p className='text-destructive text-[0.8rem] font-medium'>
+              <div className='text-destructive text-[0.8rem] font-medium'>
                 {flattenErrors(form.formState.errors).map(
                   ({ path, message }) => (
                     <div key={path}>
@@ -523,7 +523,7 @@ export const CreateRunForm = ({
                     </div>
                   )
                 )}
-              </p>
+              </div>
             )}
             <div className='flex w-full items-center justify-between'>
               <Button type='submit' disabled={isSubmitting}>

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -17,14 +17,11 @@
  * License-Filename: LICENSE
  */
 
-import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
-import { Loader2, PlusIcon, TrashIcon } from 'lucide-react';
-import { useState } from 'react';
-import { useFieldArray, useForm } from 'react-hook-form';
 import { z } from 'zod';
 
+import type { PostRepositoryRun } from '@/api';
 import {
   getOrganizationOptions,
   getProductOptions,
@@ -36,51 +33,13 @@ import {
   getPluginsForRepository,
   getRepositoryRun,
 } from '@/api/sdk.gen';
-import { CopyToClipboard } from '@/components/copy-to-clipboard';
 import { LoadingIndicator } from '@/components/loading-indicator';
-import { InlineCode } from '@/components/typography.tsx';
-import { Accordion } from '@/components/ui/accordion';
-import { Button } from '@/components/ui/button';
-import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
-import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from '@/components/ui/form';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Switch } from '@/components/ui/switch';
-import { Textarea } from '@/components/ui/textarea';
 import { useUser } from '@/hooks/use-user.ts';
 import { ApiError } from '@/lib/api-error';
 import { runCreated } from '@/lib/entity-cache';
 import { toast, toastError } from '@/lib/toast';
 import { buildRecentRun, useHomeRecentRunActions } from '@/providers/home-data';
-import {
-  AdvisorFields,
-  AnalyzerFields,
-  EvaluatorFields,
-  NotifierFields,
-  ReporterFields,
-  ScannerFields,
-} from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components';
-import {
-  createRunFormSchema,
-  CreateRunFormValues,
-  defaultValues,
-  flattenErrors,
-  formValuesToPayload,
-} from './-components';
+import { CreateRunForm } from './-components/create-run-form';
 
 const CreateRunPage = () => {
   const navigate = useNavigate();
@@ -88,24 +47,8 @@ const CreateRunPage = () => {
   const queryClient = useQueryClient();
   const { ortRun, plugins, secrets } = Route.useLoaderData();
   const { recordRecentRun } = useHomeRecentRunActions();
-  const [isTest, setIsTest] = useState(false);
   const isSuperuser = useUser().isSuperuser || false;
   const permissions = Route.useRouteContext().permissions;
-
-  const advisorPlugins =
-    plugins.data?.filter((plugin) => plugin.type === 'ADVISOR') || [];
-  const reporterPlugins =
-    plugins.data?.filter((plugin) => plugin.type === 'REPORTER') || [];
-  const scannerPlugins =
-    plugins.data?.filter((plugin) => plugin.type === 'SCANNER') || [];
-  const packageCurationProviderPlugins =
-    plugins.data?.filter(
-      (plugin) => plugin.type === 'PACKAGE_CURATION_PROVIDER'
-    ) || [];
-  const packageConfigurationProviderPlugins =
-    plugins.data?.filter(
-      (plugin) => plugin.type === 'PACKAGE_CONFIGURATION_PROVIDER'
-    ) || [];
 
   const {
     data: organization,
@@ -140,21 +83,6 @@ const CreateRunPage = () => {
     }),
   });
 
-  type AccordionSection =
-    'analyzer' | 'advisor' | 'scanner' | 'evaluator' | 'reporter' | 'notifier';
-
-  const [openAccordions, setOpenAccordions] = useState<AccordionSection[]>([]);
-
-  // Manually toggle accordion open/close state
-  const toggleAccordionOpen = (value: AccordionSection) => {
-    setOpenAccordions(
-      (prev) =>
-        prev.includes(value)
-          ? prev.filter((v) => v !== value) // Close accordion if open
-          : [...prev, value] // Open accordion if closed
-    );
-  };
-
   const { mutateAsync, isPending } = useMutation({
     ...postRepositoryRunMutation(),
     onSuccess(response) {
@@ -183,79 +111,13 @@ const CreateRunPage = () => {
     },
   });
 
-  const formSchema = createRunFormSchema(
-    advisorPlugins,
-    scannerPlugins,
-    packageCurationProviderPlugins,
-    packageConfigurationProviderPlugins
-  );
-
-  const form = useForm<z.infer<typeof formSchema>>({
-    resolver: zodResolver(formSchema),
-    defaultValues: defaultValues(
-      ortRun?.data ?? null,
-      advisorPlugins,
-      scannerPlugins,
-      isSuperuser,
-      packageCurationProviderPlugins,
-      packageConfigurationProviderPlugins
-    ),
-  });
-
-  const watchedValues = form.watch();
-
-  const {
-    fields: parametersFields,
-    append: parametersAppend,
-    remove: parametersRemove,
-  } = useFieldArray({
-    name: 'jobConfigs.parameters',
-    control: form.control,
-  });
-
-  const {
-    fields: labelsFields,
-    append: labelsAppend,
-    remove: labelsRemove,
-  } = useFieldArray({
-    name: 'labels',
-    control: form.control,
-  });
-
-  async function onSubmit(values: CreateRunFormValues) {
+  const submitRun = async (payload: PostRepositoryRun) => {
     await mutateAsync({
       path: {
         repositoryId: Number.parseInt(params.repoId),
       },
-      body: formValuesToPayload(values),
+      body: payload,
     });
-  }
-
-  const onValidationFailed = (errors: typeof form.formState.errors) => {
-    // Determine which accordions contain errors
-    const accordionsWithErrors: AccordionSection[] = [];
-
-    if (errors.jobConfigs?.analyzer) {
-      accordionsWithErrors.push('analyzer');
-    }
-    if (errors.jobConfigs?.advisor) {
-      accordionsWithErrors.push('advisor');
-    }
-    if (errors.jobConfigs?.scanner) {
-      accordionsWithErrors.push('scanner');
-    }
-    if (errors.jobConfigs?.evaluator) {
-      accordionsWithErrors.push('evaluator');
-    }
-    if (errors.jobConfigs?.reporter) {
-      accordionsWithErrors.push('reporter');
-    }
-    if (errors.jobConfigs?.notifier) {
-      accordionsWithErrors.push('notifier');
-    }
-
-    // Open the accordions with errors
-    setOpenAccordions(accordionsWithErrors);
   };
 
   if (orgIsPending || productIsPending || repositoryIsPending) {
@@ -271,388 +133,15 @@ const CreateRunPage = () => {
   }
 
   return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Create a Run</CardTitle>
-      </CardHeader>
-      <Form {...form}>
-        <form
-          onSubmit={form.handleSubmit(onSubmit, onValidationFailed)}
-          className='space-y-8'
-        >
-          <CardContent>
-            <FormField
-              control={form.control}
-              name='revision'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Revision</FormLabel>
-                  <FormControl autoFocus>
-                    <Input {...field} />
-                  </FormControl>
-                  <FormDescription>
-                    The repository revision to use. Can be a branch, tag, or
-                    commit. Uses the default branch if left empty.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name='path'
-              render={({ field }) => (
-                <FormItem className='pt-4'>
-                  <FormLabel>Path</FormLabel>
-                  <FormControl>
-                    <Input {...field} placeholder='(optional)' />
-                  </FormControl>
-                  <FormDescription>
-                    The path (relative to the repository root) to limit the
-                    analysis to, for example{' '}
-                    <InlineCode>path/to/source</InlineCode>.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name='jobConfigContext'
-              render={({ field }) => (
-                <FormItem className='pt-4'>
-                  <FormLabel>Configuration context</FormLabel>
-                  <FormControl>
-                    <Input {...field} placeholder='(optional)' />
-                  </FormControl>
-                  <FormDescription>
-                    The context to pass to the configuration provider in use.
-                    The configuration provider is responsible for obtaining
-                    configuration for this run and uses the context in an
-                    implementation-specific way. For example, if the{' '}
-                    <InlineCode>GitHubConfigFileProvider</InlineCode> is in use,
-                    the context defines the Git revision of the configuration to
-                    check out.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name='environmentConfigPath'
-              render={({ field }) => (
-                <FormItem className='pt-4'>
-                  <FormLabel>Environment configuration path</FormLabel>
-                  <FormControl>
-                    <Input {...field} placeholder='(optional)' />
-                  </FormControl>
-                  <FormDescription>
-                    The optional path to an environment configuration file. If
-                    this is not defined, the environment configuration is read
-                    from the default location
-                    <InlineCode>.ort.env.yml</InlineCode>.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name='jobConfigs.ruleSet'
-              render={({ field }) => (
-                <FormItem className='pt-4'>
-                  <FormLabel>Rule set</FormLabel>
-                  <FormControl>
-                    <Input {...field} placeholder='(optional)' />
-                  </FormControl>
-                  <FormDescription>
-                    The rule set to use for the run. This selects a set of
-                    configuration files used by the Evaluator and the Reporter,
-                    such as rules for the Evaluator or license classifications.
-                    If left empty, the default rule set is used.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-
-            <h3 className='mt-4'>Configuration parameters</h3>
-            <div className='text-sm text-gray-500'>
-              A map of key-value pairs that serve as input parameters for the
-              configuration's validation script. The script can use these
-              parameters to alter specific job configurations.
-            </div>
-            {parametersFields.map((field, index) => (
-              <div
-                key={field.id}
-                className='my-2 flex flex-row items-end space-x-2'
-              >
-                <div className='flex-auto'>
-                  <FormField
-                    control={form.control}
-                    name={`jobConfigs.parameters.${index}.key`}
-                    render={({ field }) => (
-                      <FormItem>
-                        {index === 0 && (
-                          <FormLabel className='mb-2'>Key</FormLabel>
-                        )}
-                        <FormControl>
-                          <Input {...field} />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </div>
-                <div className='flex-auto'>
-                  <FormField
-                    control={form.control}
-                    name={`jobConfigs.parameters.${index}.value`}
-                    render={({ field }) => (
-                      <FormItem>
-                        {index === 0 && (
-                          <FormLabel className='mb-2'>Value</FormLabel>
-                        )}
-                        <FormControl>
-                          <Input {...field} />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </div>
-                <Button
-                  type='button'
-                  variant='outline'
-                  size='sm'
-                  onClick={() => {
-                    parametersRemove(index);
-                  }}
-                >
-                  <TrashIcon className='h-4 w-4' />
-                </Button>
-              </div>
-            ))}
-            <Button
-              size='sm'
-              className='mt-2'
-              variant='outline'
-              type='button'
-              onClick={() => {
-                parametersAppend({ key: '', value: '' });
-              }}
-            >
-              Add parameter
-              <PlusIcon className='ml-1 h-4 w-4' />
-            </Button>
-
-            <h3 className='mt-4'>ORT labels</h3>
-            <div className='text-sm text-gray-500'>
-              A map of key-value pairs to store as labels in ORT results. ORT
-              does not interpret labels by itself, but leaves interpretation to
-              custom configuration, like evaluator rules.
-            </div>
-            {labelsFields.map((field, index) => (
-              <div
-                key={field.id}
-                className='my-2 flex flex-row items-end space-x-2'
-              >
-                <div className='flex-auto'>
-                  <FormField
-                    control={form.control}
-                    name={`labels.${index}.key`}
-                    render={({ field }) => (
-                      <FormItem>
-                        {index === 0 && (
-                          <FormLabel className='mb-2'>Key</FormLabel>
-                        )}
-                        <FormControl>
-                          <Input {...field} />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </div>
-                <div className='flex-auto'>
-                  <FormField
-                    control={form.control}
-                    name={`labels.${index}.value`}
-                    render={({ field }) => (
-                      <FormItem>
-                        {index === 0 && (
-                          <FormLabel className='mb-2'>Value</FormLabel>
-                        )}
-                        <FormControl>
-                          <Input {...field} />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </div>
-                <Button
-                  type='button'
-                  variant='outline'
-                  size='sm'
-                  onClick={() => {
-                    labelsRemove(index);
-                  }}
-                >
-                  <TrashIcon className='h-4 w-4' />
-                </Button>
-              </div>
-            ))}
-            <Button
-              size='sm'
-              className='mt-2'
-              variant='outline'
-              type='button'
-              onClick={() => {
-                labelsAppend({ key: '', value: '' });
-              }}
-            >
-              Add label
-              <PlusIcon className='ml-1 h-4 w-4' />
-            </Button>
-
-            <h3 className='mt-4'>Enable and configure jobs</h3>
-            <div className='text-sm text-gray-500'>
-              Configure the jobs to be included in the run.
-            </div>
-            <Accordion
-              type='multiple'
-              value={openAccordions}
-              onValueChange={(value) =>
-                setOpenAccordions(value as AccordionSection[])
-              }
-            >
-              <AnalyzerFields
-                form={form}
-                value='analyzer'
-                onToggle={() => toggleAccordionOpen('analyzer')}
-                isSuperuser={isSuperuser}
-                packageCurationProviderPlugins={packageCurationProviderPlugins}
-                pluginSecrets={secrets.data || []}
-                isRerun={ortRun?.data != null}
-                permissions={permissions}
-              />
-              <AdvisorFields
-                form={form}
-                value='advisor'
-                onToggle={() => toggleAccordionOpen('advisor')}
-                advisorPlugins={advisorPlugins}
-                secrets={secrets.data || []}
-                isSuperuser={isSuperuser}
-              />
-              <ScannerFields
-                form={form}
-                value='scanner'
-                onToggle={() => toggleAccordionOpen('scanner')}
-                scannerPlugins={scannerPlugins}
-                secrets={secrets.data || []}
-                isSuperuser={isSuperuser}
-              />
-              <EvaluatorFields
-                form={form}
-                value='evaluator'
-                onToggle={() => toggleAccordionOpen('evaluator')}
-                isSuperuser={isSuperuser}
-                packageConfigurationProviderPlugins={
-                  packageConfigurationProviderPlugins
-                }
-                secrets={secrets.data || []}
-                isRerun={ortRun?.data != null}
-              />
-              <ReporterFields
-                form={form}
-                value='reporter'
-                onToggle={() => toggleAccordionOpen('reporter')}
-                reporterPlugins={reporterPlugins}
-                isSuperuser={isSuperuser}
-                packageConfigurationProviderPlugins={
-                  packageConfigurationProviderPlugins
-                }
-                secrets={secrets.data || []}
-                isRerun={ortRun?.data != null}
-              />
-              <NotifierFields
-                form={form}
-                value='notifier'
-                onToggle={() => toggleAccordionOpen('notifier')}
-                isSuperuser={isSuperuser}
-              />
-            </Accordion>
-          </CardContent>
-          <CardFooter className='flex flex-col items-start gap-4'>
-            {Object.keys(form.formState.errors).length > 0 && (
-              <p className='text-destructive text-[0.8rem] font-medium'>
-                {flattenErrors(form.formState.errors).map(
-                  ({ path, message }) => (
-                    <div key={path}>
-                      <strong>{path}:</strong> {message}
-                    </div>
-                  )
-                )}
-              </p>
-            )}
-            <div className='flex w-full items-center justify-between'>
-              <Button type='submit' disabled={isPending}>
-                {isPending ? (
-                  <>
-                    <span className='sr-only'>Creating run...</span>
-                    <Loader2 size={16} className='mx-3 animate-spin' />
-                  </>
-                ) : (
-                  'Create'
-                )}
-              </Button>
-              <div className='flex items-center space-x-2'>
-                <Switch
-                  id='test-form'
-                  checked={isTest}
-                  onCheckedChange={setIsTest}
-                />
-                <Label className='text-muted-foreground' htmlFor='test-form'>
-                  Show payload
-                </Label>
-              </div>
-            </div>
-            {isTest && (
-              <>
-                <h3 className='mt-4'>Form payload</h3>
-                <Label htmlFor='payload' className='text-muted-foreground'>
-                  You can copy this payload to use it when triggering runs via
-                  the API or CLI.
-                </Label>
-                <div className='relative w-full'>
-                  <Textarea
-                    id='payload'
-                    className='h-96 pr-12 font-mono'
-                    readOnly
-                    value={JSON.stringify(
-                      formValuesToPayload(watchedValues),
-                      null,
-                      2
-                    )}
-                  />
-                  <div className='absolute top-2 right-2 z-10'>
-                    <CopyToClipboard
-                      copyText={JSON.stringify(
-                        formValuesToPayload(watchedValues),
-                        null,
-                        2
-                      )}
-                    />
-                  </div>
-                </div>
-              </>
-            )}
-          </CardFooter>
-        </form>
-      </Form>
-    </Card>
+    <CreateRunForm
+      isSubmitting={isPending}
+      isSuperuser={isSuperuser}
+      onSubmit={submitRun}
+      permissions={permissions}
+      plugins={plugins.data ?? []}
+      rerun={ortRun?.data ?? null}
+      secrets={secrets.data ?? []}
+    />
   );
 };
 

--- a/ui/tests/unit/components/card-expansion.test.tsx
+++ b/ui/tests/unit/components/card-expansion.test.tsx
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+// @vitest-environment jsdom
+
+import type { ExpandedState, SortingState } from '@tanstack/react-table';
+import { screen } from '@testing-library/react';
+import { useState } from 'react';
+import { expect, it } from 'vitest';
+
+import { DataTableCards } from '@/components/data-table-cards/data-table-cards';
+import { Button } from '@/components/ui/button';
+import { EMPTY_SORTING_STATE } from '@/helpers/handle-multisort';
+import {
+  selectNoTableState,
+  useAppTable,
+  type AppColumnDef,
+} from '@/hooks/use-app-table';
+import { renderInteractiveWithRouter } from '../fixtures/render-interactive';
+
+type TestRow = {
+  category: string;
+  name: string;
+};
+
+const data: TestRow[] = [
+  { category: 'Example category', name: 'Example project' },
+];
+const CardTableHarness = ({ sortBy }: { sortBy?: SortingState }) => {
+  const [expanded, setExpanded] = useState<ExpandedState>({});
+  const columns: AppColumnDef<TestRow>[] = [
+    {
+      id: 'details',
+      cell: ({ row }) => (
+        <Button
+          aria-label={row.getIsExpanded() ? 'Collapse row' : 'Expand row'}
+          onClick={row.getToggleExpandedHandler()}
+        >
+          Details
+        </Button>
+      ),
+    },
+    {
+      id: 'card',
+      cell: ({ row }) => row.original.name,
+    },
+    {
+      accessorKey: 'name',
+      header: 'Name',
+    },
+    {
+      accessorKey: 'category',
+      header: 'Category',
+    },
+  ];
+  const table = useAppTable(
+    {
+      columns,
+      data,
+      pageCount: 1,
+      state: {
+        columnFilters: [],
+        columnVisibility: { category: false, name: false },
+        expanded,
+        pagination: { pageIndex: 0, pageSize: 10 },
+        sorting: sortBy ?? EMPTY_SORTING_STATE,
+      },
+      onExpandedChange: setExpanded,
+      getRowCanExpand: () => true,
+      getRowId: (row) => row.name,
+      manualFiltering: true,
+      manualPagination: true,
+      manualSorting: true,
+    },
+    selectNoTableState
+  );
+
+  return (
+    <DataTableCards
+      table={table}
+      renderSubComponent={({ row }) => <div>{row.original.name} details</div>}
+      setCurrentPageOptions={() => ({ to: '/' })}
+      setPageSizeOptions={() => ({ to: '/' })}
+      setSortingOptions={() => ({ to: '/' })}
+    />
+  );
+};
+
+it('expands a card when sorting defaults to an empty state', async () => {
+  const { user } = renderInteractiveWithRouter(<CardTableHarness />, {
+    path: '/cards',
+    routes: [{ path: '/cards' }],
+  });
+
+  await user.click(await screen.findByRole('button', { name: 'Expand row' }));
+
+  expect(await screen.findByText('Example project details')).toBeVisible();
+}, 1000);

--- a/ui/tests/unit/components/create-run-form.test.tsx
+++ b/ui/tests/unit/components/create-run-form.test.tsx
@@ -1,0 +1,199 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+// @vitest-environment jsdom
+
+import { screen, within } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { CreateRunForm } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/create-run-form';
+import {
+  createOrtRun,
+  createPermissions,
+  createPluginDescriptor,
+  createPluginSecrets,
+} from '../fixtures/create-run';
+import { renderInteractiveWithRouter } from '../fixtures/render-interactive';
+
+const advisorPlugin = createPluginDescriptor({
+  id: 'OSV',
+  type: 'ADVISOR',
+  displayName: 'OSV',
+  options: [
+    {
+      name: 'serverUrl',
+      type: 'STRING',
+      defaultValue: '',
+      description: 'The OSV server URL.',
+      isFixed: false,
+      isNullable: false,
+      isRequired: true,
+    },
+  ],
+});
+
+const scannerPlugin = createPluginDescriptor({
+  id: 'ScanCode',
+  type: 'SCANNER',
+  displayName: 'ScanCode',
+});
+const permissions = createPermissions();
+const rerun = createOrtRun({ revision: '', path: '', jobConfigs: {} });
+const secrets = createPluginSecrets();
+const createRunPath =
+  '/organizations/1/products/2/repositories/3/create-run' as const;
+
+const renderCreateRunForm = (onSubmit = vi.fn()) => ({
+  onSubmit,
+  ...renderInteractiveWithRouter(
+    <CreateRunForm
+      isSubmitting={false}
+      isSuperuser={false}
+      onSubmit={onSubmit}
+      permissions={permissions}
+      plugins={[advisorPlugin, scannerPlugin]}
+      rerun={rerun}
+      secrets={secrets}
+    />,
+    {
+      path: createRunPath,
+      routes: [
+        {
+          path: '/organizations/$orgId/products/$productId/repositories/$repoId/create-run',
+        },
+      ],
+    }
+  ),
+});
+
+const enabledPackageManagers = [
+  'Bazel',
+  'Bower',
+  'Bundler',
+  'Cargo',
+  'Carthage',
+  'CocoaPods',
+  'Composer',
+  'Conan',
+  'Gleam',
+  'GoMod',
+  'GradleInspector',
+  'Maven',
+  'NPM',
+  'NuGet',
+  'OrtProjectFile',
+  'PIP',
+  'Pipenv',
+  'PNPM',
+  'Poetry',
+  'Pub',
+  'SBT',
+  'SPDX',
+  'SpdxDocumentFile',
+  'Stack',
+  'SwiftPM',
+  'Tycho',
+  'Yarn',
+  'Yarn2',
+  'Unmanaged',
+];
+
+const getJobSwitch = (job: string) => {
+  const trigger = screen.getByRole('button', { name: job });
+  const row = trigger.closest('[data-slot="accordion-item"]')!.parentElement!;
+
+  return within(row).getByRole('switch');
+};
+
+describe('CreateRunForm', () => {
+  it('submits the payload produced from entered form values', async () => {
+    const { onSubmit, user } = renderCreateRunForm();
+
+    await user.type(await screen.findByLabelText('Revision'), 'main');
+    await user.type(screen.getByLabelText('Path'), 'src');
+    await user.click(getJobSwitch('Advisor'));
+    await user.click(screen.getByRole('button', { name: 'Advisor' }));
+    await user.type(screen.getByLabelText(/serverUrl/), 'https://osv.dev');
+    await user.click(getJobSwitch('Scanner'));
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(onSubmit).toHaveBeenCalledOnce();
+    expect(onSubmit).toHaveBeenCalledWith({
+      revision: 'main',
+      path: 'src',
+      jobConfigs: {
+        analyzer: {
+          allowDynamicVersions: true,
+          repositoryConfigPath: undefined,
+          skipExcluded: true,
+          enabledPackageManagers,
+          packageManagerOptions: undefined,
+          packageCurationProviders: undefined,
+          keepAliveWorker: undefined,
+          keepAlivePhases: undefined,
+        },
+        advisor: {
+          skipExcluded: true,
+          advisors: ['OSV', 'VulnerableCode'],
+          config: {
+            OSV: {
+              options: { serverUrl: 'https://osv.dev' },
+              secrets: {},
+            },
+          },
+          keepAliveWorker: undefined,
+        },
+        scanner: {
+          createMissingArchives: true,
+          skipConcluded: true,
+          skipExcluded: true,
+          keepAliveWorker: undefined,
+          scanners: ['ScanCode'],
+          projectScanners: undefined,
+          config: {
+            ScanCode: {
+              options: {},
+              secrets: {},
+            },
+          },
+        },
+        evaluator: undefined,
+        reporter: undefined,
+        notifier: undefined,
+        parameters: {},
+      },
+      labels: {},
+      jobConfigContext: '',
+      environmentConfigPath: '',
+    });
+  });
+
+  it('shows validation errors without submitting an invalid form', async () => {
+    const { onSubmit, user } = renderCreateRunForm();
+
+    await user.click(await screen.findByRole('button', { name: 'Create' }));
+
+    expect(
+      await screen.findByText(
+        'Required option "serverUrl" is missing for "OSV".'
+      )
+    ).toBeVisible();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+});

--- a/ui/tests/unit/components/licenses-accordion.test.tsx
+++ b/ui/tests/unit/components/licenses-accordion.test.tsx
@@ -17,12 +17,15 @@
  * License-Filename: LICENSE
  */
 
+// @vitest-environment jsdom
+
+import { screen } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { Identifier } from '@/api';
 import { LicensesAccordion } from '@/components/licenses/licenses-accordion';
-import { renderStaticWithRouter } from '../fixtures/router-harness';
+import { renderInteractiveWithRouter } from '../fixtures/render-interactive';
 
 const mocks = vi.hoisted(() => ({
   queryState: {
@@ -38,19 +41,6 @@ vi.mock('@tanstack/react-query', () => ({
 
 vi.mock('@/api/@tanstack/react-query.gen', () => ({
   getRunDetectedLicensesForIdentifierOptions: mocks.getOptions,
-}));
-
-vi.mock('@/components/ui/accordion', () => ({
-  Accordion: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-  AccordionItem: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
-  AccordionTrigger: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
-  AccordionContent: ({ children }: { children: ReactNode }) => (
-    <div>{children}</div>
-  ),
 }));
 
 vi.mock('@/components/licenses', () => ({
@@ -81,12 +71,12 @@ const identifier: Identifier = {
 
 const runPath = '/organizations/1/products/2/repositories/3/runs/4' as const;
 
-const renderAccordion = (
+const renderAccordion = async (
   accordionIdentifier = identifier,
   runId = 42,
   declaredLicenses: string[] = []
-) =>
-  renderStaticWithRouter(
+) => {
+  const result = renderInteractiveWithRouter(
     <LicensesAccordion
       runId={runId}
       identifier={accordionIdentifier}
@@ -105,11 +95,17 @@ const renderAccordion = (
     }
   );
 
-const getLinkUrls = (markup: string) =>
-  Array.from(
-    markup.matchAll(/href="([^"]+)"/g),
-    ([, href]) => new URL(href!.replaceAll('&amp;', '&'), 'http://localhost')
+  await result.user.click(
+    await screen.findByRole('button', { name: 'Licenses' })
   );
+
+  return result;
+};
+
+const getLinkUrls = () =>
+  screen
+    .getAllByRole('link')
+    .map((link) => new URL(link.getAttribute('href')!, 'http://localhost'));
 
 describe('LicensesAccordion', () => {
   beforeEach(() => {
@@ -122,30 +118,32 @@ describe('LicensesAccordion', () => {
   it('shows a loading indicator while licenses are loading', async () => {
     mocks.queryState.isPending = true;
 
-    expect(await renderAccordion()).toContain('Loading data...');
+    await renderAccordion();
+
+    expect(screen.getByText('Loading data...')).toBeVisible();
   });
 
   it('shows messages when no licenses were declared or detected', async () => {
     mocks.queryState.data = [];
 
-    const markup = await renderAccordion();
+    await renderAccordion();
 
-    expect(markup).toContain('No declared licenses.');
-    expect(markup).toContain('No licenses detected.');
+    expect(screen.getByText('No declared licenses.')).toBeVisible();
+    expect(screen.getByText('No licenses detected.')).toBeVisible();
   });
 
   it('renders comma-separated declared and detected licenses in labeled rows', async () => {
     mocks.queryState.data = ['Apache-2.0', 'GPL-2.0-only'];
 
-    const markup = await renderAccordion(identifier, 42, [
+    const { container } = await renderAccordion(identifier, 42, [
       'MIT',
       'BSD-3-Clause',
     ]);
 
-    expect(markup).toContain('Declared:');
-    expect(markup).toMatch(/MIT.*?,.*?BSD-3-Clause/);
-    expect(markup).toContain('Detected:');
-    expect(markup).toMatch(/Apache-2\.0.*?,.*?GPL-2\.0-only/);
+    expect(container).toHaveTextContent('Declared:');
+    expect(container).toHaveTextContent(/MIT,.*BSD-3-Clause/);
+    expect(container).toHaveTextContent('Detected:');
+    expect(container).toHaveTextContent(/Apache-2\.0,.*GPL-2\.0-only/);
   });
 
   it('passes the raw identifier to the generated client for URL encoding', async () => {
@@ -164,10 +162,10 @@ describe('LicensesAccordion', () => {
   it('renders one link for a detected license', async () => {
     mocks.queryState.data = ['Apache-2.0'];
 
-    const markup = await renderAccordion();
-    const links = getLinkUrls(markup);
+    await renderAccordion();
+    const links = getLinkUrls();
 
-    expect(markup).toContain('Apache-2.0');
+    expect(screen.getByRole('link', { name: 'Apache-2.0' })).toBeVisible();
     expect(links).toHaveLength(1);
     expect(links[0]?.pathname).toBe(`${runPath}/license-findings`);
   });
@@ -181,7 +179,7 @@ describe('LicensesAccordion', () => {
     };
     mocks.queryState.data = ['MIT'];
 
-    const markup = await renderAccordion(projectIdentifier, 84);
+    await renderAccordion(projectIdentifier, 84);
 
     expect(mocks.getOptions).toHaveBeenCalledWith({
       path: {
@@ -189,7 +187,7 @@ describe('LicensesAccordion', () => {
         identifier: 'Gradle::example-project:',
       },
     });
-    expect(getLinkUrls(markup)[0]?.searchParams.get('packageMarked')).toBe(
+    expect(getLinkUrls()[0]?.searchParams.get('packageMarked')).toBe(
       'Gradle::example-project:'
     );
   });
@@ -197,7 +195,8 @@ describe('LicensesAccordion', () => {
   it('keeps multiple expressions in independent exact links', async () => {
     mocks.queryState.data = ['MIT', 'MIT AND Apache-2.0'];
 
-    const links = getLinkUrls(await renderAccordion());
+    await renderAccordion();
+    const links = getLinkUrls();
 
     expect(links).toHaveLength(2);
     expect(Object.fromEntries(links[0]!.searchParams)).toEqual({

--- a/ui/tests/unit/components/search-package-sorting.test.tsx
+++ b/ui/tests/unit/components/search-package-sorting.test.tsx
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+// @vitest-environment jsdom
+
+import { screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { RunWithPackage } from '@/api/types.gen';
+import { Route } from '@/routes/organizations/$orgId/search-package';
+import { useUserSettingsStore } from '@/store/user-settings.store';
+import { renderInteractiveWithRouter } from '../fixtures/render-interactive';
+
+const mocks = vi.hoisted(() => ({
+  runs: [] as RunWithPackage[],
+}));
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('@tanstack/react-query')>();
+
+  return {
+    ...original,
+    useQuery: () => ({
+      data: mocks.runs,
+      error: null,
+      isError: false,
+      isPending: false,
+    }),
+    useSuspenseQuery: () => ({ data: { name: 'Product', url: 'Repository' } }),
+  };
+});
+
+const createRun = (
+  ortRunIndex: number,
+  name: string,
+  purlName: string
+): RunWithPackage => ({
+  createdAt: '2026-01-01T00:00:00Z',
+  organizationId: 1,
+  ortRunId: ortRunIndex,
+  ortRunIndex,
+  packageId: {
+    type: 'Maven',
+    namespace: 'org.example',
+    name,
+    version: '1.0',
+  },
+  productId: 2,
+  purl: `pkg:maven/org.example/${purlName}@1.0`,
+  repositoryId: 3,
+  revision: `revision-${ortRunIndex}`,
+});
+
+const runs = [
+  createRun(1, 'zulu', 'alpha'),
+  createRun(2, 'alpha', 'zulu'),
+  createRun(3, 'mike', 'mike'),
+];
+
+const expectedIdentifiers = {
+  ORT_ID: [
+    'Maven:org.example:alpha:1.0',
+    'Maven:org.example:mike:1.0',
+    'Maven:org.example:zulu:1.0',
+  ],
+  PURL: [
+    'pkg:maven/org.example/alpha@1.0',
+    'pkg:maven/org.example/mike@1.0',
+    'pkg:maven/org.example/zulu@1.0',
+  ],
+} as const;
+
+const SearchPackageComponent = Route.options.component!;
+
+const getDisplayedPackageIdentifiers = () => {
+  const headers = screen.getAllByRole('columnheader');
+  const packageColumnIndex = headers.findIndex((header) =>
+    header.textContent.includes('Matching Package')
+  );
+  expect(packageColumnIndex).toBeGreaterThanOrEqual(0);
+
+  return screen
+    .getAllByRole('row')
+    .slice(1)
+    .map(
+      (row) =>
+        within(row).getAllByRole('cell').at(packageColumnIndex)?.textContent
+    );
+};
+
+describe('search package sorting', () => {
+  beforeEach(() => {
+    mocks.runs = runs;
+  });
+
+  afterEach(() => {
+    useUserSettingsStore.setState({ packageIdType: 'ORT_ID' });
+  });
+
+  it.each(['ORT_ID', 'PURL'] as const)(
+    'sorts the displayed %s identifiers',
+    async (packageIdType) => {
+      useUserSettingsStore.setState({ packageIdType });
+
+      const { user } = renderInteractiveWithRouter(<SearchPackageComponent />, {
+        path: '/organizations/1/search-package?pkgId=example',
+        routes: [{ path: '/organizations/$orgId/search-package/' }],
+      });
+
+      const matchingPackageHeader = (
+        await screen.findByText('Matching Package')
+      ).closest('th');
+      expect(matchingPackageHeader).not.toBeNull();
+
+      await user.click(within(matchingPackageHeader!).getByRole('link'));
+
+      expect(getDisplayedPackageIdentifiers()).toEqual(
+        expectedIdentifiers[packageIdType]
+      );
+    }
+  );
+});


### PR DESCRIPTION
This PR adds the remaining interactive UI regression tests using the jsdom, React Testing Library, and router infrastructure introduced in #5805.
                                                                                   
The tests verify sorting by displayed package identifiers, card expansion with an empty sorting state, and the license accordion with the real Radix components. The create run form is extracted from its route and tested with real controls, including Advisor and Scanner configuration, payload creation, and validation errors.

This completes the planned UI test improvements for regressions related to #5684, #5696, and #5783.

Together, #5800, #5805, and this PR enable more reliable ways to test the UI (interactively when needed) and without mocked components, to prevent hard crashes on released code.

Please see the commits for details.