### PR TITLE
ui: Improve creating new users

### DIFF
--- a/ui/src/routes/admin/users/create-user/index.tsx
+++ b/ui/src/routes/admin/users/create-user/index.tsx
@@ -97,7 +97,10 @@ export const CreateUserForm = ({
       temporary: true,
       organizations: [],
     },
+    mode: 'onChange',
   });
+
+  const isSubmitting = isPending || form.formState.isSubmitting;
 
   return (
     <Card className='col-span-2 w-full'>
@@ -247,8 +250,12 @@ export const CreateUserForm = ({
             />
           </CardContent>
           <CardFooter>
-            <Button type='submit' disabled={isPending} className='mt-4'>
-              {isPending ? (
+            <Button
+              type='submit'
+              disabled={isSubmitting || !form.formState.isValid}
+              className='mt-4'
+            >
+              {isSubmitting ? (
                 <>
                   <span className='sr-only'>Creating user...</span>
                   <Loader2 size={16} className='mx-3 animate-spin' />

--- a/ui/src/routes/admin/users/create-user/index.tsx
+++ b/ui/src/routes/admin/users/create-user/index.tsx
@@ -93,6 +93,7 @@ export const CreateUserForm = ({
     resolver: zodResolver(createUserFormSchema),
     defaultValues: {
       username: '',
+      password: '',
       temporary: true,
       organizations: [],
     },
@@ -170,8 +171,13 @@ export const CreateUserForm = ({
                 <FormItem>
                   <FormLabel>Password</FormLabel>
                   <FormControl>
-                    <PasswordInput {...field} placeholder='(optional)' />
+                    <PasswordInput {...field} />
                   </FormControl>
+                  <FormDescription>
+                    Share this initial password with the user over a secure
+                    channel. If the option below is selected, the user must
+                    change the password on first login.
+                  </FormDescription>
                   <FormMessage />
                 </FormItem>
               )}

--- a/ui/src/routes/admin/users/create-user/index.tsx
+++ b/ui/src/routes/admin/users/create-user/index.tsx
@@ -18,7 +18,7 @@
  */
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { Loader2 } from 'lucide-react';
 import { useState } from 'react';
@@ -26,6 +26,7 @@ import { useForm } from 'react-hook-form';
 
 import {
   getOrganizationsInfiniteOptions,
+  getUsersQueryKey,
   postUserMutation,
   putOrganizationRoleToUserMutation,
 } from '@/api/@tanstack/react-query.gen';
@@ -273,6 +274,7 @@ export const CreateUserForm = ({
 
 export const CreateUserPage = () => {
   const navigate = useNavigate();
+  const queryClient = useQueryClient();
 
   const { mutateAsync: createUser, isPending: isCreateUserPending } =
     useMutation({
@@ -353,6 +355,8 @@ export const CreateUserPage = () => {
             : `User "${username}" was created.`,
       });
     }
+
+    queryClient.invalidateQueries({ queryKey: getUsersQueryKey() });
 
     navigate({
       to: '/admin/users',

--- a/ui/src/routes/admin/users/create-user/index.tsx
+++ b/ui/src/routes/admin/users/create-user/index.tsx
@@ -210,7 +210,7 @@ export const CreateUserForm = ({
                   <FormControl>
                     <MultipleSelector
                       {...field}
-                      placeholder='Start typing to find organizations...'
+                      placeholder='(optional) Start typing to find organizations...'
                       badgeClassName='bg-amber-200 text-black'
                       emptyIndicator={
                         <p className='text-center text-lg leading-10 text-gray-600 dark:text-gray-400'>
@@ -237,8 +237,9 @@ export const CreateUserForm = ({
                     />
                   </FormControl>
                   <FormDescription>
-                    At least one organization needs to be chosen to which the
-                    user is granted READERS access initially.
+                    Optionally grant the user the READER role for organizations.
+                    To give access only to a product or repository, assign the
+                    appropriate role in its "Users" section.
                   </FormDescription>
                   <FormMessage />
                 </FormItem>

--- a/ui/src/routes/admin/users/create-user/index.tsx
+++ b/ui/src/routes/admin/users/create-user/index.tsx
@@ -271,32 +271,30 @@ export const CreateUserPage = () => {
   const {
     mutateAsync: addUserToReaders,
     isPending: isAddUserToReadersPending,
-  } = useMutation({
-    ...putOrganizationRoleToUserMutation(),
-    onError(error) {
-      toastError(error.message, error);
-    },
-  });
+  } = useMutation(putOrganizationRoleToUserMutation());
 
   async function onSubmit(values: CreateUserFormValues) {
     const username = values.username.toLowerCase();
-    await createUser({
-      body: {
-        username,
-        firstName: values.firstName,
-        lastName: values.lastName,
-        email: values.email,
-        password: values.password,
-        temporary: values.temporary,
-      },
-    });
-    toast.info('Create User', {
-      description: `User "${username}" created successfully.`,
-    });
-    // Add the READER role to the user for each selected organization.
-    await Promise.all(
-      values.organizations.map(async (organization) => {
-        await addUserToReaders({
+
+    try {
+      await createUser({
+        body: {
+          username,
+          firstName: values.firstName,
+          lastName: values.lastName,
+          email: values.email,
+          password: values.password,
+          temporary: values.temporary,
+        },
+      });
+    } catch {
+      // The mutation's onError callback has already reported the error.
+      return;
+    }
+
+    const assignments = await Promise.allSettled(
+      values.organizations.map((organization) =>
+        addUserToReaders({
           path: {
             organizationId: Number.parseInt(organization.value),
             role: 'READER',
@@ -304,16 +302,47 @@ export const CreateUserPage = () => {
           body: {
             username,
           },
-        });
-
-        toast.info('Add Access Rights', {
-          description: `The "${username}" user was created and assigned the READER role for the "${organization.label}" organization.`,
-        });
-        navigate({
-          to: '/admin/users',
-        });
-      })
+        })
+      )
     );
+
+    const failedAssignments = assignments.flatMap((result, index) =>
+      result.status === 'rejected'
+        ? [
+            {
+              organization: values.organizations[index]!,
+              error: result.reason,
+            },
+          ]
+        : []
+    );
+
+    if (failedAssignments.length > 0) {
+      const organizationNames = failedAssignments
+        .map(({ organization }) => `"${organization.label}"`)
+        .join(', ');
+
+      toastError(
+        `User "${username}" was created, but the READER role could not be granted for ${organizationNames}. ` +
+          `Assign the missing roles in each organization's "Users" section.`,
+        failedAssignments[0]?.error
+      );
+    } else {
+      const organizationNames = values.organizations
+        .map((organization) => `"${organization.label}"`)
+        .join(', ');
+
+      toast.info('Create User', {
+        description:
+          values.organizations.length > 0
+            ? `User "${username}" was created and granted the READER role for ${organizationNames}.`
+            : `User "${username}" was created.`,
+      });
+    }
+
+    navigate({
+      to: '/admin/users',
+    });
   }
 
   return (

--- a/ui/src/routes/admin/users/create-user/index.tsx
+++ b/ui/src/routes/admin/users/create-user/index.tsx
@@ -21,16 +21,14 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { Loader2 } from 'lucide-react';
-import { useRef, useState } from 'react';
+import { useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { z } from 'zod';
 
 import {
   getOrganizationsInfiniteOptions,
   postUserMutation,
   putOrganizationRoleToUserMutation,
 } from '@/api/@tanstack/react-query.gen';
-import { asOptionalField } from '@/components/form/as-optional-field';
 import { OptionalInput } from '@/components/form/optional-input';
 import { PasswordInput } from '@/components/form/password-input';
 import { Button } from '@/components/ui/button';
@@ -60,27 +58,17 @@ import { ApiError } from '@/lib/api-error';
 import { DROPDOWN_PAGE_SIZE } from '@/lib/constants';
 import { toSearchFilter } from '@/lib/regex';
 import { toast, toastError } from '@/lib/toast';
+import { createUserFormSchema, type CreateUserFormValues } from '@/schemas';
 
-const formSchema = z.object({
-  username: z.string().trim().min(1),
-  firstName: asOptionalField(z.string().min(1)),
-  lastName: asOptionalField(z.string().min(1)),
-  email: asOptionalField(z.email()),
-  password: asOptionalField(z.string().min(1)),
-  temporary: z.boolean(),
-  organizations: z.array(z.string()).min(1, {
-    error: 'The user must be part of at least one organization.',
-  }),
-});
+interface CreateUserFormProps {
+  isPending: boolean;
+  onSubmit: (values: CreateUserFormValues) => Promise<void> | void;
+}
 
-const CreateUser = () => {
-  const navigate = useNavigate();
-
-  // The name of every organization that has been picked so far. A picked organization is not
-  // necessarily part of the page that is shown after the search term changes, and its badge still
-  // has to show its name.
-  const organizationNames = useRef(new Map<string, string>());
-
+export const CreateUserForm = ({
+  isPending,
+  onSubmit,
+}: CreateUserFormProps) => {
   // Nothing is loaded before the user has touched the field, so opening the form costs no request.
   const [isSelectorUsed, setIsSelectorUsed] = useState(false);
   const [searchTerm, setSearchTerm] = useState('');
@@ -101,72 +89,14 @@ const CreateUser = () => {
     })
   );
 
-  const { mutateAsync: createUser, isPending: isCreateUserPending } =
-    useMutation({
-      ...postUserMutation(),
-      onError(error: ApiError) {
-        toastError(error.message, error);
-      },
-    });
-
-  const {
-    mutateAsync: addUserToReaders,
-    isPending: isAddUserToReadersPending,
-  } = useMutation({
-    ...putOrganizationRoleToUserMutation(),
-    onSuccess(_, variables) {
-      const organizationName = organizationNames.current.get(
-        variables.path.organizationId.toString()
-      );
-
-      toast.info('Add Access Rights', {
-        description: `The "${variables.body?.username}" user was created and assigned the READER role for the "${organizationName}" organization.`,
-      });
-      navigate({
-        to: '/admin/users',
-      });
-    },
-    onError(error) {
-      toastError(error.message, error);
-    },
-  });
-
-  const form = useForm<z.infer<typeof formSchema>>({
-    resolver: zodResolver(formSchema),
+  const form = useForm<CreateUserFormValues>({
+    resolver: zodResolver(createUserFormSchema),
     defaultValues: {
       username: '',
       temporary: true,
       organizations: [],
     },
   });
-
-  async function onSubmit(values: z.infer<typeof formSchema>) {
-    const username = values.username.toLowerCase();
-    await createUser({
-      body: {
-        username,
-        firstName: values.firstName,
-        lastName: values.lastName,
-        email: values.email,
-        password: values.password,
-        temporary: values.temporary,
-      },
-    });
-    toast.info('Create User', {
-      description: `User "${username}" created successfully.`,
-    });
-    // Add the READER role to the user for each selected organization.
-    await Promise.all(
-      values.organizations.map((orgId) =>
-        addUserToReaders({
-          path: { organizationId: Number.parseInt(orgId), role: 'READER' },
-          body: {
-            username,
-          },
-        })
-      )
-    );
-  }
 
   return (
     <Card className='col-span-2 w-full'>
@@ -286,12 +216,6 @@ const CreateUser = () => {
                           Loading...
                         </p>
                       }
-                      value={field.value.map((organizationId) => ({
-                        label:
-                          organizationNames.current.get(organizationId) ??
-                          organizationId,
-                        value: organizationId,
-                      }))}
                       options={organizationOptions}
                       loading={organizations.isPending}
                       hasMore={organizations.hasNextPage}
@@ -303,15 +227,6 @@ const CreateUser = () => {
                       inputProps={{
                         onValueChange: setSearchTerm,
                         onFocus: () => setIsSelectorUsed(true),
-                      }}
-                      onChange={(selected) => {
-                        selected.forEach((option) =>
-                          organizationNames.current.set(
-                            option.value,
-                            option.label
-                          )
-                        );
-                        field.onChange(selected.map((s) => s.value));
                       }}
                     />
                   </FormControl>
@@ -325,21 +240,10 @@ const CreateUser = () => {
             />
           </CardContent>
           <CardFooter>
-            <Button
-              type='submit'
-              disabled={isCreateUserPending || isAddUserToReadersPending}
-              className='mt-4'
-            >
-              {isCreateUserPending ? (
+            <Button type='submit' disabled={isPending} className='mt-4'>
+              {isPending ? (
                 <>
                   <span className='sr-only'>Creating user...</span>
-                  <Loader2 size={16} className='mx-3 animate-spin' />
-                </>
-              ) : isAddUserToReadersPending ? (
-                <>
-                  <span className='sr-only'>
-                    Adding user to organizations...
-                  </span>
                   <Loader2 size={16} className='mx-3 animate-spin' />
                 </>
               ) : (
@@ -353,6 +257,73 @@ const CreateUser = () => {
   );
 };
 
+export const CreateUserPage = () => {
+  const navigate = useNavigate();
+
+  const { mutateAsync: createUser, isPending: isCreateUserPending } =
+    useMutation({
+      ...postUserMutation(),
+      onError(error: ApiError) {
+        toastError(error.message, error);
+      },
+    });
+
+  const {
+    mutateAsync: addUserToReaders,
+    isPending: isAddUserToReadersPending,
+  } = useMutation({
+    ...putOrganizationRoleToUserMutation(),
+    onError(error) {
+      toastError(error.message, error);
+    },
+  });
+
+  async function onSubmit(values: CreateUserFormValues) {
+    const username = values.username.toLowerCase();
+    await createUser({
+      body: {
+        username,
+        firstName: values.firstName,
+        lastName: values.lastName,
+        email: values.email,
+        password: values.password,
+        temporary: values.temporary,
+      },
+    });
+    toast.info('Create User', {
+      description: `User "${username}" created successfully.`,
+    });
+    // Add the READER role to the user for each selected organization.
+    await Promise.all(
+      values.organizations.map(async (organization) => {
+        await addUserToReaders({
+          path: {
+            organizationId: Number.parseInt(organization.value),
+            role: 'READER',
+          },
+          body: {
+            username,
+          },
+        });
+
+        toast.info('Add Access Rights', {
+          description: `The "${username}" user was created and assigned the READER role for the "${organization.label}" organization.`,
+        });
+        navigate({
+          to: '/admin/users',
+        });
+      })
+    );
+  }
+
+  return (
+    <CreateUserForm
+      isPending={isCreateUserPending || isAddUserToReadersPending}
+      onSubmit={onSubmit}
+    />
+  );
+};
+
 export const Route = createFileRoute('/admin/users/create-user/')({
-  component: CreateUser,
+  component: CreateUserPage,
 });

--- a/ui/src/routes/admin/users/create-user/index.tsx
+++ b/ui/src/routes/admin/users/create-user/index.tsx
@@ -129,32 +129,72 @@ export const CreateUserForm = ({
                 </FormItem>
               )}
             />
-            <FormField
-              control={form.control}
-              name='firstName'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>First name</FormLabel>
-                  <FormControl>
-                    <OptionalInput {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name='lastName'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Last name</FormLabel>
-                  <FormControl>
-                    <OptionalInput {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
+            <div className='grid items-center gap-4 md:grid-cols-[minmax(0,1fr)_auto]'>
+              <FormField
+                control={form.control}
+                name='password'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Password</FormLabel>
+                    <FormControl>
+                      <PasswordInput {...field} />
+                    </FormControl>
+                    <FormDescription>
+                      Share this initial password with the user over a secure
+                      channel.
+                    </FormDescription>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name='temporary'
+                render={({ field }) => (
+                  <FormItem className='mb-2 flex h-9 flex-row items-center space-y-0 space-x-3 rounded-md border px-3'>
+                    <FormControl>
+                      <Checkbox
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                      />
+                    </FormControl>
+                    <div className='space-y-1 leading-none'>
+                      <FormLabel>
+                        Password change required on first login
+                      </FormLabel>
+                    </div>
+                  </FormItem>
+                )}
+              />
+            </div>
+            <div className='grid gap-4 md:grid-cols-2'>
+              <FormField
+                control={form.control}
+                name='firstName'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>First name</FormLabel>
+                    <FormControl>
+                      <OptionalInput {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name='lastName'
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Last name</FormLabel>
+                    <FormControl>
+                      <OptionalInput {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
             <FormField
               control={form.control}
               name='email'
@@ -165,43 +205,6 @@ export const CreateUserForm = ({
                     <OptionalInput type='email' {...field} />
                   </FormControl>
                   <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name='password'
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Password</FormLabel>
-                  <FormControl>
-                    <PasswordInput {...field} />
-                  </FormControl>
-                  <FormDescription>
-                    Share this initial password with the user over a secure
-                    channel. If the option below is selected, the user must
-                    change the password on first login.
-                  </FormDescription>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <FormField
-              control={form.control}
-              name='temporary'
-              render={({ field }) => (
-                <FormItem className='flex flex-row items-start space-y-0 space-x-3 rounded-md border p-4'>
-                  <FormControl>
-                    <Checkbox
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                    />
-                  </FormControl>
-                  <div className='space-y-1 leading-none'>
-                    <FormLabel>
-                      Password change required on first login
-                    </FormLabel>
-                  </div>
                 </FormItem>
               )}
             />

--- a/ui/src/schemas/index.ts
+++ b/ui/src/schemas/index.ts
@@ -35,11 +35,7 @@ export const createUserFormSchema = z.object({
   email: asOptionalField(z.email()),
   password: z.string().min(1, { error: 'A password is required.' }),
   temporary: z.boolean(),
-  organizations: z
-    .array(z.object({ value: z.string(), label: z.string() }))
-    .min(1, {
-      error: 'The user must be part of at least one organization.',
-    }),
+  organizations: z.array(z.object({ value: z.string(), label: z.string() })),
 });
 
 export type CreateUserFormValues = z.infer<typeof createUserFormSchema>;

--- a/ui/src/schemas/index.ts
+++ b/ui/src/schemas/index.ts
@@ -26,6 +26,23 @@ import {
   zSeverity,
   zVulnerabilityRating,
 } from '@/api/zod.gen';
+import { asOptionalField } from '@/components/form/as-optional-field';
+
+export const createUserFormSchema = z.object({
+  username: z.string().trim().min(1),
+  firstName: asOptionalField(z.string().min(1)),
+  lastName: asOptionalField(z.string().min(1)),
+  email: asOptionalField(z.email()),
+  password: asOptionalField(z.string().min(1)),
+  temporary: z.boolean(),
+  organizations: z
+    .array(z.object({ value: z.string(), label: z.string() }))
+    .min(1, {
+      error: 'The user must be part of at least one organization.',
+    }),
+});
+
+export type CreateUserFormValues = z.infer<typeof createUserFormSchema>;
 
 export const repositoryFormSchema = zRepository
   .pick({

--- a/ui/src/schemas/index.ts
+++ b/ui/src/schemas/index.ts
@@ -33,7 +33,7 @@ export const createUserFormSchema = z.object({
   firstName: asOptionalField(z.string().min(1)),
   lastName: asOptionalField(z.string().min(1)),
   email: asOptionalField(z.email()),
-  password: asOptionalField(z.string().min(1)),
+  password: z.string().min(1, { error: 'A password is required.' }),
   temporary: z.boolean(),
   organizations: z
     .array(z.object({ value: z.string(), label: z.string() }))

--- a/ui/tests/unit/components/create-user-form.test.tsx
+++ b/ui/tests/unit/components/create-user-form.test.tsx
@@ -63,10 +63,33 @@ describe('CreateUserForm', () => {
     ]);
   });
 
-  it('enables creating a user while idle', () => {
+  it('enables creating a user only when the form is valid', async () => {
+    const user = userEvent.setup();
+
     render(<CreateUserForm isPending={false} onSubmit={vi.fn()} />);
 
-    expect(screen.getByRole('button', { name: 'Create' })).toBeEnabled();
+    const createButton = screen.getByRole('button', { name: 'Create' });
+    const usernameInput = screen.getByLabelText('Username');
+    const passwordInput = screen.getByLabelText('Password');
+    const emailInput = screen.getByLabelText('Email address');
+
+    expect(createButton).toBeDisabled();
+
+    await user.type(usernameInput, 'jdoe');
+    expect(createButton).toBeDisabled();
+
+    await user.clear(usernameInput);
+    await user.type(passwordInput, 'initial password');
+    expect(createButton).toBeDisabled();
+
+    await user.type(usernameInput, 'jdoe');
+    await waitFor(() => expect(createButton).toBeEnabled());
+
+    await user.type(emailInput, 'invalid');
+    expect(createButton).toBeDisabled();
+
+    await user.clear(emailInput);
+    await waitFor(() => expect(createButton).toBeEnabled());
   });
 
   it('shows the creation progress while pending', () => {
@@ -75,6 +98,33 @@ describe('CreateUserForm', () => {
     expect(
       screen.getByRole('button', { name: 'Creating user...' })
     ).toBeDisabled();
+  });
+
+  it('shows the creation progress while submitting', async () => {
+    const user = userEvent.setup();
+    let resolveSubmit: (() => void) | undefined;
+    const onSubmit = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveSubmit = resolve;
+        })
+    );
+
+    render(<CreateUserForm isPending={false} onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText('Username'), 'jdoe');
+    await user.type(screen.getByLabelText('Password'), 'initial password');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(
+      await screen.findByRole('button', { name: 'Creating user...' })
+    ).toBeDisabled();
+
+    resolveSubmit?.();
+
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Create' })).toBeEnabled()
+    );
   });
 
   it('requires a password', async () => {
@@ -89,15 +139,11 @@ describe('CreateUserForm', () => {
     );
 
     await user.type(screen.getByLabelText('Username'), 'jdoe');
-    await user.click(
-      screen.getByPlaceholderText(
-        '(optional) Start typing to find organizations...'
-      )
-    );
-    await user.click(await screen.findByText('Test Organization'));
-    await user.click(screen.getByRole('button', { name: 'Create' }));
+    await user.type(screen.getByLabelText('Password'), 'x');
+    await user.clear(screen.getByLabelText('Password'));
 
     expect(await screen.findByText('A password is required.')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Create' })).toBeDisabled();
     expect(onSubmit).not.toHaveBeenCalled();
   });
 

--- a/ui/tests/unit/components/create-user-form.test.tsx
+++ b/ui/tests/unit/components/create-user-form.test.tsx
@@ -54,13 +54,46 @@ describe('CreateUserForm', () => {
 
     expect(labels).toEqual([
       'Username',
+      'Password',
+      'Password change required on first login',
       'First name',
       'Last name',
       'Email address',
-      'Password',
-      'Password change required on first login',
       'Organizations',
     ]);
+
+    const passwordField = screen
+      .getByLabelText('Password')
+      .closest('[data-slot="form-item"]');
+    const passwordChangeField = screen
+      .getByRole('checkbox', {
+        name: 'Password change required on first login',
+      })
+      .closest('[data-slot="form-item"]');
+
+    expect(passwordField?.parentElement).toBe(
+      passwordChangeField?.parentElement
+    );
+    expect(passwordField?.parentElement).toHaveClass(
+      'grid',
+      'items-center',
+      'gap-4',
+      'md:grid-cols-[minmax(0,1fr)_auto]'
+    );
+
+    const firstNameField = screen
+      .getByLabelText('First name')
+      .closest('[data-slot="form-item"]');
+    const lastNameField = screen
+      .getByLabelText('Last name')
+      .closest('[data-slot="form-item"]');
+
+    expect(firstNameField?.parentElement).toBe(lastNameField?.parentElement);
+    expect(firstNameField?.parentElement).toHaveClass(
+      'grid',
+      'gap-4',
+      'md:grid-cols-2'
+    );
   });
 
   it('enables creating a user only when the form is valid', async () => {

--- a/ui/tests/unit/components/create-user-form.test.tsx
+++ b/ui/tests/unit/components/create-user-form.test.tsx
@@ -77,6 +77,28 @@ describe('CreateUserForm', () => {
     ).toBeDisabled();
   });
 
+  it('requires a password', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(<CreateUserForm isPending={false} onSubmit={onSubmit} />);
+
+    expect(screen.getByLabelText('Password')).not.toHaveAttribute(
+      'placeholder',
+      '(optional)'
+    );
+
+    await user.type(screen.getByLabelText('Username'), 'jdoe');
+    await user.click(
+      screen.getByPlaceholderText('Start typing to find organizations...')
+    );
+    await user.click(await screen.findByText('Test Organization'));
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(await screen.findByText('A password is required.')).toBeVisible();
+    expect(onSubmit).not.toHaveBeenCalled();
+  });
+
   it('submits the user with the selected organization', async () => {
     const user = userEvent.setup();
     const onSubmit = vi.fn();
@@ -84,6 +106,7 @@ describe('CreateUserForm', () => {
     render(<CreateUserForm isPending={false} onSubmit={onSubmit} />);
 
     await user.type(screen.getByLabelText('Username'), 'jdoe');
+    await user.type(screen.getByLabelText('Password'), 'initial password');
     await user.click(
       screen.getByPlaceholderText('Start typing to find organizations...')
     );
@@ -93,6 +116,7 @@ describe('CreateUserForm', () => {
     await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
     expect(onSubmit.mock.calls[0]?.[0]).toEqual({
       organizations: [{ label: 'Test Organization', value: '1' }],
+      password: 'initial password',
       temporary: true,
       username: 'jdoe',
     });

--- a/ui/tests/unit/components/create-user-form.test.tsx
+++ b/ui/tests/unit/components/create-user-form.test.tsx
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+// @vitest-environment jsdom
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { CreateUserForm } from '@/routes/admin/users/create-user';
+
+vi.mock('@/hooks/use-in-view', () => ({
+  useInView: () => ({ ref: vi.fn(), inView: false }),
+}));
+
+vi.mock('@/hooks/use-infinite-list', () => ({
+  useInfiniteList: () => ({
+    items: [{ id: 1, name: 'Test Organization' }],
+    totalCount: 1,
+    isPending: false,
+    isError: false,
+    error: null,
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    fetchNextPage: vi.fn(),
+  }),
+}));
+
+describe('CreateUserForm', () => {
+  it('renders the fields in the expected order', () => {
+    const { container } = render(
+      <CreateUserForm isPending={false} onSubmit={vi.fn()} />
+    );
+
+    const labels = Array.from(
+      container.querySelectorAll('[data-slot="form-label"]')
+    ).map((label) => label.textContent);
+
+    expect(labels).toEqual([
+      'Username',
+      'First name',
+      'Last name',
+      'Email address',
+      'Password',
+      'Password change required on first login',
+      'Organizations',
+    ]);
+  });
+
+  it('enables creating a user while idle', () => {
+    render(<CreateUserForm isPending={false} onSubmit={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: 'Create' })).toBeEnabled();
+  });
+
+  it('shows the creation progress while pending', () => {
+    render(<CreateUserForm isPending onSubmit={vi.fn()} />);
+
+    expect(
+      screen.getByRole('button', { name: 'Creating user...' })
+    ).toBeDisabled();
+  });
+
+  it('submits the user with the selected organization', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(<CreateUserForm isPending={false} onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText('Username'), 'jdoe');
+    await user.click(
+      screen.getByPlaceholderText('Start typing to find organizations...')
+    );
+    await user.click(await screen.findByText('Test Organization'));
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+    expect(onSubmit.mock.calls[0]?.[0]).toEqual({
+      organizations: [{ label: 'Test Organization', value: '1' }],
+      temporary: true,
+      username: 'jdoe',
+    });
+  });
+});

--- a/ui/tests/unit/components/create-user-form.test.tsx
+++ b/ui/tests/unit/components/create-user-form.test.tsx
@@ -90,13 +90,34 @@ describe('CreateUserForm', () => {
 
     await user.type(screen.getByLabelText('Username'), 'jdoe');
     await user.click(
-      screen.getByPlaceholderText('Start typing to find organizations...')
+      screen.getByPlaceholderText(
+        '(optional) Start typing to find organizations...'
+      )
     );
     await user.click(await screen.findByText('Test Organization'));
     await user.click(screen.getByRole('button', { name: 'Create' }));
 
     expect(await screen.findByText('A password is required.')).toBeVisible();
     expect(onSubmit).not.toHaveBeenCalled();
+  });
+
+  it('submits the user without an organization', async () => {
+    const user = userEvent.setup();
+    const onSubmit = vi.fn();
+
+    render(<CreateUserForm isPending={false} onSubmit={onSubmit} />);
+
+    await user.type(screen.getByLabelText('Username'), 'jdoe');
+    await user.type(screen.getByLabelText('Password'), 'initial password');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    await waitFor(() => expect(onSubmit).toHaveBeenCalledOnce());
+    expect(onSubmit.mock.calls[0]?.[0]).toEqual({
+      organizations: [],
+      password: 'initial password',
+      temporary: true,
+      username: 'jdoe',
+    });
   });
 
   it('submits the user with the selected organization', async () => {
@@ -108,7 +129,9 @@ describe('CreateUserForm', () => {
     await user.type(screen.getByLabelText('Username'), 'jdoe');
     await user.type(screen.getByLabelText('Password'), 'initial password');
     await user.click(
-      screen.getByPlaceholderText('Start typing to find organizations...')
+      screen.getByPlaceholderText(
+        '(optional) Start typing to find organizations...'
+      )
     );
     await user.click(await screen.findByText('Test Organization'));
     await user.click(screen.getByRole('button', { name: 'Create' }));

--- a/ui/tests/unit/components/create-user-page.test.tsx
+++ b/ui/tests/unit/components/create-user-page.test.tsx
@@ -119,6 +119,18 @@ describe('CreateUserPage', () => {
     expect(mocks.navigate).toHaveBeenCalledWith({ to: '/admin/users' });
   });
 
+  it('creates the user without assigning an organization role', async () => {
+    await getOnSubmit()({ ...values, organizations: [] });
+
+    expect(mocks.createUser).toHaveBeenCalledOnce();
+    expect(mocks.addUserToReaders).not.toHaveBeenCalled();
+    expect(mocks.toastInfo).toHaveBeenCalledWith('Create User', {
+      description: 'User "jdoe" was created.',
+    });
+    expect(mocks.navigate).toHaveBeenCalledOnce();
+    expect(mocks.navigate).toHaveBeenCalledWith({ to: '/admin/users' });
+  });
+
   it('reports failed role assignments and still navigates', async () => {
     const error = new Error('Could not assign the role.');
     mocks.addUserToReaders

--- a/ui/tests/unit/components/create-user-page.test.tsx
+++ b/ui/tests/unit/components/create-user-page.test.tsx
@@ -28,9 +28,11 @@ import type { CreateUserFormValues } from '@/schemas';
 const mocks = vi.hoisted(() => ({
   addUserToReaders: vi.fn(),
   createUser: vi.fn(),
+  invalidateQueries: vi.fn(),
   navigate: vi.fn(),
   toastError: vi.fn(),
   toastInfo: vi.fn(),
+  usersQueryKey: ['users'],
 }));
 
 vi.mock('@tanstack/react-query', () => ({
@@ -41,6 +43,7 @@ vi.mock('@tanstack/react-query', () => ({
         : mocks.addUserToReaders,
     isPending: false,
   }),
+  useQueryClient: () => ({ invalidateQueries: mocks.invalidateQueries }),
 }));
 
 vi.mock('@tanstack/react-router', () => ({
@@ -50,6 +53,7 @@ vi.mock('@tanstack/react-router', () => ({
 
 vi.mock('@/api/@tanstack/react-query.gen', () => ({
   getOrganizationsInfiniteOptions: vi.fn(),
+  getUsersQueryKey: () => mocks.usersQueryKey,
   postUserMutation: () => ({ mutationKey: ['create-user'] }),
   putOrganizationRoleToUserMutation: () => ({
     mutationKey: ['add-user-to-readers'],
@@ -115,8 +119,14 @@ describe('CreateUserPage', () => {
         '"First Organization", "Second Organization".',
     });
     expect(mocks.toastError).not.toHaveBeenCalled();
+    expect(mocks.invalidateQueries).toHaveBeenCalledWith({
+      queryKey: mocks.usersQueryKey,
+    });
     expect(mocks.navigate).toHaveBeenCalledOnce();
     expect(mocks.navigate).toHaveBeenCalledWith({ to: '/admin/users' });
+    expect(mocks.invalidateQueries.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.navigate.mock.invocationCallOrder[0]!
+    );
   });
 
   it('creates the user without assigning an organization role', async () => {
@@ -156,6 +166,7 @@ describe('CreateUserPage', () => {
 
     expect(mocks.addUserToReaders).not.toHaveBeenCalled();
     expect(mocks.toastInfo).not.toHaveBeenCalled();
+    expect(mocks.invalidateQueries).not.toHaveBeenCalled();
     expect(mocks.navigate).not.toHaveBeenCalled();
   });
 });

--- a/ui/tests/unit/components/create-user-page.test.tsx
+++ b/ui/tests/unit/components/create-user-page.test.tsx
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+// @vitest-environment jsdom
+
+import type { ReactElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CreateUserPage } from '@/routes/admin/users/create-user';
+import type { CreateUserFormValues } from '@/schemas';
+
+const mocks = vi.hoisted(() => ({
+  addUserToReaders: vi.fn(),
+  createUser: vi.fn(),
+  navigate: vi.fn(),
+  toastError: vi.fn(),
+  toastInfo: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useMutation: (options: { mutationKey?: string[] }) => ({
+    mutateAsync:
+      options.mutationKey?.[0] === 'create-user'
+        ? mocks.createUser
+        : mocks.addUserToReaders,
+    isPending: false,
+  }),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (options: Record<string, unknown>) => options,
+  useNavigate: () => mocks.navigate,
+}));
+
+vi.mock('@/api/@tanstack/react-query.gen', () => ({
+  getOrganizationsInfiniteOptions: vi.fn(),
+  postUserMutation: () => ({ mutationKey: ['create-user'] }),
+  putOrganizationRoleToUserMutation: () => ({
+    mutationKey: ['add-user-to-readers'],
+  }),
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast: { info: mocks.toastInfo },
+  toastError: mocks.toastError,
+}));
+
+type CreateUserPageElement = ReactElement<{
+  onSubmit: (values: CreateUserFormValues) => Promise<void>;
+}>;
+
+const values: CreateUserFormValues = {
+  username: 'JDOE',
+  temporary: true,
+  organizations: [
+    { value: '1', label: 'First Organization' },
+    { value: '2', label: 'Second Organization' },
+  ],
+};
+
+function getOnSubmit() {
+  return (CreateUserPage() as CreateUserPageElement).props.onSubmit;
+}
+
+describe('CreateUserPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.createUser.mockResolvedValue(undefined);
+    mocks.addUserToReaders.mockResolvedValue(undefined);
+  });
+
+  it('creates the user, assigns roles and reports success once', async () => {
+    await getOnSubmit()(values);
+
+    expect(mocks.createUser).toHaveBeenCalledWith({
+      body: {
+        email: undefined,
+        firstName: undefined,
+        lastName: undefined,
+        password: undefined,
+        temporary: true,
+        username: 'jdoe',
+      },
+    });
+    expect(mocks.addUserToReaders).toHaveBeenCalledTimes(2);
+    expect(mocks.addUserToReaders).toHaveBeenNthCalledWith(1, {
+      body: { username: 'jdoe' },
+      path: { organizationId: 1, role: 'READER' },
+    });
+    expect(mocks.addUserToReaders).toHaveBeenNthCalledWith(2, {
+      body: { username: 'jdoe' },
+      path: { organizationId: 2, role: 'READER' },
+    });
+    expect(mocks.toastInfo).toHaveBeenCalledOnce();
+    expect(mocks.toastInfo).toHaveBeenCalledWith('Create User', {
+      description:
+        'User "jdoe" was created and granted the READER role for ' +
+        '"First Organization", "Second Organization".',
+    });
+    expect(mocks.toastError).not.toHaveBeenCalled();
+    expect(mocks.navigate).toHaveBeenCalledOnce();
+    expect(mocks.navigate).toHaveBeenCalledWith({ to: '/admin/users' });
+  });
+
+  it('reports failed role assignments and still navigates', async () => {
+    const error = new Error('Could not assign the role.');
+    mocks.addUserToReaders
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(error);
+
+    await getOnSubmit()(values);
+
+    expect(mocks.toastInfo).not.toHaveBeenCalled();
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      'User "jdoe" was created, but the READER role could not be granted ' +
+        'for "Second Organization". Assign the missing roles in each ' +
+        'organization\'s "Users" section.',
+      error
+    );
+    expect(mocks.navigate).toHaveBeenCalledOnce();
+  });
+
+  it('stops when user creation fails', async () => {
+    mocks.createUser.mockRejectedValue(new Error('Could not create the user.'));
+
+    await expect(getOnSubmit()(values)).resolves.toBeUndefined();
+
+    expect(mocks.addUserToReaders).not.toHaveBeenCalled();
+    expect(mocks.toastInfo).not.toHaveBeenCalled();
+    expect(mocks.navigate).not.toHaveBeenCalled();
+  });
+});

--- a/ui/tests/unit/components/create-user-page.test.tsx
+++ b/ui/tests/unit/components/create-user-page.test.tsx
@@ -67,6 +67,7 @@ type CreateUserPageElement = ReactElement<{
 
 const values: CreateUserFormValues = {
   username: 'JDOE',
+  password: 'initial password',
   temporary: true,
   organizations: [
     { value: '1', label: 'First Organization' },
@@ -93,7 +94,7 @@ describe('CreateUserPage', () => {
         email: undefined,
         firstName: undefined,
         lastName: undefined,
-        password: undefined,
+        password: 'initial password',
         temporary: true,
         username: 'jdoe',
       },


### PR DESCRIPTION
This PR improves the "Create User" form, by fixing some logical flaws in it, making it unit-testable (which improves its upkeeping, as it has moderate amount of logic in its functionality), and improving the layout of the form to be more condensed.

#### Create button is only enabled after both username and password are entered

Note that the user doesn't need to be put to any organization, when creating - this was legacy Keycloak requirement, which is now dropped.

<img width="1173" height="634" alt="Screenshot from 2026-09-03 07-48-21" src="https://github.com/user-attachments/assets/7b704224-8019-45e7-94ef-e99c7683de18" />

#### After the creation, the new user is immediately seen in the users table (a bug fixed here)

<img width="1175" height="450" alt="Screenshot from 2026-09-03 07-49-02" src="https://github.com/user-attachments/assets/32924374-37fe-4599-8c50-a4b4a6fa523b" />

#### Admin gave the new user _only_ WRITE rights to this repository

Verified in the UI that the user can navigate to the repository from the root, but cannot create any new organizations, products, or repositories. Runs to the repository can be created.

<img width="1392" height="631" alt="Screenshot from 2026-09-03 07-51-55" src="https://github.com/user-attachments/assets/8624b521-a8d2-4846-bae8-dcd601d4ca04" />

NOTE: A good follow-up to this is immediately obvious: improve and streamline user creation by extending the form so that when creating a new user, all organization, product, and repository rights could be immediately set up for the user in this form.

Please see the commits for details. Commits 1 and 2 prepare for addition of new features, commits 3-5 implement them. Commit 7 has the UI layout polish.