### PR TITLE
Git config file provider performance improvement

### DIFF
--- a/config/git/README.md
+++ b/config/git/README.md
@@ -15,6 +15,10 @@ Note that
 - `resolveContext` is called only once per run (by the config worker), and the returned context is used for all workers in the run
 - in case `resolveContext` is called with empty input context, the head of the default branch of the repository is returned
 
+Fetched commits remain in the local Git repository for the lifetime of the provider. When requests alternate between
+previously fetched commits, the provider checks them out directly from the local object database without fetching from
+the remote repository again.
+
 The `listFiles` function can be used to get the list of all the objects of type `file` located in the given path.
 It takes in the context (as returned by the `resolveContext` function) and requires the provided path to refer to a directory, otherwise a `ConfigException` is thrown.
 

--- a/config/git/README.md
+++ b/config/git/README.md
@@ -1,16 +1,16 @@
 # Git config file provider
 
-This module provides an implementation of the `ConfigFileProvider` interface defined by the [Configuration abstraction](../README.md) that reads configuration files from a git repository.
+This module provides an implementation of the `ConfigFileProvider` interface defined by the [Config abstraction](../README.md) that reads config files from a Git repository.
 The provider is capable of resolving files, directories, and symbolic links.
 Git submodules are not supported.
 
 ## Synopsis
 
 The implementation is located in the [GitConfigFileProvider](src/main/kotlin/GitConfigFileProvider.kt) class.
-The provider is using ORT Downloader's VersionControlSystem to check out the configuration repository from git to a temporary local folder that exists for the lifetime of a job.
+The provider is using ORT Downloader's VersionControlSystem to check out the config repository from Git to a temporary local folder that exists for the lifetime of a job.
 
 The implementation is using the provided context to make sure that the branch specified in it is present in the repository.
-If the branch is present, the `resolveContext` function returns the SHA-1 ID of the last commit in the branch, which can later be utilized to make sure that the same configuration is used for the whole ORT run.
+If the branch is present, the `resolveContext` function returns the SHA-1 ID of the last commit in the branch, which can later be utilized to make sure that the same config is used for the whole ORT run.
 Note that
 - `resolveContext` is called only once per run (by the config worker), and the returned context is used for all workers in the run
 - in case `resolveContext` is called with empty input context, the head of the default branch of the repository is returned
@@ -18,17 +18,17 @@ Note that
 The `listFiles` function can be used to get the list of all the objects of type `file` located in the given path.
 It takes in the context (as returned by the `resolveContext` function) and requires the provided path to refer to a directory, otherwise a `ConfigException` is thrown.
 
-To make sure that a configuration file is present in the given path, the `contains` function can be used.
+To make sure that a config file is present in the given path, the `contains` function can be used.
 It takes in the context and a path to a file and returns `true` if the file is present or `false` if the returned object is not a file, or if the specified path does not exist in the given repository at all.
 
-The `getFile` function returns an `InputStream` for reading the content of a configuration file with the given `path` in the given `context`, throwing an exception if the file cannot be resolved or access is not possible for whatever reason.
+The `getFile` function returns an `InputStream` for reading the content of a config file with the given `path` in the given `context`, throwing an exception if the file cannot be resolved or access is not possible for whatever reason.
 
 ## Configuration
 
 ### Enabling the provider (static configuration)
 
-To activate `GitConfigFileProvider`, the application configuration must contain a section `configManager` with a property `fileProvider` set to the value "git-config".
-In addition, the URL of the git repository is needed, for example:
+To activate `GitConfigFileProvider`, the application config must contain a section `configManager` with a property `fileProvider` set to the value "git-config".
+In addition, the URL of the Git repository is needed, for example:
 
 ```
 configManager {
@@ -71,7 +71,7 @@ configManager {
 }
 ```
 
