### PR TITLE
Search, page and sort admin/users in the back-end

### DIFF
--- a/components/authorization/backend/src/main/kotlin/service/KeycloakUserService.kt
+++ b/components/authorization/backend/src/main/kotlin/service/KeycloakUserService.kt
@@ -64,9 +64,6 @@ class KeycloakUserService(
         keycloakClient.deleteUser(userId)
     }
 
-    override suspend fun getUsers(): Set<User> =
-        keycloakClient.getUsers().mapTo(mutableSetOf()) { it.toOrtUser() }
-
     override suspend fun listUsers(parameters: ListQueryParameters, search: String?): ListQueryResult<User> {
         val users = keycloakClient.getUsers().mapTo(mutableSetOf()) { it.toOrtUser() }
             .filter { user -> search.isNullOrBlank() || user.contains(search) }

--- a/components/authorization/backend/src/main/kotlin/service/KeycloakUserService.kt
+++ b/components/authorization/backend/src/main/kotlin/service/KeycloakUserService.kt
@@ -26,7 +26,12 @@ import kotlinx.coroutines.withContext
 import org.eclipse.apoapsis.ortserver.clients.keycloak.KeycloakClient
 import org.eclipse.apoapsis.ortserver.clients.keycloak.User as KeycloakUser
 import org.eclipse.apoapsis.ortserver.clients.keycloak.UserName
+import org.eclipse.apoapsis.ortserver.dao.QueryParametersException
 import org.eclipse.apoapsis.ortserver.model.User
+import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
+import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
+import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
+import org.eclipse.apoapsis.ortserver.model.util.OrderField
 
 /**
  * An implementation of the [UserService] interface that uses Keycloak as the backend user management system. As unique
@@ -62,6 +67,24 @@ class KeycloakUserService(
     override suspend fun getUsers(): Set<User> =
         keycloakClient.getUsers().mapTo(mutableSetOf()) { it.toOrtUser() }
 
+    override suspend fun listUsers(parameters: ListQueryParameters, search: String?): ListQueryResult<User> {
+        val users = keycloakClient.getUsers().mapTo(mutableSetOf()) { it.toOrtUser() }
+            .filter { user -> search.isNullOrBlank() || user.contains(search) }
+        val totalCount = users.size.toLong()
+        val sortedUsers = users.sortedWith(createUserComparator(parameters.sortFields))
+        val offset = parameters.offset ?: 0L
+        val limit = parameters.limit ?: ListQueryParameters.DEFAULT_LIMIT
+        val page = if (offset >= sortedUsers.size.toLong()) {
+            emptyList()
+        } else {
+            sortedUsers.drop(offset.toInt()).take(limit)
+        }
+
+        val effectiveParameters = parameters.copy(limit = limit, offset = offset)
+
+        return ListQueryResult(page, effectiveParameters, totalCount)
+    }
+
     override suspend fun getUserById(id: String): User =
         keycloakClient.getUser(UserName(id)).toOrtUser()
 
@@ -73,6 +96,41 @@ class KeycloakUserService(
     override suspend fun userExists(id: String): Boolean =
         runCatching { getUserById(id) }.isSuccess
 }
+
+private fun User.contains(search: String): Boolean =
+    username.contains(search, ignoreCase = true) ||
+            firstName?.contains(search, ignoreCase = true) == true ||
+            lastName?.contains(search, ignoreCase = true) == true ||
+            email?.contains(search, ignoreCase = true) == true
+
+private fun createUserComparator(requestedSortFields: List<OrderField>): Comparator<User> {
+    val sortFields = requestedSortFields.let { fields ->
+        if (fields.any { it.name == "username" }) {
+            fields
+        } else {
+            fields + OrderField("username", OrderDirection.ASCENDING)
+        }
+    }
+
+    return sortFields.fold<_, Comparator<User>?>(null) { comparator, orderField ->
+        val nextComparator = when (orderField.name) {
+            "username" -> compareBy(User::username)
+            "firstName" -> compareBy(nullsFirst(), User::firstName)
+            "lastName" -> compareBy(nullsFirst(), User::lastName)
+            "email" -> compareBy(nullsFirst(), User::email)
+            "" -> throw QueryParametersException("Empty sort field.")
+            else -> throw QueryParametersException("Unsupported sort field: '${orderField.name}'.")
+        }.withDirection(orderField.direction)
+
+        comparator?.then(nextComparator) ?: nextComparator
+    } ?: compareBy(User::username)
+}
+
+private fun <T> Comparator<T>.withDirection(direction: OrderDirection): Comparator<T> =
+    when (direction) {
+        OrderDirection.ASCENDING -> this
+        OrderDirection.DESCENDING -> reversed()
+    }
 
 /**
  * Convert this [KeycloakUser] to a [User] in the ORT Server data model.

--- a/components/authorization/backend/src/main/kotlin/service/UserService.kt
+++ b/components/authorization/backend/src/main/kotlin/service/UserService.kt
@@ -46,11 +46,6 @@ interface UserService {
     suspend fun deleteUser(username: String)
 
     /**
-     * Get all current users of the server.
-     */
-    suspend fun getUsers(): Set<User>
-
-    /**
      * List current users according to the given [parameters]. If [search] is not blank, return only users whose
      * username, first name, last name, or email address contains it, ignoring case.
      */

--- a/components/authorization/backend/src/main/kotlin/service/UserService.kt
+++ b/components/authorization/backend/src/main/kotlin/service/UserService.kt
@@ -20,6 +20,8 @@
 package org.eclipse.apoapsis.ortserver.components.authorization.service
 
 import org.eclipse.apoapsis.ortserver.model.User
+import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
+import org.eclipse.apoapsis.ortserver.model.util.ListQueryResult
 
 /**
  * A service interface to manage users for this server instance. The service
@@ -47,6 +49,15 @@ interface UserService {
      * Get all current users of the server.
      */
     suspend fun getUsers(): Set<User>
+
+    /**
+     * List current users according to the given [parameters]. If [search] is not blank, return only users whose
+     * username, first name, last name, or email address contains it, ignoring case.
+     */
+    suspend fun listUsers(
+        parameters: ListQueryParameters = ListQueryParameters.DEFAULT,
+        search: String? = null
+    ): ListQueryResult<User>
 
     /**
      * Return the user with the given internal [id]. Throw an exception if the user does not exist.

--- a/components/authorization/backend/src/test/kotlin/service/KeycloakUserServiceTest.kt
+++ b/components/authorization/backend/src/test/kotlin/service/KeycloakUserServiceTest.kt
@@ -19,7 +19,9 @@
 
 package org.eclipse.apoapsis.ortserver.components.authorization.service
 
+import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
@@ -35,7 +37,11 @@ import org.eclipse.apoapsis.ortserver.clients.keycloak.KeycloakClientException
 import org.eclipse.apoapsis.ortserver.clients.keycloak.User as KeycloakUser
 import org.eclipse.apoapsis.ortserver.clients.keycloak.UserId
 import org.eclipse.apoapsis.ortserver.clients.keycloak.UserName
+import org.eclipse.apoapsis.ortserver.dao.QueryParametersException
 import org.eclipse.apoapsis.ortserver.model.User
+import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
+import org.eclipse.apoapsis.ortserver.model.util.OrderDirection
+import org.eclipse.apoapsis.ortserver.model.util.OrderField
 
 class KeycloakUserServiceTest : WordSpec({
     "createUser" should {
@@ -106,6 +112,157 @@ class KeycloakUserServiceTest : WordSpec({
             val users = service.getUsers()
 
             users shouldContainExactlyInAnyOrder expectedUsers
+            coVerify(exactly = 1) { client.getUsers() }
+        }
+    }
+
+    "listUsers" should {
+        "return a deterministic default page ordered by username" {
+            val keycloakUsers = (25 downTo 1).mapTo(mutableSetOf()) { index ->
+                createKeycloakUser(index, username = "user${index.toString().padStart(2, '0')}")
+            }
+            val service = createService(keycloakUsers)
+
+            val result = service.listUsers()
+
+            result.data.map(User::username) shouldContainExactly (1..ListQueryParameters.DEFAULT_LIMIT).map { index ->
+                "user${index.toString().padStart(2, '0')}"
+            }
+            result.params shouldBe ListQueryParameters(limit = ListQueryParameters.DEFAULT_LIMIT, offset = 0)
+            result.totalCount shouldBe 25L
+        }
+
+        "apply limit and offset after sorting" {
+            val service = createService(
+                setOf(
+                    createKeycloakUser(1, username = "charlie"),
+                    createKeycloakUser(2, username = "alpha"),
+                    createKeycloakUser(3, username = "bravo")
+                )
+            )
+
+            val result = service.listUsers(ListQueryParameters(limit = 1, offset = 1))
+
+            result.data.map(User::username) shouldContainExactly listOf("bravo")
+            result.totalCount shouldBe 3L
+        }
+
+        "return an empty page for an offset greater than the integer range" {
+            val service = createService(setOf(createKeycloakUser(1)))
+
+            val result = service.listUsers(ListQueryParameters(offset = Int.MAX_VALUE.toLong() + 1))
+
+            result.data.shouldBeEmpty()
+            result.totalCount shouldBe 1L
+        }
+
+        "preserve all users for null and blank searches" {
+            val service = createService(setOf(createKeycloakUser(1), createKeycloakUser(2)))
+
+            service.listUsers(search = null).totalCount shouldBe 2L
+            service.listUsers(search = "  ").totalCount shouldBe 2L
+        }
+
+        "match a partial case-insensitive search against every user field" {
+            val keycloakUsers = setOf(
+                createKeycloakUser(1, username = "Matching-Username"),
+                createKeycloakUser(2, firstName = "Matching-FirstName"),
+                createKeycloakUser(3, lastName = "Matching-LastName"),
+                createKeycloakUser(4, email = "matching-email@example.org"),
+                createKeycloakUser(5)
+            )
+            val service = createService(keycloakUsers)
+
+            val result = service.listUsers(ListQueryParameters(limit = 2, offset = 1), "MaTcHiNg")
+
+            result.data.map(User::username) shouldContainExactly listOf("user2", "user3")
+            result.totalCount shouldBe 4L
+        }
+
+        "sort every supported field in ascending and descending order" {
+            val keycloakUsers = setOf(
+                createKeycloakUser(
+                    1,
+                    username = "charlie",
+                    firstName = "Charlie",
+                    lastName = null,
+                    email = "charlie@example.org"
+                ),
+                createKeycloakUser(
+                    2,
+                    username = "alpha",
+                    firstName = null,
+                    lastName = "Alpha",
+                    email = "alpha@example.org"
+                ),
+                createKeycloakUser(
+                    3,
+                    username = "bravo",
+                    firstName = "Bravo",
+                    lastName = "Bravo",
+                    email = null
+                )
+            )
+            val service = createService(keycloakUsers)
+            val expectedAscending = mapOf(
+                "username" to listOf("alpha", "bravo", "charlie"),
+                "firstName" to listOf("alpha", "bravo", "charlie"),
+                "lastName" to listOf("charlie", "alpha", "bravo"),
+                "email" to listOf("bravo", "alpha", "charlie")
+            )
+
+            expectedAscending.forEach { (sortField, expected) ->
+                val ascending = service.listUsers(queryParameters(sortField, OrderDirection.ASCENDING))
+                val descending = service.listUsers(queryParameters(sortField, OrderDirection.DESCENDING))
+
+                ascending.data.map(User::username) shouldContainExactly expected
+                descending.data.map(User::username) shouldContainExactly expected.reversed()
+            }
+        }
+
+        "apply multiple sort fields in request order" {
+            val service = createService(
+                setOf(
+                    createKeycloakUser(1, username = "charlie", firstName = "Same", lastName = "Zulu"),
+                    createKeycloakUser(2, username = "alpha", firstName = "Same", lastName = "Alpha"),
+                    createKeycloakUser(3, username = "bravo", firstName = "Different", lastName = "Middle")
+                )
+            )
+            val parameters = ListQueryParameters(
+                sortFields = listOf(
+                    OrderField("firstName", OrderDirection.ASCENDING),
+                    OrderField("lastName", OrderDirection.DESCENDING)
+                )
+            )
+
+            val result = service.listUsers(parameters)
+
+            result.data.map(User::username) shouldContainExactly listOf("bravo", "charlie", "alpha")
+        }
+
+        "use username as a tie-breaker" {
+            val service = createService(
+                setOf(
+                    createKeycloakUser(1, username = "charlie", firstName = "Same"),
+                    createKeycloakUser(2, username = "alpha", firstName = "Same"),
+                    createKeycloakUser(3, username = "bravo", firstName = "Same")
+                )
+            )
+
+            val result = service.listUsers(queryParameters("firstName", OrderDirection.DESCENDING))
+
+            result.data.map(User::username) shouldContainExactly listOf("alpha", "bravo", "charlie")
+        }
+
+        "reject empty and unsupported sort fields" {
+            val service = createService(setOf(createKeycloakUser(1)))
+
+            shouldThrow<QueryParametersException> {
+                service.listUsers(queryParameters("", OrderDirection.ASCENDING))
+            }
+            shouldThrow<QueryParametersException> {
+                service.listUsers(queryParameters("unknown", OrderDirection.ASCENDING))
+            }
         }
     }
 
@@ -187,14 +344,37 @@ class KeycloakUserServiceTest : WordSpec({
 /**
  * Generate a test user in Keycloak with properties derived from the given [index].
  */
-private fun createKeycloakUser(index: Int): KeycloakUser =
+private fun createKeycloakUser(
+    index: Int,
+    username: String = "user$index",
+    firstName: String? = "First$index",
+    lastName: String? = "Last$index",
+    email: String? = "user$index@example.com"
+): KeycloakUser =
     KeycloakUser(
         id = UserId("id-$index"),
-        username = UserName("user$index"),
-        firstName = "First$index",
-        lastName = "Last$index",
-        email = "user$index@example.com"
+        username = UserName(username),
+        firstName = firstName,
+        lastName = lastName,
+        email = email
     )
+
+/**
+ * Create a user service backed by a client that returns the given [users].
+ */
+private fun createService(users: Set<KeycloakUser>): KeycloakUserService {
+    val client = mockk<KeycloakClient> {
+        coEvery { getUsers() } returns users
+    }
+
+    return KeycloakUserService(client)
+}
+
+/**
+ * Create list query parameters for the given sort [field] and [direction].
+ */
+private fun queryParameters(field: String, direction: OrderDirection) =
+    ListQueryParameters(sortFields = listOf(OrderField(field, direction)))
 
 /**
  * Generate a test user in the ORT Server model with properties derived from the given [index].

--- a/components/authorization/backend/src/test/kotlin/service/KeycloakUserServiceTest.kt
+++ b/components/authorization/backend/src/test/kotlin/service/KeycloakUserServiceTest.kt
@@ -23,7 +23,6 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.WordSpec
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 
 import io.mockk.coEvery
@@ -95,24 +94,6 @@ class KeycloakUserServiceTest : WordSpec({
             coVerify {
                 client.deleteUser(keycloakUser.id)
             }
-        }
-    }
-
-    "getUsers" should {
-        "return a set of all users" {
-            val userCount = 16
-            val keycloakUsers = (1..userCount).mapTo(mutableSetOf(), ::createKeycloakUser)
-            val expectedUsers = (1..userCount).mapTo(mutableSetOf(), ::createUser)
-
-            val client = mockk<KeycloakClient> {
-                coEvery { getUsers() } returns keycloakUsers
-            }
-
-            val service = KeycloakUserService(client)
-            val users = service.getUsers()
-
-            users shouldContainExactlyInAnyOrder expectedUsers
-            coVerify(exactly = 1) { client.getUsers() }
         }
     }
 

--- a/core/src/main/kotlin/api/AdminRoute.kt
+++ b/core/src/main/kotlin/api/AdminRoute.kt
@@ -43,6 +43,11 @@ import org.eclipse.apoapsis.ortserver.core.apiDocs.getUsers
 import org.eclipse.apoapsis.ortserver.core.apiDocs.postUser
 import org.eclipse.apoapsis.ortserver.core.apiDocs.putSuperuser
 import org.eclipse.apoapsis.ortserver.model.CompoundHierarchyId
+import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToApi
+import org.eclipse.apoapsis.ortserver.shared.apimappings.mapToModel
+import org.eclipse.apoapsis.ortserver.shared.apimodel.SortDirection
+import org.eclipse.apoapsis.ortserver.shared.apimodel.SortProperty
+import org.eclipse.apoapsis.ortserver.shared.ktorutils.pagingOptions
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.requireParameter
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.respondError
 
@@ -55,19 +60,21 @@ fun Route.admin() = route("admin") {
         val userService by inject<UserService>()
 
         get(getUsers, requireSuperuser()) {
+            val pagingOptions = call.pagingOptions(SortProperty("username", SortDirection.ASCENDING))
+            val users = userService.listUsers(pagingOptions.mapToModel(), call.parameters["search"])
             val superusers = authorizationService.listUsersWithRole(
                 OrganizationRole.ADMIN,
                 CompoundHierarchyId.WILDCARD
             )
 
-            val users = userService.getUsers().map { user ->
-                UserWithSuperuserStatus(
-                    user = user.mapToApi(),
-                    isSuperuser = user.username in superusers
-                )
-            }
-
-            call.respond(users)
+            call.respond(
+                users.mapToApi { user ->
+                    UserWithSuperuserStatus(
+                        user = user.mapToApi(),
+                        isSuperuser = user.username in superusers
+                    )
+                }
+            )
         }
 
         post(postUser, requireSuperuser()) {

--- a/core/src/main/kotlin/apiDocs/AdminDocs.kt
+++ b/core/src/main/kotlin/apiDocs/AdminDocs.kt
@@ -26,7 +26,12 @@ import io.ktor.http.HttpStatusCode
 import org.eclipse.apoapsis.ortserver.api.v1.model.PostUser
 import org.eclipse.apoapsis.ortserver.api.v1.model.User
 import org.eclipse.apoapsis.ortserver.api.v1.model.UserWithSuperuserStatus
+import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse
+import org.eclipse.apoapsis.ortserver.shared.apimodel.PagingData
+import org.eclipse.apoapsis.ortserver.shared.apimodel.SortDirection
+import org.eclipse.apoapsis.ortserver.shared.apimodel.SortProperty
 import org.eclipse.apoapsis.ortserver.shared.ktorutils.jsonBody
+import org.eclipse.apoapsis.ortserver.shared.ktorutils.standardListQueryParameters
 
 val runPermissionsSync: RouteConfig.() -> Unit = {
     operationId = "runPermissionsSync"
@@ -49,35 +54,51 @@ val runPermissionsSync: RouteConfig.() -> Unit = {
 
 val getUsers: RouteConfig.() -> Unit = {
     operationId = "getUsers"
-    summary = "Get all users of the server"
+    summary = "Get users of the server"
+    description = "Get users of the server. Fields available for sorting: 'username', 'firstName', 'lastName', " +
+            "'email'. By default, users are sorted by username in ascending order."
     tags = listOf("Admin")
 
     request {
+        standardListQueryParameters()
+
+        queryParameter<String>("search") {
+            description = "Filter users by a literal case-insensitive substring of their username, first name, " +
+                    "last name, or email."
+        }
     }
 
     response {
         HttpStatusCode.OK to {
             description = "Successfully retrieved the users."
-            jsonBody<List<UserWithSuperuserStatus>> {
-                example("Get all users of the server") {
-                    value = listOf(
-                        UserWithSuperuserStatus(
-                            user = User(
-                                username = "user1",
-                                firstName = "First1",
-                                lastName = "Last1",
-                                email = "user1@mail.com"
+            jsonBody<PagedResponse<UserWithSuperuserStatus>> {
+                example("Get users of the server") {
+                    value = PagedResponse(
+                        data = listOf(
+                            UserWithSuperuserStatus(
+                                user = User(
+                                    username = "user1",
+                                    firstName = "First1",
+                                    lastName = "Last1",
+                                    email = "user1@mail.com"
+                                ),
+                                isSuperuser = true
                             ),
-                            isSuperuser = true
+                            UserWithSuperuserStatus(
+                                user = User(
+                                    username = "user2",
+                                    firstName = "First2",
+                                    lastName = "Last2",
+                                    email = "user2@mail.com"
+                                ),
+                                isSuperuser = false
+                            )
                         ),
-                        UserWithSuperuserStatus(
-                            user = User(
-                                username = "user2",
-                                firstName = "First2",
-                                lastName = "Last2",
-                                email = "user2@mail.com"
-                            ),
-                            isSuperuser = false
+                        pagination = PagingData(
+                            limit = 20,
+                            offset = 0,
+                            totalCount = 2,
+                            sortProperties = listOf(SortProperty("username", SortDirection.ASCENDING))
                         )
                     )
                 }

--- a/core/src/test/kotlin/api/AdminRouteIntegrationTest.kt
+++ b/core/src/test/kotlin/api/AdminRouteIntegrationTest.kt
@@ -20,7 +20,8 @@
 package org.eclipse.apoapsis.ortserver.core.api
 
 import io.kotest.assertions.ktor.client.shouldHaveStatus
-import io.kotest.matchers.collections.shouldContain
+import io.kotest.matchers.collections.shouldBeSingleton
+import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 
@@ -31,16 +32,19 @@ import io.ktor.client.request.parameter
 import io.ktor.client.request.post
 import io.ktor.client.request.put
 import io.ktor.client.request.setBody
-import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
-
-import kotlinx.serialization.json.Json
 
 import org.eclipse.apoapsis.ortserver.api.v1.model.PostUser
 import org.eclipse.apoapsis.ortserver.api.v1.model.User
 import org.eclipse.apoapsis.ortserver.api.v1.model.UserWithSuperuserStatus
 import org.eclipse.apoapsis.ortserver.core.SUPERUSER
 import org.eclipse.apoapsis.ortserver.core.TEST_USER
+import org.eclipse.apoapsis.ortserver.model.util.ListQueryParameters
+import org.eclipse.apoapsis.ortserver.shared.apimodel.ErrorResponse
+import org.eclipse.apoapsis.ortserver.shared.apimodel.PagedResponse
+import org.eclipse.apoapsis.ortserver.shared.apimodel.PagingData
+import org.eclipse.apoapsis.ortserver.shared.apimodel.SortDirection
+import org.eclipse.apoapsis.ortserver.shared.apimodel.SortProperty
 import org.eclipse.apoapsis.ortserver.utils.test.Integration
 
 class AdminRouteIntegrationTest : AbstractIntegrationTest({
@@ -54,30 +58,97 @@ class AdminRouteIntegrationTest : AbstractIntegrationTest({
     val testTemporary = true
 
     "GET /admin/users" should {
-        "return a list of users" {
+        val expectedRealmAdmin = UserWithSuperuserStatus(
+            user = User(
+                username = "realm-admin",
+                firstName = "Realm",
+                lastName = "Admin",
+                email = "realm.admin@example.org"
+            ),
+            isSuperuser = false
+        )
+        val expectedSuperuser = UserWithSuperuserStatus(
+            user = User(
+                username = SUPERUSER.username.value,
+                firstName = SUPERUSER.firstName,
+                lastName = SUPERUSER.lastName,
+                email = SUPERUSER.email
+            ),
+            isSuperuser = true
+        )
+        val expectedUser = UserWithSuperuserStatus(
+            user = User(
+                username = TEST_USER.username.value,
+                firstName = TEST_USER.firstName,
+                lastName = TEST_USER.lastName,
+                email = TEST_USER.email
+            ),
+            isSuperuser = false
+        )
+
+        "return a page of users in the default order" {
             integrationTestApplication {
                 val response = superuserClient.get("/api/v1/admin/users")
 
                 response shouldHaveStatus HttpStatusCode.OK
-                val users = Json.decodeFromString<Set<UserWithSuperuserStatus>>(response.bodyAsText())
-                users shouldContain UserWithSuperuserStatus(
-                    user = User(
-                        username = SUPERUSER.username.value,
-                        firstName = SUPERUSER.firstName,
-                        lastName = SUPERUSER.lastName,
-                        email = SUPERUSER.email
-                    ),
-                    isSuperuser = true
+                val users = response.body<PagedResponse<UserWithSuperuserStatus>>()
+                users.data shouldContainExactly listOf(expectedRealmAdmin, expectedSuperuser, expectedUser)
+                users.pagination shouldBe PagingData(
+                    limit = ListQueryParameters.DEFAULT_LIMIT,
+                    offset = 0,
+                    totalCount = 3,
+                    sortProperties = listOf(SortProperty("username", SortDirection.ASCENDING))
                 )
-                users shouldContain UserWithSuperuserStatus(
-                    user = User(
-                        username = TEST_USER.username.value,
-                        firstName = TEST_USER.firstName,
-                        lastName = TEST_USER.lastName,
-                        email = TEST_USER.email
-                    ),
-                    isSuperuser = false
+            }
+        }
+
+        "apply limit and offset while preserving the total count" {
+            integrationTestApplication {
+                val response = superuserClient.get("/api/v1/admin/users?limit=1&offset=1")
+
+                response shouldHaveStatus HttpStatusCode.OK
+                val users = response.body<PagedResponse<UserWithSuperuserStatus>>()
+                users.data shouldContainExactly listOf(expectedSuperuser)
+                users.pagination shouldBe PagingData(
+                    limit = 1,
+                    offset = 1,
+                    totalCount = 3,
+                    sortProperties = listOf(SortProperty("username", SortDirection.ASCENDING))
                 )
+            }
+        }
+
+        "sort users and expose the requested sort property" {
+            integrationTestApplication {
+                val response = superuserClient.get("/api/v1/admin/users?sort=-username")
+
+                response shouldHaveStatus HttpStatusCode.OK
+                val users = response.body<PagedResponse<UserWithSuperuserStatus>>()
+                users.data shouldContainExactly listOf(expectedUser, expectedSuperuser, expectedRealmAdmin)
+                users.pagination.sortProperties shouldBe
+                        listOf(SortProperty("username", SortDirection.DESCENDING))
+            }
+        }
+
+        "search users before paging" {
+            integrationTestApplication {
+                val response = superuserClient.get("/api/v1/admin/users?search=SuPeR&limit=1")
+
+                response shouldHaveStatus HttpStatusCode.OK
+                val users = response.body<PagedResponse<UserWithSuperuserStatus>>()
+                users.data.shouldBeSingleton { it shouldBe expectedSuperuser }
+                users.pagination.totalCount shouldBe 1
+            }
+        }
+
+        "reject unsupported sort fields" {
+            integrationTestApplication {
+                val response = superuserClient.get("/api/v1/admin/users?sort=unknown")
+
+                response shouldHaveStatus HttpStatusCode.BadRequest
+                val error = response.body<ErrorResponse>()
+                error.message shouldBe "Invalid query parameters."
+                error.cause shouldBe "Unsupported sort field: 'unknown'."
             }
         }
 
@@ -190,7 +261,7 @@ class AdminRouteIntegrationTest : AbstractIntegrationTest({
 
                 val usersResponse = superuserClient.get("/api/v1/admin/users")
                 usersResponse shouldHaveStatus HttpStatusCode.OK
-                usersResponse.body<List<UserWithSuperuserStatus>>()
+                usersResponse.body<PagedResponse<UserWithSuperuserStatus>>().data
                     .find { it.user.username == TEST_USER.username.value }
                     .shouldNotBeNull().isSuperuser shouldBe true
             }
@@ -223,7 +294,7 @@ class AdminRouteIntegrationTest : AbstractIntegrationTest({
 
                 val usersResponse = superuserClient.get("/api/v1/admin/users")
                 usersResponse shouldHaveStatus HttpStatusCode.OK
-                usersResponse.body<List<UserWithSuperuserStatus>>()
+                usersResponse.body<PagedResponse<UserWithSuperuserStatus>>().data
                     .find { it.user.username == TEST_USER.username.value }
                     .shouldNotBeNull().isSuperuser shouldBe false
             }
@@ -245,7 +316,7 @@ class AdminRouteIntegrationTest : AbstractIntegrationTest({
 
                 val usersResponse = superuserClient.get("/api/v1/admin/users")
                 usersResponse shouldHaveStatus HttpStatusCode.OK
-                usersResponse.body<List<UserWithSuperuserStatus>>()
+                usersResponse.body<PagedResponse<UserWithSuperuserStatus>>().data
                     .find { it.user.username == SUPERUSER.username.value }
                     .shouldNotBeNull().isSuperuser shouldBe true
             }

--- a/ui/src/routes/admin/users/index.tsx
+++ b/ui/src/routes/admin/users/index.tsx
@@ -23,7 +23,14 @@ import {
   useSuspenseQuery,
 } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
-import { ShieldCheck, ShieldMinus, ShieldPlus, UserPlus } from 'lucide-react';
+import {
+  ShieldCheck,
+  ShieldMinus,
+  ShieldPlus,
+  UserPlus,
+  XCircle,
+} from 'lucide-react';
+import { useRef, useState } from 'react';
 
 import { UserWithSuperuserStatus } from '@/api';
 import {
@@ -46,11 +53,17 @@ import {
   CardHeader,
   CardTitle,
 } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from '@/components/ui/tooltip';
+import {
+  convertToBackendSorting,
+  EMPTY_SORTING_STATE,
+  updateColumnSorting,
+} from '@/helpers/handle-multisort';
 import {
   createAppColumnHelper,
   selectNoTableState,
@@ -59,26 +72,51 @@ import {
 import { ApiError } from '@/lib/api-error';
 import { routePrefetchStaleTime } from '@/lib/query-client';
 import { toast, toastError } from '@/lib/toast';
-import { paginationSearchParameterSchema } from '@/schemas';
+import {
+  adminUsersSearchParameterSchema,
+  type AdminUsersSearchParameters,
+} from '@/schemas';
 
 const defaultPageSize = 10;
+
+const getUsersOptionsForSearch = ({
+  page,
+  pageSize,
+  sortBy,
+  search,
+}: AdminUsersSearchParameters) => {
+  const requestPageSize = pageSize ?? defaultPageSize;
+
+  return getUsersOptions({
+    query: {
+      limit: requestPageSize,
+      offset: page ? (page - 1) * requestPageSize : 0,
+      sort: convertToBackendSorting(sortBy),
+      search: search || undefined,
+    },
+  });
+};
 
 const columnHelper = createAppColumnHelper<UserWithSuperuserStatus>();
 
 const columns = columnHelper.columns([
   columnHelper.accessor('user.username', {
+    id: 'username',
     header: 'Username',
     cell: ({ row }) => <TooltipIfTruncated text={row.original.user.username} />,
   }),
   columnHelper.accessor('user.firstName', {
+    id: 'firstName',
     header: 'First name',
     cell: ({ row }) => <>{row.original.user.firstName}</>,
   }),
   columnHelper.accessor('user.lastName', {
+    id: 'lastName',
     header: 'Last name',
     cell: ({ row }) => <>{row.original.user.lastName}</>,
   }),
   columnHelper.accessor('user.email', {
+    id: 'email',
     header: 'Email address',
     cell: ({ row }) => (
       <TooltipIfTruncated text={row.original.user.email ?? ''} />
@@ -86,6 +124,7 @@ const columns = columnHelper.columns([
   }),
   columnHelper.accessor('isSuperuser', {
     header: 'Superuser',
+    enableSorting: false,
     cell: ({ row }) => (
       <>
         {row.original.isSuperuser ? <ShieldCheck className='h-4 w-4' /> : null}
@@ -95,6 +134,7 @@ const columns = columnHelper.columns([
   columnHelper.display({
     id: 'actions',
     header: () => <div className='text-right'>Actions</div>,
+    enableSorting: false,
     size: 80,
     cell: function CellComponent({ row }) {
       const queryClient = useQueryClient();
@@ -200,28 +240,107 @@ const columns = columnHelper.columns([
   }),
 ]);
 
+const UserSearch = ({ search }: { search: AdminUsersSearchParameters }) => {
+  const committedSearch = search.search ?? '';
+  const navigate = Route.useNavigate();
+  const [searchInput, setSearchInput] = useState(committedSearch);
+  const lastAppliedSearch = useRef(committedSearch);
+
+  const applySearch = () => {
+    const normalizedSearch = searchInput.trim();
+
+    if (normalizedSearch === lastAppliedSearch.current) return;
+
+    lastAppliedSearch.current = normalizedSearch;
+    navigate({
+      search: {
+        ...search,
+        page: 1,
+        search: normalizedSearch || undefined,
+      },
+    });
+  };
+
+  const clearSearch = () => {
+    setSearchInput('');
+
+    if (lastAppliedSearch.current === '') return;
+
+    lastAppliedSearch.current = '';
+    navigate({
+      search: {
+        ...search,
+        page: 1,
+        search: undefined,
+      },
+    });
+  };
+
+  return (
+    <form
+      className='mb-4 max-w-xl'
+      onSubmit={(event) => {
+        event.preventDefault();
+        applySearch();
+      }}
+    >
+      <label className='mb-2 block text-sm font-medium' htmlFor='user-search'>
+        Search users
+      </label>
+      <div className='flex gap-2'>
+        <Input
+          id='user-search'
+          type='search'
+          placeholder='Search by username, first name, last name, or email'
+          value={searchInput}
+          onChange={(event) => setSearchInput(event.target.value)}
+          onBlur={applySearch}
+        />
+        <Button
+          type='button'
+          variant='ghost'
+          className='px-2'
+          onMouseDown={(event) => event.preventDefault()}
+          onClick={clearSearch}
+        >
+          <XCircle
+            className={
+              searchInput.length === 0
+                ? 'h-fit text-gray-400 opacity-40'
+                : 'h-fit text-gray-400 opacity-100'
+            }
+          />
+          <span className='sr-only'>Clear search</span>
+        </Button>
+      </div>
+    </form>
+  );
+};
+
 const Users = () => {
   const search = Route.useSearch();
   const pageIndex = search.page ? search.page - 1 : 0;
-  const pageSize = search.pageSize ? search.pageSize : defaultPageSize;
+  const pageSize = search.pageSize ?? defaultPageSize;
 
   const { data: users } = useSuspenseQuery({
-    ...getUsersOptions(),
+    ...getUsersOptionsForSearch(search),
     staleTime: routePrefetchStaleTime,
   });
 
   const table = useAppTable(
     {
-      data: users,
+      data: users.data,
       columns,
-
+      pageCount: Math.ceil(users.pagination.totalCount / pageSize),
       state: {
         pagination: {
           pageIndex,
           pageSize,
         },
+        sorting: search.sortBy ?? EMPTY_SORTING_STATE,
       },
-      manualPagination: false,
+      manualPagination: true,
+      manualSorting: true,
     },
     selectNoTableState
   );
@@ -250,33 +369,48 @@ const Users = () => {
         </div>
       </CardHeader>
       <CardContent>
-        <CardContent>
-          <DataTable
-            table={table}
-            setCurrentPageOptions={(currentPage) => {
-              return {
-                to: Route.to,
-                search: { ...search, page: currentPage },
-              };
-            }}
-            setPageSizeOptions={(size) => {
-              return {
-                to: Route.to,
-                search: { ...search, page: 1, pageSize: size },
-              };
-            }}
-          />
-        </CardContent>
+        <UserSearch key={search.search ?? ''} search={search} />
+        <DataTable
+          table={table}
+          setCurrentPageOptions={(currentPage) => {
+            return {
+              to: Route.to,
+              search: { ...search, page: currentPage },
+            };
+          }}
+          setPageSizeOptions={(size) => {
+            return {
+              to: Route.to,
+              search: { ...search, page: 1, pageSize: size },
+            };
+          }}
+          setSortingOptions={(sortBy) => {
+            return {
+              to: Route.to,
+              search: {
+                ...search,
+                page: 1,
+                sortBy: updateColumnSorting(search.sortBy, sortBy),
+              },
+            };
+          }}
+        />
       </CardContent>
     </Card>
   );
 };
 
 export const Route = createFileRoute('/admin/users/')({
-  validateSearch: paginationSearchParameterSchema,
-  loader: async ({ context: { queryClient } }) => {
+  validateSearch: adminUsersSearchParameterSchema,
+  loaderDeps: ({ search: { page, pageSize, sortBy, search: searchTerm } }) => ({
+    page,
+    pageSize,
+    sortBy,
+    search: searchTerm,
+  }),
+  loader: async ({ context: { queryClient }, deps }) => {
     await queryClient.ensureQueryData({
-      ...getUsersOptions(),
+      ...getUsersOptionsForSearch(deps),
       staleTime: routePrefetchStaleTime,
     });
   },

--- a/ui/src/schemas/index.ts
+++ b/ui/src/schemas/index.ts
@@ -176,6 +176,30 @@ export const sortingSearchParameterSchema = z.object({
     .optional(),
 });
 
+export const adminUserSortFieldSchema = z.enum([
+  'username',
+  'firstName',
+  'lastName',
+  'email',
+]);
+
+export const adminUsersSearchParameterSchema = z.object({
+  ...paginationSearchParameterSchema.shape,
+  search: z.string().trim().optional(),
+  sortBy: z
+    .array(
+      z.object({
+        id: adminUserSortFieldSchema,
+        desc: z.boolean(),
+      })
+    )
+    .optional(),
+});
+
+export type AdminUsersSearchParameters = z.infer<
+  typeof adminUsersSearchParameterSchema
+>;
+
 export const packageSortingSearchParameterSchema = z.object({
   packageSortBy: z
     .array(

--- a/ui/tests/unit/components/admin-user-search.test.tsx
+++ b/ui/tests/unit/components/admin-user-search.test.tsx
@@ -1,0 +1,250 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+// @vitest-environment jsdom
+
+import { screen, waitFor, within } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { PagedResponseUserWithSuperuserStatus } from '@/api';
+import { Route } from '@/routes/admin/users';
+import { adminUsersSearchParameterSchema } from '@/schemas';
+import { getQueryKeyRequest } from '../fixtures/loader-test-utils';
+import { renderInteractiveWithRouter } from '../fixtures/render-interactive';
+
+const mocks = vi.hoisted(() => ({
+  invalidateQueries: vi.fn(),
+  queryOptions: vi.fn(),
+  response: {
+    data: [],
+    pagination: {
+      limit: 10,
+      offset: 0,
+      totalCount: 0,
+      sortProperties: [],
+    },
+  } as PagedResponseUserWithSuperuserStatus,
+}));
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('@tanstack/react-query')>();
+
+  return {
+    ...original,
+    useMutation: () => ({ mutateAsync: vi.fn() }),
+    useQueryClient: () => ({ invalidateQueries: mocks.invalidateQueries }),
+    useSuspenseQuery: (options: unknown) => {
+      mocks.queryOptions(options);
+      return { data: mocks.response };
+    },
+  };
+});
+
+const UsersComponent = Route.options.component!;
+
+const createUser = (username: string) => ({
+  isSuperuser: false,
+  user: {
+    username,
+    firstName: `${username} first`,
+    lastName: `${username} last`,
+    email: `${username}@example.org`,
+  },
+});
+
+const renderUsers = (path = '/admin/users') =>
+  renderInteractiveWithRouter(<UsersComponent />, {
+    path,
+    routes: [{ path: '/admin/users/' }],
+  });
+
+const getLastUsersRequest = () =>
+  getQueryKeyRequest(mocks.queryOptions.mock.calls.at(-1)![0]);
+
+beforeEach(() => {
+  mocks.queryOptions.mockClear();
+  mocks.invalidateQueries.mockClear();
+  mocks.response = {
+    data: [createUser('zulu'), createUser('alpha'), createUser('mike')],
+    pagination: {
+      limit: 10,
+      offset: 0,
+      totalCount: 30,
+      sortProperties: [],
+    },
+  };
+});
+
+describe('admin user list', () => {
+  it('renders the search input between the create action and table', async () => {
+    renderUsers();
+
+    const createLink = await screen.findByRole('link', { name: /Create user/ });
+    const searchInput = screen.getByRole('searchbox', { name: 'Search users' });
+    const table = screen.getByRole('table');
+
+    expect(
+      createLink.compareDocumentPosition(searchInput) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).not.toBe(0);
+    expect(
+      searchInput.compareDocumentPosition(table) &
+        Node.DOCUMENT_POSITION_FOLLOWING
+    ).not.toBe(0);
+  });
+
+  it('applies search on Enter without applying it again on blur', async () => {
+    const { router, user } = renderUsers('/admin/users?page=3&pageSize=10');
+    const searchInput = await screen.findByRole('searchbox', {
+      name: 'Search users',
+    });
+    const initialQueryCount = mocks.queryOptions.mock.calls.length;
+
+    await user.type(searchInput, '  Example  ');
+
+    expect(router.state.location.search).toMatchObject({
+      page: 3,
+      pageSize: 10,
+    });
+    mocks.queryOptions.mock.calls.forEach(([options]) => {
+      expect(getQueryKeyRequest(options).query?.search).toBeUndefined();
+    });
+    expect(mocks.queryOptions).toHaveBeenCalledTimes(initialQueryCount);
+
+    await user.keyboard('{Enter}');
+
+    await waitFor(() => {
+      expect(router.state.location.search).toMatchObject({
+        page: 1,
+        pageSize: 10,
+        search: 'Example',
+      });
+    });
+    expect(getLastUsersRequest().query).toMatchObject({
+      limit: 10,
+      offset: 0,
+      search: 'Example',
+    });
+
+    const queryCountAfterEnter = mocks.queryOptions.mock.calls.length;
+    await user.tab();
+    await Promise.resolve();
+
+    expect(mocks.queryOptions).toHaveBeenCalledTimes(queryCountAfterEnter);
+  });
+
+  it('applies search on blur, clears it, and follows browser navigation', async () => {
+    const { router, user } = renderUsers(
+      '/admin/users?page=2&pageSize=10&search=initial'
+    );
+    const searchInput = await screen.findByRole('searchbox', {
+      name: 'Search users',
+    });
+
+    expect(searchInput).toHaveValue('initial');
+
+    await user.clear(searchInput);
+    await user.type(searchInput, '  next  ');
+    await user.tab();
+
+    await waitFor(() => {
+      expect(router.state.location.search).toMatchObject({
+        page: 1,
+        search: 'next',
+      });
+    });
+
+    const updatedSearchInput = screen.getByRole('searchbox', {
+      name: 'Search users',
+    });
+    expect(updatedSearchInput).toHaveValue('next');
+
+    const queryCountBeforeClear = mocks.queryOptions.mock.calls.length;
+    await user.click(screen.getByRole('button', { name: 'Clear search' }));
+
+    await waitFor(() => {
+      expect(router.state.location.search.search).toBeUndefined();
+    });
+    mocks.queryOptions.mock.calls
+      .slice(queryCountBeforeClear)
+      .forEach(([options]) => {
+        expect(getQueryKeyRequest(options).query?.search).toBeUndefined();
+      });
+
+    router.history.back();
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('searchbox', { name: 'Search users' })
+      ).toHaveValue('next');
+    });
+  });
+
+  it('uses the server page without slicing or reordering it', async () => {
+    renderUsers('/admin/users?page=2&pageSize=2');
+
+    await screen.findByRole('table');
+
+    expect(
+      screen
+        .getAllByRole('row')
+        .slice(1)
+        .map((row) => within(row).getAllByRole('cell')[0]?.textContent)
+    ).toEqual(['zulu', 'alpha', 'mike']);
+    expect(getLastUsersRequest().query).toMatchObject({
+      limit: 2,
+      offset: 2,
+    });
+    expect(screen.getByRole('spinbutton')).toHaveValue(2);
+    expect(
+      screen.getByRole('link', { name: 'Go to last page' })
+    ).toHaveAttribute('href', expect.stringContaining('page=15'));
+  });
+
+  it('requests sorting while preserving the server row order', async () => {
+    const { router, user } = renderUsers('/admin/users?page=2&pageSize=10');
+    const usernameHeader = (await screen.findByText('Username')).closest('th');
+
+    expect(usernameHeader).not.toBeNull();
+    await user.click(within(usernameHeader!).getByRole('link'));
+
+    await waitFor(() => {
+      expect(router.state.location.search).toMatchObject({
+        page: 1,
+        sortBy: [{ id: 'username', desc: false }],
+      });
+    });
+    expect(getLastUsersRequest().query?.sort).toBe('username');
+    expect(
+      screen
+        .getAllByRole('row')
+        .slice(1)
+        .map((row) => within(row).getAllByRole('cell')[0]?.textContent)
+    ).toEqual(['zulu', 'alpha', 'mike']);
+  });
+
+  it('rejects unsupported sort fields in URL search parameters', () => {
+    expect(
+      adminUsersSearchParameterSchema.safeParse({
+        sortBy: [{ id: 'isSuperuser', desc: false }],
+      }).success
+    ).toBe(false);
+  });
+});

--- a/ui/tests/unit/routes/admin-loader-prefetch.test.ts
+++ b/ui/tests/unit/routes/admin-loader-prefetch.test.ts
@@ -92,14 +92,51 @@ describe('admin route loaders', () => {
     expect(totalCountRequest.query).toEqual({ limit: 1 });
   });
 
-  it('awaits the users query before resolving', async () => {
+  it('forwards the admin user list parameters to the awaited query', async () => {
     const loader = AdminUsersRoute.options.loader as unknown as (
       options: unknown
     ) => Promise<void>;
 
-    await expectLoaderToAwaitQuery(loader, 'ensureQueryData', {
+    const queryFn = await expectLoaderToAwaitQuery(loader, 'ensureQueryData', {
+      deps: {
+        page: 2,
+        pageSize: 25,
+        search: 'example',
+        sortBy: [
+          { id: 'lastName', desc: false },
+          { id: 'firstName', desc: true },
+        ],
+      },
+      params: {},
+    });
+
+    const request = getQueryKeyRequest(queryFn.mock.calls[0]![0]);
+    expect(request._id).toBe('getUsers');
+    expect(request.query).toEqual({
+      limit: 25,
+      offset: 25,
+      search: 'example',
+      sort: 'lastName,-firstName',
+    });
+  });
+
+  it('normalizes absent admin user list parameters', async () => {
+    const loader = AdminUsersRoute.options.loader as unknown as (
+      options: unknown
+    ) => Promise<void>;
+
+    const queryFn = await expectLoaderToAwaitQuery(loader, 'ensureQueryData', {
       deps: {},
       params: {},
+    });
+
+    const request = getQueryKeyRequest(queryFn.mock.calls[0]![0]);
+    expect(request._id).toBe('getUsers');
+    expect(request.query).toEqual({
+      limit: 10,
+      offset: 0,
+      search: undefined,
+      sort: undefined,
     });
   });
 


### PR DESCRIPTION
Issue #4505 asks for a back-end filter for the admin/users endpoint. Combining server-side filtering with client-side pagination would paginate only the subset returned by the server, causing incomplete pages, page counts, and inaccessible matching users. Therefore this PR moves pagination, sorting and filtering completely to the API list endpoint. This also brings the benefit of a table now not only filterable, but also sortable by "Username", "First name", "Last name", and "Email address" columns.

Note that this is a breaking change.

#### No filter

<img width="1182" height="527" alt="Screenshot from 2026-09-08 08-13-06" src="https://github.com/user-attachments/assets/df805bef-6092-4b4d-8957-5714f035e63f" />

#### Filter matching both "Username" and "Last name"

<img width="1177" height="478" alt="Screenshot from 2026-09-08 08-14-17" src="https://github.com/user-attachments/assets/a11e6c45-bf71-4f36-8d76-d820095833b9" />

#### Filter matching "Last name"

<img width="1179" height="430" alt="Screenshot from 2026-09-08 08-14-36" src="https://github.com/user-attachments/assets/6af2df7a-6064-4d64-9230-d981bb8afc3e" />

Please see the commits for details.