### PR TITLE
ui: Add a private repository easily

### DIFF
--- a/ui/src/components/form/optional-input.tsx
+++ b/ui/src/components/form/optional-input.tsx
@@ -17,10 +17,23 @@
  * License-Filename: LICENSE
  */
 
+import type { ComponentProps } from 'react';
+
 import { Input } from '@/components/ui/input.tsx';
 
-export const OptionalInput = ({ ...props }) => {
+type OptionalInputProps = Omit<
+  ComponentProps<typeof Input>,
+  'placeholder' | 'value'
+> & {
+  placeholder?: string;
+  value?: ComponentProps<typeof Input>['value'] | null;
+};
+
+export const OptionalInput = ({
+  placeholder = '(optional)',
+  ...props
+}: OptionalInputProps) => {
   return (
-    <Input {...props} placeholder='(optional)' value={props.value ?? ''} />
+    <Input {...props} placeholder={placeholder} value={props.value ?? ''} />
   );
 };

--- a/ui/src/components/form/password-input.tsx
+++ b/ui/src/components/form/password-input.tsx
@@ -30,6 +30,7 @@ export const PasswordInput = ({ ...props }) => {
       <Input type={showPassword ? 'text' : 'password'} {...props} />
       <button
         type='button'
+        aria-label={showPassword ? 'Hide password' : 'Show password'}
         className='absolute inset-y-0 right-0 flex items-center px-2'
         onClick={() => setShowPassword(!showPassword)}
       >

--- a/ui/src/lib/constants.ts
+++ b/ui/src/lib/constants.ts
@@ -21,6 +21,12 @@
 // the user scrolls, so this is only the size of one page, not the number of items reachable in it.
 export const DROPDOWN_PAGE_SIZE = 50;
 
+// A repository that is just being added cannot have secrets or an infrastructure service yet, so
+// fixed names keep them recognizable in the repository's Secrets and Infrastructure Services views.
+export const REPOSITORY_USER_SECRET = 'REPOSITORY-USERNAME';
+export const REPOSITORY_PASSWORD_SECRET = 'REPOSITORY-PASSWORD';
+export const REPOSITORY_ACCESS_SERVICE = 'REPOSITORY-ACCESS';
+
 // The base download URL for the downloadable assets of the latest ORT Server release.
 export const ORT_SERVER_GITHUB_RELEASES_BASE_URL =
   'https://github.com/eclipse-apoapsis/ort-server/releases';

--- a/ui/src/lib/repository-credentials.ts
+++ b/ui/src/lib/repository-credentials.ts
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import type { CredentialsType, RepositoryType } from '@/api';
+import {
+  postRepositoryInfrastructureService,
+  postRepositorySecret,
+} from '@/api/sdk.gen';
+import {
+  REPOSITORY_ACCESS_SERVICE,
+  REPOSITORY_PASSWORD_SECRET,
+  REPOSITORY_USER_SECRET,
+} from '@/lib/constants';
+
+export function getCredentialsTypes(type: RepositoryType): CredentialsType[] {
+  return type === 'GIT' ? ['GIT_CREDENTIALS_FILE'] : [];
+}
+
+type CreateRepositoryCredentialsOptions = {
+  repositoryId: number;
+  url: string;
+  type: RepositoryType;
+  username: string;
+  password: string;
+};
+
+export async function createRepositoryCredentials({
+  repositoryId,
+  url,
+  type,
+  username,
+  password,
+}: CreateRepositoryCredentialsOptions): Promise<void> {
+  const path = { repositoryId };
+
+  await postRepositorySecret({
+    path,
+    body: {
+      name: REPOSITORY_USER_SECRET,
+      value: username,
+      description: 'The username for accessing this repository.',
+    },
+    throwOnError: true,
+  });
+
+  await postRepositorySecret({
+    path,
+    body: {
+      name: REPOSITORY_PASSWORD_SECRET,
+      value: password,
+      description:
+        'The password or personal access token for accessing this repository.',
+    },
+    throwOnError: true,
+  });
+
+  await postRepositoryInfrastructureService({
+    path,
+    body: {
+      name: REPOSITORY_ACCESS_SERVICE,
+      url,
+      description: 'Access to the source code of this repository.',
+      usernameSecretRef: REPOSITORY_USER_SECRET,
+      passwordSecretRef: REPOSITORY_PASSWORD_SECRET,
+      credentialsTypes: getCredentialsTypes(type),
+    },
+    throwOnError: true,
+  });
+}

--- a/ui/src/lib/repository-credentials.ts
+++ b/ui/src/lib/repository-credentials.ts
@@ -17,8 +17,9 @@
  * License-Filename: LICENSE
  */
 
-import type { CredentialsType, RepositoryType } from '@/api';
+import type { CredentialsType, Repository, RepositoryType } from '@/api';
 import {
+  postRepository,
   postRepositoryInfrastructureService,
   postRepositorySecret,
 } from '@/api/sdk.gen';
@@ -27,6 +28,7 @@ import {
   REPOSITORY_PASSWORD_SECRET,
   REPOSITORY_USER_SECRET,
 } from '@/lib/constants';
+import type { CreateRepositoryFormValues } from '@/schemas';
 
 export function getCredentialsTypes(type: RepositoryType): CredentialsType[] {
   return type === 'GIT' ? ['GIT_CREDENTIALS_FILE'] : [];
@@ -82,4 +84,44 @@ export async function createRepositoryCredentials({
     },
     throwOnError: true,
   });
+}
+
+type CreateRepositoryAndCredentialsOptions = {
+  productId: number;
+  values: CreateRepositoryFormValues;
+};
+
+export type CreateRepositoryResult = {
+  repository: Repository;
+  credentialsError?: unknown;
+};
+
+export async function createRepositoryAndCredentials({
+  productId,
+  values,
+}: CreateRepositoryAndCredentialsOptions): Promise<CreateRepositoryResult> {
+  const { username, password, ...body } = values;
+
+  const { data: repository } = await postRepository({
+    path: { productId },
+    body,
+    throwOnError: true,
+  });
+
+  if (!username) return { repository };
+
+  try {
+    await createRepositoryCredentials({
+      repositoryId: repository.id,
+      url: repository.url,
+      type: repository.type,
+      username,
+      password,
+    });
+
+    return { repository };
+  } catch (error) {
+    // The repository exists; only its credentials are incomplete, which is reported and not undone.
+    return { repository, credentialsError: error };
+  }
 }

--- a/ui/src/routes/organizations/$orgId/products/$productId/create-repository/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/create-repository/index.tsx
@@ -91,19 +91,48 @@ export const CreateRepositoryForm = ({
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>
           <CardContent className='space-y-4'>
-            <FormField
-              control={form.control}
-              name='url'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>URL</FormLabel>
-                  <FormControl autoFocus>
-                    <Input {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+            <div className='grid gap-4 md:grid-cols-[minmax(0,1fr)_auto]'>
+              <FormField
+                control={form.control}
+                name='url'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>URL</FormLabel>
+                    <FormControl autoFocus>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name='type'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Type</FormLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      defaultValue={field.value}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder='Select a type' />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {Object.values(zRepositoryType.enum).map((type) => (
+                          <SelectItem key={type} value={type}>
+                            {getRepositoryTypeLabel(type)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
             <FormField
               control={form.control}
               name='name'
@@ -174,33 +203,6 @@ export const CreateRepositoryForm = ({
                 )}
               />
             </div>
-            <FormField
-              control={form.control}
-              name='type'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Type</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder='Select a type' />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {Object.values(zRepositoryType.enum).map((type) => (
-                        <SelectItem key={type} value={type}>
-                          {getRepositoryTypeLabel(type)}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
           </CardContent>
           <CardFooter>
             <Button

--- a/ui/src/routes/organizations/$orgId/products/$productId/create-repository/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/create-repository/index.tsx
@@ -21,11 +21,12 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { Loader2 } from 'lucide-react';
+import type { ChangeEvent } from 'react';
 import { useForm } from 'react-hook-form';
 
-import { postRepositoryMutation } from '@/api/@tanstack/react-query.gen';
 import { zRepositoryType } from '@/api/zod.gen';
 import { OptionalInput } from '@/components/form/optional-input.tsx';
+import { PasswordInput } from '@/components/form/password-input';
 import { Button } from '@/components/ui/button';
 import {
   Card,
@@ -50,29 +51,34 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { useUser } from '@/hooks/use-user';
 import { ApiError } from '@/lib/api-error';
 import { repositoryCreated } from '@/lib/entity-cache';
+import { createRepositoryAndCredentials } from '@/lib/repository-credentials';
 import { toast, toastError } from '@/lib/toast';
 import { getRepositoryTypeLabel } from '@/lib/types';
-import { repositoryFormSchema, type RepositoryFormValues } from '@/schemas';
+import {
+  createRepositoryFormSchema,
+  type CreateRepositoryFormValues,
+} from '@/schemas';
 
 interface CreateRepositoryFormProps {
   isPending: boolean;
-  onSubmit: (values: RepositoryFormValues) => Promise<void> | void;
+  onSubmit: (values: CreateRepositoryFormValues) => Promise<void> | void;
 }
 
 export const CreateRepositoryForm = ({
   isPending,
   onSubmit,
 }: CreateRepositoryFormProps) => {
-  const form = useForm<RepositoryFormValues>({
-    resolver: zodResolver(repositoryFormSchema),
+  const form = useForm<CreateRepositoryFormValues>({
+    resolver: zodResolver(createRepositoryFormSchema),
     defaultValues: {
       description: '',
       name: '',
       url: '',
       type: 'GIT',
+      username: '',
+      password: '',
     },
     mode: 'onChange',
   });
@@ -124,6 +130,50 @@ export const CreateRepositoryForm = ({
                 </FormItem>
               )}
             />
+            <div className='grid gap-4 md:grid-cols-2'>
+              <FormField
+                control={form.control}
+                name='username'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Username</FormLabel>
+                    <FormControl>
+                      <OptionalInput
+                        placeholder='(optional, only needed for private repositories)'
+                        {...field}
+                        onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                          field.onChange(event);
+                          void form.trigger(['username', 'password']);
+                        }}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name='password'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>
+                      Password or Personal Access Token (PAT)
+                    </FormLabel>
+                    <FormControl>
+                      <PasswordInput
+                        {...field}
+                        placeholder='(optional, only needed for private repositories)'
+                        onChange={(event: ChangeEvent<HTMLInputElement>) => {
+                          field.onChange(event);
+                          void form.trigger(['username', 'password']);
+                        }}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
             <FormField
               control={form.control}
               name='type'
@@ -173,28 +223,38 @@ export const CreateRepositoryForm = ({
   );
 };
 
-const CreateRepositoryPage = () => {
+export const CreateRepositoryPage = () => {
   const navigate = useNavigate();
   const params = Route.useParams();
   const queryClient = useQueryClient();
-  const { refreshUser } = useUser();
 
   const { mutateAsync, isPending } = useMutation({
-    ...postRepositoryMutation(),
-    onSuccess(data) {
-      // Refresh the user token and data to get the new roles after creating a new repository.
-      refreshUser();
+    mutationFn: (values: CreateRepositoryFormValues) =>
+      createRepositoryAndCredentials({
+        productId: Number.parseInt(params.productId),
+        values,
+      }),
+    onSuccess({ repository, credentialsError }) {
+      repositoryCreated(queryClient, repository.productId);
 
-      toast.info('Add Repository', {
-        description: `Repository ${data.url} added successfully.`,
-      });
-      repositoryCreated(queryClient, data.productId);
+      if (credentialsError) {
+        toastError(
+          `Repository ${repository.url} was added, but its credentials could not be stored. ` +
+            'Add the missing entries under the repository’s Secrets and Infrastructure Services.',
+          credentialsError
+        );
+      } else {
+        toast.info('Add Repository', {
+          description: `Repository ${repository.url} added successfully.`,
+        });
+      }
+
       navigate({
         to: '/organizations/$orgId/products/$productId/repositories/$repoId',
         params: {
           orgId: params.orgId,
           productId: params.productId,
-          repoId: data.id.toString(),
+          repoId: repository.id.toString(),
         },
       });
     },
@@ -203,11 +263,8 @@ const CreateRepositoryPage = () => {
     },
   });
 
-  async function onSubmit(values: RepositoryFormValues) {
-    await mutateAsync({
-      path: { productId: Number.parseInt(params.productId) },
-      body: values,
-    });
+  async function onSubmit(values: CreateRepositoryFormValues) {
+    await mutateAsync(values);
   }
 
   return <CreateRepositoryForm isPending={isPending} onSubmit={onSubmit} />;

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/settings/-components/edit-repository-form.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/settings/-components/edit-repository-form.tsx
@@ -77,19 +77,48 @@ export const EditRepositoryForm = ({
       <Form {...form}>
         <form onSubmit={form.handleSubmit(onSubmit)} className='space-y-8'>
           <CardContent className='space-y-4'>
-            <FormField
-              control={form.control}
-              name='url'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>URL</FormLabel>
-                  <FormControl autoFocus>
-                    <Input {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+            <div className='grid gap-4 md:grid-cols-[minmax(0,1fr)_auto]'>
+              <FormField
+                control={form.control}
+                name='url'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>URL</FormLabel>
+                    <FormControl autoFocus>
+                      <Input {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name='type'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Type</FormLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      defaultValue={field.value}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder='Select a type' />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {Object.values(zRepositoryType.enum).map((type) => (
+                          <SelectItem key={type} value={type}>
+                            {getRepositoryTypeLabel(type)}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
             <FormField
               control={form.control}
               name='name'
@@ -112,33 +141,6 @@ export const EditRepositoryForm = ({
                   <FormControl>
                     <OptionalInput {...field} />
                   </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name='type'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Type</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder='Select a type' />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {Object.values(zRepositoryType.enum).map((type) => (
-                        <SelectItem key={type} value={type}>
-                          {getRepositoryTypeLabel(type)}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/schemas/index.ts
+++ b/ui/src/schemas/index.ts
@@ -37,6 +37,44 @@ export const repositoryFormSchema = zRepository
 
 export type RepositoryFormValues = z.infer<typeof repositoryFormSchema>;
 
+export const createRepositoryFormSchema = repositoryFormSchema
+  .extend({
+    username: z
+      .string()
+      .refine((value) => value.length === 0 || value.trim().length > 0, {
+        message: 'A username cannot consist only of whitespace.',
+      }),
+    password: z
+      .string()
+      .refine((value) => value.length === 0 || value.trim().length > 0, {
+        message:
+          'A password or personal access token cannot consist only of whitespace.',
+      }),
+  })
+  .superRefine((values, ctx) => {
+    if (values.username && !values.password) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['password'],
+        message:
+          'A password or personal access token is required for the username.',
+      });
+    }
+
+    if (!values.username && values.password) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['username'],
+        message:
+          'A username is required for the password or personal access token.',
+      });
+    }
+  });
+
+export type CreateRepositoryFormValues = z.infer<
+  typeof createRepositoryFormSchema
+>;
+
 // Schema to validate that a string is a valid regular expression.
 export const regexSchema = z
   .object({

--- a/ui/tests/unit/components/create-repository-form.test.tsx
+++ b/ui/tests/unit/components/create-repository-form.test.tsx
@@ -19,11 +19,14 @@
 
 // @vitest-environment jsdom
 
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, expect, it, vi } from 'vitest';
 
 import { CreateRepositoryForm } from '@/routes/organizations/$orgId/products/$productId/create-repository';
+
+const repositoryUrl = 'https://example.com/repository.git';
+const passwordLabel = 'Password or Personal Access Token (PAT)';
 
 describe('CreateRepositoryForm', () => {
   it('enables creating a repository only when the URL is valid', async () => {
@@ -42,10 +45,125 @@ describe('CreateRepositoryForm', () => {
       await user.clear(urlInput);
     }
 
-    await user.type(urlInput, 'https://example.com/repository.git');
+    await user.type(urlInput, repositoryUrl);
     expect(createButton).toBeEnabled();
 
     await user.clear(urlInput);
     expect(createButton).toBeDisabled();
+  });
+
+  it('renders the fields in the expected order', () => {
+    const { container } = render(
+      <CreateRepositoryForm isPending={false} onSubmit={vi.fn()} />
+    );
+
+    const labels = Array.from(container.querySelectorAll('label')).map(
+      (label) => label.textContent
+    );
+
+    expect(labels).toEqual([
+      'URL',
+      'Name',
+      'Description',
+      'Username',
+      passwordLabel,
+      'Type',
+    ]);
+    const usernameField = screen
+      .getByLabelText('Username')
+      .closest('[data-slot="form-item"]');
+    const passwordField = screen
+      .getByLabelText(passwordLabel)
+      .closest('[data-slot="form-item"]');
+
+    expect(usernameField?.parentElement).toBe(passwordField?.parentElement);
+    expect(usernameField?.parentElement).toHaveClass('grid', 'md:grid-cols-2');
+    expect(
+      screen.getAllByPlaceholderText(
+        '(optional, only needed for private repositories)'
+      )
+    ).toHaveLength(2);
+  });
+
+  it('requires a password or token when a username is entered', async () => {
+    const user = userEvent.setup();
+
+    render(<CreateRepositoryForm isPending={false} onSubmit={vi.fn()} />);
+
+    const createButton = screen.getByRole('button', { name: 'Create' });
+    const usernameInput = screen.getByLabelText('Username');
+    const passwordInput = screen.getByLabelText(passwordLabel);
+
+    await user.type(screen.getByLabelText('URL'), repositoryUrl);
+    await user.type(usernameInput, 'jdoe');
+
+    expect(createButton).toBeDisabled();
+    expect(
+      await screen.findByText(
+        'A password or personal access token is required for the username.'
+      )
+    ).toBeVisible();
+
+    await user.type(passwordInput, 'token');
+    await waitFor(() => expect(createButton).toBeEnabled());
+
+    await user.clear(passwordInput);
+    expect(createButton).toBeDisabled();
+    await user.clear(usernameInput);
+    await waitFor(() => expect(createButton).toBeEnabled());
+  });
+
+  it('requires a username when a password or token is entered', async () => {
+    const user = userEvent.setup();
+
+    render(<CreateRepositoryForm isPending={false} onSubmit={vi.fn()} />);
+
+    await user.type(screen.getByLabelText('URL'), repositoryUrl);
+    await user.type(screen.getByLabelText(passwordLabel), 'token');
+
+    expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
+    expect(
+      await screen.findByText(
+        'A username is required for the password or personal access token.'
+      )
+    ).toBeVisible();
+  });
+
+  it('shows and hides the password or token', async () => {
+    const user = userEvent.setup();
+
+    render(<CreateRepositoryForm isPending={false} onSubmit={vi.fn()} />);
+
+    const passwordInput = screen.getByLabelText(passwordLabel);
+
+    expect(passwordInput).toHaveAttribute('type', 'password');
+
+    await user.click(screen.getByRole('button', { name: 'Show password' }));
+    expect(passwordInput).toHaveAttribute('type', 'text');
+
+    await user.click(screen.getByRole('button', { name: 'Hide password' }));
+    expect(passwordInput).toHaveAttribute('type', 'password');
+  });
+
+  it('submits the repository with its credentials', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(<CreateRepositoryForm isPending={false} onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText('URL'), repositoryUrl);
+    await user.type(screen.getByLabelText('Username'), 'jdoe');
+    await user.type(screen.getByLabelText(passwordLabel), 'token');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+    expect(onSubmit.mock.calls[0]?.[0]).toEqual({
+      description: '',
+      name: '',
+      password: 'token',
+      type: 'GIT',
+      url: repositoryUrl,
+      username: 'jdoe',
+    });
   });
 });

--- a/ui/tests/unit/components/create-repository-form.test.tsx
+++ b/ui/tests/unit/components/create-repository-form.test.tsx
@@ -63,12 +63,26 @@ describe('CreateRepositoryForm', () => {
 
     expect(labels).toEqual([
       'URL',
+      'Type',
       'Name',
       'Description',
       'Username',
       passwordLabel,
-      'Type',
     ]);
+
+    const urlField = screen
+      .getByLabelText('URL')
+      .closest('[data-slot="form-item"]');
+    const typeField = screen
+      .getByLabelText('Type')
+      .closest('[data-slot="form-item"]');
+
+    expect(urlField?.parentElement).toBe(typeField?.parentElement);
+    expect(urlField?.parentElement).toHaveClass(
+      'grid',
+      'md:grid-cols-[minmax(0,1fr)_auto]'
+    );
+
     const usernameField = screen
       .getByLabelText('Username')
       .closest('[data-slot="form-item"]');

--- a/ui/tests/unit/components/create-repository-page.test.tsx
+++ b/ui/tests/unit/components/create-repository-page.test.tsx
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+// @vitest-environment jsdom
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Repository } from '@/api';
+import type { ApiError } from '@/lib/api-error';
+import type { CreateRepositoryResult } from '@/lib/repository-credentials';
+import { CreateRepositoryPage } from '@/routes/organizations/$orgId/products/$productId/create-repository';
+
+const mocks = vi.hoisted(() => ({
+  mutationOptions: undefined as unknown,
+  mutateAsync: vi.fn(),
+  navigate: vi.fn(),
+  queryClient: {},
+  repositoryCreated: vi.fn(),
+  toastError: vi.fn(),
+  toastInfo: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useMutation: (options: unknown) => {
+    mocks.mutationOptions = options;
+    return { mutateAsync: mocks.mutateAsync, isPending: false };
+  },
+  useQueryClient: () => mocks.queryClient,
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (options: Record<string, unknown>) => ({
+    ...options,
+    useParams: () => ({ orgId: '1', productId: '2' }),
+  }),
+  useNavigate: () => mocks.navigate,
+}));
+
+vi.mock('@/lib/entity-cache', () => ({
+  repositoryCreated: mocks.repositoryCreated,
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast: { info: mocks.toastInfo },
+  toastError: mocks.toastError,
+}));
+
+type MutationOptions = {
+  onSuccess: (result: CreateRepositoryResult) => void;
+  onError: (error: ApiError) => void;
+};
+
+const repository: Repository = {
+  id: 42,
+  organizationId: 1,
+  productId: 2,
+  type: 'GIT',
+  url: 'https://example.org/repository.git',
+};
+
+const getMutationOptions = () => mocks.mutationOptions as MutationOptions;
+
+describe('CreateRepositoryPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.mutationOptions = undefined;
+    CreateRepositoryPage();
+  });
+
+  it('reports success and navigates to the repository', () => {
+    getMutationOptions().onSuccess({ repository });
+
+    expect(mocks.repositoryCreated).toHaveBeenCalledWith(
+      mocks.queryClient,
+      repository.productId
+    );
+    expect(mocks.toastInfo).toHaveBeenCalledWith('Add Repository', {
+      description: `Repository ${repository.url} added successfully.`,
+    });
+    expect(mocks.navigate).toHaveBeenCalledWith({
+      to: '/organizations/$orgId/products/$productId/repositories/$repoId',
+      params: {
+        orgId: '1',
+        productId: '2',
+        repoId: repository.id.toString(),
+      },
+    });
+  });
+
+  it('reports incomplete credentials and still navigates', () => {
+    const error = new Error('Could not create the credentials.');
+
+    getMutationOptions().onSuccess({ repository, credentialsError: error });
+
+    expect(mocks.repositoryCreated).toHaveBeenCalledWith(
+      mocks.queryClient,
+      repository.productId
+    );
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      `Repository ${repository.url} was added, but its credentials could not be stored. ` +
+        'Add the missing entries under the repository’s Secrets and Infrastructure Services.',
+      error
+    );
+    expect(mocks.navigate).toHaveBeenCalledOnce();
+  });
+
+  it('reports a repository creation error without updating the cache', () => {
+    const error = new Error('Could not create the repository.') as ApiError;
+
+    getMutationOptions().onError(error);
+
+    expect(mocks.toastError).toHaveBeenCalledWith(error.message, error);
+    expect(mocks.repositoryCreated).not.toHaveBeenCalled();
+    expect(mocks.navigate).not.toHaveBeenCalled();
+  });
+});

--- a/ui/tests/unit/components/edit-repository-form.test.tsx
+++ b/ui/tests/unit/components/edit-repository-form.test.tsx
@@ -44,8 +44,16 @@ describe('EditRepositoryForm', () => {
     );
 
     const urlInput = screen.getByLabelText('URL');
+    const typeInput = screen.getByLabelText('Type');
     const submitButton = screen.getByRole('button', { name: 'Submit' });
+    const urlField = urlInput.closest('[data-slot="form-item"]');
+    const typeField = typeInput.closest('[data-slot="form-item"]');
 
+    expect(urlField?.parentElement).toBe(typeField?.parentElement);
+    expect(urlField?.parentElement).toHaveClass(
+      'grid',
+      'md:grid-cols-[minmax(0,1fr)_auto]'
+    );
     await waitFor(() => expect(submitButton).toBeEnabled());
 
     for (const invalidUrl of ['not a URL', 's:', 'httttps:']) {

--- a/ui/tests/unit/logic/repository-credentials.test.ts
+++ b/ui/tests/unit/logic/repository-credentials.test.ts
@@ -26,12 +26,14 @@ import {
   REPOSITORY_USER_SECRET,
 } from '@/lib/constants';
 import {
+  createRepositoryAndCredentials,
   createRepositoryCredentials,
   getCredentialsTypes,
 } from '@/lib/repository-credentials';
 
 const mocks = vi.hoisted(() => ({
   calls: [] as string[],
+  postRepository: vi.fn(),
   postRepositoryInfrastructureService: vi.fn(async () => {
     mocks.calls.push('infrastructure-service');
   }),
@@ -41,23 +43,42 @@ const mocks = vi.hoisted(() => ({
 }));
 
 vi.mock('@/api/sdk.gen', () => ({
+  postRepository: mocks.postRepository,
   postRepositoryInfrastructureService:
     mocks.postRepositoryInfrastructureService,
   postRepositorySecret: mocks.postRepositorySecret,
 }));
 
-const options = {
-  repositoryId: 42,
-  url: 'https://example.org/repository.git',
+const repository = {
+  id: 42,
+  organizationId: 1,
+  productId: 2,
   type: 'GIT' as const,
+  url: 'https://example.org/repository.git',
+};
+
+const options = {
+  repositoryId: repository.id,
+  url: repository.url,
+  type: repository.type,
   username: 'jdoe',
   password: 'token',
+};
+
+const formValues = {
+  description: '',
+  name: '',
+  type: repository.type,
+  url: repository.url,
+  username: '',
+  password: '',
 };
 
 describe('repository credentials', () => {
   beforeEach(() => {
     mocks.calls = [];
     vi.clearAllMocks();
+    mocks.postRepository.mockResolvedValue({ data: repository });
   });
 
   it('uses credential names accepted by the API', () => {
@@ -144,5 +165,71 @@ describe('repository credentials', () => {
 
     expect(mocks.postRepositorySecret).toHaveBeenCalledTimes(2);
     expect(mocks.postRepositoryInfrastructureService).toHaveBeenCalledOnce();
+  });
+
+  it('creates a repository without credentials', async () => {
+    const result = await createRepositoryAndCredentials({
+      productId: repository.productId,
+      values: formValues,
+    });
+
+    expect(mocks.postRepository).toHaveBeenCalledWith({
+      path: { productId: repository.productId },
+      body: {
+        description: formValues.description,
+        name: formValues.name,
+        type: formValues.type,
+        url: formValues.url,
+      },
+      throwOnError: true,
+    });
+    expect(mocks.postRepositorySecret).not.toHaveBeenCalled();
+    expect(mocks.postRepositoryInfrastructureService).not.toHaveBeenCalled();
+    expect(result).toEqual({ repository });
+  });
+
+  it('creates repository credentials', async () => {
+    const result = await createRepositoryAndCredentials({
+      productId: repository.productId,
+      values: {
+        ...formValues,
+        username: options.username,
+        password: options.password,
+      },
+    });
+
+    expect(mocks.postRepositorySecret).toHaveBeenCalledTimes(2);
+    expect(mocks.postRepositoryInfrastructureService).toHaveBeenCalledOnce();
+    expect(result).toEqual({ repository });
+  });
+
+  it('rejects if creating the repository fails', async () => {
+    const error = new Error('Could not create the repository.');
+    mocks.postRepository.mockRejectedValueOnce(error);
+
+    await expect(
+      createRepositoryAndCredentials({
+        productId: repository.productId,
+        values: formValues,
+      })
+    ).rejects.toBe(error);
+
+    expect(mocks.postRepositorySecret).not.toHaveBeenCalled();
+  });
+
+  it('returns the repository if creating credentials fails', async () => {
+    const error = new Error('Could not create the user secret.');
+    mocks.postRepositorySecret.mockRejectedValueOnce(error);
+
+    const result = await createRepositoryAndCredentials({
+      productId: repository.productId,
+      values: {
+        ...formValues,
+        username: options.username,
+        password: options.password,
+      },
+    });
+
+    expect(result).toEqual({ repository, credentialsError: error });
   });
 });

--- a/ui/tests/unit/logic/repository-credentials.test.ts
+++ b/ui/tests/unit/logic/repository-credentials.test.ts
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { zRepositoryType } from '@/api/zod.gen';
+import {
+  REPOSITORY_ACCESS_SERVICE,
+  REPOSITORY_PASSWORD_SECRET,
+  REPOSITORY_USER_SECRET,
+} from '@/lib/constants';
+import {
+  createRepositoryCredentials,
+  getCredentialsTypes,
+} from '@/lib/repository-credentials';
+
+const mocks = vi.hoisted(() => ({
+  calls: [] as string[],
+  postRepositoryInfrastructureService: vi.fn(async () => {
+    mocks.calls.push('infrastructure-service');
+  }),
+  postRepositorySecret: vi.fn(async () => {
+    mocks.calls.push('secret');
+  }),
+}));
+
+vi.mock('@/api/sdk.gen', () => ({
+  postRepositoryInfrastructureService:
+    mocks.postRepositoryInfrastructureService,
+  postRepositorySecret: mocks.postRepositorySecret,
+}));
+
+const options = {
+  repositoryId: 42,
+  url: 'https://example.org/repository.git',
+  type: 'GIT' as const,
+  username: 'jdoe',
+  password: 'token',
+};
+
+describe('repository credentials', () => {
+  beforeEach(() => {
+    mocks.calls = [];
+    vi.clearAllMocks();
+  });
+
+  it('uses credential names accepted by the API', () => {
+    expect([
+      REPOSITORY_USER_SECRET,
+      REPOSITORY_PASSWORD_SECRET,
+      REPOSITORY_ACCESS_SERVICE,
+    ]).toEqual([
+      'REPOSITORY-USERNAME',
+      'REPOSITORY-PASSWORD',
+      'REPOSITORY-ACCESS',
+    ]);
+  });
+
+  it('maps every repository type to its credentials type', () => {
+    const credentialsTypes = Object.fromEntries(
+      Object.values(zRepositoryType.enum).map((type) => [
+        type,
+        getCredentialsTypes(type),
+      ])
+    );
+
+    expect(credentialsTypes).toEqual({
+      GIT: ['GIT_CREDENTIALS_FILE'],
+      GIT_REPO: [],
+      MERCURIAL: [],
+      SUBVERSION: [],
+    });
+  });
+
+  it('creates the secrets before the infrastructure service', async () => {
+    await createRepositoryCredentials(options);
+
+    expect(mocks.calls).toEqual(['secret', 'secret', 'infrastructure-service']);
+
+    expect(mocks.postRepositorySecret).toHaveBeenNthCalledWith(1, {
+      path: { repositoryId: options.repositoryId },
+      body: {
+        name: REPOSITORY_USER_SECRET,
+        value: options.username,
+        description: 'The username for accessing this repository.',
+      },
+      throwOnError: true,
+    });
+    expect(mocks.postRepositorySecret).toHaveBeenNthCalledWith(2, {
+      path: { repositoryId: options.repositoryId },
+      body: {
+        name: REPOSITORY_PASSWORD_SECRET,
+        value: options.password,
+        description:
+          'The password or personal access token for accessing this repository.',
+      },
+      throwOnError: true,
+    });
+    expect(mocks.postRepositoryInfrastructureService).toHaveBeenCalledWith({
+      path: { repositoryId: options.repositoryId },
+      body: {
+        name: REPOSITORY_ACCESS_SERVICE,
+        url: options.url,
+        description: 'Access to the source code of this repository.',
+        usernameSecretRef: REPOSITORY_USER_SECRET,
+        passwordSecretRef: REPOSITORY_PASSWORD_SECRET,
+        credentialsTypes: ['GIT_CREDENTIALS_FILE'],
+      },
+      throwOnError: true,
+    });
+  });
+
+  it('stops if creating the first secret fails', async () => {
+    const error = new Error('Could not create the user secret.');
+    mocks.postRepositorySecret.mockRejectedValueOnce(error);
+
+    await expect(createRepositoryCredentials(options)).rejects.toBe(error);
+
+    expect(mocks.postRepositorySecret).toHaveBeenCalledTimes(1);
+    expect(mocks.postRepositoryInfrastructureService).not.toHaveBeenCalled();
+  });
+
+  it('keeps the secrets if creating the infrastructure service fails', async () => {
+    const error = new Error('Could not create the infrastructure service.');
+    mocks.postRepositoryInfrastructureService.mockRejectedValueOnce(error);
+
+    await expect(createRepositoryCredentials(options)).rejects.toBe(error);
+
+    expect(mocks.postRepositorySecret).toHaveBeenCalledTimes(2);
+    expect(mocks.postRepositoryInfrastructureService).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/tests/unit/logic/repository-form-schema.test.ts
+++ b/ui/tests/unit/logic/repository-form-schema.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { createRepositoryFormSchema } from '@/schemas';
+
+const formValues = {
+  description: '',
+  name: '',
+  type: 'GIT' as const,
+  url: 'https://example.org/repository.git',
+  username: '',
+  password: '',
+};
+
+describe('createRepositoryFormSchema', () => {
+  it('accepts a repository without credentials', () => {
+    expect(createRepositoryFormSchema.safeParse(formValues).success).toBe(true);
+  });
+
+  it('accepts and retains complete credentials', () => {
+    const values = {
+      ...formValues,
+      username: 'jdoe',
+      password: 'token',
+    };
+
+    const result = createRepositoryFormSchema.safeParse(values);
+
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual(values);
+  });
+
+  it('rejects credentials containing only whitespace', () => {
+    const result = createRepositoryFormSchema.safeParse({
+      ...formValues,
+      username: '   ',
+      password: '   ',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.map((issue) => issue.path)).toContainEqual([
+      'username',
+    ]);
+    expect(result.error?.issues.map((issue) => issue.path)).toContainEqual([
+      'password',
+    ]);
+  });
+
+  it('requires a password or token when a username is set', () => {
+    const result = createRepositoryFormSchema.safeParse({
+      ...formValues,
+      username: 'jdoe',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.map((issue) => issue.path)).toContainEqual([
+      'password',
+    ]);
+  });
+
+  it('requires a username when a password or token is set', () => {
+    const result = createRepositoryFormSchema.safeParse({
+      ...formValues,
+      password: 'token',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.map((issue) => issue.path)).toContainEqual([
+      'username',
+    ]);
+  });
+
+  it('retains the repository URL validation', () => {
+    const result = createRepositoryFormSchema.safeParse({
+      ...formValues,
+      url: 'not a URL',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.map((issue) => issue.path)).toContainEqual([
+      'url',
+    ]);
+  });
+});

--- a/website/docs/user-guide/concepts/external-services.md
+++ b/website/docs/user-guide/concepts/external-services.md
@@ -31,6 +31,16 @@ If Git should not be able to obtain the credentials from the `Netrc` file, one c
 In some cases, there could be conflicting services; for instance, if multiple repositories with different credentials are defined on the same repository server.
 Therefore, it is also possible to choose not to include the credentials in any files.
 
+### Repository Credentials
+
+When adding a repository in the UI, you can optionally provide a username and a password or personal access token (PAT).
+ORT Server then creates the repository-scoped Secrets `REPOSITORY-USERNAME` and `REPOSITORY-PASSWORD` and the repository-scoped Infrastructure Service `REPOSITORY-ACCESS`.
+The Infrastructure Service points to the repository URL and references the two Secrets.
+For a Git repository, its credentials are added to the Git credentials file; no credential types is set for other repository types.
+
+You can view and edit these resources on the repository's _Secrets_ and _Infrastructure Services_ pages.
+If credentials are shared by multiple repositories, create an Infrastructure Service at the organization or product level instead.
+
 ### `.ort.env.yml` Example
 
 ```yaml


### PR DESCRIPTION
#### The user can specify credentials directly in the "Add repository" form

<img width="1181" height="468" alt="Screenshot from 2026-08-27 13-39-20" src="https://github.com/user-attachments/assets/9308fe7e-8559-4884-afef-709411984c2a" />

#### Repository secrets for credentials and an infrastructure service for repository access are automatically added

They are listed on the respective pages for review, but once the private repository has been added with credentials, the user is taken straight away to the "Create run" page, just as usual. The user doesn't have to even look at the secrets and infrastructure service but they are there for review:

<img width="1180" height="384" alt="Screenshot from 2026-08-28 06-20-18" src="https://github.com/user-attachments/assets/b721644b-f6c5-4fa2-8594-36160e8eff45" />
<img width="1172" height="391" alt="Screenshot from 2026-08-27 13-41-04" src="https://github.com/user-attachments/assets/75dce754-5e7e-4cd9-96c8-dbadef028a19" />

#### The user can go on analyzing the new private repository right away

<img width="1185" height="435" alt="Screenshot from 2026-08-27 16-01-19" src="https://github.com/user-attachments/assets/17076b4b-89e3-4d7b-8b59-43c1f89ceaba" />

Tested manually in the UI with the author's credentials and a private git repository - works as expected.

Please see the commits for details.