### PR TITLE
docs(workers): Improve log messages when running fails

### DIFF
--- a/workers/advisor/src/main/kotlin/AdvisorWorker.kt
+++ b/workers/advisor/src/main/kotlin/AdvisorWorker.kt
@@ -143,12 +143,12 @@ internal class AdvisorWorker(
     }.getOrElse {
         when (it) {
             is JobIgnoredException -> {
-                logger.warn("Message with traceId '$traceId' ignored: ${it.message}")
+                logger.warn("Not running the advisor because message '$traceId' got ignored: ${it.message}")
                 RunResult.Ignored
             }
 
             else -> {
-                logger.error("Error while processing message with traceId '$traceId': ${it.message}")
+                logger.error("Error while running the advisor as instructed by message '$traceId': ${it.message}")
                 RunResult.Failed(it)
             }
         }

--- a/workers/analyzer/src/main/kotlin/AnalyzerWorker.kt
+++ b/workers/analyzer/src/main/kotlin/AnalyzerWorker.kt
@@ -78,12 +78,12 @@ internal class AnalyzerWorker(
     }.getOrElse {
         when (it) {
             is JobIgnoredException -> {
-                logger.warn("Message with traceId '$traceId' ignored: ${it.message}")
+                logger.warn("Not running the analyzer because message '$traceId' got ignored: ${it.message}")
                 RunResult.Ignored
             }
 
             else -> {
-                logger.error("Error while processing message with traceId '$traceId': ${it.message}")
+                logger.error("Error while running the analyzer as instructed by message '$traceId': ${it.message}")
                 RunResult.Failed(it)
             }
         }

--- a/workers/evaluator/src/main/kotlin/EvaluatorWorker.kt
+++ b/workers/evaluator/src/main/kotlin/EvaluatorWorker.kt
@@ -92,12 +92,12 @@ internal class EvaluatorWorker(
     }.getOrElse {
         when (it) {
             is JobIgnoredException -> {
-                logger.warn("Message with traceId '$traceId' ignored: ${it.message}")
+                logger.warn("Not running the evaluator because message '$traceId' got ignored: ${it.message}")
                 RunResult.Ignored
             }
 
             else -> {
-                logger.error("Error while processing message with traceId '$traceId': ${it.message}")
+                logger.error("Error while running the evaluator as instructed by message '$traceId': ${it.message}")
                 RunResult.Failed(it)
             }
         }

--- a/workers/notifier/src/main/kotlin/NotifierWorker.kt
+++ b/workers/notifier/src/main/kotlin/NotifierWorker.kt
@@ -87,12 +87,12 @@ internal class NotifierWorker(
     }.getOrElse {
         when (it) {
             is JobIgnoredException -> {
-                logger.warn("Message with traceId '$traceId' ignored: ${it.message}")
+                logger.warn("Not running the notifier because message '$traceId' got ignored: ${it.message}")
                 RunResult.Ignored
             }
 
             else -> {
-                logger.error("Error while processing message with traceId '$traceId': ${it.message}")
+                logger.error("Error while running the notifier as instructed by message '$traceId': ${it.message}")
                 RunResult.Failed(it)
             }
         }

--- a/workers/reporter/src/main/kotlin/ReporterWorker.kt
+++ b/workers/reporter/src/main/kotlin/ReporterWorker.kt
@@ -176,12 +176,12 @@ internal class ReporterWorker(
     }.getOrElse {
         when (it) {
             is JobIgnoredException -> {
-                logger.warn("Message with traceId '$traceId' ignored: ${it.message}")
+                logger.warn("Not running the reporter because message '$traceId' got ignored: ${it.message}")
                 RunResult.Ignored
             }
 
             else -> {
-                logger.error("Error while processing message with traceId '$traceId': ${it.message}")
+                logger.error("Error while running the reporter as instructed by message '$traceId': ${it.message}")
                 RunResult.Failed(it)
             }
         }

--- a/workers/scanner/src/main/kotlin/ScannerWorker.kt
+++ b/workers/scanner/src/main/kotlin/ScannerWorker.kt
@@ -149,12 +149,12 @@ class ScannerWorker(
     }.getOrElse {
         when (it) {
             is JobIgnoredException -> {
-                logger.warn("Message with traceId '$traceId' ignored: ${it.message}")
+                logger.warn("Not running the scanner because message '$traceId' got ignored: ${it.message}")
                 RunResult.Ignored
             }
 
             else -> {
-                logger.error("Error while processing message with traceId '$traceId': ${it.message}")
+                logger.error("Error while running the scanner as instructed by message '$traceId': ${it.message}")
                 RunResult.Failed(it)
             }
         }


### PR DESCRIPTION
In particular, clarify that not processing of the message itself fails, but running the work as instructed by the message.