### PR TITLE
Include report definitions from admin config in available reporter plugins

### DIFF
--- a/components/admin-config/backend/src/main/kotlin/ReporterConfig.kt
+++ b/components/admin-config/backend/src/main/kotlin/ReporterConfig.kt
@@ -237,7 +237,7 @@ data class ReporterConfig(
      * [directory references][ReportDefinitionTemplate.assetDirectoriesRefs] to concrete [ReporterAsset]s. If a
      * reference cannot be resolved, it is recorded in [unresolvedAssetFilesRefs] or [unresolvedAssetDirectoriesRefs].
      */
-    private val resolvedReportDefinitions = reportDefinitionsMap.mapValues { (name, template) ->
+    val resolvedReportDefinitions = reportDefinitionsMap.mapValues { (name, template) ->
         val resolvedAssetFilesRefs = template.assetFilesRefs.partition { it in globalAssets }
             .let { (validRefs, invalidRefs) ->
                 unresolvedAssetFilesRefs[name] = invalidRefs

--- a/components/admin-config/backend/src/main/kotlin/ReporterConfig.kt
+++ b/components/admin-config/backend/src/main/kotlin/ReporterConfig.kt
@@ -208,27 +208,6 @@ data class ReporterConfig(
             .associateBy { it.lowercase() }
 
         /**
-         * Create dummy [ReportDefinition]s for all reporter plugins that are not referenced in the given
-         * [definitions]. This makes sure that there is always a definition for each existing reporter plugin.
-         */
-        internal fun addDefinitionsForUnreferencedPlugins(
-            definitions: Map<String, ReportDefinition>
-        ): Map<String, ReportDefinition> {
-            val allReporterPlugins = reporterPluginIds
-            val referencedPlugins = definitions.values.mapTo(mutableSetOf()) { it.pluginId.lowercase() }
-
-            return definitions + (allReporterPlugins.keys - referencedPlugins).associate { pluginId ->
-                val originalPluginId = allReporterPlugins.getValue(pluginId)
-                originalPluginId to ReportDefinition(
-                    pluginId = originalPluginId,
-                    assetFiles = emptyList(),
-                    assetDirectories = emptyList(),
-                    nameMapping = null
-                )
-            }
-        }
-
-        /**
          * Merge the given [pluginConfig] with the [definitionConfig] of a report definition, so that options from
          * the definition override options from the plugin.
          */
@@ -257,9 +236,6 @@ data class ReporterConfig(
      * [file references][ReportDefinitionTemplate.assetFilesRefs] and
      * [directory references][ReportDefinitionTemplate.assetDirectoriesRefs] to concrete [ReporterAsset]s. If a
      * reference cannot be resolved, it is recorded in [unresolvedAssetFilesRefs] or [unresolvedAssetDirectoriesRefs].
-     *
-     * This map also contains report definitions for all reporter plugins that are not referenced in the given
-     * [reportDefinitionsMap]. This makes sure that there is always a definition for each existing reporter plugin.
      */
     private val resolvedReportDefinitions = reportDefinitionsMap.mapValues { (name, template) ->
         val resolvedAssetFilesRefs = template.assetFilesRefs.partition { it in globalAssets }
@@ -290,13 +266,24 @@ data class ReporterConfig(
             assetDirectories = assetDirectories + resolvedAssetDirectoriesRefs,
             nameMapping = template.nameMapping
         )
-    }.let { addDefinitionsForUnreferencedPlugins(it) }
+    }
 
     /**
      * A [Map] with the existing report definitions using lowercase names as keys. This is used to simplify
      * case-insensitive lookups of report definitions by name.
      */
     private val lowercaseReportDefinitions = resolvedReportDefinitions.mapKeys { it.key.lowercase() }
+
+    /**
+     * A set with the names of all valid report formats in lowercase. Because report definitions replace the reporter
+     * plugin they reference, this is defined as the set of all reporter plugin IDs minus all reporter plugin IDs
+     * referenced by report definitions, plus all report definition names.
+     */
+    val validFormats = buildSet {
+        addAll(reporterPluginIds.keys)
+        resolvedReportDefinitions.values.forEach { remove(it.pluginId.lowercase()) }
+        addAll(lowercaseReportDefinitions.keys)
+    }
 
     /** A set with the names of all existing report definitions. */
     val reportDefinitionNames: Set<String>

--- a/components/admin-config/backend/src/test/kotlin/AdminConfigServiceTest.kt
+++ b/components/admin-config/backend/src/test/kotlin/AdminConfigServiceTest.kt
@@ -445,7 +445,7 @@ class AdminConfigServiceTest : WordSpec({
             reporterConfig.howToFixTextProviderFile shouldBe ORT_HOW_TO_FIX_TEXT_PROVIDER_FILENAME
             reporterConfig.customLicenseTextDir should beNull()
             reporterConfig shouldBe ReporterConfig()
-            reporterConfig.reportDefinitionNames should containAll("WebApp", "PdfTemplate")
+            reporterConfig.reportDefinitionNames should beEmpty()
         }
 
         "use default values for unspecified properties" {
@@ -459,7 +459,7 @@ class AdminConfigServiceTest : WordSpec({
 
             reporterConfig.howToFixTextProviderFile shouldBe ORT_HOW_TO_FIX_TEXT_PROVIDER_FILENAME
             reporterConfig.customLicenseTextDir should beNull()
-            reporterConfig.reportDefinitionNames should containAll("WebApp", "PdfTemplate")
+            reporterConfig.reportDefinitionNames should beEmpty()
         }
 
         "parse simple properties from the reporter section of the config file" {
@@ -699,23 +699,6 @@ class AdminConfigServiceTest : WordSpec({
                 ReporterAsset("special/layout/foo"),
                 ReporterAsset("special/layout/bar")
             )
-        }
-
-        "generate default report definitions for unreferenced reporter plugins" {
-            val config = """
-                    reporter {
-                    }
-                """.trimIndent()
-            val service = createServiceWithConfig(config)
-
-            val reporterConfig = service.loadAdminConfig(context).reporterConfig
-
-            reporterConfig.getReportDefinition("HtmlTemplate") shouldNotBeNull {
-                pluginId shouldBe "HtmlTemplate"
-                assetFiles should beEmpty()
-                assetDirectories should beEmpty()
-                nameMapping should beNull()
-            }
         }
 
         "allow overriding a report definition for a reporter plugin even if the case does not match" {

--- a/components/admin-config/backend/src/test/kotlin/AdminConfigServiceTest.kt
+++ b/components/admin-config/backend/src/test/kotlin/AdminConfigServiceTest.kt
@@ -24,7 +24,6 @@ import com.typesafe.config.ConfigFactory
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.beEmpty
-import io.kotest.matchers.collections.containAll
 import io.kotest.matchers.collections.containExactly
 import io.kotest.matchers.collections.containExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldBeSingleton

--- a/components/plugin-manager/backend/build.gradle.kts
+++ b/components/plugin-manager/backend/build.gradle.kts
@@ -40,6 +40,7 @@ repositories {
 }
 
 dependencies {
+    api(projects.components.adminConfig.adminConfigBackend)
     api(projects.components.pluginManager.pluginManagerApiModel)
     api(projects.model)
 
@@ -62,6 +63,7 @@ dependencies {
     routesImplementation(ktorLibs.server.core)
     routesImplementation(libs.ktor.openApi)
 
+    testImplementation(testFixtures(projects.config.configSpi))
     testImplementation(testFixtures(projects.dao))
     testImplementation(testFixtures(projects.shared.ktorUtils))
 

--- a/components/plugin-manager/backend/src/main/kotlin/PluginTemplateService.kt
+++ b/components/plugin-manager/backend/src/main/kotlin/PluginTemplateService.kt
@@ -29,9 +29,11 @@ import com.github.michaelbull.result.toErrorIfNull
 import com.github.michaelbull.result.toResultOr
 import com.github.michaelbull.result.tryFold
 
+import org.eclipse.apoapsis.ortserver.components.adminconfig.AdminConfigService
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.queries.GetPluginTemplateForOrganizationQuery
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.queries.GetPluginTemplateQuery
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.queries.GetPluginTemplatesQuery
+import org.eclipse.apoapsis.ortserver.config.ResolvedConfigContext
 import org.eclipse.apoapsis.ortserver.dao.blockingQuery
 import org.eclipse.apoapsis.ortserver.model.OrganizationId
 import org.eclipse.apoapsis.ortserver.model.RepositoryId
@@ -53,7 +55,8 @@ class PluginTemplateService(
     private val eventStore: PluginTemplateEventStore,
     private val pluginService: PluginService,
     private val organizationRepository: OrganizationRepository,
-    private val repositoryRepository: RepositoryRepository
+    private val repositoryRepository: RepositoryRepository,
+    private val adminConfigService: AdminConfigService
 ) {
     /**
      * Assign the plugin template with the given [templateName], [pluginType], and [pluginId] to the organization with
@@ -210,10 +213,13 @@ class PluginTemplateService(
     }
 
     internal fun getPluginsForRepository(
-        repositoryId: RepositoryId
+        repositoryId: RepositoryId,
+        context: ResolvedConfigContext
     ): Result<List<PreconfiguredPluginDescriptor>, TemplateError> = db.blockingQuery {
         val organizationId = repositoryRepository.get(repositoryId.value)?.organizationId?.let { OrganizationId(it) }
             ?: return@blockingQuery TemplateError.NotFound("No repository with ID '$repositoryId' found.").toErr()
+
+        val reportDefinitions = adminConfigService.loadAdminConfig(context).reporterConfig.resolvedReportDefinitions
 
         pluginService.getPlugins().filter { it.availability != PluginAvailability.DISABLED }
             .tryFold(initial = emptyList<PreconfiguredPluginDescriptor>()) { acc, plugin ->
@@ -257,6 +263,27 @@ class PluginTemplateService(
                         )
                     }
                 }
+            }.map { plugins ->
+                val replacedReporterPlugins = reportDefinitions.values.mapTo(mutableSetOf()) { it.pluginId.lowercase() }
+
+                // Drop all plugins for which a report definition exists.
+                val filteredPlugins = plugins.filter {
+                    it.type != PluginType.REPORTER || it.id.lowercase() !in replacedReporterPlugins
+                }
+
+                // Create one plugin for each report definition
+                val pluginsFromReportDefinitions = reportDefinitions.map { (name, definition) ->
+                    PreconfiguredPluginDescriptor(
+                        id = name,
+                        type = PluginType.REPORTER,
+                        displayName = name,
+                        summary = definition.description,
+                        description = null,
+                        options = emptyList()
+                    )
+                }
+
+                filteredPlugins + pluginsFromReportDefinitions
             }
     }
 

--- a/components/plugin-manager/backend/src/routes/kotlin/Routing.kt
+++ b/components/plugin-manager/backend/src/routes/kotlin/Routing.kt
@@ -35,9 +35,11 @@ import org.eclipse.apoapsis.ortserver.components.pluginmanager.routes.getTemplat
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.routes.removeTemplateFromOrganization
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.routes.restrictPlugin
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.routes.updateTemplateOptions
+import org.eclipse.apoapsis.ortserver.config.ConfigManager
 
 /** Add routes for all plugin-manager endpoints. */
 fun Route.pluginManagerRoutes(
+    configManager: ConfigManager,
     eventStore: PluginEventStore,
     pluginService: PluginService,
     pluginTemplateService: PluginTemplateService
@@ -50,7 +52,7 @@ fun Route.pluginManagerRoutes(
     enableGlobalTemplate(pluginTemplateService)
     enablePlugin(eventStore)
     getInstalledPlugins(pluginService)
-    getPluginsForRepository(pluginTemplateService)
+    getPluginsForRepository(configManager, pluginTemplateService)
     getTemplate(pluginTemplateService)
     getTemplates(pluginTemplateService)
     removeTemplateFromOrganization(pluginTemplateService)

--- a/components/plugin-manager/backend/src/routes/kotlin/routes/GetPluginsForRepository.kt
+++ b/components/plugin-manager/backend/src/routes/kotlin/routes/GetPluginsForRepository.kt
@@ -32,10 +32,13 @@ import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PreconfiguredPluginDescriptor
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PreconfiguredPluginOption
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.handleTemplateResult
+import org.eclipse.apoapsis.ortserver.config.ConfigManager
+import org.eclipse.apoapsis.ortserver.config.RequestedConfigContext
 import org.eclipse.apoapsis.ortserver.model.RepositoryId
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireIdParameter
 
 internal fun Route.getPluginsForRepository(
+    configManager: ConfigManager,
     pluginTemplateService: PluginTemplateService
 ) = get("repositories/{repositoryId}/plugins", {
     operationId = "GetPluginsForRepository"
@@ -46,6 +49,11 @@ internal fun Route.getPluginsForRepository(
     request {
         pathParameter<Long>("repositoryId") {
             description = "The ID of the repository to retrieve plugins for."
+        }
+
+        queryParameter<String>("configContext") {
+            description = "The config context to use."
+            required = false
         }
     }
 
@@ -99,8 +107,12 @@ internal fun Route.getPluginsForRepository(
     }
 }, requirePermission(RepositoryPermission.READ)) {
     val repositoryId = RepositoryId(call.requireIdParameter("repositoryId"))
+    val requestedContext = call.parameters["configContext"]?.let(::RequestedConfigContext)
+        ?: RequestedConfigContext.EMPTY
 
-    pluginTemplateService.getPluginsForRepository(repositoryId).handleTemplateResult {
+    val resolvedContext = configManager.resolveContext(requestedContext)
+
+    pluginTemplateService.getPluginsForRepository(repositoryId, resolvedContext).handleTemplateResult {
         call.respond(HttpStatusCode.OK, it)
     }
 }

--- a/components/plugin-manager/backend/src/test/kotlin/PluginManagerIntegrationTest.kt
+++ b/components/plugin-manager/backend/src/test/kotlin/PluginManagerIntegrationTest.kt
@@ -19,9 +19,15 @@
 
 package org.eclipse.apoapsis.ortserver.components.pluginmanager
 
+import com.typesafe.config.ConfigFactory
+
 import io.ktor.client.HttpClient
 import io.ktor.server.testing.ApplicationTestBuilder
 
+import org.eclipse.apoapsis.ortserver.components.adminconfig.AdminConfigService
+import org.eclipse.apoapsis.ortserver.config.ConfigFileProviderFactoryForTesting
+import org.eclipse.apoapsis.ortserver.config.ConfigManager
+import org.eclipse.apoapsis.ortserver.config.ConfigSecretProviderFactoryForTesting
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
 
 /** An [AbstractIntegrationTest] pre-configured for testing the plugin-manager routes. */
@@ -29,12 +35,23 @@ import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractIntegrationTest
 abstract class PluginManagerIntegrationTest(
     body: PluginManagerIntegrationTest.() -> Unit
 ) : AbstractIntegrationTest({}) {
+    lateinit var adminConfigService: AdminConfigService
+    lateinit var configManager: ConfigManager
     lateinit var eventStore: PluginEventStore
     lateinit var pluginService: PluginService
     lateinit var pluginTemplateService: PluginTemplateService
 
     init {
         beforeEach {
+            val configMap = mapOf(
+                ConfigManager.CONFIG_MANAGER_SECTION to mapOf(
+                    ConfigManager.FILE_PROVIDER_NAME_PROPERTY to ConfigFileProviderFactoryForTesting.NAME,
+                    ConfigManager.SECRET_PROVIDER_NAME_PROPERTY to ConfigSecretProviderFactoryForTesting.NAME
+                )
+            )
+
+            configManager = ConfigManager.create(ConfigFactory.parseMap(configMap))
+            adminConfigService = AdminConfigService(configManager)
             eventStore = PluginEventStore(dbExtension.db)
             pluginService = PluginService(dbExtension.db)
             pluginTemplateService = PluginTemplateService(
@@ -42,7 +59,8 @@ abstract class PluginManagerIntegrationTest(
                 PluginTemplateEventStore(dbExtension.db),
                 pluginService,
                 dbExtension.fixtures.organizationRepository,
-                dbExtension.fixtures.repositoryRepository
+                dbExtension.fixtures.repositoryRepository,
+                adminConfigService
             )
         }
 
@@ -52,7 +70,7 @@ abstract class PluginManagerIntegrationTest(
     fun pluginManagerTestApplication(
         block: suspend ApplicationTestBuilder.(client: HttpClient) -> Unit
     ) = integrationTestApplication(
-        routes = { pluginManagerRoutes(eventStore, pluginService, pluginTemplateService) },
+        routes = { pluginManagerRoutes(configManager, eventStore, pluginService, pluginTemplateService) },
         block = block
     )
 }

--- a/components/plugin-manager/backend/src/test/kotlin/routes/GetPluginsForRepositoryIntegrationTest.kt
+++ b/components/plugin-manager/backend/src/test/kotlin/routes/GetPluginsForRepositoryIntegrationTest.kt
@@ -20,10 +20,14 @@
 package org.eclipse.apoapsis.ortserver.components.pluginmanager.routes
 
 import io.kotest.assertions.ktor.client.shouldHaveStatus
+import io.kotest.matchers.collections.beEmpty
+import io.kotest.matchers.collections.shouldBeSingleton
 import io.kotest.matchers.collections.shouldContain
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.collections.shouldNotContain
+import io.kotest.matchers.nulls.beNull
 import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 
 import io.ktor.client.call.body
@@ -411,7 +415,8 @@ class GetPluginsForRepositoryIntegrationTest : PluginManagerIntegrationTest({
                 PluginTemplateEventStore(dbExtension.db),
                 mockedPluginService,
                 dbExtension.fixtures.organizationRepository,
-                dbExtension.fixtures.repositoryRepository
+                dbExtension.fixtures.repositoryRepository,
+                adminConfigService
             )
 
             pluginManagerTestApplication { client ->
@@ -425,6 +430,37 @@ class GetPluginsForRepositoryIntegrationTest : PluginManagerIntegrationTest({
                             defaultValue shouldBe null
                         }
                     }
+            }
+        }
+
+        "include plugins based on report definitions in the admin config file" {
+            pluginManagerTestApplication { client ->
+                val configPath = "src/test/resources/config"
+                val response = client.get("/repositories/${repositoryId.value}/plugins?configContext=$configPath")
+
+                response shouldHaveStatus HttpStatusCode.OK
+
+                val plugins = response.body<List<PreconfiguredPluginDescriptor>>()
+
+                // Validate that the PdfTemplate report was replaced by a reporter definition.
+                plugins.find { it.id.lowercase() == "pdftemplate" } should beNull()
+                plugins.filter { it.id == "customTemplate" }.shouldBeSingleton {
+                    it.displayName shouldBe "customTemplate"
+                    it.type shouldBe PluginType.REPORTER
+                    it.summary shouldBe "Custom template report."
+                    it.description should beNull()
+                    it.options should beEmpty()
+                }
+
+                // Validate that the WebApp report was overwritten by a report definition.
+                plugins.filter { it.id.lowercase() == "webapp" }.shouldBeSingleton {
+                    it.id shouldBe "webApp"
+                    it.displayName shouldBe "webApp"
+                    it.type shouldBe PluginType.REPORTER
+                    it.summary shouldBe "Web app report."
+                    it.description should beNull()
+                    it.options should beEmpty()
+                }
             }
         }
     }

--- a/components/plugin-manager/backend/src/test/kotlin/routes/PluginManagerAuthorizationTest.kt
+++ b/components/plugin-manager/backend/src/test/kotlin/routes/PluginManagerAuthorizationTest.kt
@@ -19,12 +19,15 @@
 
 package org.eclipse.apoapsis.ortserver.components.pluginmanager.routes
 
+import com.typesafe.config.ConfigFactory
+
 import io.ktor.client.request.delete
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.HttpStatusCode
 
+import org.eclipse.apoapsis.ortserver.components.adminconfig.AdminConfigService
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginEventStore
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginOptionTemplate
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginService
@@ -32,11 +35,15 @@ import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplateEve
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginTemplateService
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.PluginType
 import org.eclipse.apoapsis.ortserver.components.pluginmanager.pluginManagerRoutes
+import org.eclipse.apoapsis.ortserver.config.ConfigFileProviderFactoryForTesting
+import org.eclipse.apoapsis.ortserver.config.ConfigManager
+import org.eclipse.apoapsis.ortserver.config.ConfigSecretProviderFactoryForTesting
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.AbstractAuthorizationTest
 
 import org.ossreviewtoolkit.plugins.advisors.vulnerablecode.VulnerableCodeFactory
 
 class PluginManagerAuthorizationTest : AbstractAuthorizationTest({
+    lateinit var configManager: ConfigManager
     lateinit var pluginEventStore: PluginEventStore
     lateinit var pluginService: PluginService
     lateinit var pluginTemplateService: PluginTemplateService
@@ -46,6 +53,14 @@ class PluginManagerAuthorizationTest : AbstractAuthorizationTest({
     val templateName = "test-template"
 
     beforeEach {
+        val configMap = mapOf(
+            ConfigManager.CONFIG_MANAGER_SECTION to mapOf(
+                ConfigManager.FILE_PROVIDER_NAME_PROPERTY to ConfigFileProviderFactoryForTesting.NAME,
+                ConfigManager.SECRET_PROVIDER_NAME_PROPERTY to ConfigSecretProviderFactoryForTesting.NAME
+            )
+        )
+
+        configManager = ConfigManager.create(ConfigFactory.parseMap(configMap))
         pluginEventStore = PluginEventStore(dbExtension.db)
         pluginService = PluginService(dbExtension.db)
         pluginTemplateService = PluginTemplateService(
@@ -53,14 +68,15 @@ class PluginManagerAuthorizationTest : AbstractAuthorizationTest({
             PluginTemplateEventStore(dbExtension.db),
             pluginService,
             dbExtension.fixtures.organizationRepository,
-            dbExtension.fixtures.repositoryRepository
+            dbExtension.fixtures.repositoryRepository,
+            AdminConfigService(configManager)
         )
     }
 
     "AddTemplateToOrganization" should {
         "require the superuser role" {
             requestShouldRequireSuperuser(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) },
+                routes = { pluginManagerRoutes(configManager, pluginEventStore, pluginService, pluginTemplateService) },
                 successStatus = HttpStatusCode.NotFound
             ) {
                 post("/admin/plugins/$pluginType/$pluginId/templates/$templateName/addToOrganization?organizationId=1")
@@ -71,7 +87,7 @@ class PluginManagerAuthorizationTest : AbstractAuthorizationTest({
     "DeleteTemplate" should {
         "require the superuser role" {
             requestShouldRequireSuperuser(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) },
+                routes = { pluginManagerRoutes(configManager, pluginEventStore, pluginService, pluginTemplateService) },
                 successStatus = HttpStatusCode.NotFound
             ) {
                 delete("/admin/plugins/$pluginType/$pluginId/templates/$templateName")
@@ -82,7 +98,7 @@ class PluginManagerAuthorizationTest : AbstractAuthorizationTest({
     "DisableGlobalTemplate" should {
         "require the superuser role" {
             requestShouldRequireSuperuser(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) },
+                routes = { pluginManagerRoutes(configManager, pluginEventStore, pluginService, pluginTemplateService) },
                 successStatus = HttpStatusCode.NotFound
             ) {
                 post("/admin/plugins/$pluginType/$pluginId/templates/$templateName/disableGlobal")
@@ -93,7 +109,7 @@ class PluginManagerAuthorizationTest : AbstractAuthorizationTest({
     "DisablePlugin" should {
         "require the superuser role" {
             requestShouldRequireSuperuser(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) },
+                routes = { pluginManagerRoutes(configManager, pluginEventStore, pluginService, pluginTemplateService) },
                 successStatus = HttpStatusCode.Accepted
             ) {
                 post("/admin/plugins/$pluginType/$pluginId/disable")
@@ -104,7 +120,7 @@ class PluginManagerAuthorizationTest : AbstractAuthorizationTest({
     "EnableGlobalTemplate" should {
         "require the superuser role" {
             requestShouldRequireSuperuser(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) },
+                routes = { pluginManagerRoutes(configManager, pluginEventStore, pluginService, pluginTemplateService) },
                 successStatus = HttpStatusCode.NotFound
             ) {
                 post("/admin/plugins/$pluginType/$pluginId/templates/$templateName/enableGlobal")
@@ -115,7 +131,7 @@ class PluginManagerAuthorizationTest : AbstractAuthorizationTest({
     "EnablePlugin" should {
         "require the superuser role" {
             requestShouldRequireSuperuser(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) },
+                routes = { pluginManagerRoutes(configManager, pluginEventStore, pluginService, pluginTemplateService) },
                 successStatus = HttpStatusCode.NotModified
             ) {
                 post("/admin/plugins/$pluginType/$pluginId/enable")
@@ -126,7 +142,7 @@ class PluginManagerAuthorizationTest : AbstractAuthorizationTest({
     "GetInstalledPlugins" should {
         "require the superuser role" {
             requestShouldRequireSuperuser(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) }
+                routes = { pluginManagerRoutes(configManager, pluginEventStore, pluginService, pluginTemplateService) }
             ) {
                 get("/admin/plugins")
             }
@@ -136,7 +152,7 @@ class PluginManagerAuthorizationTest : AbstractAuthorizationTest({
     "GetTemplate" should {
         "require the superuser role" {
             requestShouldRequireSuperuser(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) },
+                routes = { pluginManagerRoutes(configManager, pluginEventStore, pluginService, pluginTemplateService) },
                 successStatus = HttpStatusCode.NotFound
             ) {
                 get("/admin/plugins/$pluginType/$pluginId/templates/$templateName")
@@ -147,7 +163,7 @@ class PluginManagerAuthorizationTest : AbstractAuthorizationTest({
     "GetTemplates" should {
         "require the superuser role" {
             requestShouldRequireSuperuser(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) },
+                routes = { pluginManagerRoutes(configManager, pluginEventStore, pluginService, pluginTemplateService) },
                 successStatus = HttpStatusCode.OK
             ) {
                 get("/admin/plugins/$pluginType/$pluginId/templates")
@@ -158,7 +174,7 @@ class PluginManagerAuthorizationTest : AbstractAuthorizationTest({
     "RemoveTemplateFromOrganization" should {
         "require the superuser role" {
             requestShouldRequireSuperuser(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) },
+                routes = { pluginManagerRoutes(configManager, pluginEventStore, pluginService, pluginTemplateService) },
                 successStatus = HttpStatusCode.NotFound
             ) {
                 post(
@@ -172,7 +188,7 @@ class PluginManagerAuthorizationTest : AbstractAuthorizationTest({
     "RestrictPlugin" should {
         "require the superuser role" {
             requestShouldRequireSuperuser(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) },
+                routes = { pluginManagerRoutes(configManager, pluginEventStore, pluginService, pluginTemplateService) },
                 successStatus = HttpStatusCode.Accepted
             ) {
                 post("/admin/plugins/$pluginType/$pluginId/restrict")
@@ -183,7 +199,7 @@ class PluginManagerAuthorizationTest : AbstractAuthorizationTest({
     "UpdateTemplateOptions" should {
         "require the superuser role" {
             requestShouldRequireSuperuser(
-                routes = { pluginManagerRoutes(pluginEventStore, pluginService, pluginTemplateService) },
+                routes = { pluginManagerRoutes(configManager, pluginEventStore, pluginService, pluginTemplateService) },
                 successStatus = HttpStatusCode.OK
             ) {
                 post("/admin/plugins/$pluginType/$pluginId/templates/$templateName") {

--- a/components/plugin-manager/backend/src/test/resources/config/ort-server.conf
+++ b/components/plugin-manager/backend/src/test/resources/config/ort-server.conf
@@ -1,0 +1,29 @@
+# Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+# License-Filename: LICENSE
+
+reporter {
+  reports {
+    customTemplate {
+      pluginId = "PdfTemplate"
+      description = "Custom template report."
+    }
+    webApp {
+      pluginId = "WebApp"
+      description = "Web app report."
+    }
+  }
+}

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -157,7 +157,7 @@ dependencies {
     implementation(ortLibs.utils.common)
     implementation(ortLibs.utils.ort)
 
-    runtimeOnly(projects.config.secretFile)
+    runtimeOnly(platform(projects.config))
     runtimeOnly(platform(projects.logaccess))
     runtimeOnly(platform(projects.secrets))
     runtimeOnly(platform(projects.storage))

--- a/core/src/main/kotlin/di/Module.kt
+++ b/core/src/main/kotlin/di/Module.kt
@@ -28,6 +28,7 @@ import kotlinx.serialization.json.Json
 
 import org.eclipse.apoapsis.ortserver.clients.keycloak.DefaultKeycloakClient
 import org.eclipse.apoapsis.ortserver.clients.keycloak.KeycloakClient
+import org.eclipse.apoapsis.ortserver.components.adminconfig.AdminConfigService
 import org.eclipse.apoapsis.ortserver.components.authorization.keycloak.migration.RolesToDbMigration
 import org.eclipse.apoapsis.ortserver.components.authorization.service.AuthorizationService
 import org.eclipse.apoapsis.ortserver.components.authorization.service.DbAuthorizationService
@@ -187,6 +188,7 @@ fun ortServerModule(config: ApplicationConfig, db: Database?, authorizationServi
         )
     }
 
+    singleOf(::AdminConfigService)
     singleOf(::DependencyGraphService)
     singleOf(::InfrastructureServiceService)
     singleOf(::IssueService)

--- a/core/src/main/kotlin/plugins/Routing.kt
+++ b/core/src/main/kotlin/plugins/Routing.kt
@@ -66,7 +66,7 @@ fun Application.configureRouting() {
                     infrastructureServicesRoutes(get())
                     licenseFindingRoutes(get(), get())
                     organizations()
-                    pluginManagerRoutes(get(), get(), get())
+                    pluginManagerRoutes(get(), get(), get(), get())
                     products()
                     repositories()
                     resolutionRoutes(get(), get(), get())

--- a/core/src/main/resources/application.conf
+++ b/core/src/main/resources/application.conf
@@ -19,6 +19,20 @@ configManager {
   secretProvider = ${?CORE_SECRET_PROVIDER}
   configSecretFileList = ${?CORE_SECRET_FILES}
   allowSecretsFromConfig = ${?ALLOW_SECRETS_FROM_CONFIG}
+
+  fileProvider = ${?CONFIG_FILE_PROVIDER}
+  gitHubRepositoryOwner = ${?CONFIG_GITHUB_REPOSITORY_OWNER}
+  gitHubRepositoryName = ${?CONFIG_GITHUB_REPOSITORY_NAME}
+  gitHubCacheDirectory = ${?CONFIG_GITHUB_CACHE_DIRECTORY}
+  gitHubCacheLockCheckIntervalSec = 5
+  gitHubCacheLockCheckIntervalSec = ${?CONFIG_GITHUB_CACHE_LOCK_CHECK_INTERVAL}
+  gitHubCacheMaxAgeDays = 30
+  gitHubCacheMaxAgeDays = ${?CONFIG_GITHUB_CACHE_MAX_AGE}
+  gitHubCacheCleanupRatio = 50
+  gitHubCacheCleanupRatio = ${?CONFIG_GITHUB_CACHE_CLEANUP_RATIO}
+  gitUrl = ${?CONFIG_GIT_URL}
+  gitRevisionCacheTtlSeconds = ${?CONFIG_GIT_REVISION_CACHE_TTL}
+  localConfigDir = ${?CONFIG_LOCAL_CONFIG_DIR}
 }
 
 ktor {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -224,6 +224,8 @@ services:
       ORCHESTRATOR_SENDER_TRANSPORT_TYPE: rabbitMQ
       ORCHESTRATOR_SENDER_TRANSPORT_SERVER_URI: "amqp://rabbitmq:5672"
       ORCHESTRATOR_SENDER_TRANSPORT_QUEUE_NAME: orchestrator_queue
+      CONFIG_FILE_PROVIDER: local-config
+      CONFIG_LOCAL_CONFIG_DIR: /mnt/config
       SECRETS_PROVIDER_NAME: fileBased
       FILE_BASED_PATH: "/mnt/secrets-provider/secrets.store"
       GRAPHITE_HOST: "graphite"
@@ -236,6 +238,9 @@ services:
       LOKI_SERVER_URL: "http://loki:3100"
       LOKI_NAMESPACE: "compose"
     volumes:
+      - type: bind
+        source: ./scripts/compose/config
+        target: /mnt/config
       - type: bind
         source: ./scripts/compose/secrets.properties
         target: /mnt/secrets.properties

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/reporter-fields.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/-components/reporter-fields.tsx
@@ -20,7 +20,6 @@
 import { UseFormReturn } from 'react-hook-form';
 
 import { PreconfiguredPluginDescriptor, Secret } from '@/api';
-import { MultiSelectField } from '@/components/form/multi-select-field';
 import { PluginMultiSelectField } from '@/components/form/plugin-multi-select-field.tsx';
 import {
   AccordionContent,
@@ -58,11 +57,6 @@ export const ReporterFields = ({
   secrets,
   isRerun,
 }: ReporterFieldsProps) => {
-  const reporterOptions = reporterPlugins.map((plugin) => ({
-    id: plugin.id,
-    label: plugin.displayName,
-    summary: plugin.summary,
-  }));
   const evaluatorEnabled = form.watch('jobConfigs.evaluator.enabled');
 
   return (
@@ -85,14 +79,17 @@ export const ReporterFields = ({
       <AccordionItem value={value} className='flex-1'>
         <AccordionTrigger onClick={onToggle}>Reporter</AccordionTrigger>
         <AccordionContent className='flex flex-col gap-6'>
-          <MultiSelectField
+          <PluginMultiSelectField
             form={form}
             name='jobConfigs.reporter.formats'
+            configName='jobConfigs.reporter.config'
             label='Report formats'
             description={
               <>Select the report formats to generate from the run.</>
             }
-            options={reporterOptions}
+            plugins={reporterPlugins}
+            secrets={secrets}
+            showSelectedPluginsFirst={isRerun}
           />
           {!evaluatorEnabled && (
             <PluginMultiSelectField
@@ -111,37 +108,6 @@ export const ReporterFields = ({
               secrets={secrets}
               enableReordering
               showSelectedPluginsFirst={isRerun}
-            />
-          )}
-          {form.watch('jobConfigs.reporter.formats').includes('WebApp') && (
-            <FormField
-              control={form.control}
-              name='jobConfigs.reporter.deduplicateDependencyTree'
-              render={({ field }) => (
-                <FormItem className='mb-4 flex flex-row items-center justify-between rounded-lg border p-4'>
-                  <div className='space-y-0.5'>
-                    <FormLabel>Deduplicate dependency tree</FormLabel>
-                    <FormDescription>
-                      A flag to control whether subtrees occurring multiple
-                      times in the dependency tree are stripped.
-                    </FormDescription>
-                    <FormDescription>
-                      This will significantly reduce memory consumption of the
-                      Reporter and might alleviate some out-of-memory issues.
-                    </FormDescription>
-                    <FormDescription>
-                      NOTE: This option is currently effective only for the
-                      WebApp report format.
-                    </FormDescription>
-                  </div>
-                  <FormControl>
-                    <Switch
-                      checked={field.value}
-                      onCheckedChange={field.onChange}
-                    />
-                  </FormControl>
-                </FormItem>
-              )}
             />
           )}
           {isSuperuser && (

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/create-run-form.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/create-run-form.tsx
@@ -131,6 +131,7 @@ export const CreateRunForm = ({
   const formSchema = createRunFormSchema(
     advisorPlugins,
     scannerPlugins,
+    reporterPlugins,
     packageCurationProviderPlugins,
     packageConfigurationProviderPlugins
   );
@@ -141,6 +142,7 @@ export const CreateRunForm = ({
       rerun,
       advisorPlugins,
       scannerPlugins,
+      reporterPlugins,
       isSuperuser,
       packageCurationProviderPlugins,
       packageConfigurationProviderPlugins

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/create-run-form.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/create-run-form.tsx
@@ -19,7 +19,7 @@
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { Loader2, PlusIcon, TrashIcon } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -53,6 +53,7 @@ import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Switch } from '@/components/ui/switch';
 import { Textarea } from '@/components/ui/textarea';
+import { useDebounce } from '@/hooks/use-debounce';
 import type {
   OrganizationPermissions,
   ProductPermissions,
@@ -86,6 +87,7 @@ type CreateRunPermissions = {
 export type CreateRunFormProps = {
   isSubmitting: boolean;
   isSuperuser: boolean;
+  onConfigContextChange?: (configContext: string) => void;
   onSubmit: (payload: PostRepositoryRun) => Promise<void> | void;
   permissions: CreateRunPermissions;
   plugins: PreconfiguredPluginDescriptor[];
@@ -96,6 +98,7 @@ export type CreateRunFormProps = {
 export const CreateRunForm = ({
   isSubmitting,
   isSuperuser,
+  onConfigContextChange,
   onSubmit,
   permissions,
   plugins,
@@ -150,6 +153,16 @@ export const CreateRunForm = ({
   });
 
   const watchedValues = form.watch();
+
+  // Reload the available plugins when the configuration context changes, as it
+  // may influence which plugins are available for the repository. The value is
+  // debounced so that the plugins are not reloaded on every keystroke.
+  const watchedConfigContext = form.watch('jobConfigContext') ?? '';
+  const debouncedConfigContext = useDebounce(watchedConfigContext);
+
+  useEffect(() => {
+    onConfigContextChange?.(debouncedConfigContext);
+  }, [debouncedConfigContext, onConfigContextChange]);
 
   const {
     fields: parametersFields,

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/default-values.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/default-values.ts
@@ -36,6 +36,7 @@ export function defaultValues(
   ortRun: OrtRun | null,
   advisorPlugins: PreconfiguredPluginDescriptor[],
   scannerPlugins: PreconfiguredPluginDescriptor[],
+  reporterPlugins: PreconfiguredPluginDescriptor[],
   isSuperuser: boolean,
   packageCurationProviderPlugins: PreconfiguredPluginDescriptor[],
   packageConfigurationProviderPlugins: PreconfiguredPluginDescriptor[]
@@ -76,18 +77,9 @@ export function defaultValues(
     };
   };
 
-  // Find out if any of the reporters had their options.deduplicateDependencyTree set to true in the previous run.
-  // This is used to set the default value for the deduplicateDependencyTree toggle in the UI.
-  const deduplicateDependencyTreeEnabled = ortRun
-    ? ortRun.jobConfigs.reporter?.config &&
-      Object.keys(ortRun.jobConfigs.reporter.config ?? {}).some((key) => {
-        const config = ortRun.jobConfigs.reporter?.config?.[key];
-        return config?.options.deduplicateDependencyTree === 'true';
-      })
-    : false;
-
   const advisorPluginDefaultValues = getPluginDefaultValues(advisorPlugins);
   const scannerPluginDefaultValues = getPluginDefaultValues(scannerPlugins);
+  const reporterPluginDefaultValues = getPluginDefaultValues(reporterPlugins);
   const packageCurationProviderPluginDefaultValues = getPluginDefaultValues(
     packageCurationProviderPlugins
   );
@@ -187,7 +179,7 @@ export function defaultValues(
       reporter: {
         enabled: true,
         formats: ['CycloneDX', 'SpdxDocument', 'WebApp'],
-        deduplicateDependencyTree: false,
+        config: reporterPluginDefaultValues,
         keepAliveWorker: false,
         packageConfigurationProviders: [],
         packageConfigurationProviderConfig:
@@ -329,8 +321,11 @@ export function defaultValues(
               ortRun.jobConfigs.reporter?.formats?.map((format) =>
                 format === 'CycloneDx' ? 'CycloneDX' : format
               ) || baseDefaults.jobConfigs.reporter.formats,
-            deduplicateDependencyTree:
-              deduplicateDependencyTreeEnabled || undefined,
+            config: mergePluginConfigs(
+              ortRun.jobConfigs.reporter?.config,
+              reporterPluginDefaultValues,
+              reporterPlugins
+            ),
             packageConfigurationProviders:
               reporterPackageConfigurationProviderFormValues.selectedPluginIds,
             packageConfigurationProviderConfig: mergePluginConfigs(

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/payload.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/payload.ts
@@ -252,58 +252,14 @@ export function formValuesToPayload(
   // Reporter configuration
   //
 
-  const cycloneDxEnabled =
-    values.jobConfigs.reporter.formats.includes('CycloneDX');
-  const spdxDocumentEnabled =
-    values.jobConfigs.reporter.formats.includes('SpdxDocument');
-  const noticeFileEnabled =
-    values.jobConfigs.reporter.formats.includes('PlainTextTemplate');
-
-  const config: ReporterJobConfiguration['config'] = {};
-
-  if (spdxDocumentEnabled) {
-    config.SpdxDocument = {
-      options: {
-        outputFileFormats: 'YAML,JSON',
-      },
-      secrets: {},
-    };
-  }
-
-  if (cycloneDxEnabled) {
-    config.CycloneDX = {
-      options: {
-        outputFileFormats: 'XML,JSON',
-      },
-      secrets: {},
-    };
-  }
-
-  if (noticeFileEnabled) {
-    config.PlainTextTemplate = {
-      options: {
-        templateIds: 'NOTICE_DEFAULT,NOTICE_SUMMARY',
-      },
-      secrets: {},
-    };
-  }
-
-  // If WebApp and the deduplicateDependencyTree option are enabled, add the configuration.
-  const webAppEnabled = values.jobConfigs.reporter.formats.includes('WebApp');
-  if (webAppEnabled && values.jobConfigs.reporter.deduplicateDependencyTree) {
-    config.WebApp = {
-      options: {
-        deduplicateDependencyTree: 'true',
-      },
-      secrets: {},
-    };
-  }
-
   const reporterConfig: ReporterJobConfiguration | undefined = values.jobConfigs
     .reporter.enabled
     ? {
         formats: values.jobConfigs.reporter.formats,
-        config: Object.keys(config).length > 0 ? config : undefined,
+        config: createPluginPayload(
+          values.jobConfigs.reporter.config,
+          values.jobConfigs.reporter.formats
+        ),
         packageConfigurationProviders: evaluatorConfig
           ? undefined
           : createProviderPluginPayload(

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/run-schema.ts
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/-components/run-schema.ts
@@ -36,6 +36,7 @@ import {
 export const createRunFormSchema = (
   advisorPlugins: PreconfiguredPluginDescriptor[],
   scannerPlugins: PreconfiguredPluginDescriptor[],
+  reporterPlugins: PreconfiguredPluginDescriptor[],
   packageCurationProviderPlugins: PreconfiguredPluginDescriptor[],
   packageConfigurationProviderPlugins: PreconfiguredPluginDescriptor[]
 ) => {
@@ -48,6 +49,11 @@ export const createRunFormSchema = (
   const scannerConfigSchema: Record<string, z.ZodTypeAny> = {};
   scannerPlugins.forEach((plugin) => {
     scannerConfigSchema[plugin.id] = createPluginConfigSchema(plugin);
+  });
+
+  const reporterConfigSchema: Record<string, z.ZodTypeAny> = {};
+  reporterPlugins.forEach((plugin) => {
+    reporterConfigSchema[plugin.id] = createPluginConfigSchema(plugin);
   });
 
   const packageCurationProviderConfigSchema: Record<string, z.ZodTypeAny> = {};
@@ -194,16 +200,30 @@ export const createRunFormSchema = (
             .object(packageConfigurationProviderConfigSchema)
             .optional(),
         }),
-        reporter: z.object({
-          enabled: z.boolean(),
-          formats: z.array(z.string()),
-          deduplicateDependencyTree: z.boolean().optional(),
-          keepAliveWorker: z.boolean(),
-          packageConfigurationProviders: z.array(z.string()),
-          packageConfigurationProviderConfig: z
-            .object(packageConfigurationProviderConfigSchema)
-            .optional(),
-        }),
+        reporter: z
+          .object({
+            enabled: z.boolean(),
+            formats: z.array(z.string()),
+            config: z.object(reporterConfigSchema).optional(),
+            keepAliveWorker: z.boolean(),
+            packageConfigurationProviders: z.array(z.string()),
+            packageConfigurationProviderConfig: z
+              .object(packageConfigurationProviderConfigSchema)
+              .optional(),
+          })
+          .superRefine((data, ctx) => {
+            validateRequiredPluginOptions(
+              reporterPlugins,
+              data.formats,
+              data.config as
+                | Record<
+                    string,
+                    Record<string, Record<string, unknown>> | undefined
+                  >
+                | undefined,
+              ctx
+            );
+          }),
         notifier: z.object({
           enabled: z.boolean(),
           recipientAddresses: z

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/_repo-layout/create-run/index.tsx
@@ -17,13 +17,20 @@
  * License-Filename: LICENSE
  */
 
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  keepPreviousData,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
+import { useState } from 'react';
 import { z } from 'zod';
 
 import type { PostRepositoryRun } from '@/api';
 import {
   getOrganizationOptions,
+  getPluginsForRepositoryOptions,
   getProductOptions,
   getRepositoryOptions,
   postRepositoryRunMutation,
@@ -45,10 +52,26 @@ const CreateRunPage = () => {
   const navigate = useNavigate();
   const params = Route.useParams();
   const queryClient = useQueryClient();
-  const { ortRun, plugins, secrets } = Route.useLoaderData();
+  const { ortRun, plugins: loaderPlugins, secrets } = Route.useLoaderData();
   const { recordRecentRun } = useHomeRecentRunActions();
   const isSuperuser = useUser().isSuperuser || false;
   const permissions = Route.useRouteContext().permissions;
+
+  // The config context influences which plugins are available for the
+  // repository. It is initialized from the run being rerun (if any) and can be
+  // changed via the corresponding form field, which reloads the plugins.
+  const [configContext, setConfigContext] = useState(
+    ortRun?.data?.jobConfigContext ?? ''
+  );
+
+  const { data: plugins } = useQuery({
+    ...getPluginsForRepositoryOptions({
+      path: { repositoryId: Number.parseInt(params.repoId) },
+      query: configContext ? { configContext } : undefined,
+    }),
+    initialData: loaderPlugins.data ?? [],
+    placeholderData: keepPreviousData,
+  });
 
   const {
     data: organization,
@@ -136,9 +159,10 @@ const CreateRunPage = () => {
     <CreateRunForm
       isSubmitting={isPending}
       isSuperuser={isSuperuser}
+      onConfigContextChange={setConfigContext}
       onSubmit={submitRun}
       permissions={permissions}
-      plugins={plugins.data ?? []}
+      plugins={plugins}
       rerun={ortRun?.data ?? null}
       secrets={secrets.data ?? []}
     />
@@ -160,19 +184,26 @@ export const Route = createFileRoute(
   // the query will not be run. This corresponds to the "New run" case, where a new
   // ORT Run is created from scratch, using all defaults.
   loader: async ({ params, deps: { rerunIndex } }) => {
-    const [ortRun, plugins, secrets] = await Promise.all([
+    const ortRun =
       rerunIndex !== undefined
-        ? getRepositoryRun({
+        ? await getRepositoryRun({
             path: {
               repositoryId: Number.parseInt(params.repoId),
               ortRunIndex: rerunIndex,
             },
           })
-        : Promise.resolve(null as null),
+        : null;
+
+    // The config context of the run being rerun determines which plugins are
+    // available, so use it for the initial plugin fetch.
+    const configContext = ortRun?.data?.jobConfigContext || undefined;
+
+    const [plugins, secrets] = await Promise.all([
       getPluginsForRepository({
         path: {
           repositoryId: Number.parseInt(params.repoId),
         },
+        query: configContext ? { configContext } : undefined,
       }),
       getAvailableRepositorySecrets({
         path: {

--- a/ui/tests/unit/components/create-run-job-fields.test.tsx
+++ b/ui/tests/unit/components/create-run-job-fields.test.tsx
@@ -74,6 +74,7 @@ const formDefaultValues = defaultValues(
   null,
   advisorPlugins,
   scannerPlugins,
+  reporterPlugins,
   true,
   [],
   packageConfigurationProviderPlugins

--- a/ui/tests/unit/components/environment-definition-fields.test.tsx
+++ b/ui/tests/unit/components/environment-definition-fields.test.tsx
@@ -59,7 +59,7 @@ vi.mock('@/hooks/use-infrastructure-services', () => ({
   }),
 }));
 
-const baseDefaultValues = defaultValues(null, [], [], false, [], []);
+const baseDefaultValues = defaultValues(null, [], [], [], false, [], []);
 const conanDefaultEntry = ENVIRONMENT_DEFINITION_SCHEMAS.find(
   (schema) => schema.key === 'conan'
 )?.defaultEntries[0];

--- a/ui/tests/unit/logic/default-values.test.ts
+++ b/ui/tests/unit/logic/default-values.test.ts
@@ -47,7 +47,7 @@ it('preserves multiple environment definitions from reruns', () => {
     },
   });
 
-  const defaults = defaultValues(ortRun, [], [], false, [], []);
+  const defaults = defaultValues(ortRun, [], [], [], false, [], []);
 
   expect(defaults.jobConfigs.analyzer.environmentDefinitions).toEqual(
     ortRun.jobConfigs.analyzer?.environmentConfig?.environmentDefinitions
@@ -90,7 +90,7 @@ it('preserves package configuration provider config from reruns', () => {
     },
   });
 
-  const defaults = defaultValues(ortRun, [], [], false, [], []);
+  const defaults = defaultValues(ortRun, [], [], [], false, [], []);
 
   expect(defaults.jobConfigs.evaluator.packageConfigurationProviders).toEqual([
     'OrtConfig',
@@ -145,7 +145,7 @@ it('preserves package curation provider config from reruns', () => {
     },
   });
 
-  const defaults = defaultValues(ortRun, [], [], false, [], []);
+  const defaults = defaultValues(ortRun, [], [], [], false, [], []);
 
   expect(defaults.jobConfigs.analyzer.packageCurationProviders).toEqual([
     'ClearlyDefined',
@@ -165,6 +165,7 @@ it('preserves package curation provider config from reruns', () => {
 it('uses package configuration provider plugin default values for fresh runs', () => {
   const defaults = defaultValues(
     null,
+    [],
     [],
     [],
     false,
@@ -221,6 +222,7 @@ it('uses package curation provider plugin default values for fresh runs', () => 
     null,
     [],
     [],
+    [],
     false,
     [
       createPluginDescriptor({
@@ -274,6 +276,7 @@ it('uses scanner plugin default values for fresh runs', () => {
         ],
       }),
     ],
+    [],
     false,
     [],
     []
@@ -289,7 +292,44 @@ it('uses scanner plugin default values for fresh runs', () => {
   });
 });
 
-it('applies fixed plugin option precedence for advisor and scanner reruns', () => {
+it('uses reporter plugin default values for fresh runs', () => {
+  const defaults = defaultValues(
+    null,
+    [],
+    [],
+    [
+      createPluginDescriptor({
+        id: 'WebApp',
+        type: 'REPORTER',
+        options: [
+          {
+            name: 'deduplicateDependencyTree',
+            description: 'Deduplicate the dependency tree.',
+            type: 'BOOLEAN',
+            defaultValue: 'true',
+            isFixed: true,
+            isNullable: false,
+            isRequired: false,
+          },
+        ],
+      }),
+    ],
+    false,
+    [],
+    []
+  );
+
+  expect(defaults.jobConfigs.reporter.config).toEqual({
+    WebApp: {
+      options: {
+        deduplicateDependencyTree: true,
+      },
+      secrets: {},
+    },
+  });
+});
+
+it('applies fixed plugin option precedence for advisor, scanner, and reporter reruns', () => {
   const ortRun = createOrtRun({
     jobConfigs: {
       advisor: {
@@ -318,6 +358,21 @@ it('applies fixed plugin option precedence for advisor and scanner reruns', () =
             },
             secrets: {
               fixedSecret: 'legacy-scanner-secret',
+            },
+          },
+        },
+      },
+      reporter: {
+        formats: ['WebApp'],
+        config: {
+          WebApp: {
+            options: {
+              url: 'https://rerun.example/reporter',
+              fixedNoDefault: 'legacy-reporter-fixed',
+              token: 'legacy-reporter-token',
+            },
+            secrets: {
+              fixedSecret: 'legacy-reporter-secret',
             },
           },
         },
@@ -411,10 +466,54 @@ it('applies fixed plugin option precedence for advisor and scanner reruns', () =
     }),
   ];
 
+  const reporterPlugins = [
+    createPluginDescriptor({
+      id: 'WebApp',
+      type: 'REPORTER',
+      options: [
+        {
+          name: 'url',
+          description: 'Base URL.',
+          type: 'STRING',
+          defaultValue: 'https://default.example/reporter',
+          isFixed: true,
+          isNullable: false,
+          isRequired: true,
+        },
+        {
+          name: 'fixedNoDefault',
+          description: 'Fixed without default.',
+          type: 'STRING',
+          isFixed: true,
+          isNullable: false,
+          isRequired: false,
+        },
+        {
+          name: 'fixedSecret',
+          description: 'Fixed secret option.',
+          type: 'SECRET',
+          isFixed: true,
+          isNullable: false,
+          isRequired: false,
+        },
+        {
+          name: 'token',
+          description: 'Editable token.',
+          type: 'STRING',
+          defaultValue: 'default-token',
+          isFixed: false,
+          isNullable: false,
+          isRequired: false,
+        },
+      ],
+    }),
+  ];
+
   const defaults = defaultValues(
     ortRun,
     advisorPlugins,
     scannerPlugins,
+    reporterPlugins,
     false,
     [],
     []
@@ -435,6 +534,16 @@ it('applies fixed plugin option precedence for advisor and scanner reruns', () =
       options: {
         url: 'https://default.example/scanner',
         token: 'legacy-scanner-token',
+      },
+      secrets: {},
+    },
+  });
+
+  expect(defaults.jobConfigs.reporter.config).toEqual({
+    WebApp: {
+      options: {
+        url: 'https://default.example/reporter',
+        token: 'legacy-reporter-token',
       },
       secrets: {},
     },

--- a/ui/tests/unit/logic/payload.test.ts
+++ b/ui/tests/unit/logic/payload.test.ts
@@ -25,7 +25,7 @@ import type { CreateRunFormValues } from '@/routes/organizations/$orgId/products
 
 function createFormValues(): CreateRunFormValues {
   return {
-    ...defaultValues(null, [], [], false, [], []),
+    ...defaultValues(null, [], [], [], false, [], []),
     revision: 'main',
     path: '',
   };

--- a/ui/tests/unit/logic/run-schema.test.ts
+++ b/ui/tests/unit/logic/run-schema.test.ts
@@ -43,6 +43,7 @@ function createValidFormData() {
     null,
     [],
     [],
+    [],
     false,
     [],
     [packageConfigurationProviderPlugin]
@@ -75,6 +76,7 @@ describe('createRunFormSchema', () => {
       [],
       [],
       [],
+      [],
       [packageConfigurationProviderPlugin]
     );
 
@@ -98,7 +100,7 @@ describe('createRunFormSchema', () => {
         },
       ],
     });
-    const schema = createRunFormSchema([], [scannerPlugin], [], []);
+    const schema = createRunFormSchema([], [scannerPlugin], [], [], []);
     const formData = createValidFormData();
     formData.jobConfigs.scanner.scanners = ['Scanner'];
     formData.jobConfigs.scanner.config = {
@@ -136,7 +138,7 @@ describe('createRunFormSchema', () => {
         },
       ],
     });
-    const schema = createRunFormSchema([], [scannerPlugin], [], []);
+    const schema = createRunFormSchema([], [scannerPlugin], [], [], []);
     const formData = createValidFormData();
     formData.jobConfigs.scanner.scanners = ['Scanner'];
     formData.jobConfigs.scanner.config = {
@@ -163,6 +165,7 @@ describe('createRunFormSchema', () => {
 
   it('validates reporter package configuration providers when evaluator is disabled', () => {
     const schema = createRunFormSchema(
+      [],
       [],
       [],
       [],

--- a/workers/config/src/main/kotlin/AdminConfigValidator.kt
+++ b/workers/config/src/main/kotlin/AdminConfigValidator.kt
@@ -70,11 +70,11 @@ object AdminConfigValidator {
         jobConfig: ReporterJobConfiguration
     ) = buildList {
         jobConfig.formats
-            .filter { reporterConfig.getReportDefinition(it) == null }
+            .filterNot { it.lowercase() in reporterConfig.validFormats }
             .forEach { format ->
                 add(
                     "Invalid reporter format '$format' in reporter job configuration. " +
-                            "Available formats are: ${reporterConfig.reportDefinitionNames.joinToString()}."
+                            "Available formats are: ${reporterConfig.validFormats.joinToString()}."
                 )
             }
 

--- a/workers/config/src/test/kotlin/AdminConfigValidatorTest.kt
+++ b/workers/config/src/test/kotlin/AdminConfigValidatorTest.kt
@@ -112,7 +112,7 @@ class AdminConfigValidatorTest : WordSpec({
             val jobConfigs = JobConfigurations(
                 ruleSet = "valid-rule-set",
                 reporter = ReporterJobConfiguration(
-                    formats = listOf("valid-format"),
+                    formats = listOf("WebApp", "valid-format"),
                     assetFilesGroups = listOf("valid-asset-group"),
                     assetDirectoriesGroups = listOf("valid-asset-group")
                 )

--- a/workers/config/src/test/kotlin/ConfigWorkerIntegrationTest.kt
+++ b/workers/config/src/test/kotlin/ConfigWorkerIntegrationTest.kt
@@ -107,7 +107,8 @@ class ConfigWorkerIntegrationTest : WordSpec({
             eventStore = PluginTemplateEventStore(dbExtension.db),
             pluginService = pluginService,
             organizationRepository = fixtures.organizationRepository,
-            repositoryRepository = fixtures.repositoryRepository
+            repositoryRepository = fixtures.repositoryRepository,
+            adminConfigService = adminConfigService
         )
 
         configWorker = ConfigWorker(

--- a/workers/reporter/src/main/kotlin/ReporterRunner.kt
+++ b/workers/reporter/src/main/kotlin/ReporterRunner.kt
@@ -241,12 +241,10 @@ class ReporterRunner(
                         measureTimedValue {
                             val reporterFactory = reporterConfig.getReporterFactory(format)
 
-                            val pluginConfig = reporterConfig.pluginOptionsForDefinition(
-                                format,
-                                transformedOptions
-                            )?.mapToOrt().orEmpty()
+                            val pluginConfig = reporterConfig.pluginOptionsForDefinition(format, transformedOptions)
+                                ?: transformedOptions[format]
 
-                            val reporter = reporterFactory.create(pluginConfig)
+                            val reporter = reporterFactory.create(pluginConfig?.mapToOrt().orEmpty())
                             val reportFileResults = reporter.generateReport(reporterInput, outputDir)
 
                             val reportFiles = reportFileResults.mapNotNull { result ->
@@ -492,12 +490,12 @@ private fun ReporterConfig.getGlobalAssets(groupNames: Collection<String>): Muta
     }
 
 /**
- * Obtain the [ReporterFactory] for the given [format] using the definitions from this [ReporterConfig].
+ * Get the [ReporterFactory] for the given [format]. If this [ReporterConfig] contains a report definition with that
+ * name, the plugin ID of that definition is used, otherwise the format name itself is used as plugin ID. If no reporter
+ * factory can be found for the plugin ID, an exception is thrown.
  */
 private fun ReporterConfig.getReporterFactory(format: String): ReporterFactory {
-    val pluginId = requireNotNull(getReportDefinition(format)?.pluginId) {
-        "No reporter found for the configured format '$format'."
-    }
+    val pluginId = getReportDefinition(format)?.pluginId ?: format
 
     return requireNotNull(ReporterFactory.ALL[pluginId]) {
         "No reporter plugin found with the ID '$pluginId'."

--- a/workers/reporter/src/main/kotlin/ReporterWorker.kt
+++ b/workers/reporter/src/main/kotlin/ReporterWorker.kt
@@ -73,10 +73,6 @@ internal class ReporterWorker(
             EndpointComponent.generateKeepAliveFile()
         }
 
-        /**
-         * The setup of environment is only needed by a reporter that creates source code bundles.
-         * TODO: Find a better solution which would allow to set up environment only for a specific reporter if needed.
-         */
         val ortResult = ortRunService.generateOrtResult(ortRun, failIfRepoInfoMissing = false)
         val startTime = Clock.System.now()
 

--- a/workers/reporter/src/test/kotlin/ReporterRunnerTest.kt
+++ b/workers/reporter/src/test/kotlin/ReporterRunnerTest.kt
@@ -476,7 +476,7 @@ class ReporterRunnerTest : WordSpec({
 
             result.reports.keys should containExactly(generatedReport.name)
             with(result.issues.single()) {
-                message shouldContain "No reporter found"
+                message shouldContain "No reporter plugin found"
                 message shouldContain unsupportedReportFormat
                 source shouldBe "Reporter"
                 severity shouldBe Severity.ERROR


### PR DESCRIPTION
Include the report definitions from the admin config in the list of available reporter plugins. Also, generate forms for reporter plugin options in the UI as it is already done for other plugin types. See the commit messages for details.

**This contains a breaking change:**
The same config file provider that is used for the workers must now be configured for `core` as well.