### PR TITLE
feat(admin-config): Allow report definitions to use their plugin ID as name

### DIFF
--- a/components/admin-config/backend/src/main/kotlin/ReporterConfig.kt
+++ b/components/admin-config/backend/src/main/kotlin/ReporterConfig.kt
@@ -21,7 +21,6 @@ package org.eclipse.apoapsis.ortserver.components.adminconfig
 
 import com.sksamuel.hoplite.ConfigAlias
 
-import org.eclipse.apoapsis.ortserver.model.Options
 import org.eclipse.apoapsis.ortserver.model.PluginConfig
 import org.eclipse.apoapsis.ortserver.shared.plugininfo.PluginInfo
 import org.eclipse.apoapsis.ortserver.shared.plugininfo.PluginType
@@ -235,16 +234,9 @@ data class ReporterConfig(
          */
         private fun mergePluginConfigs(pluginConfig: PluginConfig, definitionConfig: PluginConfig): PluginConfig =
             PluginConfig(
-                options = mergeOptions(pluginConfig.options, definitionConfig.options),
-                secrets = mergeOptions(pluginConfig.secrets, definitionConfig.secrets)
+                options = pluginConfig.options + definitionConfig.options,
+                secrets = pluginConfig.secrets + definitionConfig.secrets
             )
-
-        /**
-         * Merge the given [pluginOptions] with the [definitionOptions] of a report definition, so that options from
-         * the definition override options from the plugin.
-         */
-        private fun mergeOptions(pluginOptions: Options, definitionOptions: Options): Options =
-            pluginOptions + definitionOptions
     }
 
     /**

--- a/components/admin-config/backend/src/main/kotlin/ReporterConfig.kt
+++ b/components/admin-config/backend/src/main/kotlin/ReporterConfig.kt
@@ -377,11 +377,12 @@ data class ReporterConfig(
                 }
             }
 
-            reportDefinitionsMap.forEach { (name, _) ->
-                if (name.lowercase() in reporterPluginIds) {
+            reportDefinitionsMap.forEach { (name, definition) ->
+                if (name.lowercase() != definition.pluginId.lowercase() && name.lowercase() in reporterPluginIds) {
                     add(
-                        "The report definition '$name' matches the name of an existing reporter plugin which is not " +
-                                "allowed to avoid ambiguity."
+                        "The report definition '$name' matches the name of the existing reporter plugin '$name', but " +
+                                "uses a different plugin ('${definition.pluginId}'). Reusing a plugin's name is only " +
+                                "allowed when the definition uses that plugin, to avoid ambiguity."
                     )
                 }
             }

--- a/components/admin-config/backend/src/test/kotlin/ReporterConfigTest.kt
+++ b/components/admin-config/backend/src/test/kotlin/ReporterConfigTest.kt
@@ -228,12 +228,18 @@ class ReporterConfigTest : WordSpec({
             }
         }
 
-        "return an issue if a report definition uses the name of an existing reporter plugin" {
+        "return an issue if a report definition uses the name of a different existing reporter plugin" {
             ReporterConfig(
-                reportDefinitionsMap = mapOf(PLUGIN_ID to ReportDefinitionTemplate(pluginId = PLUGIN_ID))
+                reportDefinitionsMap = mapOf(PLUGIN_ID to ReportDefinitionTemplate(pluginId = "WebApp"))
             ).validate().shouldBeSingleton {
                 it shouldContain PLUGIN_ID
             }
+        }
+
+        "not return an issue if a report definition uses the name of the plugin it references" {
+            ReporterConfig(
+                reportDefinitionsMap = mapOf(PLUGIN_ID to ReportDefinitionTemplate(pluginId = PLUGIN_ID))
+            ).validate() should beEmpty()
         }
 
         "return an issue if a report definition references a non-existing plugin" {


### PR DESCRIPTION
See the commit messages for details.