### PR TITLE
Git config file provider improvements

### DIFF
--- a/components/infrastructure-services/backend/build.gradle.kts
+++ b/components/infrastructure-services/backend/build.gradle.kts
@@ -17,10 +17,6 @@
  * License-Filename: LICENSE
  */
 
-import org.gradle.kotlin.dsl.withType
-
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
     id("ort-server-kotlin-component-backend-conventions")
     id("ort-server-publication-conventions")

--- a/config/git/README.md
+++ b/config/git/README.md
@@ -40,6 +40,7 @@ To avoid hard-coding the configuration of the provider in the `application.conf`
 configManager {
   fileProvider = ${?ANALYZER_CONFIG_FILE_PROVIDER}
   gitUrl = ${?ANALYZER_CONFIG_GIT_URL}
+  gitRevisionCacheTtlSeconds = ${?ANALYZER_CONFIG_GIT_REVISION_CACHE_TTL}
 }
 ```
 
@@ -52,6 +53,25 @@ configManager {
 }
 ```
 The concrete secret values are then queried from the _secrets provider_.
+
+### Revision caching
+
+When a branch name (e.g. `main`) is used as the context, resolving it to a concrete revision via `resolveContext` requires network access to the Git repository.
+In deployments where `resolveContext` is called frequently (for instance, once per API request), the provider caches the mapping from a requested context to its resolved revision for a configurable time-to-live.
+Within this time-to-live, repeated calls to `resolveContext` for the same context return the cached revision without accessing the network.
+
+The time-to-live is controlled by the optional `gitRevisionCacheTtlSeconds` property (in seconds) and defaults to `60`:
+
+```
+configManager {
+  fileProvider = "git-config"
+  gitUrl = "https://config.repository.git"
+  gitRevisionCacheTtlSeconds = 60
+}
+```
+
+Note that, as a consequence of caching, a moved branch tip may not be observed until the cache entry expires; that is, changes to the configuration repository can be delayed by up to `gitRevisionCacheTtlSeconds`.
+Setting the property to `0` effectively disables the cache, so that every call to `resolveContext` resolves the revision anew.
 
 ### Runtime configuration
 

--- a/config/git/build.gradle.kts
+++ b/config/git/build.gradle.kts
@@ -39,5 +39,6 @@ dependencies {
 
     testImplementation(libs.kotest.assertions.core)
     testImplementation(libs.kotest.runner.junit5)
+    testImplementation(libs.kotlinx.coroutines)
     testImplementation(libs.mockk)
 }

--- a/config/git/src/main/kotlin/GitConfigFileProvider.kt
+++ b/config/git/src/main/kotlin/GitConfigFileProvider.kt
@@ -26,6 +26,10 @@ import java.io.FilterInputStream
 import java.io.InputStream
 import java.util.HashMap
 
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TimeMark
+import kotlin.time.TimeSource
 import kotlin.time.measureTime
 
 import org.eclipse.apoapsis.ortserver.config.ConfigException
@@ -33,6 +37,7 @@ import org.eclipse.apoapsis.ortserver.config.ConfigFileProvider
 import org.eclipse.apoapsis.ortserver.config.Context
 import org.eclipse.apoapsis.ortserver.config.Path
 import org.eclipse.apoapsis.ortserver.config.resolveSecurely
+import org.eclipse.apoapsis.ortserver.utils.config.getLongOrDefault
 import org.eclipse.apoapsis.ortserver.utils.config.getServiceUrl
 
 import org.ossreviewtoolkit.model.VcsInfo
