### PR TITLE
docs(website): Split releasing out of contributing

### DIFF
--- a/website/docs/developer-guide/contributing.md
+++ b/website/docs/developer-guide/contributing.md
@@ -6,18 +6,6 @@ position: 2
 
 See the [contributing guide](https://github.com/eclipse-apoapsis/ort-server/?tab=contributing-ov-file) for general information on how to contribute to the ORT Server project.
 
-## Semantic versioning
-
-The version of a new release is determined by the types of the commit messages since the previous release, following the [semantic versioning](https://semver.org/) scheme.
-For this, the [git-semver-plugin](https://github.com/jmongard/Git.SemVersioning.Gradle) for Gradle is used.
-Its documentation provides a [good overview](https://github.com/jmongard/Git.SemVersioning.Gradle?tab=readme-ov-file#example-of-how-version-is-calculated) of how the version is determined.
-
-To create a new release tag, run:
-
-```sh
-./gradlew releaseVersion
-```
-
 ## Code style
 
 The two main languages used in this project are [Kotlin](https://kotlinlang.org/) and [TypeScript](https://www.typescriptlang.org/).
@@ -29,3 +17,8 @@ You can also force `detekt` to automatically fix some issues (for example, impor
 
 For TypeScript, you can run `pnpm format:check` within the `ui/` and `/website` directories to check the code style.
 You can also automatically fix issues by running `pnpm format` within the respective directories.
+
+## Commit messages
+
+Commit messages need to follow the [conventional commit](https://www.conventionalcommits.org/) specification as the version of a new release is determined by the types of the commit messages since the previous release.
+Please refer to the respective section in the [contributing guide](https://github.com/eclipse-apoapsis/ort-server/?tab=contributing-ov-file#commit-messages) for details.

--- a/website/docs/developer-guide/releasing.md
+++ b/website/docs/developer-guide/releasing.md
@@ -1,0 +1,22 @@
+---
+position: 3
+---
+
+# Releasing
+
+## Semantic versioning
+
+The version of a new release is determined by the types of the commit messages since the previous release, following the [semantic versioning](https://semver.org/) scheme.
+For this, the [git-semver-plugin](https://github.com/jmongard/Git.SemVersioning.Gradle) for Gradle is used.
+Its documentation provides a [good overview](https://github.com/jmongard/Git.SemVersioning.Gradle?tab=readme-ov-file#example-of-how-version-is-calculated) of how the version is determined.
+
+## Creating a release
+
+To create a new release tag, run
+
+```sh
+./gradlew releaseVersion
+```
+
+to create a local release tag in Git.
+Committers can then execute `git push origin <tag>` to push the tag to the remote repository, which triggers the release workflow on GitHub.


### PR DESCRIPTION
As most contributors do not do releases, split out creating releases into a dedicated section, and generally reword docs a bit.