-Note that, as a consequence of caching, a moved branch tip may not be observed until the cache entry expires; that is, changes to the configuration repository can be delayed by up to `gitRevisionCacheTtlSeconds`.
+Note that, as a consequence of caching, a moved branch tip may not be observed until the cache entry expires; that is, changes to the config repository can be delayed by up to `gitRevisionCacheTtlSeconds`.
 Setting the property to `0` effectively disables the cache, so that every call to `resolveContext` resolves the revision anew.
 
 ### Runtime configuration
@@ -80,7 +80,7 @@ When creating an ORT Run, the API accepts a `jobConfigContext` parameter, which 
 so by passing the branch name as `jobConfigContext`, the provider will use the specified branch for all workers.
 In case no `jobConfigContext` is provided, the provider will use the default branch of the repository.
 
-Because the git configuration file provider is capable of returning files using their relative paths inside the configuration repository, this gives flexibility to specify several configuration parameters when creating jobs of a run. Examples of such are:
+Because the Git config file provider is capable of returning files using their relative paths inside the config repository, this gives flexibility to specify several config parameters when creating jobs of a run. Examples of such are:
 
 ```
 "evaluator": {
@@ -91,5 +91,5 @@ Because the git configuration file provider is capable of returning files using 
 },
 ```
 
-In this example, all configuration files are located in their respective directories in the repository.
+In this example, all config files are located in their respective directories in the repository.
 Note that, for example, customer-specific rules could have many versions in their respective branches, and by varying the `jobConfigContext` parameter, different versions of the rules can be used in jobs.

--- a/config/git/README.md
+++ b/config/git/README.md
@@ -1,7 +1,8 @@
 # Git config file provider
 
 This module provides an implementation of the `ConfigFileProvider` interface defined by the [Configuration abstraction](../README.md) that reads configuration files from a git repository.
-The provider is capable of resolving files, directories, symbolic links and submodules in the repository.
+The provider is capable of resolving files, directories, and symbolic links.
+Git submodules are not supported.
 
 ## Synopsis
 