@@ -49,13 +54,27 @@ import org.slf4j.LoggerFactory
  */
 class GitConfigFileProvider internal constructor(
     private val gitUrl: String,
-    private val configDir: File
+    private val configDir: File,
+    internal val revisionCacheTtl: Duration = DEFAULT_REVISION_CACHE_TTL_SECONDS,
+    private val timeSource: TimeSource = TimeSource.Monotonic
 ) : ConfigFileProvider {
     companion object {
         /**
          * Configuration property for the Git URL.
          */
         const val GIT_URL = "gitUrl"
+
+        /**
+         * Configuration property for the time-to-live (in seconds) of the [revisionCache] that maps a requested context
+         * (like a branch name) to its resolved revision.
+         */
+        const val GIT_REVISION_CACHE_TTL_SECONDS = "gitRevisionCacheTtlSeconds"
+
+        /** The default time-to-live of the [revisionCache] if [GIT_REVISION_CACHE_TTL_SECONDS] is unset. */
+        val DEFAULT_REVISION_CACHE_TTL_SECONDS = 60.seconds
+
+        /** The maximum number of entries kept in the [revisionCache]. */
+        internal const val MAX_REVISION_CACHE_SIZE = 100
 
         private val logger = LoggerFactory.getLogger(GitConfigFileProvider::class.java)
 
@@ -64,10 +83,14 @@ class GitConfigFileProvider internal constructor(
          */
         fun create(config: Config): GitConfigFileProvider {
             val gitUrl = config.getServiceUrl(GIT_URL)
+            val revisionCacheTtl = config.getLongOrDefault(
+                GIT_REVISION_CACHE_TTL_SECONDS,
+                DEFAULT_REVISION_CACHE_TTL_SECONDS.inWholeSeconds
+            ).seconds
 
             logger.info("Creating GitConfigFileProvider for repository '{}'.", gitUrl)
 
-            return GitConfigFileProvider(gitUrl, createOrtTempDir())
+            return GitConfigFileProvider(gitUrl, createOrtTempDir(), revisionCacheTtl)
         }
     }
 
@@ -89,10 +112,37 @@ class GitConfigFileProvider internal constructor(
      */
     internal val snapshotDir = createOrtTempDir()
 
+    /**
+     * A cache mapping a requested [Context] name (like a branch name) to its most recently resolved revision together
+     * with the point in time when it expires. This is a bounded LRU map: it holds at most [MAX_REVISION_CACHE_SIZE]
+     * entries and evicts the least recently used one when that limit is exceeded, so that the cache cannot grow without
+     * bound in long-running processes.
+     */
+    private val revisionCache = object : LinkedHashMap<String, CachedRevision>(16, 0.75f, true) {
+        override fun removeEldestEntry(eldest: Map.Entry<String, CachedRevision>) = size > MAX_REVISION_CACHE_SIZE
+    }
+
     override fun resolveContext(context: Context): Context = synchronized(lock) {
-        val resolvedRevision = updateWorkingTree(context.name)
+        val requestedRevision = context.name
+
+        val cached = revisionCache[requestedRevision]
+
+        val resolvedRevision = if (cached != null && cached.expiresAt.hasNotPassedNow()) {
+            logger.debug("Using cached revision '{}' for context '{}'.", cached.revision, requestedRevision)
+            cached.revision
+        } else {
+            resolveRevision(requestedRevision).also {
+                logger.debug("Resolved revision '{}' for context '{}'.", it, requestedRevision)
+                revisionCache[requestedRevision] = CachedRevision(it, timeSource.markNow() + revisionCacheTtl)
+            }
+        }
+
         Context(resolvedRevision)
     }
+
+    /** Resolve the given [requestedRevision] to a concrete revision by updating the working tree. */
+    internal fun resolveRevision(requestedRevision: String): String =
+        synchronized(lock) { updateWorkingTree(requestedRevision) }
 
     override fun getFile(context: Context, path: Path): InputStream =
         synchronized(lock) {
@@ -205,6 +255,15 @@ class GitConfigFileProvider internal constructor(
         )
     }
 }
+
+/**
+ * A cached revision resolution: the resolved [revision] and the [expiresAt] time mark after which
+ * the entry is considered stale and must be resolved again.
+ */
+private data class CachedRevision(
+    val revision: String,
+    val expiresAt: TimeMark
+)
 
 /**
  * An [InputStream] that reads from the given [tempFile] and deletes it when the stream is closed. This is used to serve

--- a/config/git/src/main/kotlin/GitConfigFileProvider.kt
+++ b/config/git/src/main/kotlin/GitConfigFileProvider.kt
@@ -22,6 +22,7 @@ package org.eclipse.apoapsis.ortserver.config.git
 import com.typesafe.config.Config
 
 import java.io.File
+import java.io.FilterInputStream
 import java.io.InputStream
 import java.util.HashMap
 
@@ -43,7 +44,8 @@ import org.slf4j.LoggerFactory
 
 /**
  * An implementation of [ConfigFileProvider] that reads config files from Git and stores them to a local directory. The
- * directory is temporary and only exists for the lifetime of a job.
+ * directory is temporary and only exists for the lifetime of a job. The provider is thread-safe and all function calls
+ * are processed sequentially to avoid race conditions when using different [Context]s.
  */
 class GitConfigFileProvider internal constructor(
     private val gitUrl: String,
@@ -71,28 +73,60 @@ class GitConfigFileProvider internal constructor(
 
     private val git = GitFactory.create(historyDepth = 1)
 
-    override fun resolveContext(context: Context): Context {
+    /**
+     * A lock guarding all access to the working tree in [configDir]. A single provider instance can be accessed
+     * concurrently by multiple threads, and all of them share this instance's one working tree. Therefore, the sequence
+     * of updating the tree to the requested revision and reading files from it must happen atomically. Otherwise, a
+     * concurrent call requesting a different revision could re-checkout the tree between the update and the read,
+     * causing files from the wrong revision, an inconsistent tree, or read failures to be observed.
+     */
+    private val lock = Any()
+
+    /**
+     * A dedicated temporary directory for storing snapshots of configuration files served via [getFile]. It exists for
+     * the lifetime of this provider. Individual snapshot files in this directory are deleted when their stream is
+     * closed.
+     */
+    internal val snapshotDir = createOrtTempDir()
+
+    override fun resolveContext(context: Context): Context = synchronized(lock) {
         val resolvedRevision = updateWorkingTree(context.name)
-        return Context(resolvedRevision)
+        Context(resolvedRevision)
     }
 
     override fun getFile(context: Context, path: Path): InputStream =
-        runCatching {
-            updateWorkingTree(context.name)
-            configDir.resolveSecurely(path).inputStream()
-        }.getOrElse {
-            throw ConfigException("Cannot read path '${path.path}'.", it)
+        synchronized(lock) {
+            runCatching {
+                updateWorkingTree(context.name)
+
+                // Copy the file to a temporary location while holding the lock, so that reading the returned stream is
+                // not affected by a concurrent update of the working tree.
+                val sourceFile = configDir.resolveSecurely(path)
+                val tempFile = File.createTempFile("config", null, snapshotDir)
+
+                runCatching {
+                    sourceFile.inputStream().use { input ->
+                        tempFile.outputStream().use { output -> input.copyTo(output) }
+                    }
+
+                    DeleteOnCloseInputStream(tempFile)
+                }.onFailure {
+                    tempFile.delete()
+                }.getOrThrow()
+            }.getOrElse {
+                throw ConfigException("Cannot read path '${path.path}'.", it)
+            }
         }
 
-    override fun contains(context: Context, path: Path): Boolean {
+    override fun contains(context: Context, path: Path): Boolean = synchronized(lock) {
         updateWorkingTree(context.name)
         val p = configDir.resolveSecurely(path)
         val isDirectoryPath = path.path.endsWith("/")
 
-        return (!isDirectoryPath && p.isFile) || (isDirectoryPath && p.isDirectory)
+        (!isDirectoryPath && p.isFile) || (isDirectoryPath && p.isDirectory)
     }
 
-    override fun listFiles(context: Context, path: Path): Set<Path> {
+    override fun listFiles(context: Context, path: Path): Set<Path> = synchronized(lock) {
         updateWorkingTree(context.name)
 
         val dir = configDir.resolveSecurely(path)
@@ -101,42 +135,42 @@ class GitConfigFileProvider internal constructor(
             throw ConfigException("The provided path '${path.path}' does not refer a directory.")
         }
 
-        return dir.walk().maxDepth(1).filter { it.isFile }
+        dir.walk().maxDepth(1).filter { it.isFile }
             .mapTo(mutableSetOf()) { Path(it.relativeTo(configDir).path) }
     }
 
     /**
      * Update the working tree to the [requestedRevision]. If the [configDir] does not contain a ".git" subdirectory,
      * the working tree is initialized first. The resolved revision is returned.
+     *
+     * This function must not be called concurrently, all callers must make sure to synchronize against [lock].
      */
     private fun updateWorkingTree(requestedRevision: String): String {
-        synchronized(this) {
-            try {
-                val revisionToCheckout = requestedRevision.ifBlank { git.getDefaultBranchName(gitUrl) }
-                val workingTree = git.getWorkingTree(configDir)
+        try {
+            val revisionToCheckout = requestedRevision.ifBlank { git.getDefaultBranchName(gitUrl) }
+            val workingTree = git.getWorkingTree(configDir)
 
-                if (!workingTree.isValid()) {
-                    val vcsInfo = VcsInfo(VcsType.GIT, gitUrl, revisionToCheckout)
+            if (!workingTree.isValid()) {
+                val vcsInfo = VcsInfo(VcsType.GIT, gitUrl, revisionToCheckout)
 
-                    measureTime { git.initWorkingTree(configDir, vcsInfo) }.also {
-                        logger.debug("Initialized Git working tree in $it.")
-                    }
+                measureTime { git.initWorkingTree(configDir, vcsInfo) }.also {
+                    logger.debug("Initialized Git working tree in $it.")
                 }
-
-                // Check if the requested revision was already checked out.
-                if (workingTree.getRevision() == revisionToCheckout) return revisionToCheckout
-
-                // Update the working tree to the requested revision.
-                measureTime {
-                    git.updateWorkingTree(workingTree, revisionToCheckout, recursive = true).getOrThrow()
-                }.also {
-                    logger.debug("Updated Git working tree to revision '$revisionToCheckout' in $it.")
-                }
-
-                return workingTree.getRevision()
-            } finally {
-                clearHttpAuthCache()
             }
+
+            // Check if the requested revision was already checked out.
+            if (workingTree.getRevision() == revisionToCheckout) return revisionToCheckout
+
+            // Update the working tree to the requested revision.
+            measureTime {
+                git.updateWorkingTree(workingTree, revisionToCheckout, recursive = true).getOrThrow()
+            }.also {
+                logger.debug("Updated Git working tree to revision '$revisionToCheckout' in $it.")
+            }
+
+            return workingTree.getRevision()
+        } finally {
+            clearHttpAuthCache()
         }
     }
 
@@ -169,5 +203,21 @@ class GitConfigFileProvider internal constructor(
                     "setting '--add-opens java.base/sun.net.www.protocol.http=ALL-UNNAMED' javaOpts.",
             e
         )
+    }
+}
+
+/**
+ * An [InputStream] that reads from the given [tempFile] and deletes it when the stream is closed. This is used to serve
+ * the content of a configuration file from a temporary copy that is independent of the shared working tree.
+ */
+private class DeleteOnCloseInputStream(
+    private val tempFile: File
+) : FilterInputStream(tempFile.inputStream()) {
+    override fun close() {
+        try {
+            super.close()
+        } finally {
+            tempFile.delete()
+        }
     }
 }

--- a/config/git/src/main/kotlin/GitConfigFileProvider.kt
+++ b/config/git/src/main/kotlin/GitConfigFileProvider.kt
@@ -182,7 +182,7 @@ class GitConfigFileProvider internal constructor(
         val dir = configDir.resolveSecurely(path)
 
         if (!dir.isDirectory) {
-            throw ConfigException("The provided path '${path.path}' does not refer a directory.")
+            throw ConfigException("The provided path '${path.path}' does not refer to a directory.")
         }
 
         dir.walk().maxDepth(1).filter { it.isFile }

--- a/config/git/src/test/kotlin/GitConfigFileProviderCacheTest.kt
+++ b/config/git/src/test/kotlin/GitConfigFileProviderCacheTest.kt
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2024 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.config.git
+
+import com.typesafe.config.ConfigFactory
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.shouldBe
+
+import io.mockk.every
+import io.mockk.spyk
+import io.mockk.verify
+
+import java.nio.file.Files
+
+import kotlin.time.Duration.Companion.seconds
+import kotlin.time.TestTimeSource
+
+import org.eclipse.apoapsis.ortserver.config.Context
+import org.eclipse.apoapsis.ortserver.config.git.GitConfigFileProvider.Companion.MAX_REVISION_CACHE_SIZE
+
+private const val TEST_GIT_URL = "https://example.org/config-repo.git"
+
+/**
+ * Tests for the revision caching of [GitConfigFileProvider]. These tests stub the (expensive) revision resolution, so
+ * they do not require network access.
+ */
+class GitConfigFileProviderCacheTest : WordSpec({
+    "create" should {
+        "use the default cache TTL if the property is not set" {
+            val config = ConfigFactory.parseMap(mapOf(GitConfigFileProvider.GIT_URL to TEST_GIT_URL))
+
+            val provider = GitConfigFileProvider.create(config)
+
+            provider.revisionCacheTtl shouldBe GitConfigFileProvider.DEFAULT_REVISION_CACHE_TTL_SECONDS
+        }
+
+        "use the configured cache TTL" {
+            val config = ConfigFactory.parseMap(
+                mapOf(
+                    GitConfigFileProvider.GIT_URL to TEST_GIT_URL,
+                    GitConfigFileProvider.GIT_REVISION_CACHE_TTL_SECONDS to 120
+                )
+            )
+
+            val provider = GitConfigFileProvider.create(config)
+
+            provider.revisionCacheTtl shouldBe 120.seconds
+        }
+    }
+
+    "resolveContext" should {
+        "cache the resolved revision within the TTL" {
+            val timeSource = TestTimeSource()
+            val provider = createProviderSpy(timeSource)
+            every { provider.resolveRevision("main") } returns "sha-main"
+
+            provider.resolveContext(Context("main")).name shouldBe "sha-main"
+
+            timeSource += 59.seconds
+            provider.resolveContext(Context("main")).name shouldBe "sha-main"
+
+            verify(exactly = 1) { provider.resolveRevision("main") }
+        }
+
+        "resolve the revision again after the TTL has elapsed" {
+            val timeSource = TestTimeSource()
+            val provider = createProviderSpy(timeSource)
+            every { provider.resolveRevision("main") } returnsMany listOf("sha-old", "sha-new")
+
+            provider.resolveContext(Context("main")).name shouldBe "sha-old"
+
+            timeSource += 61.seconds
+            provider.resolveContext(Context("main")).name shouldBe "sha-new"
+
+            verify(exactly = 2) { provider.resolveRevision("main") }
+        }
+
+        "cache distinct contexts independently" {
+            val timeSource = TestTimeSource()
+            val provider = createProviderSpy(timeSource)
+            every { provider.resolveRevision("main") } returns "sha-main"
+            every { provider.resolveRevision("dev") } returns "sha-dev"
+
+            provider.resolveContext(Context("main")).name shouldBe "sha-main"
+            provider.resolveContext(Context("dev")).name shouldBe "sha-dev"
+            provider.resolveContext(Context("main")).name shouldBe "sha-main"
+
+            verify(exactly = 1) { provider.resolveRevision("main") }
+            verify(exactly = 1) { provider.resolveRevision("dev") }
+        }
+
+        "evict the least recently used entry when the cache is full" {
+            val timeSource = TestTimeSource()
+            val provider = createProviderSpy(timeSource)
+            every { provider.resolveRevision(any()) } answers { "sha-${firstArg<String>()}" }
+
+            // Fill the cache up to its maximum capacity. The first inserted entry is the least recently used.
+            repeat(MAX_REVISION_CACHE_SIZE) { provider.resolveContext(Context("branch-$it")) }
+
+            // Insert one more entry, which must evict the least recently used entry ("branch-0").
+            provider.resolveContext(Context("branch-$MAX_REVISION_CACHE_SIZE"))
+
+            // The evicted entry must be resolved anew, while a still-cached entry must not.
+            provider.resolveContext(Context("branch-0"))
+            provider.resolveContext(Context("branch-${MAX_REVISION_CACHE_SIZE - 1}"))
+
+            verify(exactly = 2) { provider.resolveRevision("branch-0") }
+            verify(exactly = 1) { provider.resolveRevision("branch-${MAX_REVISION_CACHE_SIZE - 1}") }
+        }
+    }
+})
+
+private fun createProviderSpy(timeSource: TestTimeSource) =
+    spyk(
+        GitConfigFileProvider(
+            TEST_GIT_URL,
+            Files.createTempDirectory("git-config-cache-test").toFile(),
+            revisionCacheTtl = 60.seconds,
+            timeSource = timeSource
+        )
+    )

--- a/config/git/src/test/kotlin/GitConfigFileProviderTest.kt
+++ b/config/git/src/test/kotlin/GitConfigFileProviderTest.kt
@@ -31,6 +31,7 @@ import org.eclipse.apoapsis.ortserver.config.ConfigException
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.config.Context
 import org.eclipse.apoapsis.ortserver.config.Path
+import org.eclipse.apoapsis.ortserver.utils.test.Integration
 
 internal const val GIT_URL = "https://github.com/doubleopen-project/ort-config-test.git"
 
@@ -43,6 +44,8 @@ private const val GIT_REVISION_DEV = "c7c011911baa064bef049c88807c4503fbe957c0"
 private val RESOLVED_CONTEXT_DEV = Context(GIT_REVISION_DEV)
 
 class GitConfigFileProviderTest : WordSpec({
+    tags(Integration)
+
     "resolveContext" should {
         "resolve an empty context successfully to HEAD of default branch" {
             val provider = GitConfigFileProvider(GIT_URL, tempdir())

--- a/config/git/src/test/kotlin/GitConfigFileProviderTest.kt
+++ b/config/git/src/test/kotlin/GitConfigFileProviderTest.kt
@@ -27,10 +27,15 @@ import io.kotest.matchers.shouldBe
 
 import java.io.IOException
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+
 import org.eclipse.apoapsis.ortserver.config.ConfigException
 import org.eclipse.apoapsis.ortserver.config.ConfigManager
 import org.eclipse.apoapsis.ortserver.config.Context
 import org.eclipse.apoapsis.ortserver.config.Path
+import org.eclipse.apoapsis.ortserver.utils.logging.runBlocking
 import org.eclipse.apoapsis.ortserver.utils.test.Integration
 
 internal const val GIT_URL = "https://github.com/doubleopen-project/ort-config-test.git"
@@ -244,6 +249,58 @@ class GitConfigFileProviderTest : WordSpec({
 
             shouldThrow<ConfigException> {
                 provider.getFile(RESOLVED_CONTEXT_MAIN, Path("/etc/passwd"))
+            }
+        }
+
+        "return a stream that is not affected by a later checkout of a different revision" {
+            val mainContent = "This is the main branch of the repository"
+            val provider = GitConfigFileProvider(GIT_URL, tempdir())
+
+            // Obtain the stream for the `main` branch but do not read it yet.
+            provider.getFile(RESOLVED_CONTEXT_MAIN, Path("README.md")).use { stream ->
+                // Change the shared working tree to a different revision before reading.
+                provider.resolveContext(RESOLVED_CONTEXT_DEV)
+
+                val fileContent = stream.bufferedReader(Charsets.UTF_8).readText()
+
+                fileContent shouldBe mainContent
+            }
+        }
+
+        "delete the backing temporary file when the returned stream is closed" {
+            val provider = GitConfigFileProvider(GIT_URL, tempdir())
+
+            val stream = provider.getFile(RESOLVED_CONTEXT_MAIN, Path("README.md"))
+
+            val tempDir = provider.snapshotDir
+            tempDir.walk().maxDepth(1).count { it.isFile } shouldBe 1
+
+            stream.use { it.bufferedReader(Charsets.UTF_8).readText() }
+
+            tempDir.walk().maxDepth(1).count { it.isFile } shouldBe 0
+        }
+    }
+
+    "concurrent access" should {
+        "read files from the correct revisions when accessed concurrently" {
+            val provider = GitConfigFileProvider(GIT_URL, tempdir())
+            val mainContent = "This is the main branch of the repository"
+            val devContent = "This is a dev branch of the repository"
+
+            runBlocking(Dispatchers.IO) {
+                (1..10).map { index ->
+                    async {
+                        if (index % 2 == 0) {
+                            val content = provider.getFile(RESOLVED_CONTEXT_MAIN, Path("README.md"))
+                                .bufferedReader(Charsets.UTF_8).use { it.readText() }
+                            content shouldBe mainContent
+                        } else {
+                            val content = provider.getFile(RESOLVED_CONTEXT_DEV, Path("README.md"))
+                                .bufferedReader(Charsets.UTF_8).use { it.readText() }
+                            content shouldBe devContent
+                        }
+                    }
+                }.awaitAll()
             }
         }
     }

--- a/dao/build.gradle.kts
+++ b/dao/build.gradle.kts
@@ -17,8 +17,6 @@
  * License-Filename: LICENSE
  */
 
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-
 plugins {
     // Apply core plugins.
     `java-test-fixtures`

--- a/workers/advisor/src/main/resources/application.conf
+++ b/workers/advisor/src/main/resources/application.conf
@@ -31,6 +31,7 @@ configManager {
   gitHubCacheCleanupRatio = 50
   gitHubCacheCleanupRatio = ${?ADVISOR_CONFIG_GITHUB_CACHE_CLEANUP_RATIO}
   gitUrl = ${?ADVISOR_CONFIG_GIT_URL}
+  gitRevisionCacheTtlSeconds = ${?ADVISOR_CONFIG_GIT_REVISION_CACHE_TTL}
   localConfigDir = ${?ADVISOR_CONFIG_LOCAL_CONFIG_DIR}
 }
 

--- a/workers/analyzer/src/main/resources/application.conf
+++ b/workers/analyzer/src/main/resources/application.conf
@@ -31,6 +31,7 @@ configManager {
   gitHubCacheCleanupRatio = 50
   gitHubCacheCleanupRatio = ${?ANALYZER_CONFIG_GITHUB_CACHE_CLEANUP_RATIO}
   gitUrl = ${?ANALYZER_CONFIG_GIT_URL}
+  gitRevisionCacheTtlSeconds = ${?ANALYZER_CONFIG_GIT_REVISION_CACHE_TTL}
   localConfigDir = ${?ANALYZER_CONFIG_LOCAL_CONFIG_DIR}
 }
 

--- a/workers/config/src/main/resources/application.conf
+++ b/workers/config/src/main/resources/application.conf
@@ -31,6 +31,7 @@ configManager {
   gitHubCacheCleanupRatio = 50
   gitHubCacheCleanupRatio = ${?CONFIG_CONFIG_GITHUB_CACHE_CLEANUP_RATIO}
   gitUrl = ${?CONFIG_CONFIG_GIT_URL}
+  gitRevisionCacheTtlSeconds = ${?CONFIG_CONFIG_GIT_REVISION_CACHE_TTL}
   localConfigDir = ${?CONFIG_CONFIG_LOCAL_CONFIG_DIR}
 }
 

--- a/workers/evaluator/src/main/resources/application.conf
+++ b/workers/evaluator/src/main/resources/application.conf
@@ -31,6 +31,7 @@ configManager {
   gitHubCacheCleanupRatio = 50
   gitHubCacheCleanupRatio = ${?EVALUATOR_CONFIG_GITHUB_CACHE_CLEANUP_RATIO}
   gitUrl = ${?EVALUATOR_CONFIG_GIT_URL}
+  gitRevisionCacheTtlSeconds = ${?EVALUATOR_CONFIG_GIT_REVISION_CACHE_TTL}
   localConfigDir = ${?EVALUATOR_CONFIG_LOCAL_CONFIG_DIR}
 }
 

--- a/workers/notifier/src/main/resources/application.conf
+++ b/workers/notifier/src/main/resources/application.conf
@@ -31,6 +31,7 @@ configManager {
   gitHubCacheCleanupRatio = 50
   gitHubCacheCleanupRatio = ${?NOTIFIER_CONFIG_GITHUB_CACHE_CLEANUP_RATIO}
   gitUrl = ${?NOTIFIER_CONFIG_GIT_URL}
+  gitRevisionCacheTtlSeconds = ${?NOTIFIER_CONFIG_GIT_REVISION_CACHE_TTL}
   localConfigDir = ${?NOTIFIER_CONFIG_LOCAL_CONFIG_DIR}
 }
 

--- a/workers/reporter/src/main/resources/application.conf
+++ b/workers/reporter/src/main/resources/application.conf
@@ -31,6 +31,7 @@ configManager {
   gitHubCacheCleanupRatio = 50
   gitHubCacheCleanupRatio = ${?REPORTER_CONFIG_GITHUB_CACHE_CLEANUP_RATIO}
   gitUrl = ${?REPORTER_CONFIG_GIT_URL}
+  gitRevisionCacheTtlSeconds = ${?REPORTER_CONFIG_GIT_REVISION_CACHE_TTL}
   localConfigDir = ${?REPORTER_CONFIG_LOCAL_CONFIG_DIR}
 }
 

--- a/workers/scanner/src/main/resources/application.conf
+++ b/workers/scanner/src/main/resources/application.conf
@@ -31,6 +31,7 @@ configManager {
   gitHubCacheCleanupRatio = 50
   gitHubCacheCleanupRatio = ${?SCANNER_CONFIG_GITHUB_CACHE_CLEANUP_RATIO}
   gitUrl = ${?SCANNER_CONFIG_GIT_URL}
+  gitRevisionCacheTtlSeconds = ${?SCANNER_CONFIG_GIT_REVISION_CACHE_TTL}
   localConfigDir = ${?SCANNER_CONFIG_LOCAL_CONFIG_DIR}
 }
 


### PR DESCRIPTION
Prepare the `GitConfigFileProvider` to be used in `:core`, see the commit messages for details.