### PR TITLE
Respect product/repository rights in aggregate endpoints

### DIFF
--- a/core/src/main/kotlin/api/OrganizationsRoute.kt
+++ b/core/src/main/kotlin/api/OrganizationsRoute.kt
@@ -247,7 +247,10 @@ fun Route.organizations() = route("organizations") {
                 val pagingOptions = call.pagingOptions(SortProperty("rating", SortDirection.DESCENDING))
                 val filters = call.vulnerabilityForRunsFilters()
 
-                val repositoryIds = organizationService.getRepositoryIdsForOrganization(organizationId)
+                val repositoryIds = organizationService.getRepositoryIdsForOrganizationAndUser(
+                    organizationId,
+                    requirePrincipal().username
+                )
 
                 val ortRunIds = repositoryIds.mapNotNull { repositoryId ->
                     repositoryService.getLatestOrtRunIdWithSuccessfulAdvisorJob(repositoryId)
@@ -269,7 +272,10 @@ fun Route.organizations() = route("organizations") {
             route("advisors") {
                 get(getOrganizationVulnerabilityAdvisors, requirePermission(OrganizationPermission.READ)) {
                     val organizationId = call.requireIdParameter("organizationId")
-                    val repositoryIds = organizationService.getRepositoryIdsForOrganization(organizationId)
+                    val repositoryIds = organizationService.getRepositoryIdsForOrganizationAndUser(
+                        organizationId,
+                        requirePrincipal().username
+                    )
                     val ortRunIds = repositoryIds.mapNotNull { repositoryId ->
                         repositoryService.getLatestOrtRunIdWithSuccessfulAdvisorJob(repositoryId)
                     }
@@ -284,7 +290,10 @@ fun Route.organizations() = route("organizations") {
                 get(getOrganizationRunStatistics, requirePermission(OrganizationPermission.READ)) {
                     val orgId = call.requireIdParameter("organizationId")
 
-                    val repositoryIds = organizationService.getRepositoryIdsForOrganization(orgId)
+                    val repositoryIds = organizationService.getRepositoryIdsForOrganizationAndUser(
+                        orgId,
+                        requirePrincipal().username
+                    )
 
                     val latestRunsWithAnalyzerJobInFinalState = repositoryIds.mapNotNull {
                         repositoryService.getLatestOrtRunIdWithAnalyzerJobInFinalState(it)

--- a/core/src/main/kotlin/api/ProductsRoute.kt
+++ b/core/src/main/kotlin/api/ProductsRoute.kt
@@ -219,7 +219,10 @@ fun Route.products() = route("products/{productId}") {
             val pagingOptions = call.pagingOptions(SortProperty("rating", SortDirection.DESCENDING))
             val filters = call.vulnerabilityForRunsFilters()
 
-            val repositoryIds = productService.getRepositoryIdsForProduct(productId)
+            val repositoryIds = productService.getRepositoryIdsForProductAndUser(
+                productId,
+                call.ortServerPrincipal.username
+            )
 
             val ortRunIds = repositoryIds.mapNotNull { repositoryId ->
                 repositoryService.getLatestOrtRunIdWithSuccessfulAdvisorJob(repositoryId)
@@ -238,7 +241,10 @@ fun Route.products() = route("products/{productId}") {
         route("advisors") {
             get(getProductVulnerabilityAdvisors, requirePermission(ProductPermission.READ)) {
                 val productId = call.requireIdParameter("productId")
-                val repositoryIds = productService.getRepositoryIdsForProduct(productId)
+                val repositoryIds = productService.getRepositoryIdsForProductAndUser(
+                    productId,
+                    call.ortServerPrincipal.username
+                )
                 val ortRunIds = repositoryIds.mapNotNull { repositoryId ->
                     repositoryService.getLatestOrtRunIdWithSuccessfulAdvisorJob(repositoryId)
                 }
@@ -253,7 +259,10 @@ fun Route.products() = route("products/{productId}") {
             get(getProductRunStatistics, requirePermission(ProductPermission.READ)) {
                 val productId = call.requireIdParameter("productId")
 
-                val repositoryIds = productService.getRepositoryIdsForProduct(productId)
+                val repositoryIds = productService.getRepositoryIdsForProductAndUser(
+                    productId,
+                    call.ortServerPrincipal.username
+                )
 
                 val latestRunsWithAnalyzerJobInFinalState = repositoryIds.mapNotNull {
                     repositoryService.getLatestOrtRunIdWithAnalyzerJobInFinalState(it)

--- a/core/src/test/kotlin/api/DownloadsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/DownloadsRouteIntegrationTest.kt
@@ -55,6 +55,7 @@ class DownloadsRouteIntegrationTest : AbstractIntegrationTest({
             dbExtension.db,
             dbExtension.fixtures.organizationRepository,
             dbExtension.fixtures.productRepository,
+            dbExtension.fixtures.repositoryRepository,
             mockk()
         )
 

--- a/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
@@ -134,6 +134,7 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
             dbExtension.db,
             dbExtension.fixtures.organizationRepository,
             dbExtension.fixtures.productRepository,
+            dbExtension.fixtures.repositoryRepository,
             authorizationService
         )
 

--- a/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/OrganizationsRouteIntegrationTest.kt
@@ -1197,6 +1197,12 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                     )
                 )
 
+                authorizationService.assignRole(
+                    TEST_USER.username.value,
+                    ProductRole.READER,
+                    CompoundHierarchyId.forProduct(OrganizationId(orgId), ProductId(prod1Id))
+                )
+
                 val response =
                     superuserClient.get(
                         "/api/v1/organizations/$orgId/vulnerabilities?sort=-rating,-repositoriesCount"
@@ -1257,6 +1263,69 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                     ),
                     VulnerabilityForRunsFilters()
                 )
+
+                val restrictedResponse = testUserClient.get(
+                    "/api/v1/organizations/$orgId/vulnerabilities?sort=-rating,-repositoriesCount"
+                )
+
+                restrictedResponse shouldHaveStatus HttpStatusCode.OK
+                restrictedResponse shouldHaveBody PagedSearchResponse(
+                    listOf(
+                        VulnerabilityWithStats(
+                            vulnerability = commonVulnerability1.mapToApi(),
+                            identifier = identifier1.mapToApi(),
+                            purl = pkg1.purl,
+                            rating = VulnerabilityRating.MEDIUM,
+                            ortRunIds = listOf(run1Id, run3Id),
+                            repositoriesCount = 2
+                        ),
+                        VulnerabilityWithStats(
+                            vulnerability = commonVulnerability2.mapToApi(),
+                            identifier = identifier2.mapToApi(),
+                            purl = pkg2.purl,
+                            rating = VulnerabilityRating.MEDIUM,
+                            ortRunIds = listOf(run3Id),
+                            repositoriesCount = 1
+                        ),
+                        VulnerabilityWithStats(
+                            vulnerability = run1Vulnerability.mapToApi(),
+                            identifier = identifier1.mapToApi(),
+                            purl = pkg1.purl,
+                            rating = VulnerabilityRating.LOW,
+                            ortRunIds = listOf(run1Id),
+                            repositoriesCount = 1
+                        )
+                    ),
+                    PagingData(
+                        limit = DEFAULT_LIMIT,
+                        offset = 0,
+                        totalCount = 3,
+                        sortProperties = listOf(
+                            SortProperty("rating", SortDirection.DESCENDING),
+                            SortProperty("repositoriesCount", SortDirection.DESCENDING)
+                        )
+                    ),
+                    VulnerabilityForRunsFilters()
+                )
+            }
+        }
+
+        "return an empty response when the user can read only an empty product" {
+            integrationTestApplication {
+                val orgId = createOrganization().id
+                val productId = dbExtension.fixtures.createProduct(organizationId = orgId).id
+                authorizationService.assignRole(
+                    TEST_USER.username.value,
+                    ProductRole.READER,
+                    CompoundHierarchyId.forProduct(OrganizationId(orgId), ProductId(productId))
+                )
+
+                val response = testUserClient.get("/api/v1/organizations/$orgId/vulnerabilities")
+
+                response shouldHaveStatus HttpStatusCode.OK
+                val vulnerabilities =
+                    response.body<PagedSearchResponse<VulnerabilityWithStats, VulnerabilityForRunsFilters>>()
+                vulnerabilities.data should beEmpty()
             }
         }
 
@@ -1703,18 +1772,36 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                     status = JobStatus.FINISHED.asPresent2()
                 )
 
+                authorizationService.assignRole(
+                    TEST_USER.username.value,
+                    ProductRole.READER,
+                    CompoundHierarchyId.forProduct(OrganizationId(orgId), ProductId(prod1Id))
+                )
+
                 val response = superuserClient.get("/api/v1/organizations/$orgId/vulnerabilities/advisors")
 
                 response shouldHaveStatus HttpStatusCode.OK
                 response.body<List<String>>() should containExactly("NexusIQ", "OSV", "VulnerableCode")
+
+                val restrictedResponse =
+                    testUserClient.get("/api/v1/organizations/$orgId/vulnerabilities/advisors")
+
+                restrictedResponse shouldHaveStatus HttpStatusCode.OK
+                restrictedResponse.body<List<String>>() should containExactly("OSV", "VulnerableCode")
             }
         }
 
-        "return an empty list when no successful advisor jobs exist in the organization" {
+        "return an empty list when the user can read only an empty product" {
             integrationTestApplication {
                 val orgId = createOrganization().id
+                val productId = dbExtension.fixtures.createProduct(organizationId = orgId).id
+                authorizationService.assignRole(
+                    TEST_USER.username.value,
+                    ProductRole.READER,
+                    CompoundHierarchyId.forProduct(OrganizationId(orgId), ProductId(productId))
+                )
 
-                val response = superuserClient.get("/api/v1/organizations/$orgId/vulnerabilities/advisors")
+                val response = testUserClient.get("/api/v1/organizations/$orgId/vulnerabilities/advisors")
 
                 response shouldHaveStatus HttpStatusCode.OK
                 response.body<List<String>>() should beEmpty()
@@ -1907,6 +1994,12 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                     )
                 )
 
+                authorizationService.assignRole(
+                    TEST_USER.username.value,
+                    ProductRole.READER,
+                    CompoundHierarchyId.forProduct(OrganizationId(orgId), ProductId(prod1Id))
+                )
+
                 val response = superuserClient.get("/api/v1/organizations/$orgId/statistics/runs")
 
                 response shouldHaveStatus HttpStatusCode.OK
@@ -1975,14 +2068,64 @@ class OrganizationsRouteIntegrationTest : AbstractIntegrationTest({
                         )
                     )
                 }
+
+                val restrictedResponse = testUserClient.get("/api/v1/organizations/$orgId/statistics/runs")
+
+                restrictedResponse shouldHaveStatus HttpStatusCode.OK
+                with(restrictedResponse.body<OrtRunStatistics>()) {
+                    issuesCount shouldBe 0
+                    issuesCountBySeverity?.shouldContainExactly(
+                        mapOf(
+                            ApiSeverity.HINT to 0,
+                            ApiSeverity.WARNING to 0,
+                            ApiSeverity.ERROR to 0
+                        )
+                    )
+                    issuesCountTotal shouldBe 0
+                    issuesCountTotalBySeverity?.shouldContainExactly(
+                        mapOf(
+                            ApiSeverity.HINT to 0,
+                            ApiSeverity.WARNING to 0,
+                            ApiSeverity.ERROR to 0
+                        )
+                    )
+                    packagesCount shouldBe 1
+                    ecosystems?.shouldContainExactly(listOf(EcosystemStats("Maven", 1)))
+                    vulnerabilitiesCount should beNull()
+                    vulnerabilitiesCountByRating should beNull()
+                    vulnerabilitiesCountTotal should beNull()
+                    vulnerabilitiesCountTotalByRating should beNull()
+                    ruleViolationsCount shouldBe 0
+                    ruleViolationsCountBySeverity?.shouldContainExactly(
+                        mapOf(
+                            ApiSeverity.HINT to 0,
+                            ApiSeverity.WARNING to 0,
+                            ApiSeverity.ERROR to 0
+                        )
+                    )
+                    ruleViolationsCountTotal shouldBe 1
+                    ruleViolationsCountTotalBySeverity?.shouldContainExactly(
+                        mapOf(
+                            ApiSeverity.HINT to 1,
+                            ApiSeverity.WARNING to 0,
+                            ApiSeverity.ERROR to 0
+                        )
+                    )
+                }
             }
         }
 
-        "return nulls for counts if no valid runs are found" {
+        "return nulls when the user can read only an empty product" {
             integrationTestApplication {
                 val orgId = createOrganization().id
+                val productId = dbExtension.fixtures.createProduct(organizationId = orgId).id
+                authorizationService.assignRole(
+                    TEST_USER.username.value,
+                    ProductRole.READER,
+                    CompoundHierarchyId.forProduct(OrganizationId(orgId), ProductId(productId))
+                )
 
-                val response = superuserClient.get("/api/v1/organizations/$orgId/statistics/runs")
+                val response = testUserClient.get("/api/v1/organizations/$orgId/statistics/runs")
 
                 response shouldHaveStatus HttpStatusCode.OK
 

--- a/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
@@ -154,6 +154,7 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
             dbExtension.db,
             dbExtension.fixtures.organizationRepository,
             dbExtension.fixtures.productRepository,
+            dbExtension.fixtures.repositoryRepository,
             mockk()
         )
 

--- a/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/ProductsRouteIntegrationTest.kt
@@ -941,6 +941,16 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                     )
                 )
 
+                authorizationService.assignRole(
+                    TEST_USER.username.value,
+                    RepositoryRole.READER,
+                    CompoundHierarchyId.forRepository(
+                        OrganizationId(orgId),
+                        ProductId(productId),
+                        RepositoryId(repository1Id)
+                    )
+                )
+
                 val response =
                     superuserClient.get("/api/v1/products/$productId/vulnerabilities?sort=-rating,-repositoriesCount")
 
@@ -983,6 +993,60 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                     ),
                     VulnerabilityForRunsFilters()
                 )
+
+                val restrictedResponse = testUserClient.get(
+                    "/api/v1/products/$productId/vulnerabilities?sort=-rating,-repositoriesCount"
+                )
+
+                restrictedResponse shouldHaveStatus HttpStatusCode.OK
+                restrictedResponse shouldHaveBody PagedSearchResponse(
+                    listOf(
+                        VulnerabilityWithStats(
+                            vulnerability = commonVulnerability.mapToApi(),
+                            identifier = identifier1.mapToApi(),
+                            purl = pkg1.purl,
+                            rating = VulnerabilityRating.MEDIUM,
+                            ortRunIds = listOf(run1Id),
+                            repositoriesCount = 1
+                        ),
+                        VulnerabilityWithStats(
+                            vulnerability = run1Vulnerability.mapToApi(),
+                            identifier = identifier1.mapToApi(),
+                            purl = pkg1.purl,
+                            rating = VulnerabilityRating.LOW,
+                            ortRunIds = listOf(run1Id),
+                            repositoriesCount = 1
+                        )
+                    ),
+                    PagingData(
+                        limit = DEFAULT_LIMIT,
+                        offset = 0,
+                        totalCount = 2,
+                        sortProperties = listOf(
+                            SortProperty("rating", SortDirection.DESCENDING),
+                            SortProperty("repositoriesCount", SortDirection.DESCENDING)
+                        )
+                    ),
+                    VulnerabilityForRunsFilters()
+                )
+            }
+        }
+
+        "return an empty response when the user can read only an empty product" {
+            integrationTestApplication {
+                val product = createProduct()
+                authorizationService.assignRole(
+                    TEST_USER.username.value,
+                    ProductRole.READER,
+                    product.hierarchyId()
+                )
+
+                val response = testUserClient.get("/api/v1/products/${product.id}/vulnerabilities")
+
+                response shouldHaveStatus HttpStatusCode.OK
+                val vulnerabilities =
+                    response.body<PagedSearchResponse<VulnerabilityWithStats, VulnerabilityForRunsFilters>>()
+                vulnerabilities.data should beEmpty()
             }
         }
 
@@ -1410,18 +1474,39 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                     status = JobStatus.FINISHED.asPresent2()
                 )
 
+                authorizationService.assignRole(
+                    TEST_USER.username.value,
+                    RepositoryRole.READER,
+                    CompoundHierarchyId.forRepository(
+                        OrganizationId(orgId),
+                        ProductId(productId),
+                        RepositoryId(repo1Id)
+                    )
+                )
+
                 val response = superuserClient.get("/api/v1/products/$productId/vulnerabilities/advisors")
 
                 response shouldHaveStatus HttpStatusCode.OK
                 response.body<List<String>>() should containExactly("NexusIQ", "OSV", "VulnerableCode")
+
+                val restrictedResponse =
+                    testUserClient.get("/api/v1/products/$productId/vulnerabilities/advisors")
+
+                restrictedResponse shouldHaveStatus HttpStatusCode.OK
+                restrictedResponse.body<List<String>>() should containExactly("OSV", "VulnerableCode")
             }
         }
 
