### PR TITLE
ui: Streamline repository deletion

### DIFF
--- a/ui/src/components/delete-dialog.tsx
+++ b/ui/src/components/delete-dialog.tsx
@@ -51,6 +51,12 @@ interface DeleteDialogProps {
   thingId?: string;
 
   /**
+   * An optional description explaining the consequences of the deletion. Replaces the generic
+   * default text.
+   */
+  description?: ReactNode;
+
+  /**
    * An optional item from which to delete. This is to generalise the delete dialog,
    * as sometimes, for example a user is only deleted from an organization, not
    * completely.
@@ -87,6 +93,7 @@ interface DeleteDialogProps {
 export const DeleteDialog = ({
   thingName,
   thingId,
+  description,
   itemName,
   uiComponent,
   onDelete,
@@ -141,8 +148,8 @@ export const DeleteDialog = ({
         </AlertDialogHeader>
         <div className='flex flex-col gap-2 overflow-auto wrap-break-word'>
           <AlertDialogDescription>
-            Note that deletion is irreversible and might have unwanted side
-            effects.
+            {description ??
+              'Note that deletion is irreversible and might have unwanted side effects.'}
           </AlertDialogDescription>
           {thingId && (
             <>

--- a/ui/src/lib/repository-deletion.ts
+++ b/ui/src/lib/repository-deletion.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import type { InfrastructureService, Secret } from '@/api';
+import {
+  deleteRepository,
+  deleteRepositoryInfrastructureService,
+  deleteRepositorySecret,
+  getRepositoryInfrastructureServices,
+  getRepositorySecrets,
+} from '@/api/sdk.gen';
+import { getNextPageParam, type PagedResponse } from '@/lib/infinite-list';
+
+const PAGE_SIZE = 100;
+
+export type RepositoryDeletionPhase =
+  'infrastructure-services' | 'secrets' | 'repository';
+
+export type RepositoryDeletionProgress = {
+  phase: RepositoryDeletionPhase;
+  deletedCount: number;
+};
+
+type GetPage<TItem> = (offset: number) => Promise<PagedResponse<TItem>>;
+
+async function getAllItems<TItem>(getPage: GetPage<TItem>) {
+  const items: TItem[] = [];
+  let offset: number | undefined = 0;
+
+  while (offset !== undefined) {
+    const page = await getPage(offset);
+    items.push(...page.data);
+    offset = getNextPageParam(page);
+  }
+
+  return items;
+}
+
+/**
+ * Delete all infrastructure services and secrets of a repository before deleting the repository
+ * itself. Items are read from every page before deletion so that removing them does not shift the
+ * offsets of subsequent pages.
+ */
+export async function deleteRepositoryWithContents(
+  repositoryId: number,
+  onProgress: (progress: RepositoryDeletionProgress) => void
+): Promise<void> {
+  const path = { repositoryId };
+
+  const infrastructureServices = await getAllItems<InfrastructureService>(
+    async (offset) => {
+      const response = await getRepositoryInfrastructureServices({
+        path,
+        query: { limit: PAGE_SIZE, offset },
+        throwOnError: true,
+      });
+
+      return response.data;
+    }
+  );
+
+  for (const service of infrastructureServices) {
+    await deleteRepositoryInfrastructureService({
+      path: { ...path, serviceName: service.name },
+      throwOnError: true,
+    });
+  }
+
+  onProgress({
+    phase: 'infrastructure-services',
+    deletedCount: infrastructureServices.length,
+  });
+
+  const secrets = await getAllItems<Secret>(async (offset) => {
+    const response = await getRepositorySecrets({
+      path,
+      query: { limit: PAGE_SIZE, offset },
+      throwOnError: true,
+    });
+
+    return response.data;
+  });
+
+  for (const secret of secrets) {
+    await deleteRepositorySecret({
+      path: { ...path, secretName: secret.name },
+      throwOnError: true,
+    });
+  }
+
+  onProgress({ phase: 'secrets', deletedCount: secrets.length });
+
+  await deleteRepository({ path, throwOnError: true });
+  onProgress({ phase: 'repository', deletedCount: 1 });
+}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/settings/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/settings/index.tsx
@@ -29,8 +29,9 @@ import {
 } from '@tanstack/react-router';
 
 import {
-  deleteRepositoryMutation,
+  getRepositoryInfrastructureServicesQueryKey,
   getRepositoryOptions,
+  getRepositorySecretsQueryKey,
   patchRepositoryMutation,
 } from '@/api/@tanstack/react-query.gen';
 import { DeleteDialog } from '@/components/delete-dialog';
@@ -38,12 +39,16 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { ApiError } from '@/lib/api-error';
 import { repositoryDeleted, repositoryUpdated } from '@/lib/entity-cache';
+import {
+  deleteRepositoryWithContents,
+  type RepositoryDeletionPhase,
+} from '@/lib/repository-deletion';
 import { toast, toastError } from '@/lib/toast';
 import { EditRepositoryForm } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/settings/-components/edit-repository-form';
 import { MoveRepository } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components';
 import type { RepositoryFormValues } from '@/schemas';
 
-const RepositorySettingsPage = () => {
+export const RepositorySettingsPage = () => {
   const params = Route.useParams();
   const navigate = useNavigate();
   const router = useRouter();
@@ -92,28 +97,67 @@ const RepositorySettingsPage = () => {
     });
   }
 
-  const { mutateAsync: deleteRepository } = useMutation({
-    ...deleteRepositoryMutation(),
-    onSuccess() {
-      toast.info('Delete Repository', {
-        description: `Repository "${repository.url}" deleted successfully.`,
-      });
-      repositoryDeleted(queryClient, repository);
-      navigate({
-        to: '/organizations/$orgId/products/$productId',
-        params: { orgId: params.orgId, productId: params.productId },
-      });
-    },
-    onError(error: ApiError) {
-      toastError(error.message, error);
-    },
-  });
-
   async function handleDelete() {
-    await deleteRepository({
-      path: {
-        repositoryId: Number.parseInt(params.repoId),
-      },
+    const deletionState: { failedPhase: RepositoryDeletionPhase } = {
+      failedPhase: 'infrastructure-services',
+    };
+
+    try {
+      await deleteRepositoryWithContents(
+        repository.id,
+        ({ phase, deletedCount }) => {
+          if (phase === 'infrastructure-services') {
+            if (deletedCount > 0) {
+              toast.info('Delete Infrastructure Services', {
+                description: `Deleted ${deletedCount} infrastructure services from repository "${repository.url}".`,
+              });
+            }
+
+            deletionState.failedPhase = 'secrets';
+          } else if (phase === 'secrets') {
+            if (deletedCount > 0) {
+              toast.info('Delete Secrets', {
+                description: `Deleted ${deletedCount} secrets from repository "${repository.url}".`,
+              });
+            }
+
+            deletionState.failedPhase = 'repository';
+          } else {
+            toast.info('Delete Repository', {
+              description: `Repository "${repository.url}" deleted successfully.`,
+            });
+          }
+        }
+      );
+    } catch (error) {
+      queryClient.invalidateQueries({
+        queryKey: getRepositoryInfrastructureServicesQueryKey({
+          path: { repositoryId: repository.id },
+        }),
+      });
+      queryClient.invalidateQueries({
+        queryKey: getRepositorySecretsQueryKey({
+          path: { repositoryId: repository.id },
+        }),
+      });
+
+      const failedEntities =
+        deletionState.failedPhase === 'repository'
+          ? 'repository'
+          : `the ${deletionState.failedPhase.replace('-', ' ')} of repository`;
+      toastError(
+        `Could not delete ${failedEntities} "${repository.url}". ` +
+          'Some infrastructure services and secrets may already have been deleted. ' +
+          'Retry the deletion to remove the rest.',
+        error
+      );
+      return;
+    }
+
+    repositoryDeleted(queryClient, repository);
+    navigate({
+      to: '/organizations/$orgId/products/$productId',
+      params: { orgId: params.orgId, productId: params.productId },
     });
   }
 
@@ -149,6 +193,7 @@ const RepositorySettingsPage = () => {
               <DeleteDialog
                 thingName={'repository'}
                 thingId={repository.url}
+                description='This deletes the repository together with all its ORT runs and their results, its secrets and its infrastructure services. Deletion is irreversible.'
                 uiComponent={
                   <Button variant='destructive'>Delete repository</Button>
                 }

--- a/ui/tests/unit/components/delete-dialog.test.tsx
+++ b/ui/tests/unit/components/delete-dialog.test.tsx
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DeleteDialog } from '@/components/delete-dialog';
+
+const defaultDescription =
+  'Note that deletion is irreversible and might have unwanted side effects.';
+
+const renderDialog = (description?: React.ReactNode, thingId?: string) =>
+  render(
+    <DeleteDialog
+      thingName='repository'
+      thingId={thingId}
+      description={description}
+      uiComponent={<button>Open dialog</button>}
+      onDelete={vi.fn()}
+    />
+  );
+
+describe('DeleteDialog', () => {
+  it('shows the default description', async () => {
+    const user = userEvent.setup();
+    renderDialog();
+
+    await user.click(screen.getByRole('button', { name: 'Open dialog' }));
+
+    expect(screen.getByText(defaultDescription)).toBeVisible();
+  });
+
+  it('shows a custom description instead of the default description', async () => {
+    const user = userEvent.setup();
+    renderDialog(<span>Custom deletion consequences.</span>);
+
+    await user.click(screen.getByRole('button', { name: 'Open dialog' }));
+
+    expect(screen.getByText('Custom deletion consequences.')).toBeVisible();
+    expect(screen.queryByText(defaultDescription)).not.toBeInTheDocument();
+  });
+
+  it('requires the thing ID to enable deletion', async () => {
+    const user = userEvent.setup();
+    renderDialog(undefined, 'repository-id');
+
+    await user.click(screen.getByRole('button', { name: 'Open dialog' }));
+
+    const deleteButton = screen.getByRole('button', { name: 'Delete' });
+    const confirmationInput = screen.getByRole('textbox');
+
+    expect(deleteButton).toBeDisabled();
+
+    await user.type(confirmationInput, 'wrong-id');
+    expect(deleteButton).toBeDisabled();
+
+    await user.clear(confirmationInput);
+    await user.type(confirmationInput, 'repository-id');
+    expect(deleteButton).toBeEnabled();
+  });
+});

--- a/ui/tests/unit/components/repository-settings-page.test.tsx
+++ b/ui/tests/unit/components/repository-settings-page.test.tsx
@@ -1,0 +1,237 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+// @vitest-environment jsdom
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { Repository } from '@/api';
+import type { RepositoryDeletionProgress } from '@/lib/repository-deletion';
+import { RepositorySettingsPage } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/settings';
+
+const mocks = vi.hoisted(() => ({
+  deleteRepositoryWithContents: vi.fn(),
+  getRepositoryInfrastructureServicesQueryKey: vi.fn(() => [
+    'repository-infrastructure-services',
+  ]),
+  getRepositorySecretsQueryKey: vi.fn(() => ['repository-secrets']),
+  invalidateQueries: vi.fn(),
+  mutateAsync: vi.fn(),
+  navigate: vi.fn(),
+  repositoryDeleted: vi.fn(),
+  repositoryUpdated: vi.fn(),
+  routerInvalidate: vi.fn(),
+  toastError: vi.fn(),
+  toastInfo: vi.fn(),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useMutation: () => ({ mutateAsync: mocks.mutateAsync, isPending: false }),
+  useQueryClient: () => ({ invalidateQueries: mocks.invalidateQueries }),
+  useSuspenseQuery: () => ({ data: repository }),
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  createFileRoute: () => (options: Record<string, unknown>) => ({
+    ...options,
+    useParams: () => ({ orgId: '1', productId: '2', repoId: '42' }),
+  }),
+  useNavigate: () => mocks.navigate,
+  useRouter: () => ({ invalidate: mocks.routerInvalidate }),
+}));
+
+vi.mock('@/api/@tanstack/react-query.gen', () => ({
+  getRepositoryInfrastructureServicesQueryKey:
+    mocks.getRepositoryInfrastructureServicesQueryKey,
+  getRepositoryOptions: () => ({}),
+  getRepositorySecretsQueryKey: mocks.getRepositorySecretsQueryKey,
+  patchRepositoryMutation: () => ({}),
+}));
+
+vi.mock('@/lib/entity-cache', () => ({
+  repositoryDeleted: mocks.repositoryDeleted,
+  repositoryUpdated: mocks.repositoryUpdated,
+}));
+
+vi.mock('@/lib/repository-deletion', () => ({
+  deleteRepositoryWithContents: mocks.deleteRepositoryWithContents,
+}));
+
+vi.mock('@/lib/toast', () => ({
+  toast: { info: mocks.toastInfo },
+  toastError: mocks.toastError,
+}));
+
+vi.mock(
+  '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/settings/-components/edit-repository-form',
+  () => ({ EditRepositoryForm: () => <div>Edit repository</div> })
+);
+
+vi.mock(
+  '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components',
+  () => ({ MoveRepository: () => <div>Move repository</div> })
+);
+
+const repository: Repository = {
+  id: 42,
+  organizationId: 1,
+  productId: 2,
+  type: 'GIT',
+  url: 'https://example.org/repository.git',
+};
+
+const dialogDescription =
+  'This deletes the repository together with all its ORT runs and their results, its secrets and its infrastructure services. Deletion is irreversible.';
+
+type ProgressCallback = (progress: RepositoryDeletionProgress) => void;
+
+function completeDeletion() {
+  mocks.deleteRepositoryWithContents.mockImplementation(
+    async (_repositoryId: number, onProgress: ProgressCallback) => {
+      onProgress({ phase: 'infrastructure-services', deletedCount: 3 });
+      onProgress({ phase: 'secrets', deletedCount: 5 });
+      onProgress({ phase: 'repository', deletedCount: 1 });
+    }
+  );
+}
+
+async function confirmDeletion(user: ReturnType<typeof userEvent.setup>) {
+  await user.click(screen.getByRole('button', { name: 'Delete repository' }));
+  await user.type(screen.getByRole('textbox'), repository.url);
+  await user.click(screen.getByRole('button', { name: 'Delete' }));
+}
+
+describe('RepositorySettingsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.deleteRepositoryWithContents.mockResolvedValue(undefined);
+  });
+
+  it('describes all repository contents that will be deleted', async () => {
+    const user = userEvent.setup();
+    render(<RepositorySettingsPage />);
+
+    await user.click(screen.getByRole('button', { name: 'Delete repository' }));
+
+    expect(screen.getByText(dialogDescription)).toBeVisible();
+  });
+
+  it('reports each completed non-empty deletion phase once', async () => {
+    const user = userEvent.setup();
+    completeDeletion();
+    render(<RepositorySettingsPage />);
+
+    await confirmDeletion(user);
+
+    await waitFor(() =>
+      expect(mocks.deleteRepositoryWithContents).toHaveBeenCalledOnce()
+    );
+    expect(mocks.toastInfo.mock.calls).toEqual([
+      [
+        'Delete Infrastructure Services',
+        {
+          description: `Deleted 3 infrastructure services from repository "${repository.url}".`,
+        },
+      ],
+      [
+        'Delete Secrets',
+        {
+          description: `Deleted 5 secrets from repository "${repository.url}".`,
+        },
+      ],
+      [
+        'Delete Repository',
+        {
+          description: `Repository "${repository.url}" deleted successfully.`,
+        },
+      ],
+    ]);
+  });
+
+  it('updates the hierarchy cache and navigates after deletion', async () => {
+    const user = userEvent.setup();
+    completeDeletion();
+    render(<RepositorySettingsPage />);
+
+    await confirmDeletion(user);
+
+    await waitFor(() =>
+      expect(mocks.repositoryDeleted).toHaveBeenCalledWith(
+        expect.objectContaining({ invalidateQueries: mocks.invalidateQueries }),
+        repository
+      )
+    );
+    expect(mocks.navigate).toHaveBeenCalledWith({
+      to: '/organizations/$orgId/products/$productId',
+      params: { orgId: '1', productId: '2' },
+    });
+  });
+
+  it('reports the failed phase without navigating', async () => {
+    const user = userEvent.setup();
+    const error = new Error('Could not delete a secret.');
+    mocks.deleteRepositoryWithContents.mockImplementation(
+      async (_repositoryId: number, onProgress: ProgressCallback) => {
+        onProgress({ phase: 'infrastructure-services', deletedCount: 2 });
+        throw error;
+      }
+    );
+    render(<RepositorySettingsPage />);
+
+    await confirmDeletion(user);
+
+    await waitFor(() =>
+      expect(mocks.toastError).toHaveBeenCalledWith(
+        `Could not delete the secrets of repository "${repository.url}". ` +
+          'Some infrastructure services and secrets may already have been deleted. ' +
+          'Retry the deletion to remove the rest.',
+        error
+      )
+    );
+    expect(mocks.toastError).toHaveBeenCalledOnce();
+    expect(mocks.repositoryDeleted).not.toHaveBeenCalled();
+    expect(mocks.navigate).not.toHaveBeenCalled();
+  });
+
+  it('invalidates cleanup queries after a failure', async () => {
+    const user = userEvent.setup();
+    mocks.deleteRepositoryWithContents.mockRejectedValue(
+      new Error('Could not delete an infrastructure service.')
+    );
+    render(<RepositorySettingsPage />);
+
+    await confirmDeletion(user);
+
+    await waitFor(() =>
+      expect(mocks.invalidateQueries).toHaveBeenCalledTimes(2)
+    );
+    expect(
+      mocks.getRepositoryInfrastructureServicesQueryKey
+    ).toHaveBeenCalledWith({ path: { repositoryId: repository.id } });
+    expect(mocks.getRepositorySecretsQueryKey).toHaveBeenCalledWith({
+      path: { repositoryId: repository.id },
+    });
+    expect(mocks.invalidateQueries.mock.calls).toEqual([
+      [{ queryKey: ['repository-infrastructure-services'] }],
+      [{ queryKey: ['repository-secrets'] }],
+    ]);
+  });
+});

