### PR TITLE
chore(azure-blob): Remove the `--skipApiVersionCheck` work-around again

### DIFF
--- a/storage/azure-blob/src/test/kotlin/AzureBlobStorageProviderTest.kt
+++ b/storage/azure-blob/src/test/kotlin/AzureBlobStorageProviderTest.kt
@@ -44,14 +44,7 @@ private const val ACCOUNT_KEY =
 private const val CONTAINER = "test"
 
 class AzureBlobStorageProviderTest : WordSpec({
-    val azuriteContainer = install(
-        TestContainerSpecExtension(
-            GenericContainer(Images.AZURITE)
-                // Skip the API version check to work around https://github.com/Azure/Azurite/issues/2623.
-                .withCommand("azurite-blob", "--skipApiVersionCheck", "--blobHost", "0.0.0.0")
-                .withExposedPorts(10000)
-        )
-    )
+    val azuriteContainer = install(TestContainerSpecExtension(GenericContainer(Images.AZURITE).withExposedPorts(10000)))
 
     lateinit var containerClient: BlobContainerClient
 


### PR DESCRIPTION
See how [1] has finally been closed.

[1]: https://github.com/Azure/Azurite/issues/2623