-        "return an empty list when no successful advisor jobs exist in the product" {
+        "return an empty list when the user can read only an empty product" {
             integrationTestApplication {
-                val productId = createProduct().id
+                val product = createProduct()
+                authorizationService.assignRole(
+                    TEST_USER.username.value,
+                    ProductRole.READER,
+                    product.hierarchyId()
+                )
 
-                val response = superuserClient.get("/api/v1/products/$productId/vulnerabilities/advisors")
+                val response = testUserClient.get("/api/v1/products/${product.id}/vulnerabilities/advisors")
 
                 response shouldHaveStatus HttpStatusCode.OK
                 response.body<List<String>>() should beEmpty()
@@ -1695,6 +1780,16 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                     )
                 )
 
+                authorizationService.assignRole(
+                    TEST_USER.username.value,
+                    RepositoryRole.READER,
+                    CompoundHierarchyId.forRepository(
+                        OrganizationId(orgId),
+                        ProductId(prodId),
+                        RepositoryId(repo1Id)
+                    )
+                )
+
                 val response = superuserClient.get("/api/v1/products/$prodId/statistics/runs")
 
                 response shouldHaveStatus HttpStatusCode.OK
@@ -1766,14 +1861,82 @@ class ProductsRouteIntegrationTest : AbstractIntegrationTest({
                         )
                     )
                 }
