### PR TITLE
ui: Allow writers and entity creators to manage secrets

### DIFF
--- a/components/authorization/backend/src/main/kotlin/rights/OrganizationRole.kt
+++ b/components/authorization/backend/src/main/kotlin/rights/OrganizationRole.kt
@@ -47,6 +47,7 @@ enum class OrganizationRole(
         organizationPermissions = setOf(
             OrganizationPermission.READ,
             OrganizationPermission.WRITE,
+            OrganizationPermission.WRITE_SECRETS,
             OrganizationPermission.READ_PRODUCTS,
             OrganizationPermission.CREATE_PRODUCT
         ),

--- a/components/authorization/backend/src/main/kotlin/rights/ProductRole.kt
+++ b/components/authorization/backend/src/main/kotlin/rights/ProductRole.kt
@@ -46,6 +46,7 @@ enum class ProductRole(
         productPermissions = setOf(
             ProductPermission.READ,
             ProductPermission.WRITE,
+            ProductPermission.WRITE_SECRETS,
             ProductPermission.READ_REPOSITORIES,
             ProductPermission.CREATE_REPOSITORY,
             ProductPermission.TRIGGER_ORT_RUN

--- a/components/authorization/backend/src/main/kotlin/rights/RepositoryRole.kt
+++ b/components/authorization/backend/src/main/kotlin/rights/RepositoryRole.kt
@@ -43,6 +43,7 @@ enum class RepositoryRole(
         repositoryPermissions = setOf(
             RepositoryPermission.READ,
             RepositoryPermission.WRITE,
+            RepositoryPermission.WRITE_SECRETS,
             RepositoryPermission.MANAGE_RESOLUTIONS,
             RepositoryPermission.READ_ORT_RUNS,
             RepositoryPermission.TRIGGER_ORT_RUN

--- a/components/secrets/backend/src/test/kotlin/routes/SecretsAuthorizationTest.kt
+++ b/components/secrets/backend/src/test/kotlin/routes/SecretsAuthorizationTest.kt
@@ -182,7 +182,7 @@ class SecretsAuthorizationTest : AbstractAuthorizationTest({
         "require OrganizationPermission.WRITE_SECRETS" {
             requestShouldRequireRole(
                 routes = { secretsRoutes(repositoryService, secretService) },
-                role = OrganizationRole.ADMIN,
+                role = OrganizationRole.WRITER,
                 successStatus = HttpStatusCode.NotFound,
                 hierarchyId = orgHierarchyId
             ) {
@@ -196,7 +196,7 @@ class SecretsAuthorizationTest : AbstractAuthorizationTest({
         "require ProductPermission.WRITE_SECRETS" {
             requestShouldRequireRole(
                 routes = { secretsRoutes(repositoryService, secretService) },
-                role = ProductRole.ADMIN,
+                role = ProductRole.WRITER,
                 successStatus = HttpStatusCode.NotFound,
                 hierarchyId = productHierarchyId
             ) {
@@ -210,7 +210,7 @@ class SecretsAuthorizationTest : AbstractAuthorizationTest({
         "require RepositoryPermission.WRITE_SECRETS" {
             requestShouldRequireRole(
                 routes = { secretsRoutes(repositoryService, secretService) },
-                role = RepositoryRole.ADMIN,
+                role = RepositoryRole.WRITER,
                 successStatus = HttpStatusCode.NotFound,
                 hierarchyId = repoHierarchyId
             ) {
@@ -224,7 +224,7 @@ class SecretsAuthorizationTest : AbstractAuthorizationTest({
         "require OrganizationPermission.WRITE_SECRETS" {
             requestShouldRequireRole(
                 routes = { secretsRoutes(repositoryService, secretService) },
-                role = OrganizationRole.ADMIN,
+                role = OrganizationRole.WRITER,
                 successStatus = HttpStatusCode.Created,
                 hierarchyId = orgHierarchyId
             ) {
@@ -238,7 +238,7 @@ class SecretsAuthorizationTest : AbstractAuthorizationTest({
         "require ProductPermission.WRITE_SECRETS" {
             requestShouldRequireRole(
                 routes = { secretsRoutes(repositoryService, secretService) },
-                role = ProductRole.ADMIN,
+                role = ProductRole.WRITER,
                 successStatus = HttpStatusCode.Created,
                 hierarchyId = productHierarchyId
             ) {
@@ -252,7 +252,7 @@ class SecretsAuthorizationTest : AbstractAuthorizationTest({
         "require RepositoryPermission.WRITE_SECRETS" {
             requestShouldRequireRole(
                 routes = { secretsRoutes(repositoryService, secretService) },
-                role = RepositoryRole.ADMIN,
+                role = RepositoryRole.WRITER,
                 successStatus = HttpStatusCode.Created,
                 hierarchyId = repoHierarchyId
             ) {

--- a/compositions/secrets-routes/src/test/kotlin/SecretsRoutesAuthorizationTest.kt
+++ b/compositions/secrets-routes/src/test/kotlin/SecretsRoutesAuthorizationTest.kt
@@ -75,7 +75,7 @@ class SecretsRoutesAuthorizationTest : AbstractAuthorizationTest({
         "require OrganizationPermission.WRITE_SECRETS" {
             requestShouldRequireRole(
                 routes = { secretsCompositionRoutes(infrastructureServiceService, secretService) },
-                role = OrganizationRole.ADMIN,
+                role = OrganizationRole.WRITER,
                 successStatus = HttpStatusCode.NotFound,
                 hierarchyId = orgHierarchyId
             ) {
@@ -88,7 +88,7 @@ class SecretsRoutesAuthorizationTest : AbstractAuthorizationTest({
         "require ProductPermission.WRITE_SECRETS" {
             requestShouldRequireRole(
                 routes = { secretsCompositionRoutes(infrastructureServiceService, secretService) },
-                role = ProductRole.ADMIN,
+                role = ProductRole.WRITER,
                 successStatus = HttpStatusCode.NotFound,
                 hierarchyId = prodHierarchyId
             ) {
@@ -101,7 +101,7 @@ class SecretsRoutesAuthorizationTest : AbstractAuthorizationTest({
         "require RepositoryPermission.WRITE_SECRETS" {
             requestShouldRequireRole(
                 routes = { secretsCompositionRoutes(infrastructureServiceService, secretService) },
-                role = RepositoryRole.ADMIN,
+                role = RepositoryRole.WRITER,
                 successStatus = HttpStatusCode.NotFound,
                 hierarchyId = repoHierarchyId
             ) {

--- a/core/src/main/kotlin/api/OrganizationsRoute.kt
+++ b/core/src/main/kotlin/api/OrganizationsRoute.kt
@@ -180,8 +180,12 @@ fun Route.organizations() = route("organizations") {
                 val createProduct = call.receive<PostProduct>()
                 val orgId = call.requireIdParameter("organizationId")
 
-                val createdProduct =
-                    organizationService.createProduct(createProduct.name, createProduct.description, orgId)
+                val createdProduct = organizationService.createProduct(
+                    createProduct.name,
+                    createProduct.description,
+                    orgId,
+                    requirePrincipal().username
+                )
 
                 call.respond(HttpStatusCode.Created, createdProduct.mapToApi())
             }

--- a/core/src/main/kotlin/api/ProductsRoute.kt
+++ b/core/src/main/kotlin/api/ProductsRoute.kt
@@ -160,7 +160,8 @@ fun Route.products() = route("products/{productId}") {
                 createRepository.url,
                 id,
                 createRepository.name,
-                createRepository.description
+                createRepository.description,
+                requirePrincipal().username
             ).mapToApi()
 
             call.respond(

--- a/services/hierarchy/src/main/kotlin/OrganizationService.kt
+++ b/services/hierarchy/src/main/kotlin/OrganizationService.kt
@@ -25,9 +25,11 @@ import org.eclipse.apoapsis.ortserver.components.authorization.service.Authoriza
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
 import org.eclipse.apoapsis.ortserver.dao.repositories.product.ProductsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.repository.RepositoriesTable
+import org.eclipse.apoapsis.ortserver.model.CompoundHierarchyId
 import org.eclipse.apoapsis.ortserver.model.Organization
 import org.eclipse.apoapsis.ortserver.model.OrganizationId
 import org.eclipse.apoapsis.ortserver.model.Product
+import org.eclipse.apoapsis.ortserver.model.ProductId
 import org.eclipse.apoapsis.ortserver.model.repositories.OrganizationRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.ProductRepository
 import org.eclipse.apoapsis.ortserver.model.util.FilterParameter
@@ -58,8 +60,26 @@ class OrganizationService(
     /**
      * Create a product inside an [organization][organizationId].
      */
-    suspend fun createProduct(name: String, description: String?, organizationId: Long) = db.dbQuery {
-        productRepository.create(name, description, organizationId)
+    suspend fun createProduct(
+        name: String,
+        description: String?,
+        organizationId: Long,
+        creatorId: String? = null
+    ): Product {
+        val product = db.dbQuery {
+            productRepository.create(name, description, organizationId)
+        }
+
+        if (creatorId != null) {
+            // TODO: Make product creation and creator role assignment atomic.
+            authorizationService.assignRole(
+                creatorId,
+                ProductRole.ADMIN,
+                CompoundHierarchyId.forProduct(OrganizationId(organizationId), ProductId(product.id))
+            )
+        }
+
+        return product
     }
 
     /**

--- a/services/hierarchy/src/main/kotlin/ProductService.kt
+++ b/services/hierarchy/src/main/kotlin/ProductService.kt
@@ -24,11 +24,14 @@ import org.eclipse.apoapsis.ortserver.components.authorization.service.Authoriza
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
 import org.eclipse.apoapsis.ortserver.dao.repositories.ortrun.OrtRunsTable
 import org.eclipse.apoapsis.ortserver.dao.repositories.repository.RepositoriesTable
+import org.eclipse.apoapsis.ortserver.model.CompoundHierarchyId
+import org.eclipse.apoapsis.ortserver.model.OrganizationId
 import org.eclipse.apoapsis.ortserver.model.OrtRun
 import org.eclipse.apoapsis.ortserver.model.OrtRunStatus
 import org.eclipse.apoapsis.ortserver.model.Product
 import org.eclipse.apoapsis.ortserver.model.ProductId
 import org.eclipse.apoapsis.ortserver.model.Repository
+import org.eclipse.apoapsis.ortserver.model.RepositoryId
 import org.eclipse.apoapsis.ortserver.model.RepositoryType
 import org.eclipse.apoapsis.ortserver.model.repositories.OrtRunRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.ProductRepository
@@ -64,15 +67,33 @@ class ProductService(
         url: String,
         productId: Long,
         name: String?,
-        description: String?
-    ): Repository = db.dbQuery {
-        repositoryRepository.create(
-            type = type,
-            url = url,
-            productId = productId,
-            name = name,
-            description = description
-        )
+        description: String?,
+        creatorId: String? = null
+    ): Repository {
+        val repository = db.dbQuery {
+            repositoryRepository.create(
+                type = type,
+                url = url,
+                productId = productId,
+                name = name,
+                description = description
+            )
+        }
+
+        if (creatorId != null) {
+            // TODO: Make repository creation and creator role assignment atomic.
+            authorizationService.assignRole(
+                creatorId,
+                RepositoryRole.ADMIN,
+                CompoundHierarchyId.forRepository(
+                    OrganizationId(repository.organizationId),
+                    ProductId(productId),
+                    RepositoryId(repository.id)
+                )
+            )
+        }
+
+        return repository
     }
 
     /**

--- a/services/hierarchy/src/test/kotlin/OrganizationServiceTest.kt
+++ b/services/hierarchy/src/test/kotlin/OrganizationServiceTest.kt
@@ -25,6 +25,7 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 
 import org.eclipse.apoapsis.ortserver.components.authorization.rights.OrganizationRole
@@ -55,6 +56,32 @@ class OrganizationServiceTest : WordSpec({
         organizationRepository = dbExtension.fixtures.organizationRepository
         productRepository = dbExtension.fixtures.productRepository
         fixtures = dbExtension.fixtures
+    }
+
+    "createProduct" should {
+        "assign the admin role to the product creator" {
+            val userId = "test-user"
+            val organizationId = fixtures.organization.id
+            val authorizationService = mockk<AuthorizationService> {
+                coEvery { assignRole(any(), any(), any()) } returns Unit
+            }
+            val service = OrganizationService(db, organizationRepository, productRepository, authorizationService)
+
+            val product = service.createProduct(
+                name = "product",
+                description = "description",
+                organizationId = organizationId,
+                creatorId = userId
+            )
+
+            coVerify {
+                authorizationService.assignRole(
+                    userId,
+                    ProductRole.ADMIN,
+                    CompoundHierarchyId.forProduct(OrganizationId(organizationId), ProductId(product.id))
+                )
+            }
+        }
     }
 
     "getRepositoryIdsForOrganization" should {

--- a/services/hierarchy/src/test/kotlin/ProductServiceTest.kt
+++ b/services/hierarchy/src/test/kotlin/ProductServiceTest.kt
@@ -27,6 +27,7 @@ import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.mockk
 
 import org.eclipse.apoapsis.ortserver.components.authorization.rights.RepositoryRole
@@ -107,6 +108,42 @@ class ProductServiceTest : WordSpec({
             repository.name shouldBe "Repository name"
             repository.description shouldBe "Repository description"
             repositoryRepository.get(repository.id)?.name shouldBe "Repository name"
+        }
+
+        "assign the admin role to the repository creator" {
+            val userId = "test-user"
+            val authorizationService = mockk<AuthorizationService> {
+                coEvery { assignRole(any(), any(), any()) } returns Unit
+            }
+            val service = ProductService(
+                db,
+                productRepository,
+                repositoryRepository,
+                ortRunRepository,
+                authorizationService
+            )
+            val product = fixtures.createProduct()
+
+            val repository = service.createRepository(
+                type = RepositoryType.GIT,
+                url = "https://example.com/repository.git",
+                productId = product.id,
+                name = "Repository name",
+                description = "Repository description",
+                creatorId = userId
+            )
+
+            coVerify {
+                authorizationService.assignRole(
+                    userId,
+                    RepositoryRole.ADMIN,
+                    CompoundHierarchyId.forRepository(
+                        OrganizationId(product.organizationId),
+                        ProductId(product.id),
+                        RepositoryId(repository.id)
+                    )
+                )
+            }
         }
 
         "allow creating repositories with the same url if their names differ" {

--- a/website/docs/user-guide/concepts/structure.md
+++ b/website/docs/user-guide/concepts/structure.md
@@ -50,9 +50,12 @@ On repository level, they can see ORT run results.
 #### Writers
 
 Users in the _writers_ group have the roles of the _readers_ group.
-Additionally, they can create child entities. On repository level, they can trigger new ORT runs.
+Additionally, they can manage secrets and infrastructure services and create child entities.
+On product and repository levels, they can trigger new ORT runs.
 
 #### Admins
 
 Users in the _admins_ group have the roles of the _writers_ group.
-Additionally, they can manage secrets, infrastructure services and user groups.
+Additionally, they can manage user groups and delete the entity.
+
+A user who creates a product or repository automatically becomes an admin of it.


### PR DESCRIPTION
Writers can now manage also secrets for organizations, products, and repositories where they have access. Users who create a new product or repository also automatically become an administrator of it, allowing them to fully configure the new entity without receiving broader rights on its parent.

Tested manually with the UI by creating a test user which had WRITER access to a product (but not ADMIN):
- before the PR: trying to create a new private repository to the product fails due to secrets not created (with a back-end error)
- after the PR: creating a new private repository succeeds

Please see the commits for details.