--- a/config/git/build.gradle.kts
+++ b/config/git/build.gradle.kts
@@ -29,9 +29,10 @@ dependencies {
     api(projects.config.configSpi)
 
     api(libs.typesafeConfig)
+    api(ortLibs.downloader)
 
+    implementation(libs.jgit)
     implementation(libs.slf4j)
-    implementation(ortLibs.downloader)
     implementation(ortLibs.ortPlugins.versionControlSystems.git)
     implementation(projects.utils.config)
 

--- a/config/git/src/main/kotlin/GitConfigFileProvider.kt
+++ b/config/git/src/main/kotlin/GitConfigFileProvider.kt
@@ -40,7 +40,12 @@ import org.eclipse.apoapsis.ortserver.config.ResolvedConfigContext
 import org.eclipse.apoapsis.ortserver.config.resolveSecurely
 import org.eclipse.apoapsis.ortserver.utils.config.getLongOrDefault
 import org.eclipse.apoapsis.ortserver.utils.config.getServiceUrl
+import org.eclipse.jgit.api.Git as JGit
+import org.eclipse.jgit.lib.Constants
+import org.eclipse.jgit.lib.ObjectId
+import org.eclipse.jgit.revwalk.RevWalk
 
+import org.ossreviewtoolkit.downloader.VersionControlSystem
 import org.ossreviewtoolkit.model.VcsInfo
 import org.ossreviewtoolkit.model.VcsType
 import org.ossreviewtoolkit.plugins.versioncontrolsystems.git.GitFactory
@@ -57,7 +62,8 @@ class GitConfigFileProvider internal constructor(
     private val gitUrl: String,
     private val configDir: File,
     internal val revisionCacheTtl: Duration = DEFAULT_REVISION_CACHE_TTL_SECONDS,
-    private val timeSource: TimeSource = TimeSource.Monotonic
+    private val timeSource: TimeSource = TimeSource.Monotonic,
+    private val git: VersionControlSystem = GitFactory.create(historyDepth = 1)
 ) : ConfigFileProvider {
     companion object {
         /**
@@ -94,8 +100,6 @@ class GitConfigFileProvider internal constructor(
             return GitConfigFileProvider(gitUrl, createOrtTempDir(), revisionCacheTtl)
         }
     }
-
-    private val git = GitFactory.create(historyDepth = 1)
 
     /**
      * A lock guarding all access to the working tree in [configDir]. A single provider instance can be accessed
@@ -148,7 +152,7 @@ class GitConfigFileProvider internal constructor(
     override fun getFile(context: ResolvedConfigContext, path: Path): InputStream =
         synchronized(lock) {
             runCatching {
-                updateWorkingTree(context.name)
+                updateWorkingTree(context.name, allowLocalCheckout = true)
 
                 // Copy the file to a temporary location while holding the lock, so that reading the returned stream is
                 // not affected by a concurrent update of the working tree.
@@ -170,7 +174,7 @@ class GitConfigFileProvider internal constructor(
         }
 
     override fun contains(context: ResolvedConfigContext, path: Path): Boolean = synchronized(lock) {
-        updateWorkingTree(context.name)
+        updateWorkingTree(context.name, allowLocalCheckout = true)
         val p = configDir.resolveSecurely(path)
         val isDirectoryPath = path.path.endsWith("/")
 
@@ -178,7 +182,7 @@ class GitConfigFileProvider internal constructor(
     }
 
     override fun listFiles(context: ResolvedConfigContext, path: Path): Set<Path> = synchronized(lock) {
-        updateWorkingTree(context.name)
+        updateWorkingTree(context.name, allowLocalCheckout = true)
 
         val dir = configDir.resolveSecurely(path)
 
@@ -194,14 +198,23 @@ class GitConfigFileProvider internal constructor(
      * Update the working tree to the [requestedRevision]. If the [configDir] does not contain a ".git" subdirectory,
      * the working tree is initialized first. The resolved revision is returned.
      *
+     * If [allowLocalCheckout] is true, the function will first try to check out the requested revision from the local
+     * object database, which avoids accessing the remote repository.
+     *
      * This function must not be called concurrently, all callers must make sure to synchronize against [lock].
      */
-    private fun updateWorkingTree(requestedRevision: String): String {
+    private fun updateWorkingTree(requestedRevision: String, allowLocalCheckout: Boolean = false): String {
+        var accessedRemote = false
+
         try {
-            val revisionToCheckout = requestedRevision.ifBlank { git.getDefaultBranchName(gitUrl) }
+            val revisionToCheckout = requestedRevision.ifBlank {
+                accessedRemote = true
+                git.getDefaultBranchName(gitUrl)
+            }
             val workingTree = git.getWorkingTree(configDir)
 
             if (!workingTree.isValid()) {
+                accessedRemote = true
                 val vcsInfo = VcsInfo(VcsType.GIT, gitUrl, revisionToCheckout)
 
                 measureTime { git.initWorkingTree(configDir, vcsInfo) }.also {
@@ -212,18 +225,46 @@ class GitConfigFileProvider internal constructor(
             // Check if the requested revision was already checked out.
             if (workingTree.getRevision() == revisionToCheckout) return revisionToCheckout
 
-            // Update the working tree to the requested revision.
             measureTime {
-                git.updateWorkingTree(workingTree, revisionToCheckout).getOrThrow()
+                val checkedOutLocally = allowLocalCheckout && checkoutRevisionLocally(revisionToCheckout)
+
+                if (!checkedOutLocally) {
+                    accessedRemote = true
+                    git.updateWorkingTree(workingTree, revisionToCheckout).getOrThrow()
+                }
             }.also {
                 logger.debug("Updated Git working tree to revision '$revisionToCheckout' in $it.")
             }
 
             return workingTree.getRevision()
         } finally {
-            clearHttpAuthCache()
+            if (accessedRemote) clearHttpAuthCache()
         }
     }
+
+    /**
+     * Check out [revision] from the local object database and return `true` if the checkout was successful, otherwise
+     * return `false`. Only full object IDs are accepted as [revision] to avoid resolving a stale local branch or tag.
+     */
+    internal fun checkoutRevisionLocally(revision: String): Boolean =
+        ObjectId.isId(revision) && runCatching {
+            JGit.open(configDir).use { jGit ->
+                val objectId = ObjectId.fromString(revision)
+
+                // Check if the object ID exists locally, otherwise parseCommit throws an exception.
+                RevWalk(jGit.repository).use { it.parseCommit(objectId) }
+
+                jGit.checkout().setName(objectId.name).setForced(true).call()
+
+                checkNotNull(jGit.repository.resolve(Constants.HEAD)).name.also {
+                    check(it.equals(revision, ignoreCase = true)) {
+                        "Local checkout resulted in revision '$it' instead of '$revision'."
+                    }
+                }
+            }
+        }.onFailure {
+            logger.debug("Could not check out revision '$revision' from the local Git repository.", it)
+        }.isSuccess
 
     /**
      * Clear the HTTP basic authentication cache used by HttpURLConnection.

--- a/config/git/src/main/kotlin/GitConfigFileProvider.kt
+++ b/config/git/src/main/kotlin/GitConfigFileProvider.kt
@@ -214,7 +214,7 @@ class GitConfigFileProvider internal constructor(
 
             // Update the working tree to the requested revision.
             measureTime {
-                git.updateWorkingTree(workingTree, revisionToCheckout, recursive = true).getOrThrow()
+                git.updateWorkingTree(workingTree, revisionToCheckout).getOrThrow()
             }.also {
                 logger.debug("Updated Git working tree to revision '$revisionToCheckout' in $it.")
             }

--- a/config/git/src/test/kotlin/GitConfigFileProviderLocalCheckoutTest.kt
+++ b/config/git/src/test/kotlin/GitConfigFileProviderLocalCheckoutTest.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+package org.eclipse.apoapsis.ortserver.config.git
+
+import io.kotest.core.spec.style.WordSpec
+import io.kotest.engine.spec.tempdir
+import io.kotest.matchers.booleans.beFalse
+import io.kotest.matchers.booleans.beTrue
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+
+import java.io.File
+
+import org.eclipse.apoapsis.ortserver.config.Path
+import org.eclipse.apoapsis.ortserver.config.ResolvedConfigContext
+import org.eclipse.jgit.api.Git as JGit
+import org.eclipse.jgit.lib.Constants
+import org.eclipse.jgit.lib.PersonIdent
+
+import org.ossreviewtoolkit.downloader.VersionControlSystem
+import org.ossreviewtoolkit.downloader.WorkingTree
+
+private const val FILE_NAME = "config.txt"
+private const val FIRST_CONTENT = "first"
+private const val SECOND_CONTENT = "second"
+private val MISSING_REVISION = "0".repeat(40)
+
+class GitConfigFileProviderLocalCheckoutTest : WordSpec({
+    "checkoutRevisionLocally" should {
+        "checkout commits from the local object database" {
+            val repositoryDir = tempdir()
+            val (firstRevision, secondRevision) = createRepository(repositoryDir)
+            val provider = GitConfigFileProvider("https://example.org/repository.git", repositoryDir)
+
+            provider.checkoutRevisionLocally(firstRevision) should beTrue()
+            repositoryDir.resolve(FILE_NAME).readText() shouldBe FIRST_CONTENT
+
+            provider.checkoutRevisionLocally(secondRevision) should beTrue()
+            repositoryDir.resolve(FILE_NAME).readText() shouldBe SECOND_CONTENT
+        }
+
+        "reject revisions that are not full object IDs" {
+            val repositoryDir = tempdir()
+            val (_, currentRevision) = createRepository(repositoryDir)
+            val provider = GitConfigFileProvider("https://example.org/repository.git", repositoryDir)
+
+            provider.checkoutRevisionLocally("main") should beFalse()
+            getHeadRevision(repositoryDir) shouldBe currentRevision
+        }
+
+        "return false if the commit is not available locally" {
+            val repositoryDir = tempdir()
+            val (_, currentRevision) = createRepository(repositoryDir)
+            val provider = GitConfigFileProvider("https://example.org/repository.git", repositoryDir)
+
+            provider.checkoutRevisionLocally(MISSING_REVISION) should beFalse()
+            getHeadRevision(repositoryDir) shouldBe currentRevision
+        }
+    }
+
+    "file operations" should {
+        "alternate between local commits without updating from the remote" {
+            val repositoryDir = tempdir()
+            val (firstRevision, secondRevision) = createRepository(repositoryDir)
+            val workingTree = createWorkingTree(repositoryDir)
+            val vcs = createVersionControlSystem(repositoryDir, workingTree)
+            val provider = GitConfigFileProvider("https://example.org/repository.git", repositoryDir, git = vcs)
+
+            provider.getFile(ResolvedConfigContext(firstRevision), Path(FILE_NAME))
+                .bufferedReader().use { it.readText() } shouldBe FIRST_CONTENT
+            provider.getFile(ResolvedConfigContext(secondRevision), Path(FILE_NAME))
+                .bufferedReader().use { it.readText() } shouldBe SECOND_CONTENT
+            provider.getFile(ResolvedConfigContext(firstRevision), Path(FILE_NAME))
+                .bufferedReader().use { it.readText() } shouldBe FIRST_CONTENT
+
+            verify(exactly = 0) { vcs.updateWorkingTree(any(), any(), any(), any()) }
+        }
+
+        "fall back to an ORT update if a commit is not available locally" {
+            val repositoryDir = tempdir()
+            repositoryDir.resolve(FILE_NAME).writeText(FIRST_CONTENT)
+            val workingTree = mockk<WorkingTree> {
+                every { isValid() } returns true
+                every { getRevision() } returnsMany listOf("current", MISSING_REVISION)
+            }
+            val vcs = createVersionControlSystem(repositoryDir, workingTree)
+            every {
+                vcs.updateWorkingTree(workingTree, MISSING_REVISION, recursive = false)
+            } returns Result.success(MISSING_REVISION)
+            val provider = GitConfigFileProvider("https://example.org/repository.git", repositoryDir, git = vcs)
+
+            provider.contains(ResolvedConfigContext(MISSING_REVISION), Path(FILE_NAME)) shouldBe true
+
+            verify(exactly = 1) {
+                vcs.updateWorkingTree(workingTree, MISSING_REVISION, recursive = false)
+            }
+        }
+
+        "fall back to an ORT update for a non-commit context" {
+            val repositoryDir = tempdir()
+            repositoryDir.resolve(FILE_NAME).writeText(FIRST_CONTENT)
+            val workingTree = mockk<WorkingTree> {
+                every { isValid() } returns true
+                every { getRevision() } returnsMany listOf("current", "resolved-main")
+            }
+            val vcs = createVersionControlSystem(repositoryDir, workingTree)
+            every {
+                vcs.updateWorkingTree(workingTree, "main", recursive = false)
+            } returns Result.success("main")
+            val provider = GitConfigFileProvider("https://example.org/repository.git", repositoryDir, git = vcs)
+
+            provider.contains(ResolvedConfigContext("main"), Path(FILE_NAME)) shouldBe true
+
+            verify(exactly = 1) { vcs.updateWorkingTree(workingTree, "main", recursive = false) }
+        }
+    }
+})
+
+private fun createRepository(directory: File): Pair<String, String> =
+    JGit.init().setDirectory(directory).call().use { git ->
+        val firstRevision = git.commitFile(FIRST_CONTENT)
+        val secondRevision = git.commitFile(SECOND_CONTENT)
+
+        firstRevision to secondRevision
+    }
+
+private fun JGit.commitFile(content: String): String {
+    repository.workTree.resolve(FILE_NAME).writeText(content)
+    add().addFilepattern(FILE_NAME).call()
+
+    val identity = PersonIdent("Test User", "test@example.org")
+    return commit()
+        .setMessage("Set test content")
+        .setAuthor(identity)
+        .setCommitter(identity)
+        .call()
+        .name
+}
+
+private fun createWorkingTree(repositoryDir: File): WorkingTree =
+    mockk {
+        every { isValid() } returns true
+        every { getRevision() } answers { getHeadRevision(repositoryDir) }
+    }
+
+private fun createVersionControlSystem(repositoryDir: File, workingTree: WorkingTree): VersionControlSystem =
+    mockk {
+        every { getWorkingTree(repositoryDir) } returns workingTree
+    }
+
+private fun getHeadRevision(repositoryDir: File): String =
+    JGit.open(repositoryDir).use { it.repository.resolve(Constants.HEAD).name }

--- a/config/git/src/test/kotlin/GitConfigFileProviderTest.kt
+++ b/config/git/src/test/kotlin/GitConfigFileProviderTest.kt
@@ -108,24 +108,6 @@ class GitConfigFileProviderTest : WordSpec({
             provider.contains(RESOLVED_CONTEXT_MAIN, Path("customer1/product1/copyright-garbage.yml")) shouldBe true
         }
 
-        "return `true`if a file from a submodule is present" {
-            val provider = GitConfigFileProvider(GIT_URL, tempdir())
-
-            provider.contains(
-                RESOLVED_CONTEXT_MAIN,
-                Path("ort-config-test-sm/license-classifications.yml")
-            ) shouldBe true
-        }
-
-        "return `true` if a file from a submodule, referred to by a symlink is present" {
-            val provider = GitConfigFileProvider(GIT_URL, tempdir())
-
-            provider.contains(
-                RESOLVED_CONTEXT_MAIN,
-                Path("customer1/product1/license-classifications.yml")
-            ) shouldBe true
-        }
-
         "return `false` if the path refers to a directory" {
             val provider = GitConfigFileProvider(GIT_URL, tempdir())
 
@@ -158,8 +140,7 @@ class GitConfigFileProviderTest : WordSpec({
             val filesPath = "customer2/product2"
             val expectedFiles = listOf(
                 "customer2/product2/copyright-garbage.yml",
-                "customer2/product2/evaluator.rules.kts",
-                "customer2/product2/license-classifications.yml"
+                "customer2/product2/evaluator.rules.kts"
             )
             val provider = GitConfigFileProvider(GIT_URL, tempdir())
 
@@ -172,8 +153,7 @@ class GitConfigFileProviderTest : WordSpec({
             val filesPath = "customer2/product2/"
             val expectedFiles = listOf(
                 "customer2/product2/copyright-garbage.yml",
-                "customer2/product2/evaluator.rules.kts",
-                "customer2/product2/license-classifications.yml"
+                "customer2/product2/evaluator.rules.kts"
             )
             val provider = GitConfigFileProvider(GIT_URL, tempdir())
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -43,6 +43,7 @@ flyway = "13.5.0"
 hikari = "7.1.0"
 hoplite = "2.9.0"
 jsonSchemaValidator = "3.0.7"
+jgit = "7.8.0.202609011348-r"
 kaml = "0.104.0"
 keycloakTestcontainerVersion = "4.3.1"
 koin = "4.2.2"
@@ -102,6 +103,7 @@ hikari = { module = "com.zaxxer:HikariCP", version.ref = "hikari" }
 hoplite-core = { module = "com.sksamuel.hoplite:hoplite-core", version.ref = "hoplite" }
 hoplite-hocon = { module = "com.sksamuel.hoplite:hoplite-hocon", version.ref = "hoplite" }
 jsonSchemaValidator = { module = "com.networknt:json-schema-validator", version.ref = "jsonSchemaValidator" }
+jgit = { module = "org.eclipse.jgit:org.eclipse.jgit", version.ref = "jgit" }
 kaml = { module = "com.charleskorn.kaml:kaml", version.ref = "kaml" }
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koin" }
 koin-ktor = { module = "io.insert-koin:koin-ktor", version.ref = "koin" }


### PR DESCRIPTION
Improve performance by trying to check out revisions locally first. See the commit messages for details.

This is required in the context of #5892. I have another performance improvement almost ready which uses a pool of working trees to improve the amount of concurrent requests that can be handled. However, as this is quite complex I first want to see if it is actually required in practice.