### PR TITLE
ui: Add license finding curation snippet

### DIFF
--- a/ui/src/components/copy-to-clipboard.tsx
+++ b/ui/src/components/copy-to-clipboard.tsx
@@ -41,22 +41,19 @@ export const CopyToClipboard = ({
   tooltipContentClassName,
   className,
 }: CopyToClipboardProps) => {
-  const [isCopied, setIsCopied] = useState(false);
+  const [copyStatus, setCopyStatus] = useState<'idle' | 'copied' | 'failed'>(
+    'idle'
+  );
 
-  async function copyTextToClipboard(text: string) {
-    return await navigator.clipboard.writeText(text);
-  }
+  const handleCopyClick = async () => {
+    try {
+      await navigator.clipboard.writeText(copyText);
+      setCopyStatus('copied');
+    } catch {
+      setCopyStatus('failed');
+    }
 
-  // onClick handler function for the copy button
-  const handleCopyClick = () => {
-    // Asynchronously call copyTextToClipboard
-    copyTextToClipboard(copyText).then(() => {
-      // If successful, update the isCopied state value
-      setIsCopied(true);
-      setTimeout(() => {
-        setIsCopied(false);
-      }, 1500);
-    });
+    setTimeout(() => setCopyStatus('idle'), 1500);
   };
   return (
     <TooltipProvider delayDuration={0}>
@@ -70,12 +67,20 @@ export const CopyToClipboard = ({
             onClick={handleCopyClick}
           >
             <span className='fg-slate-300'>
-              {isCopied ? <Check color='gray' /> : <Copy color='gray' />}
+              {copyStatus === 'copied' ? (
+                <Check color='gray' />
+              ) : (
+                <Copy color='gray' />
+              )}
             </span>
           </Button>
         </TooltipTrigger>
         <TooltipContent className={tooltipContentClassName}>
-          {isCopied ? 'Copied!' : tooltipText}
+          {copyStatus === 'copied'
+            ? 'Copied!'
+            : copyStatus === 'failed'
+              ? 'Copy failed'
+              : tooltipText}
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>

--- a/ui/src/components/copy-to-clipboard.tsx
+++ b/ui/src/components/copy-to-clipboard.tsx
@@ -64,6 +64,7 @@ export const CopyToClipboard = ({
             type='button'
             size='sm'
             className={className}
+            aria-label={tooltipText}
             onClick={handleCopyClick}
           >
             <span className='fg-slate-300'>

--- a/ui/src/components/copy-to-clipboard.tsx
+++ b/ui/src/components/copy-to-clipboard.tsx
@@ -30,12 +30,14 @@ import {
 
 type CopyToClipboardProps = {
   copyText: string;
+  tooltipText?: string;
   tooltipContentClassName?: string;
   className?: string;
 };
 
 export const CopyToClipboard = ({
   copyText,
+  tooltipText = 'Copy to clipboard',
   tooltipContentClassName,
   className,
 }: CopyToClipboardProps) => {
@@ -73,7 +75,7 @@ export const CopyToClipboard = ({
           </Button>
         </TooltipTrigger>
         <TooltipContent className={tooltipContentClassName}>
-          {isCopied ? 'Copied!' : 'Copy to clipboard'}
+          {isCopied ? 'Copied!' : tooltipText}
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>

--- a/ui/src/lib/license-finding-curation.ts
+++ b/ui/src/lib/license-finding-curation.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+const LICENSE_FINDING_CURATION_REASONS = [
+  'CODE',
+  'DATA_OF',
+  'DOCUMENTATION_OF',
+  'INCORRECT',
+  'NOT_DETECTED',
+  'REFERENCE',
+] as const;
+
+const REASON_PLACEHOLDER = LICENSE_FINDING_CURATION_REASONS.join('|');
+
+type LicenseFindingCurationTemplateOptions = {
+  id: string;
+  path: string;
+  startLine: number;
+  endLine: number;
+  detectedLicense: string;
+};
+
+const quoteYamlString = (value: string) => JSON.stringify(value);
+
+/** Create an editable package-configuration template for a license finding. */
+export function createLicenseFindingCurationTemplate({
+  id,
+  path,
+  startLine,
+  endLine,
+  detectedLicense,
+}: LicenseFindingCurationTemplateOptions): string {
+  const lines = [
+    `id: ${quoteYamlString(id)}`,
+    'license_finding_curations:',
+    `- path: ${quoteYamlString(path)}`,
+  ];
+
+  if (startLine > 0 && endLine >= startLine) {
+    lines.push(
+      `  start_lines: ${quoteYamlString(startLine.toString())}`,
+      `  line_count: ${endLine - startLine + 1}`
+    );
+  }
+
+  lines.push(
+    `  detected_license: ${quoteYamlString(detectedLicense)}`,
+    `  reason: ${quoteYamlString(REASON_PLACEHOLDER)}`,
+    '  comment: ""',
+    '  concluded_license: "<SPDX expression>|NONE"'
+  );
+
+  return lines.join('\n');
+}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/detected-license-findings-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/detected-license-findings-table.tsx
@@ -24,6 +24,7 @@ import { LicenseFinding } from '@/api';
 import { getRunDetectedLicenseFindingsOptions } from '@/api/@tanstack/react-query.gen';
 import swhLogo from '@/assets/software-heritage-logo.svg';
 import { BreakableString } from '@/components/breakable-string';
+import { CopyToClipboard } from '@/components/copy-to-clipboard';
 import { DataTable } from '@/components/data-table/data-table';
 import { LoadingIndicator } from '@/components/loading-indicator';
 import {
@@ -36,6 +37,7 @@ import {
   selectNoTableState,
   useAppTable,
 } from '@/hooks/use-app-table';
+import { createLicenseFindingCurationTemplate } from '@/lib/license-finding-curation';
 import { buildSwhBrowseUrl } from '@/lib/software-heritage';
 import { toastError } from '@/lib/toast';
 import { formatLineNumber } from '@/lib/utils';
@@ -95,9 +97,22 @@ export const DetectedLicenseFindingsTable = ({
             )
           : null;
 
+        const curationTemplate = createLicenseFindingCurationTemplate({
+          id: identifier,
+          path: row.original.path,
+          startLine: row.original.startLine,
+          endLine: row.original.endLine,
+          detectedLicense: license,
+        });
+
         return (
           <div className='flex items-start gap-2'>
             <BreakableString text={row.original.path} />
+            <CopyToClipboard
+              copyText={curationTemplate}
+              tooltipText='Copy license finding curation template to clipboard'
+              className='h-5 px-1 align-middle'
+            />
             {url && (
               <Tooltip>
                 <TooltipTrigger asChild>

--- a/ui/tests/unit/components/copy-to-clipboard.test.tsx
+++ b/ui/tests/unit/components/copy-to-clipboard.test.tsx
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+// @vitest-environment jsdom
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { expect, it, vi } from 'vitest';
+
+import { CopyToClipboard } from '@/components/copy-to-clipboard';
+
+it('shows an error when writing to the clipboard fails', async () => {
+  const user = userEvent.setup();
+  vi.spyOn(navigator.clipboard, 'writeText').mockRejectedValue(
+    new Error('Clipboard access denied')
+  );
+
+  render(<CopyToClipboard copyText='text' />);
+
+  const copyButton = screen.getByRole('button');
+
+  await user.click(copyButton);
+  await user.unhover(copyButton);
+  await user.hover(copyButton);
+
+  expect(await screen.findByText('Copy failed')).toBeVisible();
+});

--- a/ui/tests/unit/components/detected-license-findings-table.test.tsx
+++ b/ui/tests/unit/components/detected-license-findings-table.test.tsx
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+// @vitest-environment jsdom
+
+import { screen, waitFor, within } from '@testing-library/react';
+import { expect, it, vi } from 'vitest';
+
+import type { LicenseFinding } from '@/api';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { createLicenseFindingCurationTemplate } from '@/lib/license-finding-curation';
+import { buildSwhBrowseUrl } from '@/lib/software-heritage';
+import { DetectedLicenseFindingsTable } from '@/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/detected-license-findings-table';
+import { renderInteractiveWithRouter } from '../fixtures/render-interactive';
+
+const mocks = vi.hoisted(() => ({
+  finding: {
+    path: 'package/package.json',
+    startLine: 18,
+    endLine: 18,
+    score: 100,
+    scanner: 'DOS 1.0.0 (ScanCode 32.5.0)',
+  } satisfies LicenseFinding,
+}));
+
+const finding = mocks.finding;
+
+vi.mock('@tanstack/react-query', async (importOriginal) => {
+  const original =
+    await importOriginal<typeof import('@tanstack/react-query')>();
+
+  return {
+    ...original,
+    useQuery: () => ({
+      data: {
+        data: [mocks.finding],
+        pagination: { limit: 10, offset: 0, totalCount: 1 },
+      },
+      error: null,
+      isError: false,
+      isPending: false,
+    }),
+  };
+});
+
+it('copies a curation template before the Software Heritage link', async () => {
+  const identifier = 'NPM::abs-svg-path:0.1.1';
+  const license = 'MIT';
+  const purl = 'pkg:npm/abs-svg-path@0.1.1';
+  const { user } = renderInteractiveWithRouter(
+    <TooltipProvider>
+      <DetectedLicenseFindingsTable
+        runId={1}
+        identifier={identifier}
+        license={license}
+        purl={purl}
+      />
+    </TooltipProvider>,
+    {
+      path: '/organizations/1/products/2/repositories/3/runs/4/license-findings',
+      routes: [
+        {
+          path: '/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/',
+        },
+      ],
+    }
+  );
+  const writeText = vi.spyOn(navigator.clipboard, 'writeText');
+  const path = await screen.findByText(finding.path);
+  const pathCell = path.closest('td');
+
+  expect(pathCell).not.toBeNull();
+
+  const copyButton = within(pathCell!).getByRole('button');
+  const swhLink = within(pathCell!).getByRole('link', {
+    name: 'Software Heritage',
+  });
+
+  expect(Array.from(path.parentElement!.children)).toEqual([
+    path,
+    copyButton,
+    swhLink,
+  ]);
+  expect(swhLink).toHaveAttribute(
+    'href',
+    buildSwhBrowseUrl(purl, finding.path, finding.startLine, finding.endLine)
+  );
+
+  await user.click(copyButton);
+
+  await waitFor(() => {
+    expect(writeText).toHaveBeenCalledWith(
+      createLicenseFindingCurationTemplate({
+        id: identifier,
+        path: finding.path,
+        startLine: finding.startLine,
+        endLine: finding.endLine,
+        detectedLicense: license,
+      })
+    );
+  });
+});

--- a/ui/tests/unit/logic/license-finding-curation.test.ts
+++ b/ui/tests/unit/logic/license-finding-curation.test.ts
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2026 The ORT Server Authors (See <https://github.com/eclipse-apoapsis/ort-server/blob/main/NOTICE>)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * License-Filename: LICENSE
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { createLicenseFindingCurationTemplate } from '@/lib/license-finding-curation';
+
+const createTemplate = (startLine = 18, endLine = 18) =>
+  createLicenseFindingCurationTemplate({
+    id: 'NPM::abs-svg-path:0.1.1',
+    path: 'package/package.json',
+    startLine,
+    endLine,
+    detectedLicense: 'MIT',
+  });
+
+describe('createLicenseFindingCurationTemplate', () => {
+  it('creates a template for the displayed license finding', () => {
+    expect(createTemplate()).toBe(`id: "NPM::abs-svg-path:0.1.1"
+license_finding_curations:
+- path: "package/package.json"
+  start_lines: "18"
+  line_count: 1
+  detected_license: "MIT"
+  reason: "CODE|DATA_OF|DOCUMENTATION_OF|INCORRECT|NOT_DETECTED|REFERENCE"
+  comment: ""
+  concluded_license: "<SPDX expression>|NONE"`);
+  });
+
+  it('calculates the inclusive line count for a multi-line finding', () => {
+    expect(createTemplate(7, 11)).toContain(
+      '  start_lines: "7"\n  line_count: 5'
+    );
+  });
+
+  it('quotes special characters in string values', () => {
+    const id = 'NPM::quoted"name:1\\2';
+    const path = 'src/"quoted"\\file.ts';
+    const detectedLicense = 'LicenseRef-"custom"\\value';
+    const template = createLicenseFindingCurationTemplate({
+      id,
+      path,
+      startLine: 1,
+      endLine: 1,
+      detectedLicense,
+    });
+
+    expect(template).toContain(`id: ${JSON.stringify(id)}`);
+    expect(template).toContain(`- path: ${JSON.stringify(path)}`);
+    expect(template).toContain(
+      `  detected_license: ${JSON.stringify(detectedLicense)}`
+    );
+  });
+
+  it.each([
+    { name: 'unknown', startLine: -1, endLine: -1 },
+    { name: 'reversed', startLine: 5, endLine: 4 },
+  ])('omits line selectors for a $name range', ({ startLine, endLine }) => {
+    const template = createTemplate(startLine, endLine);
+
+    expect(template).not.toContain('start_lines:');
+    expect(template).not.toContain('line_count:');
+  });
+
+  it('contains only the intended package configuration fields', () => {
+    const template = createTemplate();
+
+    expect(template).toContain(
+      'reason: "CODE|DATA_OF|DOCUMENTATION_OF|INCORRECT|NOT_DETECTED|REFERENCE"'
+    );
+    expect(template).toContain('comment: ""');
+    expect(template).toContain('concluded_license: "<SPDX expression>|NONE"');
+    expect(template).not.toContain('source_artifact_url:');
+    expect(template).not.toContain('vcs:');
+    expect(template).not.toContain('path_excludes:');
+  });
+});


### PR DESCRIPTION
When starting to prepare initial testing of #2323, a need came up for a small "helper component": the license findings sub-table actually contains a lot of useful information to produce a "license finding curation template" to the clipboard:

<img width="1165" height="336" alt="Screenshot from 2026-09-08 13-38-11" src="https://github.com/user-attachments/assets/42d9c4b9-5b65-4e11-b94b-09b2028f9b20" />

Pressing the `CopyToClipboard` component produces this snippet to the clipboard, to be easily edited by the user, in case they want to add a package configuration, or a curation to a repository's `.ort.yml`:

```yaml
id: "NPM::chokidar:3.6.0"
license_finding_curations:
- path: "package/README.md"
  start_lines: "306"
  line_count: 3
  detected_license: "MIT AND LicenseRef-scancode-unknown-license-reference"
  reason: "CODE|DATA_OF|DOCUMENTATION_OF|INCORRECT|NOT_DETECTED|REFERENCE"
  comment: ""
  concluded_license: "<SPDX expression>|NONE"
```