### PR TITLE
fix(ui): Preserve UI address after logout

### DIFF
--- a/ui/src/config.ts
+++ b/ui/src/config.ts
@@ -47,6 +47,7 @@ const RUN_POLL_INTERVAL = env.VITE_RUN_POLL_INTERVAL;
 const oidcConfig = {
   authority: AUTHORITY,
   redirect_uri: UI_URL,
+  post_logout_redirect_uri: UI_URL,
   client_id: CLIENT_ID,
   automaticSilentRenew: true,
   loadUserInfo: false,


### PR DESCRIPTION
In local environment, when using the Vite dev UI (on port 5173) and logging out as a user, then logging back in (as any user), the browser is erroneously redirected to the Docker Compose version of the UI (on port 8082).

- Fix is verified on the Vite side: Vite dev UI open on 5173 -> logout -> login -> UI opens on port 5173 -> CORRECT.
- Also verified to work on the Compose UI: UI open on 8082 -> logout -> login -> UI opens on port 8082 again -> CORRECT

Please see the commit for details.