+
+                val restrictedResponse = testUserClient.get("/api/v1/products/$prodId/statistics/runs")
+
+                restrictedResponse shouldHaveStatus HttpStatusCode.OK
+                with(restrictedResponse.body<OrtRunStatistics>()) {
+                    issuesCount shouldBe 2
+                    issuesCountBySeverity?.shouldContainExactly(
+                        mapOf(
+                            ApiSeverity.HINT to 0,
+                            ApiSeverity.WARNING to 1,
+                            ApiSeverity.ERROR to 1
+                        )
+                    )
+                    issuesCountTotal shouldBe 2
+                    issuesCountTotalBySeverity?.shouldContainExactly(
+                        mapOf(
+                            ApiSeverity.HINT to 0,
+                            ApiSeverity.WARNING to 1,
+                            ApiSeverity.ERROR to 1
+                        )
+                    )
+                    packagesCount shouldBe 2
+                    ecosystems should containExactlyInAnyOrder(
+                        EcosystemStats("NPM", 1),
+                        EcosystemStats("Maven", 1)
+                    )
+                    vulnerabilitiesCount shouldBe 2
+                    vulnerabilitiesCountByRating?.shouldContainExactly(
+                        mapOf(
+                            VulnerabilityRating.NONE to 0,
+                            VulnerabilityRating.LOW to 1,
+                            VulnerabilityRating.MEDIUM to 0,
+                            VulnerabilityRating.HIGH to 0,
+                            VulnerabilityRating.CRITICAL to 1
+                        )
+                    )
+                    vulnerabilitiesCountTotal shouldBe 2
+                    vulnerabilitiesCountTotalByRating?.shouldContainExactly(
+                        mapOf(
+                            VulnerabilityRating.NONE to 0,
+                            VulnerabilityRating.LOW to 1,
+                            VulnerabilityRating.MEDIUM to 0,
+                            VulnerabilityRating.HIGH to 0,
+                            VulnerabilityRating.CRITICAL to 1
+                        )
+                    )
+                    ruleViolationsCount shouldBe 2
+                    ruleViolationsCountBySeverity?.shouldContainExactly(
+                        mapOf(
+                            ApiSeverity.HINT to 1,
+                            ApiSeverity.WARNING to 0,
+                            ApiSeverity.ERROR to 1
+                        )
+                    )
+                    ruleViolationsCountTotal shouldBe 2
+                    ruleViolationsCountTotalBySeverity?.shouldContainExactly(
+                        mapOf(
+                            ApiSeverity.HINT to 1,
+                            ApiSeverity.WARNING to 0,
+                            ApiSeverity.ERROR to 1
+                        )
+                    )
+                }
             }
         }
 
