### PR TITLE
ci(github): Use `pnpm ci` to install dependencies

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -124,7 +124,7 @@ jobs:
 
     - name: Install dependencies
       working-directory: ui
-      run: pnpm install
+      run: pnpm ci
 
     - name: Build UI
       working-directory: ui
@@ -255,7 +255,7 @@ jobs:
 
     - name: Install dependencies
       working-directory: ui
-      run: pnpm install
+      run: pnpm ci
 
     - name: Generate API client and routes
       working-directory: ui

--- a/.github/workflows/publish-website.yml
+++ b/.github/workflows/publish-website.yml
@@ -34,7 +34,7 @@ jobs:
 
     - name: Install dependencies
       working-directory: website
-      run: pnpm install --frozen-lockfile
+      run: pnpm ci
 
     - name: Test build
       working-directory: website

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -80,7 +80,7 @@ jobs:
 
     - name: Install dependencies
       working-directory: ui
-      run: pnpm install --dev
+      run: pnpm ci --dev
 
     - name: Run ESLint
       working-directory: ui
@@ -103,7 +103,7 @@ jobs:
 
     - name: Install dependencies
       working-directory: ui
-      run: pnpm install --dev
+      run: pnpm ci --dev
 
     - name: Run Prettier
       working-directory: ui
@@ -126,7 +126,7 @@ jobs:
 
     - name: Install dependencies
       working-directory: website
-      run: pnpm install --dev
+      run: pnpm ci --dev
 
     - name: Run Prettier
       working-directory: website

--- a/.github/workflows/website-test.yml
+++ b/.github/workflows/website-test.yml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Install dependencies
       working-directory: website
-      run: pnpm install --frozen-lockfile
+      run: pnpm ci
 
     - name: Test build
       working-directory: website


### PR DESCRIPTION
This is the default in CI environments, see [1].

[1]: https://pnpm.io/cli/install#--frozen-lockfile