--- a/ui/tests/unit/logic/repository-deletion.test.ts
+++ b/ui/tests/unit/logic/repository-deletion.test.ts
@@ -1,0 +1,293 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { deleteRepositoryWithContents } from '@/lib/repository-deletion';
+
+const mocks = vi.hoisted(() => ({
+  calls: [] as string[],
+  infrastructureServices: [] as Array<{ name: string }>,
+  secrets: [] as Array<{ name: string }>,
+  deleteRepository: vi.fn(),
+  deleteRepositoryInfrastructureService: vi.fn(),
+  deleteRepositorySecret: vi.fn(),
+  getRepositoryInfrastructureServices: vi.fn(),
+  getRepositorySecrets: vi.fn(),
+}));
+
+vi.mock('@/api/sdk.gen', () => ({
+  deleteRepository: mocks.deleteRepository,
+  deleteRepositoryInfrastructureService:
+    mocks.deleteRepositoryInfrastructureService,
+  deleteRepositorySecret: mocks.deleteRepositorySecret,
+  getRepositoryInfrastructureServices:
+    mocks.getRepositoryInfrastructureServices,
+  getRepositorySecrets: mocks.getRepositorySecrets,
+}));
+
+const repositoryId = 42;
+const pageSize = 100;
+
+function createPage<T>(items: T[], offset: number) {
+  return {
+    data: items.slice(offset, offset + pageSize),
+    pagination: {
+      limit: pageSize,
+      offset,
+      sortProperties: [],
+      totalCount: items.length,
+    },
+  };
+}
+
+describe('repository deletion', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.calls = [];
+    mocks.infrastructureServices = [
+      { name: 'infrastructure-service-1' },
+      { name: 'infrastructure-service-2' },
+    ];
+    mocks.secrets = [{ name: 'secret-1' }, { name: 'secret-2' }];
+
+    mocks.getRepositoryInfrastructureServices.mockImplementation(
+      async ({ query: { offset } }) => {
+        mocks.calls.push(`list-infrastructure-services:${offset}`);
+        return { data: createPage(mocks.infrastructureServices, offset) };
+      }
+    );
+    mocks.deleteRepositoryInfrastructureService.mockImplementation(
+      async ({ path: { serviceName } }) => {
+        mocks.calls.push(`delete-infrastructure-service:${serviceName}`);
+      }
+    );
+    mocks.getRepositorySecrets.mockImplementation(
+      async ({ query: { offset } }) => {
+        mocks.calls.push(`list-secrets:${offset}`);
+        return { data: createPage(mocks.secrets, offset) };
+      }
+    );
+    mocks.deleteRepositorySecret.mockImplementation(
+      async ({ path: { secretName } }) => {
+        mocks.calls.push(`delete-secret:${secretName}`);
+      }
+    );
+    mocks.deleteRepository.mockImplementation(async () => {
+      mocks.calls.push('delete-repository');
+    });
+  });
+
+  it('deletes infrastructure services before secrets and the repository', async () => {
+    await deleteRepositoryWithContents(repositoryId, vi.fn());
+
+    expect(mocks.calls).toEqual([
+      'list-infrastructure-services:0',
+      'delete-infrastructure-service:infrastructure-service-1',
+      'delete-infrastructure-service:infrastructure-service-2',
+      'list-secrets:0',
+      'delete-secret:secret-1',
+      'delete-secret:secret-2',
+      'delete-repository',
+    ]);
+    expect(mocks.getRepositoryInfrastructureServices).toHaveBeenCalledWith({
+      path: { repositoryId },
+      query: { limit: pageSize, offset: 0 },
+      throwOnError: true,
+    });
+    expect(mocks.deleteRepositoryInfrastructureService).toHaveBeenCalledWith({
+      path: {
+        repositoryId,
+        serviceName: 'infrastructure-service-1',
+      },
+      throwOnError: true,
+    });
+    expect(mocks.getRepositorySecrets).toHaveBeenCalledWith({
+      path: { repositoryId },
+      query: { limit: pageSize, offset: 0 },
+      throwOnError: true,
+    });
+    expect(mocks.deleteRepositorySecret).toHaveBeenCalledWith({
+      path: { repositoryId, secretName: 'secret-1' },
+      throwOnError: true,
+    });
+    expect(mocks.deleteRepository).toHaveBeenCalledWith({
+      path: { repositoryId },
+      throwOnError: true,
+    });
+  });
+
+  it('reads and deletes all pages before moving to the next phase', async () => {
+    mocks.infrastructureServices = Array.from({ length: 201 }, (_, index) => ({
+      name: `infrastructure-service-${index}`,
+    }));
+    mocks.secrets = Array.from({ length: 201 }, (_, index) => ({
+      name: `secret-${index}`,
+    }));
+
+    await deleteRepositoryWithContents(repositoryId, vi.fn());
+
+    expect(
+      mocks.getRepositoryInfrastructureServices.mock.calls.map(
+        ([{ query }]) => query.offset
+      )
+    ).toEqual([0, 100, 200]);
+    expect(mocks.deleteRepositoryInfrastructureService).toHaveBeenCalledTimes(
+      201
+    );
+    expect(
+      mocks.getRepositorySecrets.mock.calls.map(([{ query }]) => query.offset)
+    ).toEqual([0, 100, 200]);
+    expect(mocks.deleteRepositorySecret).toHaveBeenCalledTimes(201);
+
+    const firstSecretList = mocks.calls.indexOf('list-secrets:0');
+    expect(
+      mocks.calls
+        .slice(0, firstSecretList)
+        .filter((call) => call.startsWith('delete-infrastructure-service:'))
+    ).toHaveLength(201);
+  });
+
+  it('reports each completed phase once', async () => {
+    const onProgress = vi.fn();
+
+    await deleteRepositoryWithContents(repositoryId, onProgress);
+
+    expect(onProgress.mock.calls).toEqual([
+      [{ phase: 'infrastructure-services', deletedCount: 2 }],
+      [{ phase: 'secrets', deletedCount: 2 }],
+      [{ phase: 'repository', deletedCount: 1 }],
+    ]);
+  });
+
+  it('deletes the repository when its cleanup phases are empty', async () => {
+    mocks.infrastructureServices = [];
+    mocks.secrets = [];
+    const onProgress = vi.fn();
+
+    await deleteRepositoryWithContents(repositoryId, onProgress);
+
+    expect(mocks.deleteRepositoryInfrastructureService).not.toHaveBeenCalled();
+    expect(mocks.deleteRepositorySecret).not.toHaveBeenCalled();
+    expect(mocks.deleteRepository).toHaveBeenCalledOnce();
+    expect(onProgress.mock.calls).toEqual([
+      [{ phase: 'infrastructure-services', deletedCount: 0 }],
+      [{ phase: 'secrets', deletedCount: 0 }],
+      [{ phase: 'repository', deletedCount: 1 }],
+    ]);
+  });
+
+  it('stops when deleting an infrastructure service fails', async () => {
+    const error = new Error('Could not delete an infrastructure service.');
+    mocks.deleteRepositoryInfrastructureService
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(error);
+    const onProgress = vi.fn();
+
+    await expect(
+      deleteRepositoryWithContents(repositoryId, onProgress)
+    ).rejects.toBe(error);
+
+    expect(mocks.getRepositorySecrets).not.toHaveBeenCalled();
+    expect(mocks.deleteRepositorySecret).not.toHaveBeenCalled();
+    expect(mocks.deleteRepository).not.toHaveBeenCalled();
+    expect(onProgress).not.toHaveBeenCalled();
+  });
+
+  it('stops when deleting a secret fails', async () => {
+    const error = new Error('Could not delete a secret.');
+    mocks.deleteRepositorySecret
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(error);
+    const onProgress = vi.fn();
+
+    await expect(
+      deleteRepositoryWithContents(repositoryId, onProgress)
+    ).rejects.toBe(error);
+
+    expect(mocks.deleteRepository).not.toHaveBeenCalled();
+    expect(onProgress.mock.calls).toEqual([
+      [{ phase: 'infrastructure-services', deletedCount: 2 }],
+    ]);
+  });
+
+  it('does not report a phase that fails while listing its items', async () => {
+    const error = new Error('Could not list secrets.');
+    mocks.getRepositorySecrets.mockRejectedValueOnce(error);
+    const onProgress = vi.fn();
+
+    await expect(
+      deleteRepositoryWithContents(repositoryId, onProgress)
+    ).rejects.toBe(error);
+
+    expect(mocks.deleteRepositorySecret).not.toHaveBeenCalled();
+    expect(mocks.deleteRepository).not.toHaveBeenCalled();
+    expect(onProgress.mock.calls).toEqual([
+      [{ phase: 'infrastructure-services', deletedCount: 2 }],
+    ]);
+  });
+
+  it('can retry after a partial failure and delete the remaining items', async () => {
+    let shouldFail = true;
+
+    mocks.deleteRepositoryInfrastructureService.mockImplementation(
+      async ({ path: { serviceName } }) => {
+        const index = mocks.infrastructureServices.findIndex(
+          ({ name }) => name === serviceName
+        );
+        mocks.infrastructureServices.splice(index, 1);
+      }
+    );
+    mocks.deleteRepositorySecret.mockImplementation(
+      async ({ path: { secretName } }) => {
+        if (secretName === 'secret-2' && shouldFail) {
+          shouldFail = false;
+          throw new Error('Could not delete the secret.');
+        }
+
+        const index = mocks.secrets.findIndex(
+          ({ name }) => name === secretName
+        );
+        mocks.secrets.splice(index, 1);
+      }
+    );
+
+    const firstProgress = vi.fn();
+    await expect(
+      deleteRepositoryWithContents(repositoryId, firstProgress)
+    ).rejects.toThrow('Could not delete the secret.');
+
+    expect(mocks.infrastructureServices).toEqual([]);
+    expect(mocks.secrets).toEqual([{ name: 'secret-2' }]);
+    expect(firstProgress.mock.calls).toEqual([
+      [{ phase: 'infrastructure-services', deletedCount: 2 }],
+    ]);
+
+    const retryProgress = vi.fn();
+    await deleteRepositoryWithContents(repositoryId, retryProgress);
+
+    expect(mocks.secrets).toEqual([]);
+    expect(mocks.deleteRepository).toHaveBeenCalledOnce();
+    expect(retryProgress.mock.calls).toEqual([
+      [{ phase: 'infrastructure-services', deletedCount: 0 }],
+      [{ phase: 'secrets', deletedCount: 1 }],
+      [{ phase: 'repository', deletedCount: 1 }],
+    ]);
+  });
+});


### PR DESCRIPTION
#### Be more specific in the delete dialog about what's going to be deleted

<img width="1385" height="529" alt="Screenshot from 2026-09-03 13-52-40" src="https://github.com/user-attachments/assets/3f96223f-0130-4d77-82ab-5f62d032e091" />

#### Report deletion of each so in case of failure, the user knows what wasn't successfully deleted

Note that this was a separate repository from the picture above.

<img width="1388" height="669" alt="Screenshot from 2026-09-03 13-50-24" src="https://github.com/user-attachments/assets/cfb62571-1a30-4608-b3cd-c04f0ba0a116" />

Please see the commits for details.