-        "return nulls for counts if no valid runs are found" {
+        "return nulls when the user can read only an empty product" {
             integrationTestApplication {
-                val prodId = createProduct().id
+                val product = createProduct()
+                authorizationService.assignRole(
+                    TEST_USER.username.value,
+                    ProductRole.READER,
+                    product.hierarchyId()
+                )
 
-                val response = superuserClient.get("/api/v1/products/$prodId/statistics/runs")
+                val response = testUserClient.get("/api/v1/products/${product.id}/statistics/runs")
 
                 response shouldHaveStatus HttpStatusCode.OK
                 val statistics = response.body<OrtRunStatistics>()

--- a/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RepositoriesRouteIntegrationTest.kt
@@ -145,6 +145,7 @@ class RepositoriesRouteIntegrationTest : AbstractIntegrationTest({
             dbExtension.db,
             dbExtension.fixtures.organizationRepository,
             dbExtension.fixtures.productRepository,
+            dbExtension.fixtures.repositoryRepository,
             mockk()
         )
 

--- a/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/RunsRouteIntegrationTest.kt
@@ -175,6 +175,7 @@ class RunsRouteIntegrationTest : AbstractIntegrationTest({
             dbExtension.db,
             dbExtension.fixtures.organizationRepository,
             dbExtension.fixtures.productRepository,
+            dbExtension.fixtures.repositoryRepository,
             mockk()
         )
 

--- a/services/hierarchy/src/main/kotlin/OrganizationService.kt
+++ b/services/hierarchy/src/main/kotlin/OrganizationService.kt
@@ -27,8 +27,6 @@ import org.eclipse.apoapsis.ortserver.components.authorization.rights.ProductRol
 import org.eclipse.apoapsis.ortserver.components.authorization.rights.RepositoryRole
 import org.eclipse.apoapsis.ortserver.components.authorization.service.AuthorizationService
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
-import org.eclipse.apoapsis.ortserver.dao.repositories.product.ProductsTable
-import org.eclipse.apoapsis.ortserver.dao.repositories.repository.RepositoriesTable
 import org.eclipse.apoapsis.ortserver.model.CompoundHierarchyId
 import org.eclipse.apoapsis.ortserver.model.Organization
 import org.eclipse.apoapsis.ortserver.model.OrganizationId
@@ -42,9 +40,7 @@ import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
 import org.eclipse.apoapsis.ortserver.model.util.OptionalValue
 
-import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.jdbc.Database
-import org.jetbrains.exposed.v1.jdbc.select
 
 /**
  * A service providing functions for working with [organizations][Organization].
@@ -187,15 +183,6 @@ class OrganizationService(
         return withContext(Dispatchers.IO) {
             repositoryRepository.list(ListQueryParameters.DEFAULT, null, hierarchyFilter).data.map { it.id }
         }
-    }
-
-    /** Get IDs for all repositories found in the products of the organization. */
-    suspend fun getRepositoryIdsForOrganization(organizationId: Long): List<Long> = db.dbQuery {
-        RepositoriesTable
-            .innerJoin(ProductsTable)
-            .select(RepositoriesTable.id)
-            .where { ProductsTable.organizationId eq organizationId }
-            .map { it[RepositoriesTable.id].value }
     }
 }
 

--- a/services/hierarchy/src/main/kotlin/OrganizationService.kt
+++ b/services/hierarchy/src/main/kotlin/OrganizationService.kt
@@ -19,8 +19,12 @@
 
 package org.eclipse.apoapsis.ortserver.services
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
 import org.eclipse.apoapsis.ortserver.components.authorization.rights.OrganizationRole
 import org.eclipse.apoapsis.ortserver.components.authorization.rights.ProductRole
+import org.eclipse.apoapsis.ortserver.components.authorization.rights.RepositoryRole
 import org.eclipse.apoapsis.ortserver.components.authorization.service.AuthorizationService
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
 import org.eclipse.apoapsis.ortserver.dao.repositories.product.ProductsTable
@@ -32,6 +36,7 @@ import org.eclipse.apoapsis.ortserver.model.Product
 import org.eclipse.apoapsis.ortserver.model.ProductId
 import org.eclipse.apoapsis.ortserver.model.repositories.OrganizationRepository
 import org.eclipse.apoapsis.ortserver.model.repositories.ProductRepository
+import org.eclipse.apoapsis.ortserver.model.repositories.RepositoryRepository
 import org.eclipse.apoapsis.ortserver.model.util.FilterParameter
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
 import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
@@ -48,6 +53,7 @@ class OrganizationService(
     private val db: Database,
     private val organizationRepository: OrganizationRepository,
     private val productRepository: ProductRepository,
+    private val repositoryRepository: RepositoryRepository,
     private val authorizationService: AuthorizationService
 ) {
     /**
@@ -168,6 +174,19 @@ class OrganizationService(
         description: OptionalValue<String?> = OptionalValue.Absent
     ): Organization = db.dbQuery {
         organizationRepository.update(organizationId, name, description)
+    }
+
+    /** Return the IDs of repositories in the organization that are readable by the given user. */
+    suspend fun getRepositoryIdsForOrganizationAndUser(organizationId: Long, userId: String): List<Long> {
+        val hierarchyFilter = authorizationService.filterHierarchyIds(
+            userId,
+            RepositoryRole.READER,
+            OrganizationId(organizationId)
+        )
+
+        return withContext(Dispatchers.IO) {
+            repositoryRepository.list(ListQueryParameters.DEFAULT, null, hierarchyFilter).data.map { it.id }
+        }
     }
 
     /** Get IDs for all repositories found in the products of the organization. */

--- a/services/hierarchy/src/main/kotlin/ProductService.kt
+++ b/services/hierarchy/src/main/kotlin/ProductService.kt
@@ -19,6 +19,9 @@
 
 package org.eclipse.apoapsis.ortserver.services
 
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
 import org.eclipse.apoapsis.ortserver.components.authorization.rights.RepositoryRole
 import org.eclipse.apoapsis.ortserver.components.authorization.service.AuthorizationService
 import org.eclipse.apoapsis.ortserver.dao.dbQuery
@@ -160,6 +163,19 @@ class ProductService(
             .select(RepositoriesTable.id)
             .where { RepositoriesTable.productId eq productId }
             .map { it[RepositoriesTable.id].value }
+    }
+
+    /** Return the IDs of repositories in the product that are readable by the given user. */
+    suspend fun getRepositoryIdsForProductAndUser(productId: Long, userId: String): List<Long> {
+        val hierarchyFilter = authorizationService.filterHierarchyIds(
+            userId,
+            RepositoryRole.READER,
+            ProductId(productId)
+        )
+
+        return withContext(Dispatchers.IO) {
+            repositoryRepository.list(ListQueryParameters.DEFAULT, null, hierarchyFilter).data.map { it.id }
+        }
     }
 
     /**

--- a/services/hierarchy/src/test/kotlin/OrganizationServiceTest.kt
+++ b/services/hierarchy/src/test/kotlin/OrganizationServiceTest.kt
@@ -97,29 +97,6 @@ class OrganizationServiceTest : WordSpec({
         }
     }
 
-    "getRepositoryIdsForOrganization" should {
-        "return IDs for all repositories found in the products of the organization" {
-            val service = OrganizationService(
-                db,
-                organizationRepository,
-                productRepository,
-                repositoryRepository,
-                mockk()
-            )
-
-            val orgId = fixtures.createOrganization().id
-
-            val prod1Id = fixtures.createProduct(organizationId = orgId).id
-            val prod2Id = fixtures.createProduct("Prod2", organizationId = orgId).id
-
-            val repo1Id = fixtures.createRepository(productId = prod1Id).id
-            val repo2Id = fixtures.createRepository(url = "https://example.com/repo2.git", productId = prod2Id).id
-            val repo3Id = fixtures.createRepository(url = "https://example.com/repo3.git", productId = prod2Id).id
-
-            service.getRepositoryIdsForOrganization(orgId) should containExactlyInAnyOrder(repo1Id, repo2Id, repo3Id)
-        }
-    }
-
     "getRepositoryIdsForOrganizationAndUser" should {
         "return only repository IDs allowed by the hierarchy filter" {
             val userId = "test-user"

--- a/services/hierarchy/src/test/kotlin/OrganizationServiceTest.kt
+++ b/services/hierarchy/src/test/kotlin/OrganizationServiceTest.kt
@@ -20,7 +20,9 @@
 package org.eclipse.apoapsis.ortserver.services
 
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
@@ -30,15 +32,18 @@ import io.mockk.mockk
 
 import org.eclipse.apoapsis.ortserver.components.authorization.rights.OrganizationRole
 import org.eclipse.apoapsis.ortserver.components.authorization.rights.ProductRole
+import org.eclipse.apoapsis.ortserver.components.authorization.rights.RepositoryRole
 import org.eclipse.apoapsis.ortserver.components.authorization.service.AuthorizationService
 import org.eclipse.apoapsis.ortserver.dao.repositories.organization.DaoOrganizationRepository
 import org.eclipse.apoapsis.ortserver.dao.repositories.product.DaoProductRepository
+import org.eclipse.apoapsis.ortserver.dao.repositories.repository.DaoRepositoryRepository
 import org.eclipse.apoapsis.ortserver.dao.test.DatabaseTestExtension
 import org.eclipse.apoapsis.ortserver.dao.test.Fixtures
 import org.eclipse.apoapsis.ortserver.model.CompoundHierarchyId
 import org.eclipse.apoapsis.ortserver.model.HierarchyLevel
 import org.eclipse.apoapsis.ortserver.model.OrganizationId
 import org.eclipse.apoapsis.ortserver.model.ProductId
+import org.eclipse.apoapsis.ortserver.model.RepositoryId
 import org.eclipse.apoapsis.ortserver.model.util.HierarchyFilter
 
 import org.jetbrains.exposed.v1.jdbc.Database
@@ -49,12 +54,14 @@ class OrganizationServiceTest : WordSpec({
     lateinit var db: Database
     lateinit var organizationRepository: DaoOrganizationRepository
     lateinit var productRepository: DaoProductRepository
+    lateinit var repositoryRepository: DaoRepositoryRepository
     lateinit var fixtures: Fixtures
 
     beforeEach {
         db = dbExtension.db
         organizationRepository = dbExtension.fixtures.organizationRepository
         productRepository = dbExtension.fixtures.productRepository
+        repositoryRepository = dbExtension.fixtures.repositoryRepository
         fixtures = dbExtension.fixtures
     }
 
@@ -65,7 +72,13 @@ class OrganizationServiceTest : WordSpec({
             val authorizationService = mockk<AuthorizationService> {
                 coEvery { assignRole(any(), any(), any()) } returns Unit
             }
-            val service = OrganizationService(db, organizationRepository, productRepository, authorizationService)
+            val service = OrganizationService(
+                db,
+                organizationRepository,
+                productRepository,
+                repositoryRepository,
+                authorizationService
+            )
 
             val product = service.createProduct(
                 name = "product",
@@ -86,7 +99,13 @@ class OrganizationServiceTest : WordSpec({
 
     "getRepositoryIdsForOrganization" should {
         "return IDs for all repositories found in the products of the organization" {
-            val service = OrganizationService(db, organizationRepository, productRepository, mockk())
+            val service = OrganizationService(
+                db,
+                organizationRepository,
+                productRepository,
+                repositoryRepository,
+                mockk()
+            )
 
             val orgId = fixtures.createOrganization().id
 
@@ -98,6 +117,70 @@ class OrganizationServiceTest : WordSpec({
             val repo3Id = fixtures.createRepository(url = "https://example.com/repo3.git", productId = prod2Id).id
 
             service.getRepositoryIdsForOrganization(orgId) should containExactlyInAnyOrder(repo1Id, repo2Id, repo3Id)
+        }
+    }
+
+    "getRepositoryIdsForOrganizationAndUser" should {
+        "return only repository IDs allowed by the hierarchy filter" {
+            val userId = "test-user"
+            val organizationId = fixtures.organization.id
+            val readableRepository = fixtures.repository
+            fixtures.createRepository(url = "https://example.com/hidden.git")
+
+            val readableRepositoryId = CompoundHierarchyId.forRepository(
+                OrganizationId(organizationId),
+                ProductId(fixtures.product.id),
+                RepositoryId(readableRepository.id)
+            )
+            val authorizationService = mockk<AuthorizationService> {
+                coEvery {
+                    filterHierarchyIds(userId, RepositoryRole.READER, OrganizationId(organizationId))
+                } returns HierarchyFilter(
+                    transitiveIncludes = mapOf(HierarchyLevel.REPOSITORY to listOf(readableRepositoryId)),
+                    nonTransitiveIncludes = emptyMap()
+                )
+            }
+            val service = OrganizationService(
+                db,
+                organizationRepository,
+                productRepository,
+                repositoryRepository,
+                authorizationService
+            )
+
+            service.getRepositoryIdsForOrganizationAndUser(organizationId, userId).shouldContainExactly(
+                readableRepository.id
+            )
+
+            coVerify {
+                authorizationService.filterHierarchyIds(
+                    userId,
+                    RepositoryRole.READER,
+                    OrganizationId(organizationId)
+                )
+            }
+        }
+
+        "return an empty list if the hierarchy filter has no transitive includes" {
+            val userId = "test-user"
+            val organizationId = fixtures.organization.id
+            val authorizationService = mockk<AuthorizationService> {
+                coEvery {
+                    filterHierarchyIds(userId, RepositoryRole.READER, OrganizationId(organizationId))
+                } returns HierarchyFilter(
+                    transitiveIncludes = emptyMap(),
+                    nonTransitiveIncludes = emptyMap()
+                )
+            }
+            val service = OrganizationService(
+                db,
+                organizationRepository,
+                productRepository,
+                repositoryRepository,
+                authorizationService
+            )
+
+            service.getRepositoryIdsForOrganizationAndUser(organizationId, userId) should beEmpty()
         }
     }
 
@@ -121,7 +204,13 @@ class OrganizationServiceTest : WordSpec({
                 )
             }
 
-            val service = OrganizationService(db, organizationRepository, productRepository, authService)
+            val service = OrganizationService(
+                db,
+                organizationRepository,
+                productRepository,
+                repositoryRepository,
+                authService
+            )
             val organizations = service.listOrganizationsForUser(userId)
 
             organizations.totalCount shouldBe 2
@@ -156,7 +245,13 @@ class OrganizationServiceTest : WordSpec({
                 )
             }
 
-            val service = OrganizationService(db, organizationRepository, productRepository, authService)
+            val service = OrganizationService(
+                db,
+                organizationRepository,
+                productRepository,
+                repositoryRepository,
+                authService
+            )
             val products = service.listProductsForOrganizationAndUser(org1Id, userId)
 
             products.totalCount shouldBe 2

--- a/services/hierarchy/src/test/kotlin/ProductServiceTest.kt
+++ b/services/hierarchy/src/test/kotlin/ProductServiceTest.kt
@@ -23,6 +23,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
 import io.kotest.matchers.collections.containExactlyInAnyOrder
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
@@ -205,6 +206,66 @@ class ProductServiceTest : WordSpec({
             val repo3Id = fixtures.createRepository(url = "https://example.com/repo3.git", productId = prodId).id
 
             service.getRepositoryIdsForProduct(prodId) should containExactlyInAnyOrder(repo1Id, repo2Id, repo3Id)
+        }
+    }
+
+    "getRepositoryIdsForProductAndUser" should {
+        "return only repository IDs allowed by the hierarchy filter" {
+            val userId = "test-user"
+            val productId = fixtures.product.id
+            val readableRepository = fixtures.repository
+            fixtures.createRepository(url = "https://example.com/hidden.git")
+
+            val readableRepositoryId = CompoundHierarchyId.forRepository(
+                OrganizationId(fixtures.organization.id),
+                ProductId(productId),
+                RepositoryId(readableRepository.id)
+            )
+            val authorizationService = mockk<AuthorizationService> {
+                coEvery {
+                    filterHierarchyIds(userId, RepositoryRole.READER, ProductId(productId))
+                } returns HierarchyFilter(
+                    transitiveIncludes = mapOf(HierarchyLevel.REPOSITORY to listOf(readableRepositoryId)),
+                    nonTransitiveIncludes = emptyMap()
+                )
+            }
+            val service = ProductService(
+                db,
+                productRepository,
+                repositoryRepository,
+                ortRunRepository,
+                authorizationService
+            )
+
+            service.getRepositoryIdsForProductAndUser(productId, userId).shouldContainExactly(
+                readableRepository.id
+            )
+
+            coVerify {
+                authorizationService.filterHierarchyIds(userId, RepositoryRole.READER, ProductId(productId))
+            }
+        }
+
+        "return an empty list if the hierarchy filter has no transitive includes" {
+            val userId = "test-user"
+            val productId = fixtures.product.id
+            val authorizationService = mockk<AuthorizationService> {
+                coEvery {
+                    filterHierarchyIds(userId, RepositoryRole.READER, ProductId(productId))
+                } returns HierarchyFilter(
+                    transitiveIncludes = emptyMap(),
+                    nonTransitiveIncludes = emptyMap()
+                )
+            }
+            val service = ProductService(
+                db,
+                productRepository,
+                repositoryRepository,
+                ortRunRepository,
+                authorizationService
+            )
+
+            service.getRepositoryIdsForProductAndUser(productId, userId) should beEmpty()
         }
     }
 


### PR DESCRIPTION
A user who holds access rights to only some repositories of an organization can read vulnerabilities and statistics over the whole organization, which can be considered a security leak. Also the organization and product vulnerabilities tables show vulnerabilities from the restricted products, where clicking the link to the corresponding repository leads to nowhere.

Tested in the UI: a test user only has access to one product of this organization, but before the fix, the statistics cards and the vulnerability tables include data from all products.

<img width="1170" height="548" alt="Screenshot from 2026-09-02 07-43-39" src="https://github.com/user-attachments/assets/76874605-b08d-471b-b3e5-8db6967f5da9" />

After the fix, the data shown is correct, and gathered from only this product.

<img width="1170" height="548" alt="Screenshot from 2026-09-02 07-46-01" src="https://github.com/user-attachments/assets/ea1a5723-8164-4e22-a0a4-45d8c3efbe41" />

Please see the commits for details.