### PR TITLE
ui: Clean up user role terminology in UI

### DIFF
--- a/ui/src/components/ui/user-role-row-actions.tsx
+++ b/ui/src/components/ui/user-role-row-actions.tsx
@@ -29,28 +29,27 @@ import {
 } from '@/components/ui/dropdown-menu.tsx';
 import type { AppRow } from '@/hooks/use-app-table';
 
-type UserGroupRowActionsProps = {
+type UserRoleRowActionsProps = {
   row: AppRow<UserWithGroups>;
-  onJoinAdminsGroup: (user: UserWithGroups) => Promise<void>;
-  onJoinWritersGroup: (user: UserWithGroups) => Promise<void>;
-  onJoinReadersGroup: (user: UserWithGroups) => Promise<void>;
+  onAssignAdminRole: (user: UserWithGroups) => Promise<void>;
+  onAssignWriterRole: (user: UserWithGroups) => Promise<void>;
+  onAssignReaderRole: (user: UserWithGroups) => Promise<void>;
   disabled: boolean;
 };
 
 /**
- * Component for rendering row actions in a user group table.
- * Provides options to join different user groups (ADMINS, WRITERS, READERS).
+ * Render actions for assigning hierarchy roles to a user.
  *
- * @param {UserGroupRowActionsProps} props - The props for the component.
+ * @param {UserRoleRowActionsProps} props - The props for the component.
  * @returns {JSX.Element} The rendered component.
  */
-export function UserGroupRowActions({
+export function UserRoleRowActions({
   row,
-  onJoinAdminsGroup,
-  onJoinWritersGroup,
-  onJoinReadersGroup,
+  onAssignAdminRole,
+  onAssignWriterRole,
+  onAssignReaderRole,
   ...nativeButtonAttributes // From standard HTML button attributes
-}: UserGroupRowActionsProps) {
+}: UserRoleRowActionsProps) {
   const userWithGroups: UserWithGroups = row.original;
   const groups: UserGroup[] = row.original.groups;
 
@@ -62,27 +61,27 @@ export function UserGroupRowActions({
 
       <DropdownMenuContent side='bottom' align='end'>
         {!groups.includes('ADMINS') && (
-          <DropdownMenuItem onSelect={() => onJoinAdminsGroup(userWithGroups)}>
+          <DropdownMenuItem onSelect={() => onAssignAdminRole(userWithGroups)}>
             <div className='flex items-center gap-x-2'>
-              <span>Join ADMINS</span>
+              <span>Assign ADMIN role</span>
               <Shield size={16} />
             </div>
           </DropdownMenuItem>
         )}
 
         {!groups.includes('WRITERS') && (
-          <DropdownMenuItem onSelect={() => onJoinWritersGroup(userWithGroups)}>
+          <DropdownMenuItem onSelect={() => onAssignWriterRole(userWithGroups)}>
             <div className='flex items-center gap-x-2'>
-              <span>Join WRITERS</span>
+              <span>Assign WRITER role</span>
               <Pen size={16} />
             </div>
           </DropdownMenuItem>
         )}
 
         {!groups.includes('READERS') && (
-          <DropdownMenuItem onSelect={() => onJoinReadersGroup(userWithGroups)}>
+          <DropdownMenuItem onSelect={() => onAssignReaderRole(userWithGroups)}>
             <div className='flex items-center gap-x-2'>
-              <span>Join READERS</span>
+              <span>Assign READER role</span>
               <Eye size={16} />
             </div>
           </DropdownMenuItem>

--- a/ui/src/helpers/role-helpers.ts
+++ b/ui/src/helpers/role-helpers.ts
@@ -27,9 +27,10 @@ import {
   RepositoryRole,
   UserGroup,
 } from '@/api';
-import { groupsSchema } from '@/schemas';
+import { roleSchema } from '@/schemas';
 
-// Temporary helper functions to help with migration from groups to roles.
+// These helpers bridge the inconsistent generated list response and role
+// mutation contracts until the API uses role terminology consistently.
 
 export const mapUserGroupToOrganizationRole = (
   group: UserGroup
@@ -68,54 +69,13 @@ export const mapUserGroupToRepositoryRole = (
   }
 };
 
-export const mapGroupSchemaToOrganizationRole = (
-  group: z.infer<typeof groupsSchema>
-): OrganizationRole => {
-  switch (group) {
-    case 'admins':
-      return 'ADMIN';
-    case 'writers':
-      return 'WRITER';
-    case 'readers':
-      return 'READER';
-  }
-};
-
-export const mapGroupSchemaToProductRole = (
-  group: z.infer<typeof groupsSchema>
-): ProductRole => {
-  switch (group) {
-    case 'admins':
-      return 'ADMIN';
-    case 'writers':
-      return 'WRITER';
-    case 'readers':
-      return 'READER';
-  }
-};
-
-export const mapGroupSchemaToRepositoryRole = (
-  group: z.infer<typeof groupsSchema>
-): RepositoryRole => {
-  switch (group) {
-    case 'admins':
-      return 'ADMIN';
-    case 'writers':
-      return 'WRITER';
-    case 'readers':
-      return 'READER';
-  }
-};
-
-export const getGroupIcon = (
-  group: z.infer<typeof groupsSchema>
-): JSX.Element => {
-  switch (group) {
-    case 'admins':
+export const getRoleIcon = (role: z.infer<typeof roleSchema>): JSX.Element => {
+  switch (role) {
+    case 'ADMIN':
       return createElement(Shield, { size: 16 });
-    case 'writers':
+    case 'WRITER':
       return createElement(Pen, { size: 16 });
-    case 'readers':
+    case 'READER':
       return createElement(Eye, { size: 16 });
   }
 };

--- a/ui/src/routes/admin/users/authorization/index.tsx
+++ b/ui/src/routes/admin/users/authorization/index.tsx
@@ -18,15 +18,8 @@
  */
 
 import { createFileRoute } from '@tanstack/react-router';
-import { ExternalLink } from 'lucide-react';
 
-import {
-  Card,
-  CardContent,
-  CardFooter,
-  CardHeader,
-  CardTitle,
-} from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
 const Authorization = () => {
   return (
@@ -37,31 +30,15 @@ const Authorization = () => {
       <CardContent>
         <div>
           <p>
-            When an organization, a product, or a repository is created, groups
-            for admins, writers and readers for that entity are automatically
-            added.
+            Organizations, products, and repositories have reader, writer, and
+            admin roles.
           </p>
           <p className='mt-2'>
-            To give user access to an entity, browse to the corresponding entity
-            and add the user to the appropriate group in the "Users" section.
+            To give a user access to an organization, product, or repository,
+            browse to it and assign the appropriate role in its "Users" section.
           </p>
         </div>
       </CardContent>
-      <CardFooter>
-        <div className='text-sm'>
-          More information on{' '}
-          <a
-            href={
-              'https://eclipse-apoapsis.github.io/ort-server/docs/architecture/authorization'
-            }
-            target='_blank'
-            className='gap-1 text-blue-400 hover:underline'
-          >
-            <span>how authorization is implemented on ORT Server</span>
-            <ExternalLink className='mb-1 ml-1 inline' size={16} />
-          </a>
-        </div>
-      </CardFooter>
     </Card>
   );
 };

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/-components/repository-users-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/-components/repository-users-table.tsx
@@ -36,7 +36,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { UserGroupRowActions } from '@/components/ui/user-group-row-actions.tsx';
+import { UserRoleRowActions } from '@/components/ui/user-role-row-actions.tsx';
 import { mapUserGroupToRepositoryRole } from '@/helpers/role-helpers.ts';
 import {
   createAppColumnHelper,
@@ -67,20 +67,20 @@ const columns = columnHelper.columns([
     cell: ({ row }) => <>{row.original.user.email}</>,
   }),
   columnHelper.accessor('groups', {
-    header: 'Group',
+    header: 'Role',
     cell: ({ row }) => {
       const groups = row.original.groups;
       let IconComponent;
-      let effectiveGroup;
+      let effectiveRole;
       if (groups.includes('ADMINS')) {
         IconComponent = Shield;
-        effectiveGroup = 'ADMINS';
+        effectiveRole = 'ADMIN';
       } else if (groups.includes('WRITERS')) {
         IconComponent = Pen;
-        effectiveGroup = 'WRITERS';
+        effectiveRole = 'WRITER';
       } else if (groups.includes('READERS')) {
         IconComponent = Eye;
-        effectiveGroup = 'READERS';
+        effectiveRole = 'READER';
       } else {
         return <>{groups.join(' ')}</>;
       }
@@ -90,7 +90,7 @@ const columns = columnHelper.columns([
           <TooltipTrigger asChild>
             <IconComponent size={16} />
           </TooltipTrigger>
-          <TooltipContent>{effectiveGroup}</TooltipContent>
+          <TooltipContent>{effectiveRole}</TooltipContent>
         </Tooltip>
       );
     },
@@ -104,7 +104,7 @@ const columns = columnHelper.columns([
       const params = routeApi.useParams();
       const repoId = Number.parseInt(params.repoId);
 
-      const { mutateAsync: joinGroup, isPending: isJoinGroupPending } =
+      const { mutateAsync: assignRole, isPending: isAssignRolePending } =
         useMutation({
           ...putRepositoryRoleToUserMutation(),
           onSuccess(_response, parameters) {
@@ -113,8 +113,8 @@ const columns = columnHelper.columns([
                 path: { repositoryId: repoId },
               }),
             });
-            toast.info('Join Group', {
-              description: `User "${row.original.user.username}" joined group ${parameters.path.role} successfully.`,
+            toast.info('Assign Role', {
+              description: `Role ${parameters.path.role} assigned to user "${row.original.user.username}" successfully.`,
             });
           },
           onError(error: ApiError) {
@@ -122,13 +122,13 @@ const columns = columnHelper.columns([
           },
         });
 
-      const { mutateAsync: leaveGroup, isPending: isLeaveGroupPending } =
+      const { mutateAsync: removeRole, isPending: isRemoveRolePending } =
         useMutation({
           ...deleteRepositoryRoleFromUserMutation(),
           onSuccess(_response, parameters) {
-            // Intentionally, no queryClient.invalidateQueries() here. This is done after joining the new group.
-            toast.info('Leave Group', {
-              description: `User "${row.original.user.username}" left group ${parameters.path.role} successfully.`,
+            // The users query is invalidated after all roles have been removed.
+            toast.info('Remove Role', {
+              description: `Role ${parameters.path.role} removed from user "${row.original.user.username}" successfully.`,
             });
           },
           onError(error: ApiError) {
@@ -136,8 +136,8 @@ const columns = columnHelper.columns([
           },
         });
 
-      async function joinAdminsGroup() {
-        await joinGroup({
+      async function assignAdminRole() {
+        await assignRole({
           path: {
             repositoryId: repoId,
             role: 'ADMIN',
@@ -148,8 +148,8 @@ const columns = columnHelper.columns([
         });
       }
 
-      async function joinWritersGroup() {
-        await joinGroup({
+      async function assignWriterRole() {
+        await assignRole({
           path: {
             repositoryId: repoId,
             role: 'WRITER',
@@ -160,8 +160,8 @@ const columns = columnHelper.columns([
         });
       }
 
-      async function joinReadersGroup() {
-        await joinGroup({
+      async function assignReaderRole() {
+        await assignRole({
           path: {
             repositoryId: repoId,
             role: 'READER',
@@ -172,13 +172,12 @@ const columns = columnHelper.columns([
         });
       }
 
-      // Remove the user from the repository
-      // This is identical to removing the user from all groups.
+      // Remove the user from the repository by removing all assigned roles.
       async function removeFromRepository() {
         try {
           await Promise.all(
             row.original.groups.map((group) =>
-              leaveGroup({
+              removeRole({
                 path: {
                   repositoryId: repoId,
                   role: mapUserGroupToRepositoryRole(group),
@@ -211,15 +210,15 @@ const columns = columnHelper.columns([
         <div className='flex gap-2'>
           <Tooltip delayDuration={300}>
             <TooltipTrigger asChild>
-              <UserGroupRowActions
+              <UserRoleRowActions
                 row={row}
-                onJoinAdminsGroup={joinAdminsGroup}
-                onJoinWritersGroup={joinWritersGroup}
-                onJoinReadersGroup={joinReadersGroup}
-                disabled={isJoinGroupPending || isLeaveGroupPending}
+                onAssignAdminRole={assignAdminRole}
+                onAssignWriterRole={assignWriterRole}
+                onAssignReaderRole={assignReaderRole}
+                disabled={isAssignRolePending || isRemoveRolePending}
               />
             </TooltipTrigger>
-            <TooltipContent>Join group</TooltipContent>
+            <TooltipContent>Assign role</TooltipContent>
           </Tooltip>
 
           <DeleteDialog
@@ -231,7 +230,7 @@ const columns = columnHelper.columns([
             uiComponent={
               <DeleteIconButton
                 icon={<FileOutput size={16} />}
-                disabled={isLeaveGroupPending}
+                disabled={isRemoveRolePending}
                 srDescription='Remove user from this repository'
               />
             }

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/index.tsx
@@ -148,52 +148,54 @@ const ManageUsers = () => {
       <CardContent className='space-y-4'>
         <Form {...form}>
           <form className='space-y-8'>
-            <FormField
-              control={form.control}
-              name='username'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Username</FormLabel>
-                  <FormControl autoFocus>
-                    <Input {...field} />
-                  </FormControl>
-                  <FormDescription>
-                    Enter the exact username of an existing user account.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name='role'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Role</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder='Select a role' />
-                      </SelectTrigger>
+            <div className='grid items-start gap-4 md:grid-cols-[minmax(0,1fr)_auto]'>
+              <FormField
+                control={form.control}
+                name='username'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Username</FormLabel>
+                    <FormControl autoFocus>
+                      <Input {...field} />
                     </FormControl>
-                    <SelectContent>
-                      {roleSchema.options.map((role) => (
-                        <SelectItem key={role} value={role}>
-                          <div className='flex items-center gap-2'>
-                            {getRoleIcon(role)}
-                            {role}
-                          </div>
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+                    <FormDescription>
+                      Enter the exact username of an existing user account.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name='role'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Role</FormLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      defaultValue={field.value}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder='Select a role' />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {roleSchema.options.map((role) => (
+                          <SelectItem key={role} value={role}>
+                            <div className='flex items-center gap-2'>
+                              {getRoleIcon(role)}
+                              {role}
+                            </div>
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
             <Button
               size='sm'
               className='ml-auto gap-1'

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/users/index.tsx
@@ -58,18 +58,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import {
-  getGroupIcon,
-  mapGroupSchemaToRepositoryRole,
-} from '@/helpers/role-helpers.ts';
+import { getRoleIcon } from '@/helpers/role-helpers.ts';
 import { ApiError } from '@/lib/api-error';
 import { toast, toastError } from '@/lib/toast';
-import { groupsSchema } from '@/schemas';
+import { roleSchema } from '@/schemas';
 import { RepositoryUsersTable } from './-components/repository-users-table';
 
 const formSchema = z.object({
   username: z.string().trim().min(1),
-  groupId: groupsSchema,
+  role: roleSchema,
 });
 
 const ManageUsers = () => {
@@ -79,7 +76,7 @@ const ManageUsers = () => {
     resolver: zodResolver(formSchema),
     defaultValues: {
       username: '',
-      groupId: 'readers',
+      role: 'READER',
     },
   });
 
@@ -104,7 +101,7 @@ const ManageUsers = () => {
         }),
       });
       toast.info('Add User', {
-        description: `Successfully assigned role "${form.getValues().groupId.toUpperCase()}" to user "${form.getValues().username}".`,
+        description: `Successfully assigned role "${form.getValues().role}" to user "${form.getValues().username}".`,
       });
     },
     onError(error: ApiError) {
@@ -116,7 +113,7 @@ const ManageUsers = () => {
     await addUser({
       path: {
         repositoryId: Number.parseInt(params.repoId),
-        role: mapGroupSchemaToRepositoryRole(values.groupId),
+        role: values.role,
       },
       body: {
         username: values.username,
@@ -146,7 +143,6 @@ const ManageUsers = () => {
             <Shield size={16} />
             <span>ADMINS can view, edit, and delete the repository.</span>
           </div>
-          <span>NOTE: The username must already exist in Keycloak.</span>
         </CardDescription>
       </CardHeader>
       <CardContent className='space-y-4'>
@@ -162,7 +158,7 @@ const ManageUsers = () => {
                     <Input {...field} />
                   </FormControl>
                   <FormDescription>
-                    Usernames are case-insensitive and stored in lowercase.
+                    Enter the exact username of an existing user account.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -170,7 +166,7 @@ const ManageUsers = () => {
             />
             <FormField
               control={form.control}
-              name='groupId'
+              name='role'
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Role</FormLabel>
@@ -184,11 +180,11 @@ const ManageUsers = () => {
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>
-                      {groupsSchema.options.map((group) => (
-                        <SelectItem key={group} value={group}>
+                      {roleSchema.options.map((role) => (
+                        <SelectItem key={role} value={role}>
                           <div className='flex items-center gap-2'>
-                            {getGroupIcon(group)}
-                            {group.toUpperCase()}
+                            {getRoleIcon(role)}
+                            {role}
                           </div>
                         </SelectItem>
                       ))}

--- a/ui/src/routes/organizations/$orgId/products/$productId/users/-components/product-users-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/users/-components/product-users-table.tsx
@@ -36,7 +36,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { UserGroupRowActions } from '@/components/ui/user-group-row-actions.tsx';
+import { UserRoleRowActions } from '@/components/ui/user-role-row-actions.tsx';
 import { mapUserGroupToProductRole } from '@/helpers/role-helpers.ts';
 import {
   createAppColumnHelper,
@@ -67,20 +67,20 @@ const columns = columnHelper.columns([
     cell: ({ row }) => <>{row.original.user.email}</>,
   }),
   columnHelper.accessor('groups', {
-    header: 'Group',
+    header: 'Role',
     cell: ({ row }) => {
       const groups = row.original.groups;
       let IconComponent;
-      let effectiveGroup;
+      let effectiveRole;
       if (groups.includes('ADMINS')) {
         IconComponent = Shield;
-        effectiveGroup = 'ADMINS';
+        effectiveRole = 'ADMIN';
       } else if (groups.includes('WRITERS')) {
         IconComponent = Pen;
-        effectiveGroup = 'WRITERS';
+        effectiveRole = 'WRITER';
       } else if (groups.includes('READERS')) {
         IconComponent = Eye;
-        effectiveGroup = 'READERS';
+        effectiveRole = 'READER';
       } else {
         return <>{groups.join(' ')}</>;
       }
@@ -90,7 +90,7 @@ const columns = columnHelper.columns([
           <TooltipTrigger asChild>
             <IconComponent size={16} />
           </TooltipTrigger>
-          <TooltipContent>{effectiveGroup}</TooltipContent>
+          <TooltipContent>{effectiveRole}</TooltipContent>
         </Tooltip>
       );
     },
@@ -104,7 +104,7 @@ const columns = columnHelper.columns([
       const params = routeApi.useParams();
       const productId = Number.parseInt(params.productId);
 
-      const { mutateAsync: joinGroup, isPending: isJoinGroupPending } =
+      const { mutateAsync: assignRole, isPending: isAssignRolePending } =
         useMutation({
           ...putProductRoleToUserMutation(),
           onSuccess(_response, parameters) {
@@ -113,8 +113,8 @@ const columns = columnHelper.columns([
                 path: { productId: productId },
               }),
             });
-            toast.info('Join Group', {
-              description: `User "${row.original.user.username}" joined group ${parameters.path.role} successfully.`,
+            toast.info('Assign Role', {
+              description: `Role ${parameters.path.role} assigned to user "${row.original.user.username}" successfully.`,
             });
           },
           onError(error: ApiError) {
@@ -122,13 +122,13 @@ const columns = columnHelper.columns([
           },
         });
 
-      const { mutateAsync: leaveGroup, isPending: isLeaveGroupPending } =
+      const { mutateAsync: removeRole, isPending: isRemoveRolePending } =
         useMutation({
           ...deleteProductRoleFromUserMutation(),
           onSuccess(_response, parameters) {
-            // Intentionally, no queryClient.invalidateQueries() here. This is done after joining the new group.
-            toast.info('Leave Group', {
-              description: `User "${row.original.user.username}" left group ${parameters.path.role} successfully.`,
+            // The users query is invalidated after all roles have been removed.
+            toast.info('Remove Role', {
+              description: `Role ${parameters.path.role} removed from user "${row.original.user.username}" successfully.`,
             });
           },
           onError(error: ApiError) {
@@ -136,8 +136,8 @@ const columns = columnHelper.columns([
           },
         });
 
-      async function joinAdminsGroup() {
-        await joinGroup({
+      async function assignAdminRole() {
+        await assignRole({
           path: { productId: productId, role: 'ADMIN' },
           body: {
             username: row.original.user.username,
@@ -145,8 +145,8 @@ const columns = columnHelper.columns([
         });
       }
 
-      async function joinWritersGroup() {
-        await joinGroup({
+      async function assignWriterRole() {
+        await assignRole({
           path: { productId: productId, role: 'WRITER' },
           body: {
             username: row.original.user.username,
@@ -154,8 +154,8 @@ const columns = columnHelper.columns([
         });
       }
 
-      async function joinReadersGroup() {
-        await joinGroup({
+      async function assignReaderRole() {
+        await assignRole({
           path: { productId: productId, role: 'READER' },
           body: {
             username: row.original.user.username,
@@ -163,13 +163,12 @@ const columns = columnHelper.columns([
         });
       }
 
-      // Remove the user from the product
-      // This is identical to removing the user from all groups.
+      // Remove the user from the product by removing all assigned roles.
       async function removeFromProduct() {
         try {
           await Promise.all(
             row.original.groups.map((group) =>
-              leaveGroup({
+              removeRole({
                 path: {
                   productId: productId,
                   role: mapUserGroupToProductRole(group),
@@ -202,15 +201,15 @@ const columns = columnHelper.columns([
         <div className='flex gap-2'>
           <Tooltip delayDuration={300}>
             <TooltipTrigger asChild>
-              <UserGroupRowActions
+              <UserRoleRowActions
                 row={row}
-                onJoinAdminsGroup={joinAdminsGroup}
-                onJoinWritersGroup={joinWritersGroup}
-                onJoinReadersGroup={joinReadersGroup}
-                disabled={isJoinGroupPending || isLeaveGroupPending}
+                onAssignAdminRole={assignAdminRole}
+                onAssignWriterRole={assignWriterRole}
+                onAssignReaderRole={assignReaderRole}
+                disabled={isAssignRolePending || isRemoveRolePending}
               />
             </TooltipTrigger>
-            <TooltipContent>Join group</TooltipContent>
+            <TooltipContent>Assign role</TooltipContent>
           </Tooltip>
 
           <DeleteDialog
@@ -222,7 +221,7 @@ const columns = columnHelper.columns([
             uiComponent={
               <DeleteIconButton
                 icon={<FileOutput size={16} />}
-                disabled={isLeaveGroupPending}
+                disabled={isRemoveRolePending}
                 srDescription='Remove user from this product'
               />
             }

--- a/ui/src/routes/organizations/$orgId/products/$productId/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/users/index.tsx
@@ -58,18 +58,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import {
-  getGroupIcon,
-  mapGroupSchemaToProductRole,
-} from '@/helpers/role-helpers.ts';
+import { getRoleIcon } from '@/helpers/role-helpers.ts';
 import { ApiError } from '@/lib/api-error';
 import { toast, toastError } from '@/lib/toast';
-import { groupsSchema } from '@/schemas';
+import { roleSchema } from '@/schemas';
 import { ProductUsersTable } from './-components/product-users-table';
 
 const formSchema = z.object({
   username: z.string().trim().min(1),
-  groupId: groupsSchema,
+  role: roleSchema,
 });
 
 const ManageUsers = () => {
@@ -79,7 +76,7 @@ const ManageUsers = () => {
     resolver: zodResolver(formSchema),
     defaultValues: {
       username: '',
-      groupId: 'readers',
+      role: 'READER',
     },
   });
 
@@ -104,7 +101,7 @@ const ManageUsers = () => {
         }),
       });
       toast.info('Add User', {
-        description: `Successfully assigned role "${form.getValues().groupId.toUpperCase()}" to user "${form.getValues().username}".`,
+        description: `Successfully assigned role "${form.getValues().role}" to user "${form.getValues().username}".`,
       });
     },
     onError(error: ApiError) {
@@ -116,7 +113,7 @@ const ManageUsers = () => {
     await addUser({
       path: {
         productId: Number.parseInt(params.productId),
-        role: mapGroupSchemaToProductRole(values.groupId),
+        role: values.role,
       },
       body: {
         username: values.username,
@@ -148,7 +145,6 @@ const ManageUsers = () => {
               repositories.
             </span>
           </div>
-          <span>NOTE: The username must already exist in Keycloak.</span>
         </CardDescription>
       </CardHeader>
       <CardContent className='space-y-4'>
@@ -164,7 +160,7 @@ const ManageUsers = () => {
                     <Input {...field} />
                   </FormControl>
                   <FormDescription>
-                    Usernames are case-insensitive and stored in lowercase.
+                    Enter the exact username of an existing user account.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -172,7 +168,7 @@ const ManageUsers = () => {
             />
             <FormField
               control={form.control}
-              name='groupId'
+              name='role'
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Role</FormLabel>
@@ -186,11 +182,11 @@ const ManageUsers = () => {
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>
-                      {groupsSchema.options.map((group) => (
-                        <SelectItem key={group} value={group}>
+                      {roleSchema.options.map((role) => (
+                        <SelectItem key={role} value={role}>
                           <div className='flex items-center gap-2'>
-                            {getGroupIcon(group)}
-                            {group.toUpperCase()}
+                            {getRoleIcon(role)}
+                            {role}
                           </div>
                         </SelectItem>
                       ))}

--- a/ui/src/routes/organizations/$orgId/products/$productId/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/users/index.tsx
@@ -150,52 +150,54 @@ const ManageUsers = () => {
       <CardContent className='space-y-4'>
         <Form {...form}>
           <form className='space-y-8'>
-            <FormField
-              control={form.control}
-              name='username'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Username</FormLabel>
-                  <FormControl autoFocus>
-                    <Input {...field} />
-                  </FormControl>
-                  <FormDescription>
-                    Enter the exact username of an existing user account.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name='role'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Role</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder='Select a role' />
-                      </SelectTrigger>
+            <div className='grid items-start gap-4 md:grid-cols-[minmax(0,1fr)_auto]'>
+              <FormField
+                control={form.control}
+                name='username'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Username</FormLabel>
+                    <FormControl autoFocus>
+                      <Input {...field} />
                     </FormControl>
-                    <SelectContent>
-                      {roleSchema.options.map((role) => (
-                        <SelectItem key={role} value={role}>
-                          <div className='flex items-center gap-2'>
-                            {getRoleIcon(role)}
-                            {role}
-                          </div>
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+                    <FormDescription>
+                      Enter the exact username of an existing user account.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name='role'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Role</FormLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      defaultValue={field.value}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder='Select a role' />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {roleSchema.options.map((role) => (
+                          <SelectItem key={role} value={role}>
+                            <div className='flex items-center gap-2'>
+                              {getRoleIcon(role)}
+                              {role}
+                            </div>
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
             <Button
               size='sm'
               className='ml-auto gap-1'

--- a/ui/src/routes/organizations/$orgId/users/-components/organization-users-table.tsx
+++ b/ui/src/routes/organizations/$orgId/users/-components/organization-users-table.tsx
@@ -36,7 +36,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
-import { UserGroupRowActions } from '@/components/ui/user-group-row-actions.tsx';
+import { UserRoleRowActions } from '@/components/ui/user-role-row-actions.tsx';
 import { mapUserGroupToOrganizationRole } from '@/helpers/role-helpers.ts';
 import {
   createAppColumnHelper,
@@ -67,20 +67,20 @@ const columns = columnHelper.columns([
     cell: ({ row }) => <>{row.original.user.email}</>,
   }),
   columnHelper.accessor('groups', {
-    header: 'Group',
+    header: 'Role',
     cell: ({ row }) => {
       const groups = row.original.groups;
       let IconComponent;
-      let effectiveGroup;
+      let effectiveRole;
       if (groups.includes('ADMINS')) {
         IconComponent = Shield;
-        effectiveGroup = 'ADMINS';
+        effectiveRole = 'ADMIN';
       } else if (groups.includes('WRITERS')) {
         IconComponent = Pen;
-        effectiveGroup = 'WRITERS';
+        effectiveRole = 'WRITER';
       } else if (groups.includes('READERS')) {
         IconComponent = Eye;
-        effectiveGroup = 'READERS';
+        effectiveRole = 'READER';
       } else {
         return <>{groups.join(' ')}</>;
       }
@@ -90,7 +90,7 @@ const columns = columnHelper.columns([
           <TooltipTrigger asChild>
             <IconComponent size={16} />
           </TooltipTrigger>
-          <TooltipContent>{effectiveGroup}</TooltipContent>
+          <TooltipContent>{effectiveRole}</TooltipContent>
         </Tooltip>
       );
     },
@@ -104,7 +104,7 @@ const columns = columnHelper.columns([
       const params = routeApi.useParams();
       const organizationId = Number.parseInt(params.orgId);
 
-      const { mutateAsync: joinGroup, isPending: isJoinGroupPending } =
+      const { mutateAsync: assignRole, isPending: isAssignRolePending } =
         useMutation({
           ...putOrganizationRoleToUserMutation(),
           onSuccess(_response, parameters) {
@@ -115,8 +115,8 @@ const columns = columnHelper.columns([
                 },
               }),
             });
-            toast.info('Join Group', {
-              description: `User "${row.original.user.username}" joined group ${parameters.path.role} successfully.`,
+            toast.info('Assign Role', {
+              description: `Role ${parameters.path.role} assigned to user "${row.original.user.username}" successfully.`,
             });
           },
           onError(error: ApiError) {
@@ -124,13 +124,13 @@ const columns = columnHelper.columns([
           },
         });
 
-      const { mutateAsync: leaveGroup, isPending: isLeaveGroupPending } =
+      const { mutateAsync: removeRole, isPending: isRemoveRolePending } =
         useMutation({
           ...deleteOrganizationRoleFromUserMutation(),
           onSuccess(_response, parameters) {
-            // Intentionally, no queryClient.invalidateQueries() here. This is done after joining the new group.
-            toast.info('Leave Group', {
-              description: `User "${row.original.user.username}" left group ${parameters.path.role} successfully.`,
+            // The users query is invalidated after all roles have been removed.
+            toast.info('Remove Role', {
+              description: `Role ${parameters.path.role} removed from user "${row.original.user.username}" successfully.`,
             });
           },
           onError(error: ApiError) {
@@ -138,8 +138,8 @@ const columns = columnHelper.columns([
           },
         });
 
-      async function joinAdminsGroup() {
-        await joinGroup({
+      async function assignAdminRole() {
+        await assignRole({
           path: { organizationId: organizationId, role: 'ADMIN' },
           body: {
             username: row.original.user.username,
@@ -147,8 +147,8 @@ const columns = columnHelper.columns([
         });
       }
 
-      async function joinWritersGroup() {
-        await joinGroup({
+      async function assignWriterRole() {
+        await assignRole({
           path: { organizationId: organizationId, role: 'WRITER' },
           body: {
             username: row.original.user.username,
@@ -156,8 +156,8 @@ const columns = columnHelper.columns([
         });
       }
 
-      async function joinReadersGroup() {
-        await joinGroup({
+      async function assignReaderRole() {
+        await assignRole({
           path: { organizationId: organizationId, role: 'READER' },
           body: {
             username: row.original.user.username,
@@ -165,13 +165,12 @@ const columns = columnHelper.columns([
         });
       }
 
-      // Remove the user from the organization.
-      // This is identical to removing the user from all groups.
+      // Remove the user from the organization by removing all assigned roles.
       async function removeFromOrganization() {
         try {
           await Promise.all(
             row.original.groups.map((group) =>
-              leaveGroup({
+              removeRole({
                 path: {
                   organizationId: organizationId,
                   role: mapUserGroupToOrganizationRole(group),
@@ -206,15 +205,15 @@ const columns = columnHelper.columns([
         <div className='flex gap-2'>
           <Tooltip delayDuration={300}>
             <TooltipTrigger asChild>
-              <UserGroupRowActions
+              <UserRoleRowActions
                 row={row}
-                onJoinAdminsGroup={joinAdminsGroup}
-                onJoinWritersGroup={joinWritersGroup}
-                onJoinReadersGroup={joinReadersGroup}
-                disabled={isJoinGroupPending || isLeaveGroupPending}
+                onAssignAdminRole={assignAdminRole}
+                onAssignWriterRole={assignWriterRole}
+                onAssignReaderRole={assignReaderRole}
+                disabled={isAssignRolePending || isRemoveRolePending}
               />
             </TooltipTrigger>
-            <TooltipContent>Join group</TooltipContent>
+            <TooltipContent>Assign role</TooltipContent>
           </Tooltip>
 
           <DeleteDialog
@@ -226,7 +225,7 @@ const columns = columnHelper.columns([
             uiComponent={
               <DeleteIconButton
                 icon={<FileOutput size={16} />}
-                disabled={isLeaveGroupPending}
+                disabled={isRemoveRolePending}
                 srDescription='Remove user from this organization'
               />
             }

--- a/ui/src/routes/organizations/$orgId/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/users/index.tsx
@@ -155,52 +155,54 @@ const ManageUsers = () => {
       <CardContent className='space-y-4'>
         <Form {...form}>
           <form className='space-y-8'>
-            <FormField
-              control={form.control}
-              name='username'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Username</FormLabel>
-                  <FormControl autoFocus>
-                    <Input {...field} />
-                  </FormControl>
-                  <FormDescription>
-                    Enter the exact username of an existing user account.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name='role'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Role</FormLabel>
-                  <Select
-                    onValueChange={field.onChange}
-                    defaultValue={field.value}
-                  >
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder='Select a role' />
-                      </SelectTrigger>
+            <div className='grid items-start gap-4 md:grid-cols-[minmax(0,1fr)_auto]'>
+              <FormField
+                control={form.control}
+                name='username'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Username</FormLabel>
+                    <FormControl autoFocus>
+                      <Input {...field} />
                     </FormControl>
-                    <SelectContent>
-                      {roleSchema.options.map((role) => (
-                        <SelectItem key={role} value={role}>
-                          <div className='flex items-center gap-2'>
-                            {getRoleIcon(role)}
-                            {role}
-                          </div>
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+                    <FormDescription>
+                      Enter the exact username of an existing user account.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name='role'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Role</FormLabel>
+                    <Select
+                      onValueChange={field.onChange}
+                      defaultValue={field.value}
+                    >
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue placeholder='Select a role' />
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {roleSchema.options.map((role) => (
+                          <SelectItem key={role} value={role}>
+                            <div className='flex items-center gap-2'>
+                              {getRoleIcon(role)}
+                              {role}
+                            </div>
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
             <Button
               size='sm'
               className='ml-auto gap-1'

--- a/ui/src/routes/organizations/$orgId/users/index.tsx
+++ b/ui/src/routes/organizations/$orgId/users/index.tsx
@@ -58,18 +58,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import {
-  getGroupIcon,
-  mapGroupSchemaToOrganizationRole,
-} from '@/helpers/role-helpers.ts';
+import { getRoleIcon } from '@/helpers/role-helpers.ts';
 import { ApiError } from '@/lib/api-error';
 import { toast, toastError } from '@/lib/toast';
-import { groupsSchema } from '@/schemas';
+import { roleSchema } from '@/schemas';
 import { OrganizationUsersTable } from './-components/organization-users-table';
 
 const formSchema = z.object({
   username: z.string().trim().min(1),
-  groupId: groupsSchema,
+  role: roleSchema,
 });
 
 const ManageUsers = () => {
@@ -79,7 +76,7 @@ const ManageUsers = () => {
     resolver: zodResolver(formSchema),
     defaultValues: {
       username: '',
-      groupId: 'readers',
+      role: 'READER',
     },
   });
 
@@ -104,7 +101,7 @@ const ManageUsers = () => {
         }),
       });
       toast.info('Add User', {
-        description: `Successfully assigned role "${form.getValues().groupId.toUpperCase()}" to user "${form.getValues().username}".`,
+        description: `Successfully assigned role "${form.getValues().role}" to user "${form.getValues().username}".`,
       });
     },
     onError(error: ApiError) {
@@ -116,7 +113,7 @@ const ManageUsers = () => {
     await addUser({
       path: {
         organizationId: Number.parseInt(params.orgId),
-        role: mapGroupSchemaToOrganizationRole(values.groupId),
+        role: values.role,
       },
       body: {
         username: values.username,
@@ -153,7 +150,6 @@ const ManageUsers = () => {
               projects and repositories.
             </span>
           </div>
-          <span>NOTE: The username must already exist in Keycloak.</span>
         </CardDescription>
       </CardHeader>
       <CardContent className='space-y-4'>
@@ -169,7 +165,7 @@ const ManageUsers = () => {
                     <Input {...field} />
                   </FormControl>
                   <FormDescription>
-                    Usernames are case-insensitive and stored in lowercase.
+                    Enter the exact username of an existing user account.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>
@@ -177,7 +173,7 @@ const ManageUsers = () => {
             />
             <FormField
               control={form.control}
-              name='groupId'
+              name='role'
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Role</FormLabel>
@@ -191,11 +187,11 @@ const ManageUsers = () => {
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>
-                      {groupsSchema.options.map((group) => (
-                        <SelectItem key={group} value={group}>
+                      {roleSchema.options.map((role) => (
+                        <SelectItem key={role} value={role}>
                           <div className='flex items-center gap-2'>
-                            {getGroupIcon(group)}
-                            {group.toUpperCase()}
+                            {getRoleIcon(role)}
+                            {role}
                           </div>
                         </SelectItem>
                       ))}

--- a/ui/src/schemas/index.ts
+++ b/ui/src/schemas/index.ts
@@ -99,8 +99,8 @@ export const regexSchema = z
   })
   .optional();
 
-// Enum schema for the groupId parameter of the Groups endpoints
-export const groupsSchema = z.enum(['admins', 'writers', 'readers']);
+// Enum schema for roles assigned to users at all hierarchy levels.
+export const roleSchema = z.enum(['ADMIN', 'WRITER', 'READER']);
 
 // Enum schema and type for the resolved statuses of issues, vulnerabilites, and rule violations
 export const itemResolvedSchema = z.enum(['Resolved', 'Unresolved']);

--- a/ui/tests/unit/components/user-role-row-actions.test.tsx
+++ b/ui/tests/unit/components/user-role-row-actions.test.tsx
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { UserGroup, UserWithGroups } from '@/api';
+import { UserRoleRowActions } from '@/components/ui/user-role-row-actions';
+import {
+  selectNoTableState,
+  useAppTable,
+  type AppColumnDef,
+} from '@/hooks/use-app-table';
+
+const columns: AppColumnDef<UserWithGroups>[] = [];
+
+type UserRoleRowActionsHarnessProps = {
+  groups: UserGroup[];
+  onAssignAdminRole?: () => Promise<void>;
+  onAssignWriterRole?: () => Promise<void>;
+  onAssignReaderRole?: () => Promise<void>;
+};
+
+const UserRoleRowActionsHarness = ({
+  groups,
+  onAssignAdminRole = async () => {},
+  onAssignWriterRole = async () => {},
+  onAssignReaderRole = async () => {},
+}: UserRoleRowActionsHarnessProps) => {
+  const table = useAppTable(
+    {
+      columns,
+      data: [{ groups, user: { username: 'test-user' } }],
+    },
+    selectNoTableState
+  );
+
+  return (
+    <UserRoleRowActions
+      row={table.getRowModel().rows[0]!}
+      onAssignAdminRole={onAssignAdminRole}
+      onAssignWriterRole={onAssignWriterRole}
+      onAssignReaderRole={onAssignReaderRole}
+      disabled={false}
+    />
+  );
+};
+
+describe('UserRoleRowActions', () => {
+  it.each([
+    ['ADMINS', 'Assign ADMIN role'],
+    ['WRITERS', 'Assign WRITER role'],
+    ['READERS', 'Assign READER role'],
+  ] as const)(
+    'does not offer a role represented by %s',
+    async (group, label) => {
+      const user = userEvent.setup();
+      render(<UserRoleRowActionsHarness groups={[group]} />);
+
+      await user.click(screen.getByRole('button'));
+
+      expect(
+        screen.queryByRole('menuitem', { name: label })
+      ).not.toBeInTheDocument();
+    }
+  );
+
+  it('uses assignment labels and invokes the selected role callback', async () => {
+    const user = userEvent.setup();
+    const onAssignWriterRole = vi.fn().mockResolvedValue(undefined);
+    render(
+      <UserRoleRowActionsHarness
+        groups={[]}
+        onAssignWriterRole={onAssignWriterRole}
+      />
+    );
+
+    await user.click(screen.getByRole('button'));
+
+    expect(
+      screen.getByRole('menuitem', { name: 'Assign ADMIN role' })
+    ).toBeVisible();
+    expect(
+      screen.getByRole('menuitem', { name: 'Assign READER role' })
+    ).toBeVisible();
+
+    await user.click(
+      screen.getByRole('menuitem', { name: 'Assign WRITER role' })
+    );
+
+    expect(onAssignWriterRole).toHaveBeenCalledOnce();
+  });
+});

--- a/ui/tests/unit/helpers/role-helpers.test.ts
+++ b/ui/tests/unit/helpers/role-helpers.test.ts
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from 'vitest';
+
+import { getRoleIcon } from '@/helpers/role-helpers';
+
+describe('getRoleIcon', () => {
+  it.each([
+    ['ADMIN', 'lucide-shield'],
+    ['WRITER', 'lucide-pen'],
+    ['READER', 'lucide-eye'],
+  ] as const)('returns the expected icon for %s', (role, iconClass) => {
+    expect(renderToStaticMarkup(getRoleIcon(role))).toContain(iconClass);
+  });
+});


### PR DESCRIPTION
This PR completes the clean-up of the UI, removing any references to "groups" (from legacy Keycloak auth implementation) and replacing with "roles". It also cleans up parts of the UI code which can be cleaned now. For cleaning up further, the OpenAPI contract needs to be cleaned up and for this, refer to issue #5861.

<img width="1172" height="517" alt="Screenshot from 2026-09-01 13-46-29" src="https://github.com/user-attachments/assets/936ea378-3189-4c5d-85be-32d2d957336a" />

<img width="1168" height="179" alt="Screenshot from 2026-09-01 13-46-43" src="https://github.com/user-attachments/assets/5f44de92-5146-4a5e-8385-6827ff0a6e12" />

Please see the commits for details.