### PR TITLE
fix(ui): Say "Job Statuses" instead of "Last Job Status"

### DIFF
--- a/ui/src/routes/organizations/$orgId/-components/organization-product-table.tsx
+++ b/ui/src/routes/organizations/$orgId/-components/organization-product-table.tsx
@@ -235,7 +235,7 @@ export const OrganizationProductTable = () => {
         }),
         columnHelper.display({
           id: 'jobStatus',
-          header: 'Last Job Status',
+          header: 'Job Statuses',
           cell: function CellComponent({ row }) {
             const { data, isPending, isError } = useQuery({
               ...getProductRepositoriesOptions({

--- a/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repository-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/-components/product-repository-table.tsx
@@ -211,7 +211,7 @@ export const ProductRepositoryTable = () => {
         }),
         columnHelper.display({
           id: 'jobStatus',
-          header: 'Last Job Status',
+          header: 'Job Statuses',
           cell: ({ row }) => <LastJobStatus repoId={row.original.id} />,
           meta: {
             widthPercentage: 8,


### PR DESCRIPTION
The original text was misleading as there is no (single) last job status. Instead, the status for each job of the last run is shown.