### PR TITLE
ui: Streamline showing start and end lines for snippet and license findings

### DIFF
--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -43,3 +43,10 @@ export function formatTimestamp(
 export function formatLineNumber(line: number) {
   return line === -1 ? 'UNKNOWN' : line;
 }
+
+export function formatLineRange(startLine: number, endLine: number) {
+  if (startLine === -1 && endLine === -1) return 'UNKNOWN';
+  if (startLine === endLine) return `${formatLineNumber(startLine)}`;
+
+  return `${formatLineNumber(startLine)}-${formatLineNumber(endLine)}`;
+}

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/detected-license-findings-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/license-findings/-components/detected-license-findings-table.tsx
@@ -40,7 +40,7 @@ import {
 import { createLicenseFindingCurationTemplate } from '@/lib/license-finding-curation';
 import { buildSwhBrowseUrl } from '@/lib/software-heritage';
 import { toastError } from '@/lib/toast';
-import { formatLineNumber } from '@/lib/utils';
+import { formatLineRange } from '@/lib/utils';
 
 const findingColumnHelper = createAppColumnHelper<LicenseFinding>();
 const defaultPageSize = 10;
@@ -141,16 +141,9 @@ export const DetectedLicenseFindingsTable = ({
     }),
     findingColumnHelper.accessor('startLine', {
       id: 'startLine',
-      header: 'Start Line',
-      cell: ({ row }) => formatLineNumber(row.original.startLine),
-      meta: {
-        widthPercentage: 10,
-      },
-    }),
-    findingColumnHelper.accessor('endLine', {
-      id: 'endLine',
-      header: 'End Line',
-      cell: ({ row }) => formatLineNumber(row.original.endLine),
+      header: 'Line Range',
+      cell: ({ row }) =>
+        formatLineRange(row.original.startLine, row.original.endLine),
       meta: {
         widthPercentage: 10,
       },

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/provenance-snippet-findings-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/provenance-snippet-findings-table.tsx
@@ -40,7 +40,7 @@ import {
   useAppTable,
 } from '@/hooks/use-app-table';
 import { toastError } from '@/lib/toast';
-import { formatLineNumber } from '@/lib/utils';
+import { formatLineRange } from '@/lib/utils';
 import { SnippetFindingSnippetsTable } from './snippet-finding-snippets-table';
 
 const findingColumnHelper = createAppColumnHelper<SnippetFinding>();
@@ -127,18 +127,10 @@ export const ProvenanceSnippetFindingsTable = ({
     }),
     findingColumnHelper.accessor('startLine', {
       id: 'startLine',
-      header: 'Start Line',
+      header: 'Line Range',
       enableSorting: false,
-      cell: ({ row }) => formatLineNumber(row.original.startLine),
-      meta: {
-        widthPercentage: 10,
-      },
-    }),
-    findingColumnHelper.accessor('endLine', {
-      id: 'endLine',
-      header: 'End Line',
-      enableSorting: false,
-      cell: ({ row }) => formatLineNumber(row.original.endLine),
+      cell: ({ row }) =>
+        formatLineRange(row.original.startLine, row.original.endLine),
       meta: {
         widthPercentage: 10,
       },

--- a/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/snippet-finding-snippets-table.tsx
+++ b/ui/src/routes/organizations/$orgId/products/$productId/repositories/$repoId/runs/$runIndex/snippet-findings/-components/snippet-finding-snippets-table.tsx
@@ -38,7 +38,7 @@ import {
   useAppTable,
 } from '@/hooks/use-app-table';
 import { toastError } from '@/lib/toast';
-import { formatLineNumber } from '@/lib/utils';
+import { formatLineRange } from '@/lib/utils';
 
 const snippetColumnHelper = createAppColumnHelper<SnippetSource>();
 const defaultPageSize = 10;
@@ -106,11 +106,14 @@ const SnippetSourceCard = ({ snippet }: { snippet: SnippetSource }) => {
       </div>
 
       <div className='flex items-start justify-between gap-4 text-sm'>
-        <div className='flex min-w-0 gap-2'>
-          <div className='text-muted-foreground shrink-0'>Location:</div>
-          <div className='wrap-break-word'>
-            {snippet.path} ({formatLineNumber(snippet.startLine)}-
-            {formatLineNumber(snippet.endLine)})
+        <div className='flex min-w-0 flex-col gap-2'>
+          <div className='flex min-w-0 gap-2'>
+            <div className='text-muted-foreground shrink-0'>Path:</div>
+            <div className='wrap-break-word'>{snippet.path}</div>
+          </div>
+          <div className='flex gap-2'>
+            <div className='text-muted-foreground shrink-0'>Line Range:</div>
+            <div>{formatLineRange(snippet.startLine, snippet.endLine)}</div>
           </div>
         </div>
         <div className='flex shrink-0 gap-2'>

--- a/ui/tests/unit/logic/lib-utils.test.ts
+++ b/ui/tests/unit/logic/lib-utils.test.ts
@@ -19,12 +19,24 @@
 
 import { expect, it } from 'vitest';
 
-import { formatLineNumber, formatTimestamp } from '@/lib/utils';
+import {
+  formatLineNumber,
+  formatLineRange,
+  formatTimestamp,
+} from '@/lib/utils';
 
 it('formatLineNumber', () => {
   expect(formatLineNumber(-1)).toBe('UNKNOWN');
   expect(formatLineNumber(0)).toBe(0);
   expect(formatLineNumber(1)).toBe(1);
+});
+
+it('formatLineRange', () => {
+  expect(formatLineRange(12, 18)).toBe('12-18');
+  expect(formatLineRange(-1, 18)).toBe('UNKNOWN-18');
+  expect(formatLineRange(12, -1)).toBe('12-UNKNOWN');
+  expect(formatLineRange(-1, -1)).toBe('UNKNOWN');
+  expect(formatLineRange(12, 12)).toBe('12');
 });
 
 it('formatTimestamp', () => {


### PR DESCRIPTION
#### Detected snippets

<img width="1151" height="657" alt="Screenshot from 2026-09-11 11-29-14" src="https://github.com/user-attachments/assets/5ad2d192-c3ea-48be-89b1-1e7cf0f3a70b" />

#### Detected licenses

<img width="1147" height="600" alt="Screenshot from 2026-09-11 11-30-00" src="https://github.com/user-attachments/assets/217f47c2-544b-4cd4-a830-800ce65ccd32" />

Please see the commit for details.